### PR TITLE
deleteSelected: fix request method check

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -954,8 +954,7 @@ class AttributesController extends AppController {
 	}
 	
 	public function deleteSelected($id) {
-		if (!$this->request->is('post') || !$this->request->is('ajax')) {
-		//if (!$this->request->is('post')) {
+		if (!$this->request->is('post') && !$this->request->is('ajax')) {
 			throw new MethodNotAllowedException();
 		}
 		// get a json object with a list of attribute IDs to be deleted


### PR DESCRIPTION
if i understood this part correctly, it should check if either POST or AJAX is used.
without the suggested change, the if-clause would always return true and hence the Exception would always be thrown, because the request can't be POST and AJAX at the same time, can it?
