### PR TITLE
Added libapache2-mod-php5 as a dependency

### DIFF
--- a/INSTALL/INSTALL.ubuntu1404.txt
+++ b/INSTALL/INSTALL.ubuntu1404.txt
@@ -29,7 +29,7 @@ Once the system is installed you can perform the following steps as root:
 apt-get install vim
 
 # Install the dependencies:
-apt-get install zip php-pear git redis-server make python-dev python-pip libxml2-dev libxslt-dev zlib1g-dev php5-dev
+apt-get install zip php-pear git redis-server make python-dev python-pip libxml2-dev libxslt-dev zlib1g-dev php5-dev libapache2-mod-php5
 pear install Crypt_GPG    # we need version >1.3.0 
 pear install Net_GeoIP
 


### PR DESCRIPTION
Added libapache2-mod-php5 as a dependency, so that even installs from bare ubuntu 14.04 work.
Related to closed issue #398