### PR TITLE
remove deprecation warning.

### DIFF
--- a/app/View/Tasks/index.ctp
+++ b/app/View/Tasks/index.ctp
@@ -19,7 +19,7 @@
     </div>
 	<?php
 		echo $this->Form->create('Task', array(
-		'action' => 'setTask',
+		'url' => 'setTask',
 		'controller' => 'Tasks',
 		'inputDefaults' => array(
 		'label' => false


### PR DESCRIPTION
Deprecated (16384): Using key `action` is deprecated, use `url` directly instead. [APP/Lib/cakephp/lib/Cake/View/Helper/FormHelper.php, line 383]
