### PR TITLE
Resolving the sql_mode=only_full_group_by error in Search Log

### DIFF
--- a/app/Controller/LogsController.php
+++ b/app/Controller/LogsController.php
@@ -244,7 +244,7 @@ class LogsController extends AppController {
 			$models = array('Attribute', 'Event', 'EventBlacklist', 'EventTag', 'Organisation', 'Post', 'Regexp', 'Role', 'Server', 'ShadowAttribute', 'SharingGroup', 'Tag', 'Task', 'Taxonomy', 'Template', 'Thread', 'User', 'Whitelist');
 			$existing_models = $this->Log->find('list', array(
 					'fields' => array('Log.model'),
-					'group' => array('Log.model')
+					'group' => array('Log.model','Log.id')
 			));
 			$models = array_intersect($models, $existing_models);
 			$models = array('' => 'ALL') + $this->_arrayToValuesIndexArray($models);


### PR DESCRIPTION
Similar to pull request #1121 and issue #749, the ID needs to be in group_by to solve this error in /admin/logs/search

> Error: [PDOException] SQLSTATE[42000]: Syntax error or access violation: 1055 Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'Log.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
