### PR TITLE
allow related events to send org uuid, since events send them already

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -508,8 +508,7 @@ class Event extends AppModel {
 		// now look up the event data for these attributes
 		$conditions = array("Event.id" => $relatedEventIds);
 		$fields = array('id', 'date', 'threat_level_id', 'info', 'published', 'uuid', 'analysis', 'timestamp', 'distribution', 'org_id', 'orgc_id');
-		$orgfields = array('id', 'name');
-		if ($user['Role']['perm_site_admin']) $orgfields[] = 'uuid';
+		$orgfields = array('id', 'name', 'uuid');
 		$relatedEvents = $this->find('all',
 			array('conditions' => $conditions,
 				'recursive' => 0,


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:
- One Pull Request per fix/feature/change/...
- Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
- Always make sure it is mergeable in the default branch (as of today 2016-06-03: branch 2.4)
- Please make sure Travis CI works on this request, or update the test cases if needed
- Any major changes adding a functionality should be disabled by default in the config
#### What does it do?

If it fixes an existing issue, please use github syntax: `#<IssueID>`
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch

There is the potential, that an org shows up in the RelatedEvent before it shows up in an Event and causes sync to fail. Already submitted a pull request to fix the crash, but potential for incomplete data.
