### PR TITLE
Casting the sharing_group_id to int value

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1812,7 +1812,12 @@ class Event extends AppModel {
 		}
 		
 		if ($data['Event']['distribution'] == 4) {
-			$data['Event']['sharing_group_id'] = intval($this->SharingGroup->captureSG($data['Event']['SharingGroup'], $user));
+			$sg = $this->SharingGroup->captureSG($data['Event']['SharingGroup'], $user);
+			if ($sg===false){
+				$sg = 0;
+				$data['Event']['distribution'] = 0;
+			}
+			$data['Event']['sharing_group_id'] = $sg;
 			unset ($data['Event']['SharingGroup']);
 		}
 		if (isset($data['Event']['Attribute'])) {

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1812,7 +1812,7 @@ class Event extends AppModel {
 		}
 		
 		if ($data['Event']['distribution'] == 4) {
-			$data['Event']['sharing_group_id'] = $this->SharingGroup->captureSG($data['Event']['SharingGroup'], $user);
+			$data['Event']['sharing_group_id'] = intval($this->SharingGroup->captureSG($data['Event']['SharingGroup'], $user));
 			unset ($data['Event']['SharingGroup']);
 		}
 		if (isset($data['Event']['Attribute'])) {

--- a/app/Model/SharingGroup.php
+++ b/app/Model/SharingGroup.php
@@ -352,7 +352,7 @@ class SharingGroup extends AppModel {
 			if (!$this->save($newSG)) return false;
 			$sgids = $this->id;
 		} else {
-			if (!$this->checkIfAuthorised($user, $existingSG['SharingGroup']['id'])) return false;
+			if (!$this->checkIfAuthorised($user, $existingSG['SharingGroup']['id'])) throw new Exception('User not authorised to modify sharing groups.');
 			if ($sg['modified'] > $existingSG['SharingGroup']['modified']) {
 				if ($user['Role']['perm_sync'] && $existingSG['SharingGroup']['local'] == 0) $force = true;
 				if ($force) {


### PR DESCRIPTION
Saving the sharing_group_id as it is returned by CaptureSG results in 

> Error: [PDOException] SQLSTATE[HY000]: General error: 1366 Incorrect integer value: '' for column 'sharing_group_id' at row 1. 

Wrapping it in intval will insert the correct int value.
