### PR TITLE
Small Visual Tweak to Event View

### DIFF
--- a/app/View/Events/view.ctp
+++ b/app/View/Events/view.ctp
@@ -15,9 +15,9 @@ $mayPublish = ($isAclPublish && $event['Event']['orgc'] == $me['org']);
 	?>
 	<div class="row-fluid">
 		<div class="span8">
-			<h2>Event</h2>
+			<h2><?php echo nl2br(h($event['Event']['info'])); ?></h2>
 			<dl>
-				<dt>ID</dt>
+				<dt>Event ID</dt>
 				<dd>
 					<?php echo h($event['Event']['id']); ?>
 					&nbsp;
@@ -120,7 +120,7 @@ $mayPublish = ($isAclPublish && $event['Event']['orgc'] == $me['org']);
 					<?php echo h($event['Event']['date']); ?>
 					&nbsp;
 				</dd>
-				<dt title="<?php echo $eventDescriptions['threat_level_id']['desc'];?>">Risk</dt>
+				<dt title="<?php echo $eventDescriptions['threat_level_id']['desc'];?>">Threat Level</dt>
 				<dd>
 					<?php 
 						if ($event['ThreatLevel']['name']) echo h($event['ThreatLevel']['name']);
@@ -137,7 +137,7 @@ $mayPublish = ($isAclPublish && $event['Event']['orgc'] == $me['org']);
 				<dd <?php if($event['Event']['distribution'] == 0) echo 'class = "privateRedText"';?>>
 					<?php echo h($distributionLevels[$event['Event']['distribution']] . ', ' . strtolower(substr(($distributionDescriptions[$event['Event']['distribution']]['formdesc']), 0, 1)) . substr($distributionDescriptions[$event['Event']['distribution']]['formdesc'], 1) . '.'); ?>
 				</dd>
-				<dt>Info</dt>
+				<dt>Description</dt>
 				<dd>
 					<?php echo nl2br(h($event['Event']['info'])); ?>
 					&nbsp;


### PR DESCRIPTION
I wanted to push up a tweak I made internally, I felt it was beneficial to throw the event description up top instead of a generic "Event" in the header space. 

This may not be desirable if most people use the info/description box for more than a "title".

The result looks like this (info from Fireeye/Shadowserver reports, public)

![screen shot 2014-03-04 at 10 48 48 am](https://f.cloud.github.com/assets/2313682/2322797/2ea16eb0-a3b5-11e3-922a-823e0117df40.png)

I also modified my event add/edit fields as such: 

![screen shot 2014-03-04 at 10 54 33 am](https://f.cloud.github.com/assets/2313682/2322815/557a61a4-a3b5-11e3-8baa-b84d9a8769bb.png)

```
    echo $this->Form->input('info', array(
                            'label' => 'Event Description',
                            'div' => 'clear',
                            'type' => 'text',
                            'class' => 'form-control span6',
                            'placeholder' => 'Quick Event Description or Tracking Info'
                            ));
```

The goal was to ensure anything which may be sensitive in nature, or detailed was input as an attribute for better tracking/securitycontrols/search though I did not put a hard limit on chars for the input fields/db as I didn't want to upset existing or imported no conforming events.
