### PR TITLE
Update UsersController.php

### DIFF
--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -744,7 +744,7 @@ class UsersController extends AppController {
 							'fields' => $fields,
 							'recursive' => -1,
 							'contain' => array('Organisation'),
-							'group' => array('Organisation.name'),
+							'group' => array('Organisation.id'),
 							'order' => array('UPPER(Organisation.name)'),
 		);
 		$orgs = $this->User->find('all', $params);


### PR DESCRIPTION
Grouping by Organization.name will throw a MySQL error 

> Syntax error or access violation: 1055 Expression #3 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'misp.Organisation.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by" 

in "Request URL: /users/memberslist" , since Organization.name is not a unique field. Grouping by Organization.id instead will fix the issue.
