### PR TITLE
Fix for mod_proxy_fcgi + Apache 2.2 REST API authentication

### DIFF
--- a/INSTALL/apache.misp.centos6
+++ b/INSTALL/apache.misp.centos6
@@ -10,6 +10,7 @@
 	</Directory>
 
 	<IfModule !mod_php5.c>
+		SetEnvIfNoCase Authorization "(.*)" HTTP_AUTHORIZATION=$1
 		DirectoryIndex /index.php index.php
 		ProxyPassMatch ^/(.*\.php(/.*)?)$ fcgi://127.0.0.1:9000/var/www/MISP/app/webroot/$1
 	</IfModule>

--- a/INSTALL/apache.misp.centos7
+++ b/INSTALL/apache.misp.centos7
@@ -10,6 +10,7 @@
 	</Directory>
 
 	<IfModule !mod_php5.c>
+		SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
 		DirectoryIndex /index.php index.php
 		<FilesMatch \.php$>
 			SetHandler "proxy:fcgi://127.0.0.1:9000"


### PR DESCRIPTION
When using rh-php56-php-fpm together with mod_proxy_fcgi and mod_fcgid under (the CentOS 6 default) Apache 2.2 all environment variables are stripped. This means the Authorization HTTP header is not passed to PHP as the HTTP_AUTHORIZATION environment variable.

This patch converts the Authorization HTTP header to the AUTHORIZATION CGI parameter and accepts this parameter as an alternative method for authenticating REST API calls.
