### PR TITLE
Tweaks To Email Output

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1071,15 +1071,14 @@ class Event extends AppModel {
 		$body .= '==============================================' . "\n";
 		$appendlen = 20;
 		$body .= 'URL         : ' . Configure::read('MISP.baseurl') . '/events/view/' . $event['Event']['id'] . "\n";
-		$body .= 'Event       : ' . $event['Event']['id'] . "\n";
+		$body .= 'Event ID    : ' . $event['Event']['id'] . "\n";
 		$body .= 'Date        : ' . $event['Event']['date'] . "\n";
 		if ('true' == Configure::read('MISP.showorg')) {
 			$body .= 'Reported by : ' . $event['Event']['org'] . "\n";
 		}
-		$body .= 'Risk        : ' . $event['ThreatLevel']['name'] . "\n";
+		$body .= 'Threat Level: ' . $event['ThreatLevel']['name'] . "\n";
 		$body .= 'Analysis    : ' . $this->analysisLevels[$event['Event']['analysis']] . "\n";
-		$body .= 'Info  : ' . "\n";
-		$body .= $event['Event']['info'] . "\n";
+		$body .= 'Description : ' . $event['Event']['info'] . "\n\n";
 		$user['org'] = $org;
 		$relatedEvents = $this->getRelatedEvents($user, false);
 		if (!empty($relatedEvents)) {
@@ -1154,7 +1153,7 @@ class Event extends AppModel {
 						$Email = new CakeEmail();
 						$Email->from(Configure::read('MISP.email'));
 						$Email->to($user['User']['email']);
-						$Email->subject("[" . Configure::read('MISP.org') . " " . Configure::read('MISP.name') . "] Event " . $id . " - " . $event['ThreatLevel']['name'] . " - TLP Amber");
+						$Email->subject("[" . Configure::read('MISP.org') . " " . Configure::read('MISP.name') . "] Event " . $id . " - " . $event['Event']['info'] . " - " . $event['ThreatLevel']['name'] . " - TLP Amber");
 						$Email->emailFormat('text');	// both text or html
 						// send it
 						$Email->send($bodySigned);
@@ -1184,7 +1183,7 @@ class Event extends AppModel {
  				$Email = new CakeEmail();
  				$Email->from(Configure::read('MISP.email'));
  				$Email->to($user['User']['email']);
- 				$Email->subject("[" . Configure::read('MISP.org') . " " . Configure::read('MISP.name') . "] Event " . $id . " - " . $event['ThreatLevel']['name'] . " - TLP Amber");
+				$Email->subject("[" . Configure::read('MISP.org') . " " . Configure::read('MISP.name') . "] Event " . $id . " - " . $event['Event']['info'] . " - " . $event['ThreatLevel']['name'] . " - TLP Amber");
  				$Email->emailFormat('text');		// both text or html
   					// import the key of the user into the keyring
  				// this is not really necessary, but it enables us to find
@@ -1453,7 +1452,7 @@ class Event extends AppModel {
 						unset($data['Event']['Attribute'][$k]);
 					} else {
 					unset($data['Event']['Attribute'][$k]);
-					}
+						}
 				} else {
 					unset($data['Event']['Attribute'][$k]['id']);
 					$data['Attribute'][] = $data['Event']['Attribute'][$k];


### PR DESCRIPTION
Small tweaks to email formatting to sync up with UI Changes.. also added event title to Subject (questionable if this is something desired globally as it would not be encrypted). Possibly best to use the same substr code if adopted as was done in the UI. 

Ex of old Subject: [YourOrg MISP] Event 2 - High - TLP Amber

Ex of new Subject: [YourOrg MISP] Event 2 - Unveiling “ Careto ” - The Masked APT - High - TLP Amber
