### PR TITLE
Export MISP tags as STIX journal entries

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1776,6 +1776,11 @@ class Event extends AppModel {
 				}
 			}
 		}
+                if (Configure::read('MISP.tagging')) {
+			foreach ($events as &$event) {
+				$event['Tag'] = $this->EventTag->Tag->findEventTags($event['Event']['id']);
+                        }
+                }
 		// generate a randomised filename for the temporary file that will be passed to the python script
 		$randomFileName = $this->generateRandomFileName();
 		$tempFile = new File (APP . "files" . DS . "scripts" . DS . "tmp" . DS . $randomFileName, true, 0644);

--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -84,6 +84,7 @@ class Tag extends AppModel {
 		return array($acceptIds, $rejectIds);
 	}
 	
+	// find all of the event Ids that belong to tags with certain names
 	public function findTags($array) {
 		$ids = array();
 		foreach ($array as $a) {
@@ -102,5 +103,23 @@ class Tag extends AppModel {
 			}
 		}
 		return $ids;
+	}
+
+	// find all tags that belong to a given eventId
+	public function findEventTags($eventId) {
+		$tags = array();
+		$params = array(
+				'recursive' => 1,
+				'contain' => 'EventTag',
+		);
+		$result = $this->find('all', $params);
+		foreach ($result as $tag) {
+			foreach ($tag['EventTag'] as $eventTag) {
+				if ($eventTag['event_id'] == $eventId) {
+					$tags[] = $tag['Tag'];
+				}
+			}
+		}
+		return $tags;
 	}
 }

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -157,6 +157,7 @@ def generateSTIXObjects(event):
         incident.status = IncidentStatus(incident_status_name)
     setTLP(incident, event["Event"]["distribution"])
     setOrg(incident, event["Event"]["org"])
+    setTag(incident, event["Tag"])
     resolveAttributes(incident, ttps, event["Attribute"])
     return [incident, ttps]
 
@@ -306,6 +307,11 @@ def setOrg(target, org):
     ident = Identity(name=org)
     information_source = InformationSource(identity = ident)
     target.information_source = information_source
+
+# takes an object and adds the passed tags as journal entries to it. 
+def setTag(target, tags):
+    for tag in tags:
+        addJournalEntry(target, "MISP Tag: " + tag["name"])
 
 def addReference(target, reference):
     if hasattr(target.information_source, "references"):


### PR DESCRIPTION
For MISP converting them to Journal Entries seems logical. I can do the same for other formats, but we need to agree how to represent the tags in those formats.
