### PR TITLE
CakePHP 2.6.7 requires the php mbstring extension

### DIFF
--- a/INSTALL/INSTALL.centos6.txt
+++ b/INSTALL/INSTALL.centos6.txt
@@ -26,7 +26,7 @@ rpm -Uvh epel.rpm
 yum install vim
 
 # Install the dependencies:
-yum install gcc git zip redis mysql-server php-mysql python-devel python-pip libxslt-devel zlib-devel php-devel php-xml
+yum install gcc git zip redis mysql-server php-mysql python-devel python-pip libxslt-devel zlib-devel php-devel php-xml php-mbstring
 yum install php-pear php-pecl-geoip
 
 pear channel-update pear.php.net

--- a/INSTALL/INSTALL.centos7.txt
+++ b/INSTALL/INSTALL.centos7.txt
@@ -26,7 +26,7 @@ rpm -Uvh epel.rpm
 yum install vim
 
 # Install the dependencies:
-yum install git httpd zip php redis mysql-server php-mysql python-devel python-pip libxslt-devel zlib-devel php-devel php-xml
+yum install git httpd zip php redis mysql-server php-mysql python-devel python-pip libxslt-devel zlib-devel php-devel php-xml php-mbstring
 yum install php-pear php-pecl-geoip
 
 pear channel-update pear.php.net


### PR DESCRIPTION
- on CentOS this is a separate package php-mbstring
- on Ubuntu this is part of libapache2-mod-php5