### PR TITLE
Use descriptive STIX titles and namespace

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1851,7 +1851,7 @@ class Event extends AppModel {
 		$scriptFile = APP . "files" . DS . "scripts" . DS . "misp2stix.py";
 		
 		// Execute the python script and point it to the temporary filename
-		$result = shell_exec('python ' . $scriptFile . ' ' . $randomFileName . ' ' . $returnType);
+		$result = shell_exec('python ' . $scriptFile . ' ' . $randomFileName . ' ' . $returnType . ' ' . Configure::read('MISP.baseurl') . ' "' . Configure::read('MISP.org') . '"');
 		
 		// The result of the script will be a returned JSON object with 2 variables: success (boolean) and message
 		// If success = 1 then the temporary output file was successfully written, otherwise an error message is passed along

--- a/app/files/scripts/misp2ciq.py
+++ b/app/files/scripts/misp2ciq.py
@@ -1,7 +1,7 @@
 from stix.extensions.identity.ciq_identity_3_0 import (CIQIdentity3_0Instance, STIXCIQIdentity3_0, OrganisationInfo, PartyName, Address, ElectronicAddressIdentifier, FreeTextAddress)
 from stix.common import Identity
 
-def resolveIdentityAttribute(incident, attribute):
+def resolveIdentityAttribute(incident, attribute, namespace):
     ciq_identity = CIQIdentity3_0Instance()
     identity_spec = STIXCIQIdentity3_0()
     if attribute["type"] == 'target-user':

--- a/app/files/scripts/misp2ciq.py
+++ b/app/files/scripts/misp2ciq.py
@@ -20,6 +20,6 @@ def resolveIdentityAttribute(incident, attribute):
     ciq_identity.id_ = "example:Identity-" + attribute["uuid"]
 
     # is this a good idea?
-    ciq_identity.name = "MISP Attribute #" + attribute["id"] + " uuid: " + attribute["uuid"]
+    ciq_identity.name = attribute["type"] + ": " + attribute["value"] + " (MISP Attribute #" + attribute["id"] + ")"
     incident.add_victim(ciq_identity)
     return incident

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -20,10 +20,6 @@ from cybox.utils import Namespace
 
 namespace = ['https://github.com/MISP/MISP', 'MISP']
 
-cybox.utils.idgen.set_id_namespace(Namespace(namespace[0], namespace[1]))
-stix.utils.idgen.set_id_namespace({namespace[0]: namespace[1]})
-
-
 NS_DICT = {
 	"http://cybox.mitre.org/common-2" : 'cyboxCommon',
 	"http://cybox.mitre.org/cybox-2" : 'cybox',	
@@ -55,7 +51,6 @@ NS_DICT = {
 	"urn:oasis:names:tc:ciq:xal:3" : 'xal',
 	"urn:oasis:names:tc:ciq:xnl:3" : 'xnl',
 	"urn:oasis:names:tc:ciq:xpil:3" : 'xpil',
-        namespace[0] : namespace[1]
 }
 
 SCHEMALOC_DICT = {
@@ -126,7 +121,7 @@ def saveFile(args, pathname, package):
 def generateMainPackage(events):
     stix_package = STIXPackage()
     stix_header = STIXHeader()
-    stix_header.title="Export from MISP"
+    stix_header.title="Export from " + namespace[1] + " MISP"
     stix_header.package_intents="Threat Report"
     stix_package.stix_header = stix_header
     return stix_package
@@ -226,7 +221,7 @@ def handleNonIndicatorAttribute(incident, ttps, attribute):
         else:
             addReference(incident, attribute["value"])
     elif attribute["type"].startswith('target-'):
-        resolveIdentityAttribute(incident, attribute)
+        resolveIdentityAttribute(incident, attribute, namespace[1])
     elif attribute["type"] == "attachment":
         observable = returnAttachmentComposition(attribute)
         related_observable = RelatedObservable(observable, relationship=attribute["category"])
@@ -322,6 +317,13 @@ def addJournalEntry(incident, entry_line):
 # main
 def main(args):
     pathname = os.path.dirname(sys.argv[0])
+    if len(sys.argv) > 3:
+        namespace[0] = sys.argv[3]
+    if len(sys.argv) > 4:
+        namespace[1] = sys.argv[4].replace(" ", "_")
+    NS_DICT[namespace[0]]=namespace[1]
+    cybox.utils.idgen.set_id_namespace(Namespace(namespace[0], namespace[1]))
+    stix.utils.idgen.set_id_namespace({namespace[0]: namespace[1]})
     events = loadEvent(args, pathname)
     stix_package = generateMainPackage(events)
     for event in events:

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -136,7 +136,7 @@ def generateEventPackage(event):
     package_name = namespace[1] + ':STIXPackage-' + event["Event"]["uuid"]
     stix_package = STIXPackage(id_=package_name)
     stix_header = STIXHeader()
-    stix_header.title="MISP event #" + event["Event"]["id"] + " uuid: " + event["Event"]["uuid"]
+    stix_header.title=event["Event"]["info"] + " (MISP Event #" + event["Event"]["id"] + ")"
     stix_header.package_intents="Threat Report"
     stix_package.stix_header = stix_header
     objects = generateSTIXObjects(event)
@@ -189,7 +189,6 @@ def resolveAttributes(incident, ttps, attributes):
 # Create the indicator and pass the attribute further for observable creation - this can be called from resolveattributes directly or from handleNonindicatorAttribute, for some special cases
 def handleIndicatorAttribute(incident, ttps, attribute):
     indicator = generateIndicator(attribute)
-    indicator.title = "MISP Attribute #" + attribute["id"] + " uuid: " + attribute["uuid"]
     if attribute["type"] == "email-attachment":
         generateEmailAttachmentObject(indicator, attribute["value"])
     else:
@@ -239,7 +238,7 @@ def generateTTP(incident, attribute):
     ttp = TTP()
     ttp.id_= namespace[1] + ":ttp-" + attribute["uuid"]
     setTLP(ttp, attribute["distribution"])
-    ttp.title = "MISP Attribute #" + attribute["id"] + " uuid: " + attribute["uuid"]
+    ttp.title = attribute["category"] + ": " + attribute["value"] + " (MISP Attribute #" + attribute["id"] + ")"
     if attribute["type"] == "vulnerability":
         vulnerability = Vulnerability()
         vulnerability.cve_id = attribute["value"]
@@ -260,7 +259,7 @@ def generateTTP(incident, attribute):
 def generateThreatActor(attribute):
     ta = ThreatActor()
     ta.id_= namespace[1] + ":threatactor-" + attribute["uuid"]
-    ta.title = "MISP Attribute #" + attribute["id"] + " uuid: " + attribute["uuid"]
+    ta.title = attribute["category"] + ": " + attribute["value"] + " (MISP Attribute #" + attribute["id"] + ")"
     if attribute["comment"] != "":
         ta.description = attribute["value"] + " (" + attribute["comment"] + ")"
     else:
@@ -274,7 +273,7 @@ def generateIndicator(attribute):
     if attribute["comment"] != "":
         indicator.description = attribute["comment"]
     setTLP(indicator, attribute["distribution"])
-    indicator.title = "MISP Attribute #" + attribute["id"] + " uuid: " + attribute["uuid"]
+    indicator.title = attribute["category"] + ": " + attribute["value"] + " (MISP Attribute #" + attribute["id"] + ")"
     confidence_description = "Derived from MISP's IDS flag. If an attribute is marked for IDS exports, the confidence will be high, otherwise none"
     confidence_value = confidence_mapping.get(attribute["to_ids"], None)
     if confidence_value is None:


### PR DESCRIPTION
Other tools that are more STIX centric will display the titles in their views. The non-descriptive "MISP Attribute #x" as a title is not ideal in that situation.

To keep track of which events came from which instance, it is beneficial to put the local MISP organization name into the STIX namespace.
 
This patch also closes #380 