### PR TITLE
Fixed a bug where adding attributes fails if the event has been creat…

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -1191,7 +1191,7 @@ class EventsController extends AppController {
 					// user.org == event.org
 					// edit timestamp newer than existing event timestamp
 					if (!isset($this->request->data['Event']['timestamp'])) $this->request->data['Event']['timestamp'] = $date;
-					if ($this->request->data['Event']['timestamp'] > $existingEvent['Event']['timestamp']) {
+					if ($this->request->data['Event']['timestamp'] >= $existingEvent['Event']['timestamp']) {
 						// If the above is true, we have two more options:
 						// For users that are of the creating org of the event, always allow the edit
 						// For users that are sync users, only allow the edit if the event is locked


### PR DESCRIPTION
When creating a new event and shortly after adding attributes it happens that the creation time of the event `$existingEvent['Event']['timestamp']` equals the time of the modification data `$this->request->data['Event']['timestamp']` which is set to 

`$dateObj = new DateTime();`
`$date = dateObj->getTimestamp()`
`...`
`$this->request->data['Event']['timestamp'] = $date`

in which case the condition

`if ($this->request->data['Event']['timestamp'] > $existingEvent['Event']['timestamp']) {`

is false and the operation fails.
