### PR TITLE
add margin between fileupload and submit button

### DIFF
--- a/app/webroot/css/main.css
+++ b/app/webroot/css/main.css
@@ -7,6 +7,10 @@ input, button, select, textarea{
 
 }
 
+input[type="file"]{
+	margin-bottom: 10px;
+}
+
 button .full-width{
   width:100%;
 }


### PR DESCRIPTION
forms that have a file upload input item at the end should have a margin after the upload-item.
(n the long-term, it might be better to use a more bootstrap-based approach for form-styling)
