### PR TITLE
Add MISP attribute comments as STIX descriptions

### DIFF
--- a/app/files/scripts/misp2cybox.py
+++ b/app/files/scripts/misp2cybox.py
@@ -190,6 +190,8 @@ def returnAttachmentComposition(attribute):
         observable.observable_composition = composition
     else:
         observable = Observable(file_object)
+    if attribute["comment"] != "":
+        observable.description = attribute["comment"]
     return observable
 
 # email-attachment are mapped to an email message observable that contains the attachment as a file object

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -263,7 +263,7 @@ def generateThreatActor(attribute):
     ta.title = "MISP Attribute #" + attribute["id"] + " uuid: " + attribute["uuid"]
     if attribute["comment"] != "":
         ta.description = attribute["value"] + " " + attribute["comment"]
-    else
+    else:
         ta.description = attribute["value"]
     return ta
 

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -215,7 +215,7 @@ def handleNonIndicatorAttribute(incident, ttps, attribute):
     elif attribute["type"] == "target-machine":
         aa = AffectedAsset()
         if attribute["comment"] != "":
-            aa.description = attribute["value"] + " " + attribute["comment"]
+            aa.description = attribute["value"] + " (" + attribute["comment"] + ")"
         else:
             aa.description = attribute["value"]
         incident.affected_assets.append(aa)
@@ -262,7 +262,7 @@ def generateThreatActor(attribute):
     ta.id_= namespace[1] + ":threatactor-" + attribute["uuid"]
     ta.title = "MISP Attribute #" + attribute["id"] + " uuid: " + attribute["uuid"]
     if attribute["comment"] != "":
-        ta.description = attribute["value"] + " " + attribute["comment"]
+        ta.description = attribute["value"] + " (" + attribute["comment"] + ")"
     else:
         ta.description = attribute["value"]
     return ta

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -215,6 +215,8 @@ def handleNonIndicatorAttribute(incident, ttps, attribute):
     elif attribute["type"] == "target-machine":
         aa = AffectedAsset()
         aa.description = attribute["value"]
+        if attribute["comment"] != "":
+            aa.description += " " + attribute["comment"]
         incident.affected_assets.append(aa)
     elif attribute["type"] == "vulnerability":
         generateTTP(incident, attribute)
@@ -248,6 +250,8 @@ def generateTTP(incident, attribute):
         malware.add_name(attribute["value"])
         ttp.behavior = Behavior()
         ttp.behavior.add_malware_instance(malware)
+    if attribute["comment"] != "":
+        ttp.description = attribute["comment"]
     relatedTTP = RelatedTTP(ttp, relationship=attribute["category"])
     incident.leveraged_ttps.append(relatedTTP)
 
@@ -257,6 +261,8 @@ def generateThreatActor(attribute):
     ta.id_= namespace[1] + ":threatactor-" + attribute["uuid"]
     ta.title = "MISP Attribute #" + attribute["id"] + " uuid: " + attribute["uuid"]
     ta.description = attribute["value"]
+    if attribute["comment"] != "":
+        ta.description += " " + attribute["comment"]
     return ta
 
 # generate the indicator and add the relevant information

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -263,6 +263,8 @@ def generateThreatActor(attribute):
 def generateIndicator(attribute):
     indicator = Indicator()
     indicator.id_= namespace[1] + ":indicator-" + attribute["uuid"]
+    if attribute["comment"] != "":
+        indicator.description = attribute["comment"]
     setTLP(indicator, attribute["distribution"])
     indicator.title = "MISP Attribute #" + attribute["id"] + " uuid: " + attribute["uuid"]
     confidence_description = "Derived from MISP's IDS flag. If an attribute is marked for IDS exports, the confidence will be high, otherwise none"

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -216,7 +216,7 @@ def handleNonIndicatorAttribute(incident, ttps, attribute):
         aa = AffectedAsset()
         if attribute["comment"] != "":
             aa.description = attribute["value"] + " " + attribute["comment"]
-        else
+        else:
             aa.description = attribute["value"]
         incident.affected_assets.append(aa)
     elif attribute["type"] == "vulnerability":

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -214,9 +214,10 @@ def handleNonIndicatorAttribute(incident, ttps, attribute):
             addJournalEntry(incident, entry_line)
     elif attribute["type"] == "target-machine":
         aa = AffectedAsset()
-        aa.description = attribute["value"]
         if attribute["comment"] != "":
-            aa.description += " " + attribute["comment"]
+            aa.description = attribute["value"] + " " + attribute["comment"]
+        else
+            aa.description = attribute["value"]
         incident.affected_assets.append(aa)
     elif attribute["type"] == "vulnerability":
         generateTTP(incident, attribute)
@@ -260,9 +261,10 @@ def generateThreatActor(attribute):
     ta = ThreatActor()
     ta.id_= namespace[1] + ":threatactor-" + attribute["uuid"]
     ta.title = "MISP Attribute #" + attribute["id"] + " uuid: " + attribute["uuid"]
-    ta.description = attribute["value"]
     if attribute["comment"] != "":
-        ta.description += " " + attribute["comment"]
+        ta.description = attribute["value"] + " " + attribute["comment"]
+    else
+        ta.description = attribute["value"]
     return ta
 
 # generate the indicator and add the relevant information


### PR DESCRIPTION
This is a fix for #323 

It maps all possible attribute comments into STIX, except for the victim Identity which is created with resolveIdentityAttribute() in misp2ciq.py. The STIX/CIQ data model doesn't seem to have an appropriate field in this case.