### PR TITLE
Add kerberos Authentification fonction

### DIFF
--- a/app/Config/config.default.php
+++ b/app/Config/config.default.php
@@ -85,17 +85,18 @@ $config = array (
   /*
    'ApacheSecureAuth' => // Configuration for kerberos authentification
     array(
-        'apacheEnv' => 'REMOTE_USER',           // If proxy variable = HTTP_REMOTE_USER
+        'apacheEnv' => 'REMOTE_USER', // If proxy variable = HTTP_REMOTE_USER
         'ldapServer' => 'ldap://sample.com',    // fqdn or ip
         'ldapProtocol' => 3,
-        'ldapReaderUser' => 'cn=userWithReadAccess,ou=users,', // DN ou RDN LDAP with reader user right
+        'ldapReaderUser' => 'cn=userWithReadAccess,ou=users,dc=sample,dc=com', // DN ou RDN LDAP with reader user right
         'ldapReaderPassword' => 'UserPassword', //the ldap reader user password
         'ldapDN' => 'dc=sample,dc=com', 
+        'ldapSearchAttribut' => 'uid', // filter for search. Maybe can be "samacountname"
         'ldapFilter' => array(
-            'mail',                             // filter for ldap search
+            'mail',
         ),
         'ldapDefaultRoleId' => 3,   // 3:User-1:admin. Maybe good to make 1 for the first user
-        'ldapDefaultOrg' => '',     // if not define default org = 1 misp org
+        'ldapDefaultOrg' => 'sample.com',     // if not define default org = 1 misp org
     ),
    */
 );

--- a/app/Config/config.default.php
+++ b/app/Config/config.default.php
@@ -80,4 +80,22 @@ $config = array (
     ),
   ),
   */
+  // Uncomment the following to enable Kerberos authentification
+  // need php5-ldap mod for apache
+  /*
+   'ApacheSecureAuth' => // Configuration for kerberos authentification
+    array(
+        'apacheEnv' => 'REMOTE_USER',           // If proxy variable = HTTP_REMOTE_USER
+        'ldapServer' => 'ldap://sample.com',    // fqdn or ip
+        'ldapProtocol' => 3,
+        'ldapReaderUser' => 'cn=userWithReadAccess,ou=users,', // DN ou RDN LDAP with reader user right
+        'ldapReaderPassword' => 'UserPassword', //the ldap reader user password
+        'ldapDN' => 'dc=sample,dc=com', 
+        'ldapFilter' => array(
+            'mail',                             // filter for ldap search
+        ),
+        'ldapDefaultRoleId' => 3,   // 3:User-1:admin. Maybe good to make 1 for the first user
+        'ldapDefaultOrg' => '',     // if not define default org = 1 misp org
+    ),
+   */
 );

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -61,12 +61,6 @@ class AppController extends Controller {
 	public $components = array(
 			'Session',
 			'Auth' => array(
-				'className' => 'SecureAuth',
-				'authenticate' => array(
-					'Form' => array(
-						'fields' => array('username' => 'email')
-					)
-				),
 				'authError' => 'Unauthorised access.',
 				'loginRedirect' => array('controller' => 'users', 'action' => 'routeafterlogin'),
 				'logoutRedirect' => array('controller' => 'users', 'action' => 'login', 'admin' => false),
@@ -78,6 +72,24 @@ class AppController extends Controller {
 	
 	
 	public function beforeFilter() {
+                //Let s check if Apache have kerberos auth.
+                $envvar = Configure::read('ApacheSecureAuth.apacheEnv');
+                if (isset($_SERVER[$envvar])) {
+                    $this->Auth->className = 'ApacheSecureAuth';
+                    $this->Auth->authenticate = array(
+                        'Apache' => array(
+                            // envvar = field return by Apache when used Authentificatied
+                            'fields' => array('username' => 'email', 'envvar' => $envvar)
+                        )
+                    );
+                } else {
+                    $this->Auth->className = 'SecureAuth';
+                    $this->Auth->authenticate = array(
+                        'Form' => array(
+                            'fields' => array('username' => 'email')
+                        )
+                    );
+                }
 		$versionArray = $this->{$this->modelClass}->checkMISPVersion();
 		$this->mispVersion = implode('.', array_values($versionArray));
 

--- a/app/Controller/Component/ApacheSecureAuthComponent.php
+++ b/app/Controller/Component/ApacheSecureAuthComponent.php
@@ -1,0 +1,39 @@
+<?php
+
+App::uses('AuthComponent', 'Controller/Component');
+
+class ApacheSecureAuthComponent extends AuthComponent {
+
+    /**
+     * No brut force test needed because Apache do this job
+     * 
+     * If a $user is provided that data will be stored as the logged in user.  If `$user` is empty or not
+     * specified, the request will be used to identify a user. If the identification was successful,
+     * the user record is written to the session key specified in AuthComponent::$sessionKey. Logging in
+     * will also change the session id in order to help mitigate session replays.
+     *
+     * @param mixed $user Either an array of user data, or null to identify a user using the current request.
+     * @return boolean True on login success, false on failure
+     * @link http://book.cakephp.org/2.0/en/core-libraries/components/authentication.html#identifying-users-and-logging-them-in
+     * @throws ForbiddenException
+     */
+    public function login($user = null) {
+        $this->_setDefaults();
+        if (empty($user)) {
+            // "envvar" is define in AppControler.php
+            $usernameField = $this->authenticate['Apache']['fields']['envvar'];
+            if (isset($_SERVER[$usernameField])) {
+                $username = $_SERVER[$usernameField];
+                // check if the user credentials are valid
+                $user = $this->identify($this->request, $this->response);
+                unset($user['gpgkey']);
+            }
+        }
+        if ($user) {
+            $this->Session->renew();
+            $this->Session->write(self::$sessionKey, $user);
+        }
+        return $this->loggedIn();
+    }
+
+}

--- a/app/Controller/Component/Auth/ApacheAuthenticate.php
+++ b/app/Controller/Component/Auth/ApacheAuthenticate.php
@@ -32,7 +32,7 @@ class ApacheAuthenticate extends BaseAuthenticate {
 
         // make LDAP request to get user email require for misp auth
         $ldapdn = Configure::read('ApacheSecureAuth.ldapDN');
-        $ldaprdn = Configure::read('ApacheSecureAuth.ldapReaderUser') . $ldapdn;     // DN ou RDN LDAP
+        $ldaprdn = Configure::read('ApacheSecureAuth.ldapReaderUser');     // DN ou RDN LDAP
         $ldappass = Configure::read('ApacheSecureAuth.ldapReaderPassword');
 
         // The  LDAP connexion
@@ -43,17 +43,17 @@ class ApacheAuthenticate extends BaseAuthenticate {
         ldap_set_option($ldapconn, LDAP_OPT_PROTOCOL_VERSION, Configure::read('ApacheSecureAuth.ldapProtocol'));
 
         if ($ldapconn) {
-            // LDAP Connecion
+            // Connexion au serveur LDAP
             $ldapbind = ldap_bind($ldapconn, $ldaprdn, $ldappass);
-            // Connecion verification
+            // Vérification de l'authentification
             if (!$ldapbind) {
                 die("LDAP Connexion error.");
             }
-            // search information
-            $filter = '(uid=' . $_SERVER[$envvar] . ')';
-            // get filter from config.php
+            // sample : '(uuid=ApacheUser)'
+            $filter = '('.Configure::read('ApacheSecureAuth.ldapSearchAttribut').'=' . $_SERVER[$envvar] . ')';
+            // sample : mail
             $getLdapUserInfo = Configure::read('ApacheSecureAuth.ldapFilter');
-
+            
             $result = ldap_search($ldapconn, $ldapdn, $filter, $getLdapUserInfo)
                     or die("Error in search query: " . ldap_error($ldapconn));
 
@@ -63,6 +63,8 @@ class ApacheAuthenticate extends BaseAuthenticate {
             if (isset($ldapUserData[0]['mail'][0])) {
                 // assigne the real user for misp
                 $mispUsername = $ldapUserData[0]['mail'][0];
+            }else{
+                die("User not find in ldap. Maybe some with your config.php");
             }
             // close the 
             ldap_close($ldapconn);

--- a/app/Controller/Component/Auth/ApacheAuthentificate.php
+++ b/app/Controller/Component/Auth/ApacheAuthentificate.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * Classe custom authentification Apache
+ */
+App::uses('BaseAuthenticate', 'Controller/Component/Auth');
+
+/*
+ *
+ * User for ApacheAuthenticate you can pass in settings to which fields, model and additional conditions
+ * are used. See FormAuthenticate::$settings for more information.
+ *
+ * @package       Controller.Component.Auth
+ * @since 2.0
+ * @see ApacheAuthComponent::$authenticate
+ */
+
+class ApacheAuthenticate extends BaseAuthenticate {
+
+    /**
+     * Authentification class
+     *
+     * @param CakeRequest $request The request that contains login information.
+     * @param CakeResponse $response Unused response object.
+     * @return mixed False on login failure. An array of User data on success.
+     */
+    public function authenticate(CakeRequest $request, CakeResponse $response) {
+
+        // Get information user for misp auth
+        $envvar = $this->settings['fields']['envvar'];
+        $mispUsername = $_SERVER[$envvar];
+
+        // make LDAP request to get user email require for misp auth
+        $ldapdn = Configure::read('ApacheSecureAuth.ldapDN');
+        $ldaprdn = Configure::read('ApacheSecureAuth.ldapReaderUser') . $ldapdn;     // DN ou RDN LDAP
+        $ldappass = Configure::read('ApacheSecureAuth.ldapReaderPassword');
+
+        // The  LDAP connexion
+        $ldapconn = ldap_connect(Configure::read('ApacheSecureAuth.ldapServer'))
+                or die('LDAP Server Ko');
+
+        // Ldap protocol configuration 
+        ldap_set_option($ldapconn, LDAP_OPT_PROTOCOL_VERSION, Configure::read('ApacheSecureAuth.ldapProtocol'));
+
+        if ($ldapconn) {
+            // LDAP Connecion
+            $ldapbind = ldap_bind($ldapconn, $ldaprdn, $ldappass);
+            // Connecion verification
+            if (!$ldapbind) {
+                die("LDAP Connexion error.");
+            }
+            // search information
+            $filter = '(uid=' . $_SERVER[$envvar] . ')';
+            // get filter from config.php
+            $getLdapUserInfo = Configure::read('ApacheSecureAuth.ldapFilter');
+
+            $result = ldap_search($ldapconn, $ldapdn, $filter, $getLdapUserInfo)
+                    or die("Error in search query: " . ldap_error($ldapconn));
+
+            $ldapUserData = ldap_get_entries($ldapconn, $result);
+
+            // the request return only 1 field
+            if (isset($ldapUserData[0]['mail'][0])) {
+                // assigne the real user for misp
+                $mispUsername = $ldapUserData[0]['mail'][0];
+            }
+            // close the 
+            ldap_close($ldapconn);
+        }
+
+        // Find user with reel username (mail)
+        $user = $this->_findUser($mispUsername);
+
+        if ($user) {
+            return $user;
+        }
+
+        // insert user in database if not exist
+        $userModel = ClassRegistry::init($this->settings['userModel']);
+        $org_id = Configure::read('ApacheSecureAuth.ldapDefaultOrg');
+        // If not in config, take default org
+        if(!isset($org_id)) {
+            $firstOrg = $userModel->Organisation->find(
+                    'first', array(
+                'conditions' => array(
+                    'Organisation.local' => true),
+                'order' => 'Organisation.id ASC'
+                    )
+            );
+            $org_id = $firstOrg['Organisation']['id'];
+        }
+        
+        // create user 
+        $userData = array('User' => array(
+                'email' => $mispUsername,
+                'org_id' => $org_id,
+                'password' => '',
+                'confirm_password' => '',
+                'authkey' => $userModel->generateAuthKey(),
+                'nids_sid' => 4000000,
+                'newsread' => date('Y-m-d'),
+                'role_id' => Configure::read('ApacheSecureAuth.ldapDefaultRoleId'),
+                'change_pw' => 0
+        ));
+        // save it
+        $userModel->save($userData, false);
+
+        return $this->_findUser(
+                        $mispUsername
+        );
+    }
+
+}


### PR DESCRIPTION
## Activate  kerberos authentification.
## Apache configuration

`a2enmod ldap`

Need : 
`sudo apt-get install php5-ldap`
But if your apache work with kerberos, this is ok ^^
## Configuration

look for app/config/config.php for configuration 
add the "array" 
`'ApacheSecureAuth' => // Configuration for kerberos authentification
-    array( [...]`
  and configure it.

for "app/Controller/AppController.php"
comment line 64 to 69 and add the code for kerberos class in line 74

``` php
/*'className' => 'SecureAuth',
                'authenticate' => array(
                    'Form' => array(
                        'fields' => array('username' => 'email')
                    )
                ),*/
```

Add this line just after `public function beforeFilter() {` (line 81)

``` php
$envvar = Configure::read('ApacheSecureAuth.apacheEnv');
                if (isset($_SERVER[$envvar])) {
                    $this->Auth->className = 'ApacheSecureAuth';
                    $this->Auth->authenticate = array(
                        'Apache' => array(
                            // envvar = field return by Apache when used Authentificatied
                            'fields' => array('username' => 'email', 'envvar' => $envvar)
                        )
                    );
                } else {
                    $this->Auth->className = 'SecureAuth';
                    $this->Auth->authenticate = array(
                        'Form' => array(
                            'fields' => array('username' => 'email')
                        )
                    );
                }
```

add file `app/Controller/Component/ApacheSecureAuthComponent.php` & `app/Controller/Component/Auth/ApacheAuthenticate.php`

If no kerberos detect, nothing change.
