### PR TITLE
Changed text Find valid IOCs in search page

### DIFF
--- a/app/View/Attributes/search.ctp
+++ b/app/View/Attributes/search.ctp
@@ -28,7 +28,7 @@
 		<?php
 			echo $this->Form->input('ioc', array(
 				'type' => 'checkbox',
-				'label' => 'Only find valid IOCs',
+				'label' => 'Only find IOCs to use in IDS',
 			));
 			echo $this->Form->input('alternate', array(
 					'type' => 'checkbox',


### PR DESCRIPTION
Using "Only find IOCs to use in IDS" instead since the IOCs where to_ids=0 are not invalid.
It was confusing to some users.
