### PR TITLE
remove obsolete semicolon after closing curly bracket

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -1132,7 +1132,7 @@ class Attribute extends AppModel {
 			exec("zip -j -P infected " . $zipfile->path . ' \'' . addslashes($fileInZip->path) . '\'', $execOutput, $execRetval);
 			if ($execRetval != 0) { // not EXIT_SUCCESS
 				// TODO: error handling
-			};
+			}
 			$fileInZip->delete(); // delete the original non-zipped-file
 			rename($zipfile->path, $file->path); // rename the .zip to .nothing
 		} else {

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -347,7 +347,7 @@ class Event extends AppModel {
 			if (!$this->destroyDir($dir . DS . $file)) {
 				chmod($dir . DS . $file, 0777);
 				if (!$this->destroyDir($dir . DS . $file)) return false;
-			};
+			}
 		}
 		return rmdir($dir);
 	}

--- a/app/Model/ShadowAttribute.php
+++ b/app/Model/ShadowAttribute.php
@@ -456,7 +456,7 @@ class ShadowAttribute extends AppModel {
 			exec("zip -j -P infected " . $zipfile->path . ' \'' . addslashes($fileInZip->path) . '\'', $execOutput, $execRetval);
 			if ($execRetval != 0) { // not EXIT_SUCCESS
 				// TODO: error-handling
-			};
+			}
 			$fileInZip->delete(); // delete the original non-zipped-file
 			rename($zipfile->path, $file->path); // rename the .zip to .nothing
 		} else {


### PR DESCRIPTION
command:
`grep -rlI "\s};" | grep "\.php" | while read file; do sed -i -r $'s|(\s});|\\1|' $file; done`
