### PR TITLE
Remove Missing GPG flash if Unencrypted Email is enabled

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -184,7 +184,7 @@ class EventsController extends AppController {
 			),
 		));
 		$this->set('events', $this->paginate());
-		if (!$this->Auth->user('gpgkey')) {
+		if (!$this->Auth->user('gpgkey') and Configure::read('GnuPG.onlyencrypted') == 'true') {
 			$this->Session->setFlash(__('No GPG key set in your profile. To receive emails, submit your public key in your profile.'));
 		}
 		$this->set('eventDescriptions', $this->Event->fieldDescriptions);


### PR DESCRIPTION
Adds a check for a true value in GnuPG.onlyencrypted and will only display the "No GPG Key Set in your Profile" message to the user if it is missing AND MISP is set to send only encrypted email. This way orgs not using GPG will not see the banner on every index view.
