### PR TITLE
Use setupHttpSocket for fetchPGPKey

### DIFF
--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -526,8 +526,9 @@ class User extends AppModel {
 	}
 	
 	public function fetchPGPKey($email) {
-		App::uses('HttpSocket', 'Network/Http');
-		$HttpSocket = new HttpSocket();
+		App::uses('SyncTool', 'Tools');
+		$syncTool = new SyncTool();
+		$HttpSocket = $syncTool->setupHttpSocket();
 		$response = $HttpSocket->get('https://pgp.mit.edu/pks/lookup?search=' . $email . '&op=index&fingerprint=on');
 		if ($response->code != 200) return $response->code;
 		$string = str_replace(array("\r", "\n"), "", $response->body);


### PR DESCRIPTION
Using setupHttpSocket will ensure the HttpSocket proxy configuration is properly set up.
