### PR TITLE
Export md5 hashes without file name in STIX

### DIFF
--- a/app/files/scripts/misp2cybox.py
+++ b/app/files/scripts/misp2cybox.py
@@ -66,8 +66,8 @@ def generateFileObservable(filenameValue, hashValue):
             file_object.file_name = ntpath.basename(filenameValue)
         else:
             file_object.file_name = filenameValue
-        if (hashValue != ""):
-            file_object.add_hash(Hash(hashValue))
+    if (hashValue != ""):
+        file_object.add_hash(Hash(hashValue))
     return file_object
 
 def generateIPObservable(attribute):


### PR DESCRIPTION
Attributes of category "Artifacts dropped" and type "md5" do not have a file name, just a hash value in MISP. This hash was not being exported in STIX. This patch fixes that.

See issue #363 