### PR TITLE
Resolve only_full_group_by error in filterEventIndex

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -644,7 +644,7 @@ class EventsController extends AppController {
 					'fields' => array('Orgc.name'),
 					'contain' => array('Orgc'),
 					'conditions' => $conditions,
-					'group' => 'LOWER(Orgc.name)'
+					'group' => array('LOWER(Orgc.name)','Event.id')
 			));
 			$this->set('showorg', true);
 			$this->set('orgs', $this->_arrayToValuesIndexArray($orgs));


### PR DESCRIPTION
Event.id required in group by, to resolve 

> Error: [PDOException] SQLSTATE[42000]: Syntax error or access violation: 1055 Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'Event.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by

in Request URL: /events/filterEventIndex
