### PR TITLE
Update to include note on starting the BG Workers.

### DIFF
--- a/INSTALL/INSTALL.txt
+++ b/INSTALL/INSTALL.txt
@@ -122,6 +122,10 @@ sudo -u www-data gpg --homedir /var/www/MISP/.gnupg --gen-key
 # And export the public key to the webroot
 sudo -u www-data gpg --homedir /var/www/MISP/.gnupg --export --armor YOUR-EMAIL > /var/www/MISP/app/webroot/gpg.asc
 
+# Start the workers to enable background jobs 
+cd /var/www/MISP/app/Console/worker/
+./start.sh
+
 Now log in using the webinterface:
 The default user/pass = admin@admin.test/admin 
 


### PR DESCRIPTION
This is present in the upgrade.txt but not the install.txt. I'm not sure if this is the right location for noting this, but in the current version publishing events will not function w/out starting the BG workers.
