### PR TITLE
Added Attribute Category and Types to Track Targeting Data

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -42,15 +42,16 @@ class Attribute extends AppModel {
 	public $virtualFields = array(
 			'value' => 'IF (Attribute.value2="", Attribute.value1, CONCAT(Attribute.value1, "|", Attribute.value2))',
 			'category_order' => 'IF (Attribute.category="Internal reference", "a",
-			IF (Attribute.category="Antivirus detection", "b",
-			IF (Attribute.category="Payload delivery", "c",
-			IF (Attribute.category="Payload installation", "d",
-			IF (Attribute.category="Artifacts dropped", "e",
-			IF (Attribute.category="Persistence mechanism", "f",
-			IF (Attribute.category="Network activity", "g",
-			IF (Attribute.category="Payload type", "h",
-			IF (Attribute.category="Attribution", "i",
-			IF (Attribute.category="External analysis", "j", "k"))))))))))'
+			IF (Attribute.category="Targeting data", "b",
+ 			IF (Attribute.category="Antivirus detection", "c",
+ 			IF (Attribute.category="Payload delivery", "d",
+ 			IF (Attribute.category="Payload installation", "e",
+ 			IF (Attribute.category="Artifacts dropped", "f",
+ 			IF (Attribute.category="Persistence mechanism", "g",
+ 			IF (Attribute.category="Network activity", "h",
+ 			IF (Attribute.category="Payload type", "i",
+ 			IF (Attribute.category="Attribution", "j",
+ 			IF (Attribute.category="External analysis", "k", "l")))))))))))'
 	); // TODO hardcoded
 
 /**
@@ -126,6 +127,12 @@ class Attribute extends AppModel {
 			'other' => array('desc' => 'Other attribute'),
 			'named pipe' => array('desc' => 'Named pipe, use the format \\.\pipe\<PipeName>'),
 			'mutex' => array('desc' => 'Mutex, use the format \BaseNamedObjects\<Mutex>'),
+ 			'target-user' => array('desc' => 'Attack Targets Username(s)'),
+ 			'target-email' => array('desc' => 'Attack Targets Email(s)'),
+ 			'target-machine' => array('desc' => 'Attack Targets Machine Name(s)'),
+ 			'target-org' => array('desc' => 'Attack Targets Department or Orginization(s)'),
+ 			'target-location' => array('desc' => 'Attack Targets Physical Location(s)'),
+ 			'target-external' => array('desc' => 'External Target Orginizations Affected by this Attack'),
 	);
 
 	// definitions of categories
@@ -134,6 +141,11 @@ class Attribute extends AppModel {
 					'desc' => 'Reference used by the publishing party (e.g. ticket number)',
 					'types' => array('link', 'comment', 'text', 'other')
 					),
+ 			'Targeting data' => array(
+ 					'desc' => 'Internal Attack Targeting and Compromise Information',
+ 					'formdesc' => 'Targeting information to include recipient email, infected machines, department, and or locations.<br/>',
+ 					'types' => array('target-user', 'target-email', 'target-machine', 'target-org', 'target-location', 'target-external', 'comment')
+ 					),
 			'Antivirus detection' => array(
 					'desc' => 'All the info about how the malware is detected by the antivirus products',
 					'formdesc' => 'List of anti-virus vendors detecting the malware or information on detection performance (e.g. 13/43 or 67%).<br/>Attachment with list of detection or link to VirusTotal could be placed here as well.',
@@ -214,6 +226,7 @@ class Attribute extends AppModel {
 		'category' => array(
 			'rule' => array('inList', array(
 							'Internal reference',
+							'Targeting data',
 							'Antivirus detection',
 							'Payload delivery',
 							'Payload installation',
@@ -675,6 +688,42 @@ class Attribute extends AppModel {
 			case 'other':
 				$returnValue = true;
 				break;
+ 			case 'target-user':
+ 				// no newline
+ 				if (!preg_match("#\n#", $value)) {
+ 					$returnValue = true;
+ 				}
+ 				break;
+ 			case 'target-email':
+ 				if (preg_match("#^[A-Z0-9._%+-]*@[A-Z0-9.-]+\.[A-Z]{2,4}$#i", $value)) {
+ 					$returnValue = true;
+ 				} else {
+ 					$returnValue = 'Email address has invalid format. Please double check the value or select "other" for a type.';
+ 				}
+ 				break;
+ 			case 'target-machine':
+ 				// no newline
+ 				if (!preg_match("#\n#", $value)) {
+ 					$returnValue = true;
+ 				}
+ 				break;
+ 			case 'target-org':
+ 				// no newline
+ 				if (!preg_match("#\n#", $value)) {
+ 					$returnValue = true;
+ 				}
+ 				break;
+ 			case 'target-location':
+ 				// no newline
+ 				if (!preg_match("#\n#", $value)) {
+ 					$returnValue = true;
+ 				}
+ 				break;
+ 			case 'target-external':
+ 				// no newline
+ 				if (!preg_match("#\n#", $value)) {
+ 					$returnValue = true;
+ 				}
 		}
 		return $returnValue;
 	}


### PR DESCRIPTION
In order to leverage this platform to better track incoming attacks (blocked and successful) as well as to contextfully ingest threat indicators from them I wanted to add some additional targeting attribute types. These will hopefully allow for creation useful long term metrics and potentially identify highly vulnerable (or highly targeted) users/departments/orgs. 

I broke this out from within the other categories as separation seemed best since this is org. specific data which won't be of value externally as threat indicators, I'll later force all entries into this category type to be "Organization Only" classified to limit sharing and potential mistakes upon manual entry, while allowing other attributes attached to the event to be shared across trusted partners. 

This appears to be functional, and I haven't hit any errors, but I feel as though I might need to duplicate these changes to ShadowAttribute.php as well? Feel free to use this or not :)  Thanks again for a great platform! 

Example in types/attribute matrix & descriptions:
![screen shot 2013-12-19 at 1 02 25 pm](https://f.cloud.github.com/assets/2313682/1784831/08a5a986-68d9-11e3-9735-adf7704bfac5.png)
![screen shot 2013-12-19 at 1 02 46 pm](https://f.cloud.github.com/assets/2313682/1784832/0c3bae4c-68d9-11e3-8be7-7674c237eae4.png)

Example in event:
![screen shot 2013-12-19 at 1 14 39 pm](https://f.cloud.github.com/assets/2313682/1784842/38e171c0-68d9-11e3-9669-182f5c31e896.png)
