### PR TITLE
Do not send details of events unencrypted

### DIFF
--- a/app/Config/config.default.php
+++ b/app/Config/config.default.php
@@ -33,6 +33,7 @@ $config = array (
     'email' => '',
     'homedir' => '',
     'password' => '',
+    'bodyonlyencrypted' => false,
   ),
   'SecureAuth' => 
   array (

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -461,6 +461,8 @@ class EventsController extends AppController {
 		
 		if (!$this->Event->User->getPGP($this->Auth->user('id')) && Configure::read('GnuPG.onlyencrypted')) {
 			$this->Session->setFlash(__('No GPG key set in your profile. To receive emails, submit your public key in your profile.'));
+		} elseif ($this->Auth->user('autoalert') && !$this->Event->User->getPGP($this->Auth->user('id')) && Configure::read('GnuPG.bodyonlyencrypted')) {
+			$this->Session->setFlash(__('No GPG key set in your profile. To receive attributes in emails, submit your public key in your profile.'));
 		}
 		$this->set('eventDescriptions', $this->Event->fieldDescriptions);
 		$this->set('analysisLevels', $this->Event->analysisLevels);

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1201,7 +1201,7 @@ class Event extends AppModel {
  				$Email = new CakeEmail();
  				$Email->from(Configure::read('MISP.email'));
  				$Email->to($user['User']['email']);
-				$Email->subject("[" . Configure::read('MISP.org') . " MISP] Event " . $id . " - " . $subject . " - " . $event['ThreatLevel']['name'] . " - TLP Amber");
+				$Email->subject("[" . Configure::read('MISP.org') . " MISP] Event " . $id . " - " . $subject . $event['ThreatLevel']['name'] . " - TLP Amber");
  				$Email->emailFormat('text');		// both text or html
   					// import the key of the user into the keyring
  				// this is not really necessary, but it enables us to find

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -2,6 +2,7 @@
 App::uses('AppModel', 'Model');
 App::uses('CakeEmail', 'Network/Email');
 App::import('Controller', 'Attributes');
+Configure::load('config'); // This is needed to load GnuPG.bodyonlyencrypted
 /**
  * Event Model
  *
@@ -1140,7 +1141,11 @@ class Event extends AppModel {
 		try {
 			$gpg = new Crypt_GPG(array('homedir' => Configure::read('GnuPG.homedir')));	// , 'debug' => true
 			$gpg->addSignKey(Configure::read('GnuPG.email'), Configure::read('GnuPG.password'));
-			$bodySigned = $gpg->sign($body, Crypt_GPG::SIGN_MODE_CLEAR);
+			if (Configure::read('GnuPG.bodyonlyencrypted')) {
+				$bodySigned = $gpg->sign("A new or modified event was just published on " . Configure::read('MISP.baseurl') . "/events/view/" . $event['Event']['id'], Crypt_GPG::SIGN_MODE_CLEAR);
+			} else {
+				$bodySigned = $gpg->sign($body, Crypt_GPG::SIGN_MODE_CLEAR);
+			}
 			//
 			// Build a list of the recipients that get a non-encrypted mail
 			// But only do this if it is allowed in the bootstrap.php file.
@@ -1173,6 +1178,9 @@ class Event extends AppModel {
 				}
 			}
 
+			if (Configure::read('GnuPG.bodyonlyencrypted')) {
+				$bodySigned = $gpg->sign($body, Crypt_GPG::SIGN_MODE_CLEAR);
+			}
 			//
 			// Build a list of the recipients that wish to receive encrypted mails.
 			//
@@ -1268,41 +1276,43 @@ class Event extends AppModel {
 		// LATER place event-to-email-layout in a function
 		$appendlen = 20;
 		$body .= 'URL		 : ' . Configure::read('MISP.baseurl') . '/events/view/' . $event['Event']['id'] . "\n";
-		$body .= 'Event	   : ' . $event['Event']['id'] . "\n";
-		$body .= 'Date		: ' . $event['Event']['date'] . "\n";
+		$bodyevent = $body;
+		$bodyevent .= 'Event	   : ' . $event['Event']['id'] . "\n";
+		$bodyevent .= 'Date		: ' . $event['Event']['date'] . "\n";
 		if (Configure::read('MISP.showorg')) {
-			$body .= 'Reported by : ' . $event['Event']['org'] . "\n";
+			$bodyevent .= 'Reported by : ' . $event['Event']['org'] . "\n";
 		}
-		$body .= 'Risk		: ' . $event['ThreatLevel']['name'] . "\n";
-		$body .= 'Analysis  : ' . $event['Event']['analysis'] . "\n";
+		$bodyevent .= 'Risk		: ' . $event['ThreatLevel']['name'] . "\n";
+		$bodyevent .= 'Analysis  : ' . $event['Event']['analysis'] . "\n";
 		$relatedEvents = $this->getRelatedEvents($user['User'], $isSiteAdmin);
 		if (!empty($relatedEvents)) {
 			foreach ($relatedEvents as &$relatedEvent) {
-				$body .= 'Related to  : ' . Configure::read('MISP.baseurl') . '/events/view/' . $relatedEvent['Event']['id'] . ' (' . $relatedEvent['Event']['date'] . ')' . "\n";
+				$bodyevent .= 'Related to  : ' . Configure::read('MISP.baseurl') . '/events/view/' . $relatedEvent['Event']['id'] . ' (' . $relatedEvent['Event']['date'] . ')' . "\n";
 	
 			}
 		}
-		$body .= 'Info  : ' . "\n";
-		$body .= $event['Event']['info'] . "\n";
-		$body .= "\n";
-		$body .= 'Attributes  :' . "\n";
+		$bodyevent .= 'Info  : ' . "\n";
+		$bodyevent .= $event['Event']['info'] . "\n";
+		$bodyevent .= "\n";
+		$bodyevent .= 'Attributes  :' . "\n";
 		$bodyTempOther = "";
 		if (!empty($event['Attribute'])) {
 			foreach ($event['Attribute'] as &$attribute) {
 				$line = '- ' . $attribute['type'] . str_repeat(' ', $appendlen - 2 - strlen( $attribute['type'])) . ': ' . $attribute['value'] . "\n";
 				if ('other' == $attribute['type']) // append the 'other' attribute types to the bottom.
 					$bodyTempOther .= $line;
-				else $body .= $line;
+				else $bodyevent .= $line;
 			}
 		}
-		$body .= "\n";
-		$body .= $bodyTempOther;	// append the 'other' attribute types to the bottom.
+		$bodyevent .= "\n";
+		$bodyevent .= $bodyTempOther;	// append the 'other' attribute types to the bottom.
 		$Email = new CakeEmail();
 		// sign the body
 		require_once 'Crypt/GPG.php';
 		$gpg = new Crypt_GPG(array('homedir' => Configure::read('GnuPG.homedir')));	// , 'debug' => true
 		$gpg->addSignKey(Configure::read('GnuPG.email'), Configure::read('GnuPG.password'));
 		$bodySigned = $gpg->sign($body, Crypt_GPG::SIGN_MODE_CLEAR);
+		$bodyeventSigned = $gpg->sign($bodyevent, Crypt_GPG::SIGN_MODE_CLEAR);
 		// Add the GPG key of the user as attachment
 		// LATER sign the attached GPG key
 		if ($user['User']['gpgkey'] != null) {
@@ -1326,14 +1336,16 @@ class Event extends AppModel {
 				$gpg = new Crypt_GPG(array('homedir' => Configure::read('GnuPG.homedir')));
 				$gpg->addEncryptKey($keyImportOutput['fingerprint']); // use the key that was given in the import
 	
-				$bodyEncSig = $gpg->encrypt($bodySigned, true);
+				$bodyEncSig = $gpg->encrypt($bodyeventSigned, true);
 				} catch (Exception $e){
 				// catch errors like expired PGP keys
 					$this->log($e->getMessage());
 					// no need to return here, as we want to send out mails to the other users if GPG encryption fails for a single user
 				}
-			} else {
+			} elseif (Configure::read('GnuPG.bodyonlyencrypted')) {
 				$bodyEncSig = $bodySigned;
+			} else {
+				$bodyEncSig = $bodyeventSigned;
 				// FIXME should I allow sending unencrypted "contact" mails to people if they didn't import they GPG key?
 			}
 			$Email->from(Configure::read('MISP.email'));

--- a/app/Model/Post.php
+++ b/app/Model/Post.php
@@ -89,15 +89,24 @@ class Post extends AppModel {
 		$body = "";
 		$body .= "Hello, \n";
 		$body .= "\n";
-		$body .= "Someone just posted to a MISP discussion you participated in with title:\n";
-		$body .= $title . "\n";
+		$body .= "Someone just posted to a MISP discussion you participated in.\n";
 		$body .= "\n";
 		$body .= "The full discussion can be found at: \n";
 		$body .= Configure::read('MISP.baseurl') . '/posts/view/' . $post['Post']['id'] . "\n";
-		$body .= "\n";
-		$body .= "The following message was added: \n";
-		$body .= "\n";
-		$body .= $message . "\n";
+
+		// body containing all details ($title and $message)
+		$bodyDetail = "";
+		$bodyDetail .= "Hello, \n";
+		$bodyDetail .= "\n";
+		$bodyDetail .= "Someone just posted to a MISP discussion you participated in with title:\n";
+		$bodyDetail .= $title . "\n";
+		$bodyDetail .= "\n";
+		$bodyDetail .= "The full discussion can be found at: \n";
+		$bodyDetail .= Configure::read('MISP.baseurl') . '/posts/view/' . $post['Post']['id'] . "\n";
+		$bodyDetail .= "\n";
+		$bodyDetail .= "The following message was added: \n";
+		$bodyDetail .= "\n";
+		$bodyDetail .= $message . "\n";
 
 		// LATER place event-to-email-layout in a function
 		$Email = new CakeEmail();
@@ -106,6 +115,7 @@ class Post extends AppModel {
 		$gpg = new Crypt_GPG(array('homedir' => Configure::read('GnuPG.homedir')));	// , 'debug' => true
 		$gpg->addSignKey(Configure::read('GnuPG.email'), Configure::read('GnuPG.password'));
 		$bodySigned = $gpg->sign($body,Crypt_GPG::SIGN_MODE_CLEAR);
+		$bodyDetailSigned = $gpg->sign($bodyDetail,Crypt_GPG::SIGN_MODE_CLEAR);
 		$result = false;
 		foreach ($orgMembers as &$recipient) {
 			if (!empty($recipient['User']['gpgkey'])) {
@@ -116,7 +126,7 @@ class Post extends AppModel {
 				try {
 				$gpg = new Crypt_GPG(array('homedir' => Configure::read('GnuPG.homedir')));
 				$gpg->addEncryptKey($keyImportOutput['fingerprint']); // use the key that was given in the import
-				$bodyEncSig = $gpg->encrypt($bodySigned, true);
+				$bodyEncSig = $gpg->encrypt($bodyDetailSigned, true);
 				} catch (Exception $e){
 				// catch errors like expired PGP keys
 					$this->log($e->getMessage());
@@ -124,8 +134,10 @@ class Post extends AppModel {
 				}
 			} elseif (Configure::read('GnuPG.onlyencrypted')) {
 				continue;
-			} else {
+			} elsif (Configure::read('GnuPG.bodyonlyencrypted')) {
 				$bodyEncSig = $bodySigned;
+			} else {
+				$bodyEncSig = $bodyDetailSigned;
 			}
 			$Email->from(Configure::read('MISP.email'));
 			$Email->to($recipient['User']['email']);

--- a/app/Model/Post.php
+++ b/app/Model/Post.php
@@ -134,7 +134,7 @@ class Post extends AppModel {
 				}
 			} elseif (Configure::read('GnuPG.onlyencrypted')) {
 				continue;
-			} elsif (Configure::read('GnuPG.bodyonlyencrypted')) {
+			} elseif (Configure::read('GnuPG.bodyonlyencrypted')) {
 				$bodyEncSig = $bodySigned;
 			} else {
 				$bodyEncSig = $bodyDetailSigned;

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -386,7 +386,15 @@ class Server extends AppModel {
 					'branch' => 1,
 					'onlyencrypted' => array(
 							'level' => 0,
-							'description' => 'Allow unencrypted e-mails to be sent to users that don\'t have a PGP key.',
+							'description' => 'Allow (false) unencrypted e-mails to be sent to users that don\'t have a PGP key.',
+							'value' => '',
+							'errorMessage' => '',
+							'test' => 'testBool',
+							'type' => 'boolean',
+					),
+					'bodyonlyencrypted' => array(
+							'level' => 2,
+							'description' => 'Allow (false) the body of unencrypted e-mails to contain details about the event.',
 							'value' => '',
 							'errorMessage' => '',
 							'test' => 'testBool',


### PR DESCRIPTION
When a MISP user does not have a GPG/PGP key there is only the option GnuPG.onlyencrypted to prevent them from receiving E-mail alerts. This patch adds a new GnuPG.bodyonlyencrypted option to do send them E-mail but only containing a link to the event. The details of the event are only sent in the E-mail when a GPG/PGP key is present.