### PR TITLE
Fixed a bug where adding attributes fails if the event has been creat…

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1878,7 +1878,7 @@ class Event extends AppModel {
 			// user.org == event.org
 			// edit timestamp newer than existing event timestamp
 			if (!isset($data['Event']['timestamp'])) $data['Event']['timestamp'] = $date;
-			if ($data['Event']['timestamp'] > $existingEvent['Event']['timestamp']) {
+			if ($data['Event']['timestamp'] >= $existingEvent['Event']['timestamp']) {
 				if ($data['Event']['distribution'] == 4) {
 					$data['Event']['sharing_group_id'] = $this->SharingGroup->captureSG($data['Event']['SharingGroup'], $user);
 					if ($data['Event']['sharing_group_id'] === false) return (array('error' => 'Event could not be saved: User not authorised to create the associated sharing group.'));


### PR DESCRIPTION
When creating a new event and shortly after adding attributes it happens that the creation time of the event `$existingEvent['Event']['timestamp']` equals the time of the modification data `$this->request->data['Event']['timestamp']` which is set to 

`$dateObj = new DateTime();`
`$date = dateObj->getTimestamp()`
`...`
`$this->request->data['Event']['timestamp'] = $date`

in which case the condition

`if ($this->request->data['Event']['timestamp'] > $existingEvent['Event']['timestamp']) {`

is false and the operation fails.
