### PR TITLE
don't query every event for proposals, when you don't have permission…

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1073,6 +1073,10 @@ class Event extends AppModel {
 		$response = $HttpSocket->post($uri, json_encode($uuidList), $request);
 		if ($response->isOk()) {
 			return(json_decode($response->body, true));
+		} elseif ($response->code == '405') {
+			// HACKY: without correct permission, the returning null causes Fallback for < 2.4.7 instances
+			// which queries every event, for proposal, which it doesn't have permission for
+			return array();
 		} else {
 			// TODO parse the XML response and keep the reason why it failed
 			return null;


### PR DESCRIPTION
… to get proposals

A little hacky, but without correct permission, the returning null causes the else case ( Fallback for < 2.4.7 instances )  which then queries every event, for proposals which it doesn't have permission for, so wastes resources on both side.
