### PR TITLE
Defang hostname attributes

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1673,7 +1673,7 @@ class Event extends AppModel {
 	 			elseif ('email-src' == $attribute['type'] or 'email-dst' == $attribute['type']) {
 	 				$line = str_replace("@","[at]", $line);
 	 			}
-	 			elseif ('domain' == $attribute['type'] or 'ip-src' == $attribute['type'] or 'ip-dst' == $attribute['type']) {
+				elseif ('hostname' == $attribute['type'] or 'domain' == $attribute['type'] or 'ip-src' == $attribute['type'] or 'ip-dst' == $attribute['type']) {
 	 				$line = str_replace(".","[.]", $line);
 	 			}
 	 	


### PR DESCRIPTION
IP addresses and domain names are _defanged_ (. replaced by [.]) but hostnames are not. Clicking on hostnames can be just as dangerous. This simple patch also defangs hostnames.
