### PR TITLE
Only log exception for not found only if the debugging mode is enabled

### DIFF
--- a/app/Controller/ShadowAttributesController.php
+++ b/app/Controller/ShadowAttributesController.php
@@ -824,9 +824,12 @@ class ShadowAttributesController extends AppController {
 		}
 		$this->ShadowAttribute->recursive = -1;
 		$temp = $this->ShadowAttribute->findAllByEventUuid($uuid);
-		if ($temp == null) throw new NotFoundException(__('Invalid event'));
-		$this->set('proposal', $temp);
-		$this->render('get_proposals_by_uuid');
+		if ($temp == null && Configure::read('debug') > 0 ) {
+			throw new NotFoundException(__('Invalid event'));
+		} else {
+			$this->set('proposal', $temp);
+			$this->render('get_proposals_by_uuid');
+		}
 	}
 	
 	public function fetchEditForm($id, $field = null) {


### PR DESCRIPTION
Only log exception for not found shadowAttributes/proposals by EventUuid only if the debugging mode is enabled.

This would have save me 20.000 lines of log per month... :)