### PR TITLE
Change job_id to varchar to resolve #1180

### DIFF
--- a/INSTALL/MYSQL.sql
+++ b/INSTALL/MYSQL.sql
@@ -514,7 +514,7 @@ CREATE TABLE IF NOT EXISTS `tasks` (
   `type` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
   `timer` int(11) NOT NULL,
   `scheduled_time` varchar(8) NOT NULL DEFAULT '6:00',
-  `job_id` int(11) NOT NULL,
+  `job_id` varchar(32) DEFAULT NULL,
   `description` varchar(255) NOT NULL,
   `next_execution_time` int(11) NOT NULL,
   `message` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,


### PR DESCRIPTION
As mentioned in #1180, every spot that task->job_id is being set:
- app/Model/Task.php
- app/Controller/TasksController.php

it's the returned value from CakeResque::enqueueAt which is the process_id (MD5).
And I think renaming the field to process_id might be more representative of what it is?
#### What does it do?

Fixes #1180 
#### Questions
- [X] Does it require a DB change?
- [X] Are you using it in production?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
