### PR TITLE
mention install howto in Documentation part

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Documentation
 
 [MISP user-guide](https://github.com/MISP/misp-book) is available [online](https://www.circl.lu/doc/misp/) or as [PDF](https://www.circl.lu/doc/misp/book.pdf) or as [EPUB](https://www.circl.lu/doc/misp/book.epub) or as [MOBI/Kindle](https://www.circl.lu/doc/misp/book.mobi).
 
+For installation guide see [INSTALL](https://github.com/MISP/MISP/tree/2.4/INSTALL)
+
 Contributing
 ------------
 


### PR DESCRIPTION
Spent some minutes to find the documentation how tot install MISP (and it is not mentioned in the PDF btw)
