### PR TITLE
Add SMIME encryption & signing -- Update MISP 2.4

### DIFF
--- a/INSTALL/INSTALL.SMIME.txt
+++ b/INSTALL/INSTALL.SMIME.txt
@@ -1,0 +1,55 @@
+#SMIME patch
+
+## Update the database schema
+
+mysql -u misp -p misp < INSTALL/patch_smime.sql
+
+## Create SMIME directory
+
+mkdir /var/www/MISP/.smime
+
+## Copy your public x509 certificate (for signing) in PEM format
+
+cp email@address.com.pem /var/www/MISP/.smime/email@address.com.pem
+
+## Copy your private key for signing email
+
+cp email@address.com.key /var/www/MISP/.smime/email@address.com.key
+
+### Set permissions
+
+chown www-data:www-data /var/www/MISP/.smime
+chmod 500 /var/www/MISP/.smime
+chmod 440 /var/www/MISP/.smime/*
+
+## Export the public certificate (for Encipherment) to the webroot
+
+cp public_certificate.pem /var/www/MISP/app/webroot/public_certificate.pem
+
+Due to this action, the MISP users will be able to download your public certificate (for Encipherment) by clicking on the footer
+
+### Set permissions
+
+chown www-data:www-data /var/www/MISP/app/webroot/public_certificate.pem
+chmod 440 /var/www/MISP/app/webroot/public_certificate.pem
+
+## Configure the section "SMIME" in file /var/www/MISP/app/Config/config.php
+
+Fill out the section "SMIME"
+
+
+```
+  'SMIME' => 
+  array (
+    'onlyencrypted' => false,
+    'email' => 'email@address.com',
+    'cert_public_sign' => '/var/www/MISP/.smime/email@address.com.pem',
+    'key_sign' => '/var/www/MISP/.smime/email@address.com.key',
+    'password' => 'XXXXXXXXXXXXXXXXXXXXXX',
+```
+
+## Copy a specific transport class to send SMIME with CakePHP (add SMIME headers)
+
+cp -fa /var/www/MISP/INSTALL/setup/SmimeTransport.php /var/www/MISP/app/Lib/cakephp/lib/Cake/Network/Email/SmimeTransport.php
+chown www-data:www-data /var/www/MISP/app/Lib/cakephp/lib/Cake/Network/Email/SmimeTransport.php
+chmod 750 /var/www/MISP/app/Lib/cakephp/lib/Cake/Network/Email/SmimeTransport.php

--- a/INSTALL/SmimeTransport.php
+++ b/INSTALL/SmimeTransport.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Send mail using mail() function
+ * with SMIME headers
+ */
+
+/**
+ * Send mail using mail() function
+ *
+ * @package       Cake.Network.Email
+ */
+class SmimeTransport extends AbstractTransport {
+
+/**
+ * Send mail
+ *
+ * @param CakeEmail $email CakeEmail
+ * @return array
+ * @throws SocketException When mail cannot be sent.
+ */
+	public function send(CakeEmail $email) {
+		$eol = PHP_EOL;
+		if (isset($this->_config['eol'])) {
+			$eol = $this->_config['eol'];
+		}
+		$headers = $email->getHeaders(array('from', 'sender', 'replyTo', 'readReceipt', 'returnPath', 'to', 'cc', 'bcc'));
+		// DIRTY HEADERS
+		$headers = array_merge($headers, array('Content-Transfer-Encoding' => 'base64', 'Content-Type' => 'application/pkcs7-mime; name="smime.p7m"; smime-type=enveloped-data', 'Content-Disposition' => 'attachment; filename="smime.p7m"', 'Content-Description' => 'S/MIME Encrypted Message'));
+		$to = $headers['To'];
+		unset($headers['To']);
+		foreach ($headers as $key => $header) {
+			$headers[$key] = str_replace(array("\r", "\n"), '', $header);
+		}
+		$headers = $this->_headersToString($headers, $eol);
+		$subject = str_replace(array("\r", "\n"), '', $email->subject());
+		$to = str_replace(array("\r", "\n"), '', $to);
+
+		$message = implode($eol, $email->message());
+
+		$params = isset($this->_config['additionalParameters']) ? $this->_config['additionalParameters'] : null;
+		$this->_mail($to, $subject, $message, $headers, $params);
+		return array('headers' => $headers, 'message' => $message);
+	}
+
+/**
+ * Wraps internal function mail() and throws exception instead of errors if anything goes wrong
+ *
+ * @param string $to email's recipient
+ * @param string $subject email's subject
+ * @param string $message email's body
+ * @param string $headers email's custom headers
+ * @param string $params additional params for sending email, will be ignored when in safe_mode
+ * @throws SocketException if mail could not be sent
+ * @return void
+ */
+	protected function _mail($to, $subject, $message, $headers, $params = null) {
+		if (ini_get('safe_mode')) {
+			//@codingStandardsIgnoreStart
+			if (!@mail($to, $subject, $message, $headers)) {
+				$error = error_get_last();
+				$msg = 'Could not send email: ' . isset($error['message']) ? $error['message'] : 'unknown';
+				throw new SocketException($msg);
+			}
+		} elseif (!@mail($to, $subject, $message, $headers, $params)) {
+			$error = error_get_last();
+			$msg = 'Could not send email: ' . isset($error['message']) ? $error['message'] : 'unknown';
+			//@codingStandardsIgnoreEnd
+			throw new SocketException($msg);
+		}
+	}
+
+}

--- a/INSTALL/patch_smime.sql
+++ b/INSTALL/patch_smime.sql
@@ -1,0 +1,3 @@
+-- Patch to add column in users table in order to save x509 certificate
+
+ALTER TABLE `users` ADD `certif_public` longtext COLLATE utf8_bin NOT NULL AFTER `gpgkey`;

--- a/app/Config/Schema/schema.php
+++ b/app/Config/Schema/schema.php
@@ -259,6 +259,7 @@ class AppSchema extends CakeSchema {
 		'authkey' => array('type' => 'string', 'null' => false, 'default' => null, 'length' => 40, 'collate' => 'utf8_bin', 'charset' => 'utf8'),
 		'invited_by' => array('type' => 'integer', 'null' => false, 'default' => null),
 		'gpgkey' => array('type' => 'text', 'null' => false, 'default' => null, 'collate' => 'utf8_bin', 'charset' => 'utf8'),
+		'certif_public' => array('type' => 'text', 'null' => false, 'default' => null, 'collate' => 'utf8_bin', 'charset' => 'utf8'),
 		'nids_sid' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 15),
 		'termsaccepted' => array('type' => 'boolean', 'null' => false, 'default' => null),
 		'newsread' => array('type' => 'date', 'null' => false, 'default' => null),

--- a/app/Config/config.default.php
+++ b/app/Config/config.default.php
@@ -37,7 +37,15 @@ $config = array (
     'homedir' => '',
     'password' => '',
     'bodyonlyencrypted' => false,
-  ),
+	),
+  'SMIME' => 
+  array (
+    'onlyencrypted' => false,
+    'email' => 'email@address.com',
+    'cert_public_sign' => '/var/www/MISP/.smime/email@address.com.pem',
+    'key_sign' => '/var/www/MISP/.smime/email@address.com.key',
+    'password' => 'XXXXXXXXXXXXXXXXXXXXXX',
+	),
   'Proxy' =>
   array (
     'host' => '',

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -124,6 +124,7 @@ class AppController extends Controller {
 					if ($found_misp_auth_key) {
 						if ($user) {
 							unset($user['User']['gpgkey']);
+							unset($user['User']['certif_public']);
 						    // User found in the db, add the user info to the session
 						    if (Configure::read('MISP.log_auth')) {
 								$this->Log = ClassRegistry::init('Log');
@@ -173,6 +174,7 @@ class AppController extends Controller {
 						$user = $this->Auth->user();
 						if ($user) {
 							unset($user['gpgkey']);
+							unset($user['certif_public']);
 							// User found in the db, add the user info to the session
 							$this->Session->renew();
 							$this->Session->write(AuthComponent::$sessionKey, $user);
@@ -567,6 +569,7 @@ class AppController extends Controller {
 				$user['User'] = $temp;
 				if ($user['User']) {
 					unset($user['User']['gpgkey']);
+					unset($user['User']['certif_public']);
 					$this->Session->renew();
 					$this->Session->write(AuthComponent::$sessionKey, $user['User']);
 					if (Configure::read('MISP.log_auth')) {

--- a/app/Controller/Component/SecureAuthComponent.php
+++ b/app/Controller/Component/SecureAuthComponent.php
@@ -29,6 +29,7 @@ class SecureAuthComponent extends AuthComponent {
 					// check if the user credentials are valid
 					$user = $this->identify($this->request, $this->response);
 					unset($user['gpgkey']);
+					unset($user['certif_public']);
 					if ($user === false) {
 						$this->Log = ClassRegistry::init('Log');
 						$this->Log->create();

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -516,12 +516,24 @@ class EventsController extends AppController {
 			if (Configure::read('MISP.showCorrelationsOnIndex')) $this->Event->attachCorrelationCountToEvents($this->Auth->user(), $events);
 			$this->set('events', $events);
 		}
-		
-		if (!$this->Event->User->getPGP($this->Auth->user('id')) && Configure::read('GnuPG.onlyencrypted')) {
-			$this->Session->setFlash(__('No GPG key set in your profile. To receive emails, submit your public key in your profile.'));
-		} elseif ($this->Auth->user('autoalert') && !$this->Event->User->getPGP($this->Auth->user('id')) && Configure::read('GnuPG.bodyonlyencrypted')) {
-			$this->Session->setFlash(__('No GPG key set in your profile. To receive attributes in emails, submit your public key in your profile.'));
-		}
+	
+    if (!$this->Event->User->getPGP($this->Auth->user('id')) && Configure::read('GnuPG.onlyencrypted')) {
+      // No GPG
+      if (!$this->Event->User->getCertificate($this->Auth->user('id')) && Configure::read('SMIME.onlyencrypted')) {
+        // No GPG and No SMIME
+        $this->Session->setFlash(__('No x509 certificate or GPG key set in your profile. To receive emails, submit your public certificate or GPG key in your profile.'));
+      } elseif (!Configure::read('SMIME.onlyencrypted')) {
+        $this->Session->setFlash(__('No GPG key set in your profile. To receive emails, submit your public key in your profile.'));
+      }
+    } elseif ($this->Auth->user('autoalert') && !$this->Event->User->getPGP($this->Auth->user('id')) && Configure::read('GnuPG.bodyonlyencrypted')) {
+      // No GPG & autoalert
+      if ($this->Auth->user('autoalert') && !$this->Event->User->getCertificate($this->Auth->user('id')) && Configure::read('SMIME.onlyencrypted')) {
+        // No GPG and No SMIME & autoalert
+        $this->Session->setFlash(__('No x509 certificate or GPG key set in your profile. To receive attributes in emails, submit your public certificate or GPG key in your profile.'));
+      } elseif (!Configure::read('SMIME.onlyencrypted')) {
+        $this->Session->setFlash(__('No GPG key set in your profile. To receive attributes in emails, submit your public key in your profile.'));
+      }
+    }
 		$this->set('eventDescriptions', $this->Event->fieldDescriptions);
 		$this->set('analysisLevels', $this->Event->analysisLevels);
 		$this->set('distributionLevels', $this->Event->distributionLevels);
@@ -665,7 +677,9 @@ class EventsController extends AppController {
 					}
 				}
 			}
-			if ($proposalStatus && empty($this->Session->read('Message'))) $this->Session->setFlash('This event has active proposals for you to accept or discard.');
+			$mess = $this->Session->read('Message');
+#			if ($proposalStatus && empty($this->Session->read('Message'))) $this->Session->setFlash('This event has active proposals for you to accept or discard.');
+			if ($proposalStatus && empty($mess)) $this->Session->setFlash('This event has active proposals for you to accept or discard.');
 		}
 		// set the pivot data
 		$this->helpers[] = 'Pivot';
@@ -1382,6 +1396,7 @@ class EventsController extends AppController {
 			$creator_only = $this->request->data['Event']['person'];
 			$user = $this->Auth->user();
 			$user['gpgkey'] = $this->Event->User->getPGP($user['id']);
+			$user['certif_public'] = $this->Event->User->getCertificate($user['id']);
 			if ($this->Event->sendContactEmailRouter($id, $message, $creator_only, $user, $this->_isSiteAdmin())) {
 				// redirect to the view event page
 				$this->Session->setFlash(__('Email sent to the reporter.', true));
@@ -1636,7 +1651,7 @@ class EventsController extends AppController {
 			}
 			$user = $this->Auth->user();
 		}
-		
+
 		// display the full snort rulebase
 		$this->loadModel('Attribute');
 		$rules = $this->Attribute->nids($user, $format, $id, $continue, $tags, $from, $to, $last);
@@ -2318,7 +2333,6 @@ class EventsController extends AppController {
 					$subcondition = array();
 				}
 			}
-			
 			// If we sent any tags along, load the associated tag names for each attribute
 			if ($tags) {
 				$args = $this->Event->Attribute->dissectArgs($tags);

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -74,7 +74,7 @@ class UsersController extends AppController {
 		}
 		if ($this->request->is('post') || $this->request->is('put')) {
 			// What fields should be saved (allowed to be saved)
-			$fieldList = array('email', 'autoalert', 'gpgkey', 'nids_sid', 'contactalert', 'disabled');
+			$fieldList = array('email', 'autoalert', 'gpgkey', 'certif_public', 'nids_sid', 'contactalert', 'disabled');
 			if ("" != $this->request->data['User']['password'])
 				$fieldList[] = 'password';
 			// Save the data
@@ -238,7 +238,7 @@ class UsersController extends AppController {
 		if (!$this->User->Organisation->exists() || !($this->_isSiteAdmin() || $this->Auth->user('org_id') == $id)) {
 			throw new MethodNotAllowedException('Organisation not found or no authorisation to view it.');
 		}
-		$user_fields = array('id', 'email', 'gpgkey', 'nids_sid');
+		$user_fields = array('id', 'email', 'gpgkey', 'certif_public', 'nids_sid');
 		$conditions = array('org_id' => $id);
 		if ($this->_isSiteAdmin() || ($this->_isAdmin() && $this->Auth->user('org_id') == $id)) {
 			$user_fields = array_merge($user_fields, array('current_login', 'termsaccepted', 'change_pw', 'authkey'));
@@ -970,6 +970,7 @@ class UsersController extends AppController {
 		$temp = $this->User->find('all', array('recursive' => -1, 'fields' => array('id', 'email'), 'order' => array('email ASC'), 'conditions' => $conditions));
 		$emails = array();
 		$gpgKeys = array();
+		$certif_public_certs = array();
 		// save all the emails of the users and set it for the dropdown list in the form
 		foreach ($temp as $user) {
 			$emails[$user['User']['id']] = $user['User']['email'];
@@ -1077,7 +1078,13 @@ class UsersController extends AppController {
 		$user_results = $this->User->verifyGPG();
 		$this->set('users', $user_results);
 	}
-	
+
+  public function verifyCertificate() {
+    if (!self::_isSiteAdmin()) throw new NotFoundException();
+    $user_results = $this->User->verifyCertificate();
+    $this->set('users', $user_results);
+  }	
+
 	/**
 	 * Refreshes the Auth session with new/updated data
 	 * @return void

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1638,13 +1638,13 @@ class Event extends AppModel {
 			$orgMembers = array();
 			$this->User->recursive = 0;
 			$temp = $this->User->find('all', array(
-					'fields' => array('email', 'gpgkey', 'contactalert', 'id', 'org_id'),
+					'fields' => array('email', 'gpgkey', 'certif_public', 'contactalert', 'id', 'org_id'),
 					'conditions' => array('disabled' => 0, 'User.org_id' => $event['Event']['orgc_id']),
 					'recursive' => -1
 			));
 			if (empty($temp)) {
 				$temp = $this->User->find('all', array(
-						'fields' => array('email', 'gpgkey', 'contactalert', 'id', 'org_id'),
+						'fields' => array('email', 'gpgkey', 'certif_public', 'contactalert', 'id', 'org_id'),
 						'conditions' => array('disabled' => 0, 'User.org_id' => $event['Event']['org_id']),
 						'recursive' => -1
 				));
@@ -1657,7 +1657,7 @@ class Event extends AppModel {
 		} else {
 			$temp = $this->User->find('first', array(
 					'conditions' => array('User.id' => $event['Event']['user_id'], 'User.disabled' => 0),
-					'fields' => array('User.email', 'User.gpgkey'),
+					'fields' => array('User.email', 'User.gpgkey', 'User.certif_public'),
 			));
 			if (!empty($temp)) $orgMembers = array(0 => $temp);
 		}
@@ -1671,6 +1671,8 @@ class Event extends AppModel {
 		$body .= "You can reach him at " . $user['User']['email'] . "\n";
 		if (!$user['User']['gpgkey'])
 			$body .= "His GPG/PGP key is added as attachment to this email. \n";
+    if (!$user['User']['certif_public'])
+			$body .= "His Public certificate is added as attachment to this email. \n";
 		$body .= "\n";
 		$body .= "He wrote the following message: \n";
 		$body .= $message . "\n";

--- a/app/Model/Post.php
+++ b/app/Model/Post.php
@@ -64,7 +64,7 @@ class Post extends AppModel {
 			//limit this array to users with contactalerts turned on!
 			$orgMembers = array();
 			$this->User->recursive = -1;
-			$temp = $this->User->findAllByOrgId($event['Event']['org_id'], array('email', 'gpgkey', 'contactalert', 'id'));
+			$temp = $this->User->findAllByOrgId($event['Event']['org_id'], array('email', 'gpgkey', 'certif_public', 'contactalert', 'id'));
 			foreach ($temp as $tempElement) {
 				if ($tempElement['User']['id'] != $user_id && ($tempElement['User']['contactalert'] || $tempElement['User']['id'] == $event['Event']['user_id'])) {
 					array_push($orgMembers, $tempElement);
@@ -76,14 +76,14 @@ class Post extends AppModel {
 			if ($thread['Thread']['user_id'] == $user_id ) {
 				$orgMembers = array();
 			} else {
-				$orgMembers = $this->User->findAllById($thread['Thread']['user_id'], array('email', 'gpgkey', 'contactalert', 'id'));
+				$orgMembers = $this->User->findAllById($thread['Thread']['user_id'], array('email', 'gpgkey', 'certif_public', 'contactalert', 'id'));
 			}
 		}
 
 		// Add all users who posted in this thread
 		$temp = $this->findAllByThreadId($post['Post']['thread_id'],array('user_id'));
 		foreach ($temp as $tempElement) {
-			$user = $this->User->findById($tempElement['Post']['user_id'], array('email', 'gpgkey', 'contactalert', 'id'));
+			$user = $this->User->findById($tempElement['Post']['user_id'], array('email', 'gpgkey', 'certif_public', 'contactalert', 'id'));
 			if(!empty($user) && $user['User']['id'] != $user_id && !in_array($user, $orgMembers)) {
 				array_push($orgMembers, $user);
 			}

--- a/app/Model/ShadowAttribute.php
+++ b/app/Model/ShadowAttribute.php
@@ -532,7 +532,7 @@ class ShadowAttribute extends AppModel {
 						'contactalert' => 1,
 						'disabled' => 0
 				),
-				'fields' => array('email', 'gpgkey', 'contactalert', 'id')
+				'fields' => array('email', 'gpgkey', 'certif_public', 'contactalert', 'id')
 		));
 	
 		$body = "Hello, \n\n";

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -725,7 +725,7 @@ class User extends AppModel {
     if (isset($user['User']['certif_public']) && !empty($user['User']['certif_public'])) $canEncryptSMIME = true;
 	
 		// If bodyonlencrypted is enabled and the user has no encryption key, use the alternate body (if it exists)
-		if (Configure::read('GnuPG.bodyonlyencrypted') && !$canEncryptSMIME && $canEncryptGPG && $bodyNoEnc) {
+		if (Configure::read('GnuPG.bodyonlyencrypted') && !$canEncryptSMIME && !$canEncryptGPG && $bodyNoEnc) {
 			$body = $bodyNoEnc;
 		}
 		$body = str_replace('\n', PHP_EOL, $body);

--- a/app/View/Elements/footer.ctp
+++ b/app/View/Elements/footer.ctp
@@ -9,6 +9,12 @@
 					<span>Download: <?php echo $this->Html->link('PGP/GPG key', $this->webroot.'gpg.asc');?></span>
 				<?php }else{ ?>
 					<span>Could not locate the PGP/GPG public key.</span>
+				<?php }
+				$smimepath = ROOT.DS.APP_DIR.DS.WEBROOT_DIR.DS.'public_certificate.pem';
+				if(file_exists($smimepath) && is_file($smimepath)){ ?>
+					<span>Download: <?php echo $this->Html->link('Certificate (Encipherment)', $this->webroot.'public_certificate.pem');?></span>
+				<?php }else{ ?>
+					<span>Could not locate the Certificate (Encipherment).</span>
 				<?php } ?>
 			</div>
 			<div class = "footerText footerCenterText">

--- a/app/View/Pages/administration.ctp
+++ b/app/View/Pages/administration.ctp
@@ -15,6 +15,7 @@ if (!$isSiteAdmin) exit();
 		<li><?php echo $this->Form->postLink('Recorrelate attributes', $baseurl . '/attributes/generateCorrelation');?></li>
 		<li><?php echo $this->Form->postLink('Recorrelate proposals', $baseurl . '/shadow_attributes/generateCorrelation');?></li>
 		<li><a href="<?php echo $baseurl;?>/users/verifyGPG">Verify GPG keys</a> (Check whether every user's GPG key is usable)</li>
+		<li><a href="<?php echo $baseurl;?>/users/verifyCertificate">Verify Certificates</a> (Check whether every user's certificate is usable</li>
 		<li><?php echo $this->Form->postLink('Extend Organization length', $baseurl . '/servers/updateDatabase/extendServerOrganizationLength');?> (Hotfix 2.3.57: Increase the max length of the organization field when adding a new server connection.)</li>
 		<li><?php echo $this->Form->postLink('Convert log fields to text', $baseurl . '/servers/updateDatabase/convertLogFieldsToText');?> (Hotfix 2.3.78: Some of the log fields that were varchar(255) ended up truncating the data. This function will change them to "text")</li>
 		<li><?php echo $this->Form->postLink('Fix duplicate UUIDs', $baseurl . '/servers/pruneDuplicateUUIDs');?> (Hotfix 2.3.107: it was previously possible to get duplicate attribute UUIDs in the database, this script will remove all duplicates and ensure that duplicates will not be entered into the database in the future.)</li>

--- a/app/View/Users/admin_add.ctp
+++ b/app/View/Users/admin_add.ctp
@@ -61,7 +61,8 @@
 		echo $this->Form->input('gpgkey', array('label' => 'GPG key', 'div' => 'clear', 'class' => 'input-xxlarge'));
 	?>
 		<div class="clear"><span onClick="lookupPGPKey('UserEmail');" class="btn btn-inverse" style="margin-bottom:10px;">Fetch GPG key</span></div>
-	<?php 
+	<?php
+		echo $this->Form->input('certif_public', array('label' => 'Public certificate (Encryption -- PEM format)', 'div' => 'clear', 'class' => 'input-xxlarge'));
 		echo $this->Form->input('autoalert', array('label' => 'Receive alerts when events are published'));
 		echo $this->Form->input('contactalert', array('label' => 'Receive alerts from "contact reporter" requests'));
 	?>

--- a/app/View/Users/admin_edit.ctp
+++ b/app/View/Users/admin_edit.ctp
@@ -60,7 +60,8 @@
 		echo $this->Form->input('gpgkey', array('label' => 'GPG key', 'div' => 'clear', 'class' => 'input-xxlarge'));
 	?>
 			<div class="clear"><span onClick="lookupPGPKey('UserEmail');" class="btn btn-inverse" style="margin-bottom:10px;">Fetch GPG key</span></div>
-	<?php 
+	<?php
+		echo $this->Form->input('certif_public', array('label' => 'Public certificate (Encryption -- PEM format)', 'div' => 'clear', 'class' => 'input-xxlarge'));
 		echo $this->Form->input('termsaccepted', array('label' => 'Terms accepted'));
 		echo $this->Form->input('change_pw', array('type' => 'checkbox', 'label' => 'Change Password'));
 		echo $this->Form->input('autoalert', array('label' => 'Receive alerts when events are published'));

--- a/app/View/Users/admin_index.ctp
+++ b/app/View/Users/admin_index.ctp
@@ -50,6 +50,7 @@
 			<th><?php echo $this->Paginator->sort('autoalert');?></th>
 			<th><?php echo $this->Paginator->sort('contactalert');?></th>
 			<th><?php echo $this->Paginator->sort('gpgkey');?></th>
+      <th><?php echo $this->Paginator->sort('certif_public');?></th>
 			<th><?php echo $this->Paginator->sort('nids_sid');?></th>
 			<th><?php echo $this->Paginator->sort('termsaccepted');?></th>
 			<th><?php echo $this->Paginator->sort('current_login', 'Last login');?></th>
@@ -83,6 +84,8 @@
 			<td class="short" ondblclick="document.location ='<?php echo $this->Html->url(array('admin' => true, 'action' => 'view', $user['User']['id']), true);?>';">
 			<?php echo $user['User']['gpgkey']? 'Yes' : 'No'; ?>&nbsp;</td>
 			<td class="short" ondblclick="document.location ='<?php echo $this->Html->url(array('admin' => true, 'action' => 'view', $user['User']['id']), true);?>';">
+	    <?php echo $user['User']['certif_public']? 'Yes' : 'No'; ?>&nbsp;</td>
+  	  <td class="short" ondblclick="document.location ='<?php echo $this->Html->url(array('admin' => true, 'action' => 'view', $user['User']['id']), true);?>';">
 			<?php echo h($user['User']['nids_sid']); ?>&nbsp;</td>
 			<td class="short" ondblclick="document.location ='<?php echo $this->Html->url(array('admin' => true, 'action' => 'view', $user['User']['id']), true);?>';">
 			<?php

--- a/app/View/Users/admin_view.ctp
+++ b/app/View/Users/admin_view.ctp
@@ -57,6 +57,15 @@ if (h($user['User']['gpgkey'])) {
 						echo "N/A";
 }?>
 			</dd>
+    <dt><?php echo __('Public certificate (Encryption - PEM format)'); ?></dt>
+      <dd>
+        <?php
+if (h($user['User']['certif_public'])) {
+            echo "<code>" . nl2br(h($user['User']['certif_public'])) . "</code>";
+} else {
+            echo "N/A";
+}?>
+      </dd>
 		<dt><?php echo __('Nids Sid'); ?></dt>
 		<dd>
 			<?php echo h($user['User']['nids_sid']); ?>

--- a/app/View/Users/ajax/index.ctp
+++ b/app/View/Users/ajax/index.ctp
@@ -21,6 +21,7 @@
 			<th><?php echo $this->Paginator->sort('email');?></th>
 			<th>Role</th>
 			<th>GPGKey set</th>
+			<th>Certificate (x509) set</th>
 			<th><?php echo $this->Paginator->sort('nids_sid');?></th>
 			<?php 
 				if ($isSiteAdmin):

--- a/app/View/Users/edit.ctp
+++ b/app/View/Users/edit.ctp
@@ -14,7 +14,8 @@
 		echo $this->Form->input('gpgkey', array('label' => 'GPG key', 'div' => 'clear', 'class' => 'input-xxlarge'));
 		?>
 			<div class="clear"><span onClick="lookupPGPKey('UserEmail');" class="btn btn-inverse" style="margin-bottom:10px;">Fetch GPG key</span></div>
-		<?php 
+		<?php
+		echo $this->Form->input('certif_public', array('label' => 'Public certificate (Encryption -- PEM format)', 'div' => 'clear', 'class' => 'input-xxlarge'));
 		echo $this->Form->input('autoalert', array('label' => 'Receive alerts when events are published'));
 		echo $this->Form->input('contactalert', array('label' => 'Receive alerts from "contact reporter" requests'));
 	?>

--- a/app/View/Users/verify_certificate.ctp
+++ b/app/View/Users/verify_certificate.ctp
@@ -1,0 +1,18 @@
+<div class="index">
+	<h3>Certificates validation</h3>
+	<ul>
+	<?php foreach ($users as $k => $user) { 
+		echo $k . ' (' . $user[1] . '):<br />';
+    if (isset($user[0])) {
+      echo '-> <span style="color:red;">Invalid.</span><br />';
+    } else {
+      echo '-> <span style="color:green;">OK</span><br />';
+    }
+    echo '------------------------------------------------------------------------------<br />';
+  }
+   ?>
+	 </ul>
+</div>
+<?php
+	echo $this->element('side_menu', array('menuList' => 'admin', 'menuItem' => 'adminTools'));
+?>

--- a/app/View/Users/view.ctp
+++ b/app/View/Users/view.ctp
@@ -62,6 +62,17 @@ if (!empty($user['User']['gpgkey'])) {
 		?>
 			&nbsp;
 		</dd>
+    <dt><?php echo __('certif_public'); ?></dt>
+    <dd>
+    <?php
+if (!empty($user['User']['certif_public'])) {
+  echo "<code>" . nl2br(h($user['User']['certif_public'])) . "</code>";
+} else {
+  echo "N/A";
+}
+    ?>
+      &nbsp;
+    </dd>
 	</dl>
 </div>
 <?php 


### PR DESCRIPTION
Hello all,

I finally updated the old pull request [306](https://github.com/MISP/MISP/pull/306) (open since 1 year and half :smiley: ). This SMIME patch works with the latest MISP version (2.4.33). 

Don't hesitate to contact me if you need some help or if you have some question about the S/MIME patch.

I attached the original message of the pull request [306](https://github.com/MISP/MISP/pull/306) to add additional details. Don't hesitate review the small [instructions](https://github.com/MISP/MISP/commit/536adba5bbf4b55955ba6960e70963898a746179) regarding the installation of this patch.

-------------------------------------- original pull request 306 ----------------------------------------------------

Hello all,

The mission of this patch is to add the support of SMIME [1](https://en.wikipedia.org/wiki/S/MIME) in order to improve the solutions to encrypt & sign emails in MISP :)

This patch works when:
- SMIME enabled & GPG disabled: In this context, all emails will be sent encrypted and signed using S/MIME. If the user doesn't set a public certificate (for encipherment), he will receive an email (clear text) to invite him to connect to MISP in order to obtain the detail on the published event (the template for this email is attached to this "Pull request").
- GPG & SMIME enabled: By default, GPG is always preferred :). Thus, if the user sets a GPG key and a public certificate in this profile, he will receive all email encrypted & signed using GPG. If the user doesn't set a GPG key but has set a public certificate, the emails will be encrypted & signed using S/MIME. Of course, if no GPG key and public certificate are set, he will receive an email (clear text) to invite him to connect to MISP in order to obtain the detail on the published event (the template for this email is attached to this "Pull request").
- SMIME disabled: In this context, the email will be sent encrypted & signed using GPG, if GPG is enabled. If no GPG key is set in the user profile, the user will receive an email (clear text) to invite him to connect to MISP in order to obtain the detail on the published event (the template for this email is attached to this "Pull request"). 

The different steps to install this patch is defined the INSTALL.txt (section: ' 9/ SMIME patch')

At the moment, I currently use this patch (and it's working well) but this patch is still in the "beta phase" and don't blame me for bugs and dirty hacks in the code.

devnull-

[2]: At the moment, AES_256_CBC is used to encrypt the email

---

```
Hello, 

The event number 43 was published on the MISP platform. 

Since no GPG/PGP key or public certificate is set in your MISP profile, you can not directly receive the information in an encrypted email. 
You can fill out you profile with your GPG/PGP key or public to receive encrypted email. 

To access to the event involved, please click on the following link:
URL    : https://misp.xxx.xxx.com/events/view/43


Best regards,

XXXXXX  xxxx

```

---

-------------------------------------- original pull request  306 ----------------------------------------------------
