### PR TITLE
Use STIX best practices

### DIFF
--- a/app/files/scripts/misp2cybox.py
+++ b/app/files/scripts/misp2cybox.py
@@ -41,6 +41,7 @@ def generateObservable(indicator, attribute):
             action = getattr(this_module, simple_type_to_method[attribute["type"]], None)
             if (action != None):
                 property = action(attribute)
+		property.condition = "Equals"
                 object = Object(property)
                 object.id_ = cybox.utils.idgen.__generator.namespace.prefix + ":" + property.__class__.__name__ + "-" + attribute["uuid"]
                 observable = Observable(object)
@@ -71,7 +72,7 @@ def generateFileObservable(filenameValue, hashValue):
         else:
             file_object.file_name = filenameValue
     if (hashValue != ""):
-        file_object.add_hash(Hash(hashValue))
+        file_object.add_hash(Hash(hash_value=hashValue, exact=True))
     return file_object
 
 def generateIPObservable(attribute):

--- a/app/files/scripts/misp2cybox.py
+++ b/app/files/scripts/misp2cybox.py
@@ -31,6 +31,7 @@ simple_type_to_method.update(dict.fromkeys(["pattern-in-file", "pattern-in-traff
 # mapping for the attributes that can go through the simpleobservable script
 misp_cybox_name = {"domain" : "DomainName", "hostname" : "Hostname", "url" : "URI", "AS" : "AutonomousSystem", "mutex" : "Mutex", "named pipe" : "Pipe", "link" : "URI"}
 cybox_name_attribute = {"DomainName" : "value", "Hostname" : "hostname_value", "URI" : "value", "AutonomousSystem" : "number", "Pipe" : "name", "Mutex" : "name"}
+misp_indicator_type = {"domain" : "Domain Watchlist", "hostname" : "Domain Watchlist", "url" : "URL Watchlist", "AS" : "", "mutex" : "Host Characteristics", "named pipe" : "Host Characteristics", "link" : ""}
 
 def generateObservable(indicator, attribute):
     if (attribute["type"] in ("snort", "yara")):
@@ -40,7 +41,7 @@ def generateObservable(indicator, attribute):
         if (attribute["type"] in simple_type_to_method.keys()):
             action = getattr(this_module, simple_type_to_method[attribute["type"]], None)
             if (action != None):
-                property = action(attribute)
+                property = action(indicator, attribute)
 		property.condition = "Equals"
                 object = Object(property)
                 object.id_ = cybox.utils.idgen.__generator.namespace.prefix + ":" + property.__class__.__name__ + "-" + attribute["uuid"]
@@ -48,18 +49,20 @@ def generateObservable(indicator, attribute):
                 observable.id_ = cybox.utils.idgen.__generator.namespace.prefix + ":observable-" + attribute["uuid"]
                 indicator.add_observable(observable)
 
-def resolveFileObservable(attribute):
+def resolveFileObservable(indicator, attribute):
     hashValue = ""
     filenameValue = ""
     if (attribute["type"] in ("filename|md5", "filename|sha1", "filename|sha256", "malware-sample")):
         values = attribute["value"].split('|')
         filenameValue = values[0]
         hashValue = values[1]
+        indicator.add_indicator_type("File Hash Watchlist")
     else:
         if (attribute["type"] in ("filename", "attachment")):
             filenameValue = attribute["value"]
         else:
             hashValue = attribute["value"]
+            indicator.add_indicator_type("File Hash Watchlist")
     observable = generateFileObservable(filenameValue, hashValue)
     return observable
 
@@ -75,7 +78,8 @@ def generateFileObservable(filenameValue, hashValue):
         file_object.add_hash(Hash(hash_value=hashValue, exact=True))
     return file_object
 
-def generateIPObservable(attribute):
+def generateIPObservable(indicator, attribute):
+    indicator.add_indicator_type("IP Watchlist")
     address_object = Address()
     cidr = False
     if ("/" in attribute["value"]):
@@ -101,7 +105,8 @@ def generateIPObservable(attribute):
     address_object.address_value = attribute["value"]
     return address_object
 
-def generateRegkeyObservable(attribute):
+def generateRegkeyObservable(indicator, attribute):
+    indicator.add_indicator_type("Host Characteristics")
     regkey = ""
     regvalue = ""
     if (attribute["type"] == "regkey|value"):
@@ -117,9 +122,12 @@ def generateRegkeyObservable(attribute):
         reg_object.values = RegistryValues(reg_value_object)
     return reg_object
 
-def generateSimpleObservable(attribute):
+def generateSimpleObservable(indicator, attribute):
     cyboxName = misp_cybox_name[attribute["type"]]
     constructor = getattr(this_module, cyboxName, None)
+    indicatorType = misp_indicator_type[attribute["type"]]
+    if (indicatorType != ""):
+        indicator.add_indicator_type(indicatorType)
     new_object = constructor()
     setattr(new_object, cybox_name_attribute[cyboxName], attribute["value"])
     return new_object
@@ -135,7 +143,8 @@ def generateTM(indicator, attribute):
         #tm.rules = [attribute["value"]]
     indicator.test_mechanisms = [tm]
 
-def resolveEmailObservable(attribute):
+def resolveEmailObservable(indicator, attribute):
+    indicator.add_indicator_type("Malicious E-mail")
     new_object = EmailMessage()
     email_header = EmailHeader()
     if (attribute["type"] == "email-src"):
@@ -147,7 +156,7 @@ def resolveEmailObservable(attribute):
     new_object.header = email_header
     return new_object
 
-def resolveHTTPObservable(attribute):
+def resolveHTTPObservable(indicator, attribute):
     request_response = HTTPRequestResponse()
     client_request = HTTPClientRequest()
     if (attribute["type"] == "user-agent"):
@@ -167,7 +176,7 @@ def resolveHTTPObservable(attribute):
     return new_object
 
 # use this when implementing pattern in memory and pattern in traffic
-def resolvePatternObservable(attribute):
+def resolvePatternObservable(indicator, attribute):
     new_object = None
     if attribute["type"] == "pattern-in-file":
         byte_run = ByteRun()

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -146,7 +146,7 @@ def generateEventPackage(event):
 
 # generate the incident information. MISP events are currently mapped to incidents with the event metadata being stored in the incident information
 def generateSTIXObjects(event):
-    incident = Incident(id_ = namespace[1] + ":incident-" + event["Event"]["uuid"], description=event["Event"]["info"])
+    incident = Incident(id_ = namespace[1] + ":incident-" + event["Event"]["uuid"], title=event["Event"]["info"])
     setDates(incident, event["Event"]["date"], int(event["Event"]["publish_timestamp"]))
     addJournalEntry(incident, "Event Threat Level: " + event["ThreatLevel"]["name"])
     ttps = []
@@ -287,6 +287,7 @@ def generateIndicator(attribute):
         indicator.description = attribute["comment"]
     setTLP(indicator, attribute["distribution"])
     indicator.title = attribute["category"] + ": " + attribute["value"] + " (MISP Attribute #" + attribute["id"] + ")"
+    indicator.description = indicator.title
     confidence_description = "Derived from MISP's IDS flag. If an attribute is marked for IDS exports, the confidence will be high, otherwise none"
     confidence_value = confidence_mapping.get(attribute["to_ids"], None)
     if confidence_value is None:

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -3,6 +3,7 @@ from misp2cybox import *
 from misp2ciq import *
 from dateutil.tz import tzutc
 from stix.indicator import Indicator
+from stix.indicator.valid_time import ValidTime
 from stix.ttp import TTP, Behavior
 from stix.ttp.malware_instance import MalwareInstance
 from stix.incident import Incident, Time, ImpactAssessment, ExternalID, AffectedAsset
@@ -186,6 +187,7 @@ def resolveAttributes(incident, ttps, attributes):
 def handleIndicatorAttribute(incident, ttps, attribute):
     indicator = generateIndicator(attribute)
     indicator.add_indicator_type("Malware Artifacts")
+    indicator.add_valid_time_position(ValidTime())
     if attribute["type"] == "email-attachment":
         indicator.add_indicator_type("Malicious E-mail")
         generateEmailAttachmentObject(indicator, attribute)

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -297,7 +297,7 @@ def generateIndicator(attribute):
 
 # converts timestamp to the format used by STIX
 def getDateFromTimestamp(timestamp):
-    return datetime.datetime.fromtimestamp(timestamp).isoformat()
+    return datetime.datetime.fromtimestamp(timestamp).isoformat() + "+00:00"
 
 # converts a date (YYYY-mm-dd) to the format used by stix
 def convertToStixDate(date):

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -185,7 +185,7 @@ def resolveAttributes(incident, ttps, attributes):
         ttp = TTP(timestamp=incident.timestamp)
         ttp.id_= incident.id_.replace("incident","ttp")
         ttp.title = "Unknown"
-	ttps.append(ttp)
+        ttps.append(ttp)
     for rindicator in incident.related_indicators:
         for ttp in ttps:
             ittp=TTP(idref=ttp.id_, timestamp=ttp.timestamp)

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -185,7 +185,9 @@ def resolveAttributes(incident, ttps, attributes):
 # Create the indicator and pass the attribute further for observable creation - this can be called from resolveattributes directly or from handleNonindicatorAttribute, for some special cases
 def handleIndicatorAttribute(incident, ttps, attribute):
     indicator = generateIndicator(attribute)
+    indicator.add_indicator_type("Malware Artifacts")
     if attribute["type"] == "email-attachment":
+        indicator.add_indicator_type("Malicious E-mail")
         generateEmailAttachmentObject(indicator, attribute)
     else:
         generateObservable(indicator, attribute)

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -186,8 +186,6 @@ def resolveAttributes(incident, ttps, attributes):
         ttp.id_= incident.id_.replace("incident","ttp")
         ttp.title = "Unknown"
 	ttps.append(ttp)
-        rttp = TTP(idref=ttp.id_, timestamp=ttp.timestamp)
-        relatedTTP = RelatedTTP(rttp, relationship="Indicated")
     for rindicator in incident.related_indicators:
         for ttp in ttps:
             ittp=TTP(idref=ttp.id_, timestamp=ttp.timestamp)


### PR DESCRIPTION
I tried to get rid of most warnings that "stix_validator.py --best-practices" throws on the MISP STIX export. The only things left are some 

```
Indicator Pattern Properties Missing Condition Attributes
```

It seems that python-cybox does not support condition attributes for all indicator types.
