### PR TITLE
Update cake-resque and php-resque-ex

### DIFF
--- a/INSTALL/INSTALL.centos6.txt
+++ b/INSTALL/INSTALL.centos6.txt
@@ -77,7 +77,7 @@ git submodule update
 # Once done, install CakeResque along with its dependencies if you intend to use the built in background jobs:
 cd /var/www/MISP/app
 curl -s https://getcomposer.org/installer | php
-php composer.phar require --no-update kamisama/cake-resque:4.1.0
+php composer.phar require kamisama/cake-resque:4.1.2
 php composer.phar config vendor-dir Vendor
 php composer.phar install
 

--- a/INSTALL/INSTALL.centos7.txt
+++ b/INSTALL/INSTALL.centos7.txt
@@ -77,7 +77,7 @@ git submodule update
 # Once done, install CakeResque along with its dependencies if you intend to use the built in background jobs:
 cd /var/www/MISP/app
 curl -s https://getcomposer.org/installer | php
-php composer.phar require --no-update kamisama/cake-resque:4.1.0
+php composer.phar require kamisama/cake-resque:4.1.2
 php composer.phar config vendor-dir Vendor
 php composer.phar install
 

--- a/INSTALL/INSTALL.ubuntu1404.txt
+++ b/INSTALL/INSTALL.ubuntu1404.txt
@@ -64,7 +64,7 @@ git submodule update
 # Once done, install CakeResque along with its dependencies if you intend to use the built in background jobs:
 cd /var/www/MISP/app
 curl -s https://getcomposer.org/installer | php
-php composer.phar require --no-update kamisama/cake-resque:4.1.0
+php composer.phar require kamisama/cake-resque:4.1.2
 php composer.phar config vendor-dir Vendor
 php composer.phar install
 

--- a/INSTALL/UPDATE.txt
+++ b/INSTALL/UPDATE.txt
@@ -28,6 +28,7 @@ cd /var/www/MISP/app
 # "kamisama/cake-resque": ">=4.1.2"
 
 vim composer.json
+php composer.phar self-update
 php composer.phar update
 
 # To use the scheduler worker for scheduled tasks, do the following:

--- a/INSTALL/UPDATE.txt
+++ b/INSTALL/UPDATE.txt
@@ -1,0 +1,53 @@
+# After installing MISP you can keep it up to date by periodically running the commands below.
+
+# 1. Update the MISP code to the latest hotfix. If a new major version (2.4.x) has been released, refer to UPGRADE.txt instead.
+
+cd /var/www/MISP
+git pull
+
+# 2. Update CakePHP to the latest 2.6 code
+
+cd /var/www/MISP/Lib/cakephp
+git fetch origin
+git checkout 2.6
+
+# 3. Update Mitre's STIX and its dependencies
+
+cd /var/www/MISP/app/files/scripts/python-cybox
+git pull
+python setup.py install
+cd /var/www/MISP/app/files/scripts/python-stix
+git pull
+python setup.py install
+
+# 4. Update CakeResque and it's dependencies
+
+cd /var/www/MISP/app
+
+# Edit composer.json so that cake-resque is allowed to be updated
+# "kamisama/cake-resque": ">=4.1.2"
+
+vim composer.json
+php composer.phar update
+
+# To use the scheduler worker for scheduled tasks, do the following:
+cp -fa /var/www/MISP/INSTALL/setup/config.php /var/www/MISP/app/Plugin/CakeResque/Config/config.php
+
+# 5. Make sure all file permissions are set correctly
+
+chown -R root:www-data /var/www/MISP
+find /var/www/MISP -type d -exec chmod g=rx {} \;
+chmod -R g+r,o= /var/www/MISP
+chown www-data:www-data /var/www/MISP/app/files
+chown www-data:www-data /var/www/MISP/app/files/terms
+chown www-data:www-data /var/www/MISP/app/files/scripts/tmp
+chown www-data:www-data /var/www/MISP/app/Plugin/CakeResque/tmp
+chown -R www-data:www-data /var/www/MISP/app/tmp
+chown -R www-data:www-data /var/www/MISP/app/webroot/img/orgs
+chown -R www-data:www-data /var/www/MISP/app/webroot/img/custom
+
+# 6. Restart the CakeResque workers
+
+su www-data -c 'bash /var/www/MISP/app/Console/worker/start.sh'
+
+# You can also do this using the MISP application by navigating to the workers tab in the server settings and clicking on the "Restart all workers" button.

--- a/INSTALL/UPGRADE.txt
+++ b/INSTALL/UPGRADE.txt
@@ -32,7 +32,7 @@ python setup.py install
 # install / update CakeResque (using the background workers is optional buy highly recommended)
 cd /var/www/MISP/app
 curl -s https://getcomposer.org/installer | php
-php composer.phar require --no-update kamisama/cake-resque:4.1.0
+php composer.phar require kamisama/cake-resque:4.1.2
 php composer.phar config vendor-dir Vendor
 php composer.phar install
 


### PR DESCRIPTION
The new bugfix releases of cake-resque and php-resque-ex should be used for MISP as well. 

- Update references to cake-resque:4.1.2
- Remove --no-update for cake-resque
- Added UPDATE.txt for keeping up2date between major releases