### PR TITLE
Fix cakephp path in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,6 @@
 /app/Config/database.php
 /app/Config/core.php
 /app/Config/config.php
-/cakephp
+/app/Lib/cakephp
 /app/webroot/gpg.asc
 /app/tmp/logs


### PR DESCRIPTION
This fixes the error message below (after a "git rm --cached app/Lib/cakephp").
```
git diff
diff --git a/app/Lib/cakephp b/app/Lib/cakephp
--- a/app/Lib/cakephp
+++ b/app/Lib/cakephp
@@ -1 +1 @@
-Subproject commit a0aac5cfa9acf2ccbde65c45ad6ee06ecd32fb54
+Subproject commit a0aac5cfa9acf2ccbde65c45ad6ee06ecd32fb54-dirty
```