### PR TITLE
Braces

### DIFF
--- a/app/Console/Command/EventShell.php
+++ b/app/Console/Command/EventShell.php
@@ -326,7 +326,7 @@ class EventShell extends AppShell
 		// the special cache files containing all events
 		$i = 0;
 		foreach ($users as $user) {
-			foreach($this->Event->export_types as $k => $type) {
+			foreach ($this->Event->export_types as $k => $type) {
 				$this->Job->cache($k, $user['User'], 'Events visible to: ' . ($user['Role']['perm_site_admin'] ? 'ADMIN' : $user['Organisation']['name']));
 				$i++;
 			}

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -118,7 +118,7 @@ class AppController extends Controller {
 		// send users away that are using ancient versions of IE
 		// Make sure to update this if IE 20 comes out :)
 		if (isset($_SERVER['HTTP_USER_AGENT'])) {
-			if(preg_match('/(?i)msie [2-8]/',$_SERVER['HTTP_USER_AGENT']) && !strpos($_SERVER['HTTP_USER_AGENT'], 'Opera')) throw new MethodNotAllowedException('You are using an unsecure and outdated version of IE, please download Google Chrome, Mozilla Firefox or update to a newer version of IE. If you are running IE9 or newer and still receive this error message, please make sure that you are not running your browser in compatibility mode. If you still have issues accessing the site, get in touch with your administration team at ' . Configure::read('MISP.contact'));
+			if (preg_match('/(?i)msie [2-8]/',$_SERVER['HTTP_USER_AGENT']) && !strpos($_SERVER['HTTP_USER_AGENT'], 'Opera')) throw new MethodNotAllowedException('You are using an unsecure and outdated version of IE, please download Google Chrome, Mozilla Firefox or update to a newer version of IE. If you are running IE9 or newer and still receive this error message, please make sure that you are not running your browser in compatibility mode. If you still have issues accessing the site, get in touch with your administration team at ' . Configure::read('MISP.contact'));
 		}
 
 		$userLoggedIn = false;
@@ -185,12 +185,12 @@ class AppController extends Controller {
 					}
 				}
 				if ($this->Auth->user() == null) throw new ForbiddenException('Authentication failed. Please make sure you pass the API key of an API enabled user along in the Authorization header.');
-			} else if(!$this->Session->read(AuthComponent::$sessionKey)) {
+			} else if (!$this->Session->read(AuthComponent::$sessionKey)) {
 				// load authentication plugins from Configure::read('Security.auth')
 				$auth = Configure::read('Security.auth');
-				if($auth) {
+				if ($auth) {
 					$this->Auth->authenticate = array_merge($auth, $this->Auth->authenticate);
-					if($this->Auth->startup($this)) {
+					if ($this->Auth->startup($this)) {
 						$user = $this->Auth->user();
 						if ($user) {
 							// User found in the db, add the user info to the session

--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -496,7 +496,7 @@ class AttributesController extends AppController {
 			$entries = array();
 			if (($handle = fopen($filename, 'r')) !== FALSE) {
 				while (($row = fgetcsv($handle, 0, ',', '"')) !== FALSE) {
-					if(!$header)
+					if (!$header)
 						$header = $row;
 					else
 						$entries[] = array_combine($header, $row);
@@ -515,7 +515,7 @@ class AttributesController extends AppController {
 			// import attributes
 			//
 			$attributes = array();  // array with all the attributes we're going to save
-			foreach($entries as $entry) {
+			foreach ($entries as $entry) {
 				$attribute = array();
 				$attribute['event_id'] = $this->request->data['Attribute']['event_id'];
 				$attribute['value'] = $entry['Value'];
@@ -529,7 +529,7 @@ class AttributesController extends AppController {
 						$attribute['distribution'] = Configure::read('MISP.default_attribute_distribution');
 					}
 				}
-				switch($entry['Type']) {
+				switch ($entry['Type']) {
 					case 'Address':
 						$attribute['category'] = 'Network activity';
 						$attribute['type'] = 'ip-dst';
@@ -575,12 +575,12 @@ class AttributesController extends AppController {
 			// 3/ if url format -> 'link'
 			//	else 'comment'
 			$references = array();
-			foreach($entries as $entry) {
+			foreach ($entries as $entry) {
 				$references[$entry['Source']] = true;
 			}
 			$references = array_keys($references);
 			// generate the Attributes
-			foreach($references as $reference) {
+			foreach ($references as $reference) {
 				$attribute = array();
 				$attribute['event_id'] = $this->request->data['Attribute']['event_id'];
 				$attribute['category'] = 'Internal reference';
@@ -1066,7 +1066,7 @@ class AttributesController extends AppController {
 				$attribute['Attribute']['timestamp'] = $timestamp;
 			}
 
-			if($this->Attribute->saveMany($attributes)) {
+			if ($this->Attribute->saveMany($attributes)) {
 				$event['Event']['timestamp'] = $date->getTimestamp();
 				$event['Event']['published'] = 0;
 				$this->Attribute->Event->save($event, array('fieldList' => array('published', 'timestamp', 'info', 'id')));
@@ -1475,11 +1475,11 @@ class AttributesController extends AppController {
 
 	// Sort the array of arrays based on a value of a sub-array
 	private function __subval_sort($a,$subkey) {
-		foreach($a as $k=>$v) {
+		foreach ($a as $k=>$v) {
 			$b[$k] = strtolower($v[$subkey]);
 		}
 		arsort($b);
-		foreach($b as $key=>$val) {
+		foreach ($b as $key=>$val) {
 			$c[] = $a[$key];
 		}
 		return $c;
@@ -1557,7 +1557,7 @@ class AttributesController extends AppController {
 			if (isset(${$parameters[$k]}) && ${$parameters[$k]}!==false) {
 				if (is_array(${$parameters[$k]})) $elements = ${$parameters[$k]};
 				else $elements = explode('&&', ${$parameters[$k]});
-				foreach($elements as $v) {
+				foreach ($elements as $v) {
 					if (empty($v)) continue;
 					if (substr($v, 0, 1) == '!') {
 						if ($parameters[$k] === 'value' && preg_match('@^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(\d|[1-2]\d|3[0-2]))$@', substr($v, 1))) {
@@ -1691,7 +1691,7 @@ class AttributesController extends AppController {
 		// If there is a type set, create the include and exclude arrays from it
 		if (isset($type)) {
 			$elements = explode('&&', $type);
-			foreach($elements as $v) {
+			foreach ($elements as $v) {
 				if (substr($v, 0, 1) == '!') {
 					$exclude[] = substr($v, 1);
 				} else {
@@ -1701,7 +1701,7 @@ class AttributesController extends AppController {
 		}
 
 		// check each attribute
-		foreach($this->Event->data['Attribute'] as $k => $attribute) {
+		foreach ($this->Event->data['Attribute'] as $k => $attribute) {
 			$contained = false;
 			// If the include list is empty, then the first check should always set contained to true (basically we chose type = all - exclusions, or simply all)
 			if (empty($include)) {
@@ -1754,7 +1754,7 @@ class AttributesController extends AppController {
 			throw new UnauthorizedException('This authentication key is not authorized to be used for exports. Contact your administrator.');
 		}
 		$this->Attribute->id = $id;
-		if(!$this->Attribute->exists()) {
+		if (!$this->Attribute->exists()) {
 			throw new NotFoundException('Invalid attribute or no authorisation to view it.');
 		}
 		$this->Attribute->read(null, $id);

--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -1591,7 +1591,7 @@ class AttributesController extends AppController {
 									'conditions' => array('LOWER(name) LIKE' => '%' . strtolower($v) . '%'),
 							));
 							foreach ($found_orgs as $o) $subcondition['OR'][] = array('Event.orgc_id' => $o['Org']['id']);
-						} else if ($parameters[$k] === 'eventid'){
+						} else if ($parameters[$k] === 'eventid') {
 							if (!empty($v)) $subcondition['OR'][] = array('Attribute.event_id' => $v);
 						} else {
 							if (!empty($v)) $subcondition['OR'][] = array('Attribute.' . $parameters[$k] . ' LIKE' => '%'.$v.'%');

--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -211,7 +211,7 @@ class AttributesController extends AppController {
 						if ($this->response->type() === 'application/json') $this->render('/Attributes/json/view');
 						else $this->render('view');
 						return false;
-					} elseif ($this->request->is('ajax')) {
+					} else if ($this->request->is('ajax')) {
 						$this->autoRender = false;
 						return new CakeResponse(array('body'=> json_encode(array('saved' => true, 'success' => 'Attribute added.')),'status'=>200));
 					} else {
@@ -227,7 +227,7 @@ class AttributesController extends AppController {
 							$message .= '[' . $k . ']: ' . $v[0] . PHP_EOL;
 						}
 						throw new NotFoundException('Could not save the attribute. ' . $message);
-					}  elseif ($this->request->is('ajax')) {
+					}  else if ($this->request->is('ajax')) {
 						$this->autoRender = false;
 						return new CakeResponse(array('body'=> json_encode(array('saved' => false, 'errors' => $this->Attribute->validationErrors)),'status'=>200));
 					} else {
@@ -296,7 +296,7 @@ class AttributesController extends AppController {
 			$filename = $attribute['value'];
 			$fileExt = pathinfo($filename, PATHINFO_EXTENSION);
 			$filename = substr($filename, 0, strlen($filename) - strlen($fileExt) - 1);
-		} elseif ('malware-sample' == $attribute['type']) {
+		} else if ('malware-sample' == $attribute['type']) {
 			$filenameHash = explode('|', $attribute['value']);
 			$filename = substr($filenameHash[0], strrpos($filenameHash[0], '\\'));
 			$fileExt = "zip";
@@ -1519,7 +1519,7 @@ class AttributesController extends AppController {
 		if ($this->request->is('post')) {
 			if ($this->response->type() === 'application/json') {
 				$data = $this->request->input('json_decode', true);
-			} elseif ($this->response->type() === 'application/xml' && !empty($this->request->data)) {
+			} else if ($this->response->type() === 'application/xml' && !empty($this->request->data)) {
 				$data = $this->request->data;
 			} else {
 				throw new BadRequestException('Either specify the search terms in the url, or POST a json array / xml (with the root element being "request" and specify the correct accept and content type headers.');
@@ -1657,7 +1657,7 @@ class AttributesController extends AppController {
 		if ($this->request->is('post')) {
 			if ($this->response->type() === 'application/json') {
 				$data = $this->request->input('json_decode', true);
-			} elseif ($this->response->type() === 'application/xml' && !empty($this->request->data)) {
+			} else if ($this->response->type() === 'application/xml' && !empty($this->request->data)) {
 				$data = $this->request->data;
 			} else {
 				throw new BadRequestException('Either specify the search terms in the url, or POST a json array / xml (with the root element being "request" and specify the correct accept and content type headers.');
@@ -2127,7 +2127,7 @@ class AttributesController extends AppController {
 		$error = false;
 		if ($this->response->type() === 'application/json') {
 			$data = $this->request->input('json_decode', true);
-		} elseif ($this->response->type() === 'application/xml') {
+		} else if ($this->response->type() === 'application/xml') {
 			$data = $this->request->data;
 		} else {
 			throw new BadRequestException('This action is for the API only. Please refer to the automation page for information on how to use it.');

--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -263,7 +263,7 @@ class AttributesController extends AppController {
 		$this->set('sharingGroups', $sgs);
 
 		$distributionLevels = $this->Attribute->distributionLevels;
-		if (empty($sgs)) unset ($distributionLevels[4]);
+		if (empty($sgs)) unset($distributionLevels[4]);
 		$this->set('distributionLevels', $distributionLevels);
 
 		$this->set('attrDescriptions', $this->Attribute->fieldDescriptions);
@@ -750,7 +750,7 @@ class AttributesController extends AppController {
 		$this->set('sharingGroups', $sgs);
 
 		$distributionLevels = $this->Attribute->distributionLevels;
-		if (empty($sgs)) unset ($distributionLevels[4]);
+		if (empty($sgs)) unset($distributionLevels[4]);
 		$this->set('distributionLevels', $distributionLevels);
 
 		$this->set('attrDescriptions', $this->Attribute->fieldDescriptions);

--- a/app/Controller/Component/Auth/ApacheAuthenticate.php
+++ b/app/Controller/Component/Auth/ApacheAuthenticate.php
@@ -80,7 +80,7 @@ class ApacheAuthenticate extends BaseAuthenticate {
         $userModel = ClassRegistry::init($this->settings['userModel']);
         $org_id = Configure::read('ApacheSecureAuth.ldapDefaultOrg');
         // If not in config, take default org
-        if(!isset($org_id)) {
+        if (!isset($org_id)) {
             $firstOrg = $userModel->Organisation->find(
                     'first', array(
                         'conditions' => array(

--- a/app/Controller/Component/IOCImportComponent.php
+++ b/app/Controller/Component/IOCImportComponent.php
@@ -166,7 +166,7 @@ class IOCImportComponent extends Component {
 		$attributes = null;
 		if (isset($tree['branches'][0]['leaves'])) $attributes = $tree['branches'][0]['leaves'];
 		if (isset($tree['leaves'])) $attributes = $tree['leaves'];
-		unset ($tree['branches'], $tree['leaves'], $tree['type']);
+		unset($tree['branches'], $tree['leaves'], $tree['type']);
 		// set the basic info the event in case we want to populate the uuid, info and date fields
 		$event = $tree;
 		// attach the attributes to the event
@@ -410,7 +410,7 @@ class IOCImportComponent extends Component {
 		foreach ($branch['branches'] as $key => $value) {
 			$r = $this->__resolveBranch($value, $branch['uuid'], $branch['type'], $branch['leaves']);
 			if ($r === 'getFromTemp') {
-				unset ($branch['branches'][$key]);
+				unset($branch['branches'][$key]);
 				foreach ($this->tempLeaves as $tempLeaf) {
 					$branch['leaves'][] = $tempLeaf;
 				}
@@ -427,7 +427,7 @@ class IOCImportComponent extends Component {
 		// First, let's see if we can get rid of some of the indicators in here
 		foreach ($branch['leaves'] as $key => $value) {
 			if ($this->__checkOmit($value)) {
-				unset ($branch['leaves'][$key]);
+				unset($branch['leaves'][$key]);
 			}
 		}
 		// try to reverse AND-OR
@@ -477,7 +477,7 @@ class IOCImportComponent extends Component {
 		if (count($branch['leaves']) != 0 && count($branch['branches']) == 0 && $branch['type'] === 'AND') {
 			$branch['leaves'] = array($this->__resolveAndBranch($branch['leaves'], $uuid));
 			if ($branch['leaves'][0] == null) {
-				unset ($branch['leaves']);
+				unset($branch['leaves']);
 			} else {
 				$this->saved_uuids[] = $branch['uuid'];
 			}

--- a/app/Controller/EventBlacklistsController.php
+++ b/app/Controller/EventBlacklistsController.php
@@ -6,7 +6,7 @@ class EventBlacklistsController extends AppController {
 
 	public function beforeFilter() {
 		parent::beforeFilter();
-		if(!$this->_isSiteAdmin()) $this->redirect('/');
+		if (!$this->_isSiteAdmin()) $this->redirect('/');
 		if (!Configure::read('MISP.enableEventBlacklisting')) {
 			$this->Session->setFlash(__('Event Blacklisting is not currently enabled on this instance.'));
 			$this->redirect('/');

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -646,7 +646,7 @@ class EventsController extends AppController {
 		}
 		$rules = array('published', 'eventid', 'tag', 'date', 'eventinfo', 'threatlevel', 'distribution', 'analysis', 'attribute');
 		if ($this->_isSiteAdmin()) $rules[] = 'email';
-		if (Configure::read('MISP.showorg')){
+		if (Configure::read('MISP.showorg')) {
 			$orgs = $this->Event->find('list', array(
 					'recursive' => -1,
 					'fields' => array('Orgc.name'),
@@ -848,13 +848,13 @@ class EventsController extends AppController {
 		if (!$this->_isRest()) $this->__viewUI($event, $continue, $fromEvent);
 	}
 
-	private function __startPivoting($id, $info, $date){
+	private function __startPivoting($id, $info, $date) {
 		$this->Session->write('pivot_thread', null);
 		$initial_pivot = array('id' => $id, 'info' => $info, 'date' => $date, 'depth' => 0, 'height' => 0, 'children' => array(), 'deletable' => true);
 		$this->Session->write('pivot_thread', $initial_pivot);
 	}
 
-	private function __continuePivoting($id, $info, $date, $fromEvent){
+	private function __continuePivoting($id, $info, $date, $fromEvent) {
 		$pivot = $this->Session->read('pivot_thread');
 		$newPivot = array('id' => $id, 'info' => $info, 'date' => $date, 'depth' => null, 'children' => array(), 'deletable' => true);
 		if (!$this->__checkForPivot($pivot, $id)) {

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -542,7 +542,7 @@ class EventsController extends AppController {
 			$events = $this->Event->find('all', $rules);
 			foreach ($events as $k => &$event) {
 				foreach ($event['EventTag'] as $k2 => &$et) {
-					if (empty($et['Tag'])) unset ($events[$k]['EventTag'][$k2]);
+					if (empty($et['Tag'])) unset($events[$k]['EventTag'][$k2]);
 				}
 				$event['EventTag'] = array_values($event['EventTag']);
 			}
@@ -927,7 +927,7 @@ class EventsController extends AppController {
 	private function __doRemove(&$pivot, $id) {
 		foreach ($pivot['children'] as $k => $v) {
 			if ($v['id'] == $id) {
-				unset ($pivot['children'][$k]);
+				unset($pivot['children'][$k]);
 				return $pivot;
 			} else {
 				$pivot['children'][$k] = $this->__doRemove($pivot['children'][$k], $id);
@@ -1057,7 +1057,7 @@ class EventsController extends AppController {
 		// tooltip for distribution
 		$this->set('distributionDescriptions', $this->Event->distributionDescriptions);
 		$distributionLevels = $this->Event->distributionLevels;
-		if (empty($sgs)) unset ($distributionLevels[4]);
+		if (empty($sgs)) unset($distributionLevels[4]);
 		$this->set('distributionLevels', $distributionLevels);
 
 		// combobox for risks
@@ -1234,7 +1234,7 @@ class EventsController extends AppController {
 		$this->set('sharingGroups', $sgs);
 
 		$distributionLevels = $this->Event->distributionLevels;
-		if (empty($sgs)) unset ($distributionLevels[4]);
+		if (empty($sgs)) unset($distributionLevels[4]);
 		$this->set('distributionLevels', $distributionLevels);
 
 		// combobox for types
@@ -1961,7 +1961,7 @@ class EventsController extends AppController {
 			if (isset($dataArray['response'][0])) {
 				foreach ($dataArray['response'] as $k => &$temp) {
 					$dataArray['Event'][] = $temp['Event'];
-					unset ($dataArray['response'][$k]);
+					unset($dataArray['response'][$k]);
 				}
 			}
 		}
@@ -2716,7 +2716,7 @@ class EventsController extends AppController {
 			// remove all duplicates
 			foreach ($resultArray as $k => $v) {
 				for ($i = 0; $i < $k; $i++) {
-					if (isset($resultArray[$i]) && $v == $resultArray[$i]) unset ($resultArray[$k]);
+					if (isset($resultArray[$i]) && $v == $resultArray[$i]) unset($resultArray[$k]);
 				}
 			}
 			foreach ($resultArray as &$result) {
@@ -3133,7 +3133,7 @@ class EventsController extends AppController {
 		if (isset($data['files'])) {
 			foreach ($data['files'] as $k => $file) {
 				if (!isset($file['filename']) || !isset($file['data'])) {
-					unset ($data['files'][$k]);
+					unset($data['files'][$k]);
 				} else {
 					$data['files'][$k]['md5'] = md5(base64_decode($file['data']));
 				}

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -825,7 +825,7 @@ class EventsController extends AppController {
 		}
 
 		$this->Event->id = $id;
-		if(!$this->Event->exists()) {
+		if (!$this->Event->exists()) {
 			throw new NotFoundException(__('Invalid event.'));
 		}
 
@@ -870,7 +870,7 @@ class EventsController extends AppController {
 			$pivot['children'][] = $newPivot;
 			return $pivot;
 		}
-		foreach($pivot['children'] as $k => $v) {
+		foreach ($pivot['children'] as $k => $v) {
 			$pivot['children'][$k] = $this->__insertPivot($v, $oldId, $newPivot, $depth);
 		}
 		return $pivot;
@@ -960,7 +960,7 @@ class EventsController extends AppController {
 			if ($this->_isRest()) {
 
 				// rearrange the response if the event came from an export
-				if(isset($this->request->data['response'])) $this->request->data = $this->request->data['response'];
+				if (isset($this->request->data['response'])) $this->request->data = $this->request->data['response'];
 
 				// Distribution, reporter for the events pushed will be the owner of the authentication key
 				$this->request->data['Event']['user_id'] = $this->Auth->user('id');
@@ -1025,7 +1025,7 @@ class EventsController extends AppController {
 						}
 					} else {
 						if ($this->_isRest()) { // TODO return error if REST
-							if(is_numeric($add)) {
+							if (is_numeric($add)) {
 								$this->response->header('Location', Configure::read('MISP.baseurl') . '/events/' . $add);
 								$this->response->send();
 								throw new NotFoundException('Event already exists, if you would like to edit it, use the url in the location header.');
@@ -1217,7 +1217,7 @@ class EventsController extends AppController {
 				$this->Session->setFlash(__('The event could not be saved. Please, try again.'));
 			}
 		} else {
-			if(!$this->userRole['perm_modify']) $this->redirect(array('controller' => 'events', 'action' => 'index', 'admin' => false));
+			if (!$this->userRole['perm_modify']) $this->redirect(array('controller' => 'events', 'action' => 'index', 'admin' => false));
 			$this->request->data = $this->Event->read(null, $id);
 		}
 
@@ -1549,11 +1549,11 @@ class EventsController extends AppController {
 		$periods = array("second", "minute", "hour", "day", "week", "month", "year");
 		$lengths = array("60","60","24","7","4.35","12");
 		$difference = $now - $then;
-		for($j = 0; $difference >= $lengths[$j] && $j < count($lengths)-1; $j++) {
+		for ($j = 0; $difference >= $lengths[$j] && $j < count($lengths)-1; $j++) {
 			$difference /= $lengths[$j];
 		}
 		$difference = round($difference);
-		if($difference != 1) {
+		if ($difference != 1) {
 			$periods[$j].= "s";
 		}
 		return $difference . " " . $periods[$j] . " ago";
@@ -1803,7 +1803,7 @@ class EventsController extends AppController {
 				foreach ($attributes as $attribute) {
 					$line = $attribute['Attribute']['uuid'] . ',' . $attribute['Attribute']['event_id'] . ',' . $attribute['Attribute']['category'] . ',' . $attribute['Attribute']['type'] . ',' . $attribute['Attribute']['value'] . ',' . $attribute['Attribute']['comment'] . ',' . intval($attribute['Attribute']['to_ids']) . ',' . $attribute['Attribute']['timestamp'];
 					if ($includeContext) {
-						foreach($this->Event->csv_event_context_fields_to_fetch as $header => $field) {
+						foreach ($this->Event->csv_event_context_fields_to_fetch as $header => $field) {
 							if ($field['object']) $line .= ',' . $attribute['Event'][$field['object']][$field['var']];
 							else $line .= ',' . $attribute['Event'][$field['var']];
 						}
@@ -2270,7 +2270,7 @@ class EventsController extends AppController {
 					} else {
 						$elements = explode('&&', ${$parameters[$k]});
 					}
-					foreach($elements as $v) {
+					foreach ($elements as $v) {
 						if ($v == '') continue;
 						if (substr($v, 0, 1) == '!') {
 							// check for an IPv4 address and subnet in CIDR notation (e.g. 127.0.0.1/8)
@@ -2621,7 +2621,7 @@ class EventsController extends AppController {
 			}
 		}
 		$this->Event->EventTag->Tag->id = $tag_id;
-		if(!$this->Event->EventTag->Tag->exists()) {
+		if (!$this->Event->EventTag->Tag->exists()) {
 			return new CakeResponse(array('body'=> json_encode(array('saved' => false, 'errors' => 'Invalid Tag.')), 'status'=>200));
 		}
 		$found = $this->Event->EventTag->find('first', array(
@@ -2960,7 +2960,7 @@ class EventsController extends AppController {
 					}
 					$sa['event_id'] = $event['Event']['id'];
 					if ($sa['old_id'] != 0) {
-						foreach($event['Attribute'] as $attribute) {
+						foreach ($event['Attribute'] as $attribute) {
 							if ($sa['uuid'] == $attribute['uuid']) {
 								$sa['old_id'] = $attribute['id'];
 							}
@@ -3146,7 +3146,7 @@ class EventsController extends AppController {
 		if (isset($event_id)) $data['event_id'] = $event_id;
 		if (isset($data['event_id'])) {
 			$this->Event->id = $data['event_id'];
-			if(!$this->Event->exists()) throw new NotFoundException('Event not found');
+			if (!$this->Event->exists()) throw new NotFoundException('Event not found');
 		}
 
 		// check if the user has permission to create attributes for an event, if the event ID has been passed
@@ -3356,7 +3356,7 @@ class EventsController extends AppController {
 				}
 				$l1 = $this->__graphJsonContainsLink($current_event_id, $current_attribute_id, $json);
 				if ($l1 === false) $json['links'][] = array('source' => $current_event_id, 'target' => $current_attribute_id);
-				foreach($event[0]['RelatedAttribute'][$att['id']] as $relation) {
+				foreach ($event[0]['RelatedAttribute'][$att['id']] as $relation) {
 					$found = $this->__graphJsonContains('event', $relation, $json);
 					if ($found !== false) {
 						$l3 = $this->__graphJsonContainsLink($found, $current_attribute_id, $json);

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -558,15 +558,15 @@ class EventsController extends AppController {
 	      if (Configure::read('SMIME.enabled') && !$this->Event->User->getCertificate($this->Auth->user('id'))) {
 	        // No GPG and No SMIME
 	        $this->Session->setFlash(__('No x509 certificate or GPG key set in your profile. To receive emails, submit your public certificate or GPG key in your profile.'));
-	      } elseif (!Configure::read('SMIME.enabled')) {
+	      } else if (!Configure::read('SMIME.enabled')) {
 	        $this->Session->setFlash(__('No GPG key set in your profile. To receive emails, submit your public key in your profile.'));
 	      }
-	    } elseif ($this->Auth->user('autoalert') && !$this->Event->User->getPGP($this->Auth->user('id')) && Configure::read('GnuPG.bodyonlyencrypted')) {
+	    } else if ($this->Auth->user('autoalert') && !$this->Event->User->getPGP($this->Auth->user('id')) && Configure::read('GnuPG.bodyonlyencrypted')) {
 	      // No GPG & autoalert
 	      if ($this->Auth->user('autoalert') && Configure::read('SMIME.enabled') && !$this->Event->User->getCertificate($this->Auth->user('id'))) {
 	        // No GPG and No SMIME & autoalert
 	        $this->Session->setFlash(__('No x509 certificate or GPG key set in your profile. To receive attributes in emails, submit your public certificate or GPG key in your profile.'));
-	      } elseif (!Configure::read('SMIME.enabled')) {
+	      } else if (!Configure::read('SMIME.enabled')) {
 	        $this->Session->setFlash(__('No GPG key set in your profile. To receive attributes in emails, submit your public key in your profile.'));
 	      }
 	    }
@@ -1394,7 +1394,7 @@ class EventsController extends AppController {
 					$resultString = (count($result) > 0) ? implode(', ', $result) . ' and ' . $lastResult : $lastResult;
 					$this->Session->setFlash(__(sprintf('Not published given no connection to %s but email sent to all participants.', $resultString), true));
 				}
-			} elseif (!is_bool($emailResult)) {
+			} else if (!is_bool($emailResult)) {
 				// Performs all the actions required to publish an event
 				$result = $this->Event->publishRouter($id, null, $this->Auth->user());
 				if (!is_array($result)) {
@@ -2232,7 +2232,7 @@ class EventsController extends AppController {
 		if ($this->request->is('post')) {
 			if ($this->response->type() === 'application/json') {
 				$data = $this->request->input('json_decode', true);
-			} elseif ($this->response->type() === 'application/xml') {
+			} else if ($this->response->type() === 'application/xml') {
 				$data = $this->request->data;
 			} else {
 				throw new BadRequestException('Either specify the search terms in the url, or POST a json array / xml (with the root element being "request" and specify the correct headers based on content type.');
@@ -2288,7 +2288,7 @@ class EventsController extends AppController {
 									foreach ($found_orgs as $o) {
 										$subcondition['AND'][] = array('Event.orgc_id !=' => $o['Org']['id']);
 									}
-								} elseif ($parameters[$k] === 'eventid') {
+								} else if ($parameters[$k] === 'eventid') {
 									$subcondition['AND'][] = array('Attribute.event_id !=' => substr($v, 1));
 								} else {
 									$subcondition['AND'][] = array('Attribute.' . $parameters[$k] . ' NOT LIKE' => '%'.substr($v, 1).'%');
@@ -2310,7 +2310,7 @@ class EventsController extends AppController {
 									foreach ($found_orgs as $o) {
 										$subcondition['OR'][] = array('Event.orgc_id' => $o['Org']['id']);
 									}
-								} elseif ($parameters[$k] === 'eventid') {
+								} else if ($parameters[$k] === 'eventid') {
 									$subcondition['OR'][] = array('Attribute.event_id' => $v);
 								} else {
 									if (!empty($v)) $subcondition['OR'][] = array('Attribute.' . $parameters[$k] . ' LIKE' => '%'.$v.'%');
@@ -3112,7 +3112,7 @@ class EventsController extends AppController {
 		if (!$this->request->is('post')) throw new MethodNotAllowedException('Please POST the samples as described on the automation page.');
 		if ($this->response->type() === 'application/json') {
 			$data = $this->request->input('json_decode', true);
-		} elseif ($this->response->type() === 'application/xml') {
+		} else if ($this->response->type() === 'application/xml') {
 			$data = $this->request->data;
 		} else {
 			throw new BadRequestException('Please POST the samples as described on the automation page.');

--- a/app/Controller/FeedsController.php
+++ b/app/Controller/FeedsController.php
@@ -57,7 +57,7 @@ class FeedsController extends AppController {
 			$this->loadModel('Event');
 			$sgs = $this->Event->SharingGroup->fetchAllAuthorised($this->Auth->user(), 'name',  1);
 			$distributionLevels = $this->Event->distributionLevels;
-			if (empty($sgs)) unset ($distributionLevels[4]);
+			if (empty($sgs)) unset($distributionLevels[4]);
 			$this->set('distributionLevels', $distributionLevels);
 			$this->set('sharingGroups', $sgs);
 			$tags = $this->Event->EventTag->Tag->find('list', array('fields' => array('Tag.name'), 'order' => array('lower(Tag.name) asc')));
@@ -89,7 +89,7 @@ class FeedsController extends AppController {
 			$this->loadModel('Event');
 			$sgs = $this->Event->SharingGroup->fetchAllAuthorised($this->Auth->user(), 'name',  1);
 			$distributionLevels = $this->Event->distributionLevels;
-			if (empty($sgs)) unset ($distributionLevels[4]);
+			if (empty($sgs)) unset($distributionLevels[4]);
 			$this->set('distributionLevels', $distributionLevels);
 			$this->set('sharingGroups', $sgs);
 			$tags = $this->Event->EventTag->Tag->find('list', array('fields' => array('Tag.name'), 'order' => array('lower(Tag.name) asc')));

--- a/app/Controller/JobsController.php
+++ b/app/Controller/JobsController.php
@@ -28,7 +28,7 @@ class JobsController extends AppController {
 		$queues = array('email', 'default', 'cache');
 		if ($queue && in_array($queue, $queues)) $this->paginate['conditions'] = array('Job.worker' => $queue);
 		$jobs = $this->paginate();
-		foreach($jobs as &$job) {
+		foreach ($jobs as &$job) {
 			if ($job['Job']['process_id']) {
 				$job['Job']['status'] = $this->__jobStatusConverter(CakeResque::getJobStatus($job['Job']['process_id']));
 			} else {

--- a/app/Controller/LogsController.php
+++ b/app/Controller/LogsController.php
@@ -39,7 +39,7 @@ class LogsController extends AppController {
  * @return void
  */
 	public function admin_index() {
-		if(!$this->userRole['perm_audit']) $this->redirect(array('controller' => 'events', 'action' => 'index', 'admin' => false));
+		if (!$this->userRole['perm_audit']) $this->redirect(array('controller' => 'events', 'action' => 'index', 'admin' => false));
 		$this->set('isSearch', 0);
 		$this->recursive = 0;
 		$validFilters = $this->Log->logMeta;
@@ -131,7 +131,7 @@ class LogsController extends AppController {
 	public $helpers = array('Js' => array('Jquery'), 'Highlight');
 
 	public function admin_search($new = false) {
-		if(!$this->userRole['perm_audit']) $this->redirect(array('controller' => 'events', 'action' => 'index', 'admin' => false));
+		if (!$this->userRole['perm_audit']) $this->redirect(array('controller' => 'events', 'action' => 'index', 'admin' => false));
 		$orgRestriction = null;
 		if ($this->_isSiteAdmin()) {
 			$orgRestriction = false;

--- a/app/Controller/OrgBlacklistsController.php
+++ b/app/Controller/OrgBlacklistsController.php
@@ -6,7 +6,7 @@ class OrgBlacklistsController extends AppController {
 
 	public function beforeFilter() {
 		parent::beforeFilter();
-		if(!$this->_isSiteAdmin()) $this->redirect('/');
+		if (!$this->_isSiteAdmin()) $this->redirect('/');
 		if (!Configure::read('MISP.enableOrgBlacklisting')) {
 			$this->Session->setFlash(__('Organisation Blacklisting is not currently enabled on this instance.'));
 			$this->redirect('/');

--- a/app/Controller/OrganisationsController.php
+++ b/app/Controller/OrganisationsController.php
@@ -6,7 +6,7 @@ class OrganisationsController extends AppController {
 
 	public function beforeFilter() {
 		parent::beforeFilter();
-		if(!empty($this->request->params['admin']) && !$this->_isSiteAdmin()) $this->redirect('/');
+		if (!empty($this->request->params['admin']) && !$this->_isSiteAdmin()) $this->redirect('/');
 	}
 
 	public $paginate = array(
@@ -63,7 +63,7 @@ class OrganisationsController extends AppController {
 	}
 
 	public function admin_add() {
-		if($this->request->is('post')) {
+		if ($this->request->is('post')) {
 			$this->Organisation->create();
 			$this->request->data['Organisation']['created_by'] = $this->Auth->user('id');
 			if ($this->Organisation->save($this->request->data)) {

--- a/app/Controller/RegexpController.php
+++ b/app/Controller/RegexpController.php
@@ -30,7 +30,7 @@ class RegexpController extends AppController {
 	public function admin_add() {
 		$this->loadModel('Attribute');
 		$types = array_keys($this->Attribute->typeDefinitions);
-		if(!$this->userRole['perm_regexp_access']) $this->redirect(array('controller' => 'regexp', 'action' => 'index', 'admin' => false));
+		if (!$this->userRole['perm_regexp_access']) $this->redirect(array('controller' => 'regexp', 'action' => 'index', 'admin' => false));
 		if ($this->request->is('post')) {
 			if ($this->request->data['Regexp']['all'] == 1) {
 				$this->Regexp->create();
@@ -69,7 +69,7 @@ class RegexpController extends AppController {
  * @return void
  */
 	public function admin_index() {
-		if(!$this->userRole['perm_regexp_access']) $this->redirect(array('controller' => 'regexp', 'action' => 'index', 'admin' => false));
+		if (!$this->userRole['perm_regexp_access']) $this->redirect(array('controller' => 'regexp', 'action' => 'index', 'admin' => false));
 		$this->AdminCrud->adminIndex();
 	}
 
@@ -176,7 +176,7 @@ class RegexpController extends AppController {
  * @throws NotFoundException
  */
 	public function admin_delete($id = null) {
-		if(!$this->userRole['perm_regexp_access']) $this->redirect(array('controller' => 'regexp', 'action' => 'index', 'admin' => false));
+		if (!$this->userRole['perm_regexp_access']) $this->redirect(array('controller' => 'regexp', 'action' => 'index', 'admin' => false));
 		$this->AdminCrud->adminDelete($id);
 	}
 
@@ -194,7 +194,7 @@ class RegexpController extends AppController {
  *
  */
 	public function admin_clean() {
-		if(!$this->_isSiteAdmin() || !$this->request->is('post')) throw new MethodNotAllowedException('This action is only accessible via a POST request.');
+		if (!$this->_isSiteAdmin() || !$this->request->is('post')) throw new MethodNotAllowedException('This action is only accessible via a POST request.');
 		$allRegexp = $this->Regexp->find('all');
 		$deletable = array();
 		$modifications = 0;
@@ -226,7 +226,7 @@ class RegexpController extends AppController {
 		if (!$this->_isSiteAdmin() || !$this->request->is('post')) throw new MethodNotAllowedException();
 		$entries = $this->Regexp->find('all', array());
 		$changes = 0;
-		foreach($entries as $entry) {
+		foreach ($entries as $entry) {
 			$length = strlen($entry['Regexp']['regexp']);
 			$this->Regexp->sanitizeModifiers($entry['Regexp']['regexp']);
 			if (strlen($entry['Regexp']['regexp']) < $length) {

--- a/app/Controller/RegexpController.php
+++ b/app/Controller/RegexpController.php
@@ -93,7 +93,7 @@ class RegexpController extends AppController {
 			throw new NotFoundException('Invalid Regexp');
 		}
 		if ($this->request->is('post') || $this->request->is('put')) {
-			unset ($this->request->data['Regexp']['id']);
+			unset($this->request->data['Regexp']['id']);
 			// If 'all' is set, it overrides all other type settings. Create an attribute with the "all" setting and save it. Also, delete the original(s)
 			if ($this->request->data['Regexp']['all'] == 1) {
 				$this->Regexp->create();

--- a/app/Controller/RolesController.php
+++ b/app/Controller/RolesController.php
@@ -54,7 +54,7 @@ class RolesController extends AppController {
  * @return void
  */
 	public function admin_add() {
-		if(!$this->_isSiteAdmin()) $this->redirect(array('controller' => 'roles', 'action' => 'index', 'admin' => false));
+		if (!$this->_isSiteAdmin()) $this->redirect(array('controller' => 'roles', 'action' => 'index', 'admin' => false));
 		if ($this->request->is('post')) {
 			$this->Role->create();
 			if ($this->Role->save($this->request->data)) {
@@ -78,7 +78,7 @@ class RolesController extends AppController {
  * @return void
  */
 	public function admin_index() {
-		if(!$this->_isSiteAdmin()) $this->redirect(array('controller' => 'roles', 'action' => 'index', 'admin' => false));
+		if (!$this->_isSiteAdmin()) $this->redirect(array('controller' => 'roles', 'action' => 'index', 'admin' => false));
 		$this->AdminCrud->adminIndex();
 		$this->set('permFlags', $this->Role->permFlags);
 		$this->set('options', $this->options);
@@ -92,7 +92,7 @@ class RolesController extends AppController {
  * @throws NotFoundException
  */
 	public function admin_edit($id = null) {
-		if(!$this->_isSiteAdmin()) $this->redirect(array('controller' => 'roles', 'action' => 'index', 'admin' => false));
+		if (!$this->_isSiteAdmin()) $this->redirect(array('controller' => 'roles', 'action' => 'index', 'admin' => false));
 		$this->AdminCrud->adminEdit($id);
 		$passAlong = $this->Role->read(null, $id);
 		$this->set('options', $this->options);

--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -82,7 +82,7 @@ class ServersController extends AppController {
 		$server = $this->Server->find('first', array('conditions' => array('Server.id' => $id), 'recursive' => -1, 'fields' => array('Server.id', 'Server.url', 'Server.name')));
 		if (empty($server)) throw new NotFoundException('Invalid server ID.');
 		$validFilters = $this->Server->validEventIndexFilters;
-		foreach($validFilters as $k => $filter) {
+		foreach ($validFilters as $k => $filter) {
 			if (isset($this->passedArgs[$filter])) {
 				$passedArgs[$filter] = $this->passedArgs[$filter];
 				if ($k != 0) $urlparams .= '/';

--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -1020,7 +1020,7 @@ class ServersController extends AppController {
 							if ($version[$k] > $local_version[$v]) {
 								$mismatch = $v;
 								$newer = 'remote';
-							} elseif ($version[$k] < $local_version[$v]) {
+							} else if ($version[$k] < $local_version[$v]) {
 								$mismatch = $v;
 								$newer = 'local';
 							}

--- a/app/Controller/ShadowAttributesController.php
+++ b/app/Controller/ShadowAttributesController.php
@@ -191,7 +191,7 @@ class ShadowAttributesController extends AppController {
 		}
 		$response = $this->__accept($id);
 		if ($this->_isRest()) {
-			if(isset($response['success'])) {
+			if (isset($response['success'])) {
 				$this->set('name', $response['success']);
 				$this->set('message', $response['success']);
 				$this->set('url', '/shadow_attributes/accept/' . $id);
@@ -417,7 +417,7 @@ class ShadowAttributesController extends AppController {
 					if ($this->request->is('ajax')) {
 						$this->autoRender = false;
 						return new CakeResponse(array('body'=> json_encode(array('saved' => true, 'success' => 'Proposal added' . $emailResult)),'status'=>200));
-					} else if($this->_isRest()) {
+					} else if ($this->_isRest()) {
 						$sa = $this->ShadowAttribute->find(
 							'first',
 							array(
@@ -436,7 +436,7 @@ class ShadowAttributesController extends AppController {
 					if ($this->request->is('ajax')) {
 						$this->autoRender = false;
 						return new CakeResponse(array('body'=> json_encode(array('saved' => false, 'errors' => $this->ShadowAttribute->validationErrors)),'status'=>200));
-					} else if($this->_isRest()) {
+					} else if ($this->_isRest()) {
 						$message = '';
 						foreach ($this->ShadowAttribute->validationErrors as $k => $v) {
 							$message .= '[' . $k . ']: ' . $v[0] . PHP_EOL;

--- a/app/Controller/ShadowAttributesController.php
+++ b/app/Controller/ShadowAttributesController.php
@@ -206,7 +206,7 @@ class ShadowAttributesController extends AppController {
 	}
 
 	// If we accept a proposed attachment, then the attachment itself needs to be moved from files/eventId/shadow/shadowId to files/eventId/attributeId
-	private function _moveFile($shadowId, $newId, $eventId){
+	private function _moveFile($shadowId, $newId, $eventId) {
 		$pathOld = APP . "files" . DS . $eventId . DS . "shadow" . DS . $shadowId;
 		$pathNew = APP . "files" . DS . $eventId . DS . $newId;
 		if (rename($pathOld, $pathNew)) {

--- a/app/Controller/ShadowAttributesController.php
+++ b/app/Controller/ShadowAttributesController.php
@@ -488,7 +488,7 @@ class ShadowAttributesController extends AppController {
 			$filename = $shadowAttribute['value'];
 			$fileExt = pathinfo($filename, PATHINFO_EXTENSION);
 			$filename = substr($filename, 0, strlen($filename) - strlen($fileExt) - 1);
-		} elseif ('malware-sample' == $shadowAttribute['type']) {
+		} else if ('malware-sample' == $shadowAttribute['type']) {
 			$filenameHash = explode('|', $shadowAttribute['value']);
 			$filename = substr($filenameHash[0], strrpos($filenameHash[0], '\\'));
 			$fileExt = "zip";

--- a/app/Controller/SharingGroupsController.php
+++ b/app/Controller/SharingGroupsController.php
@@ -6,7 +6,7 @@ class SharingGroupsController extends AppController {
 
 	public function beforeFilter() {
 		parent::beforeFilter();
-		if(!empty($this->request->params['admin']) && !$this->_isSiteAdmin()) $this->redirect('/');
+		if (!empty($this->request->params['admin']) && !$this->_isSiteAdmin()) $this->redirect('/');
 		$sgs = $this->SharingGroup->fetchAllAuthorised($this->Auth->user());
 		$this->paginate = Set::merge($this->paginate,array('conditions' => array('SharingGroup.id' => $sgs)));
 	}
@@ -36,7 +36,7 @@ class SharingGroupsController extends AppController {
 
 	public function add() {
 		if (!$this->userRole['perm_sharing_group']) throw new MethodNotAllowedException('You don\'t have the required privileges to do that.');
-		if($this->request->is('post')) {
+		if ($this->request->is('post')) {
 			$json = json_decode($this->request->data['SharingGroup']['json'], true);
 			$this->SharingGroup->create();
 			$sg = $json['sharingGroup'];
@@ -111,7 +111,7 @@ class SharingGroupsController extends AppController {
 					),
 			),
 		));
-		if($this->request->is('post')) {
+		if ($this->request->is('post')) {
 			$json = json_decode($this->request->data['SharingGroup']['json'], true);
 			$sg = $json['sharingGroup'];
 			$sg['id'] = $id;

--- a/app/Controller/TemplatesController.php
+++ b/app/Controller/TemplatesController.php
@@ -69,11 +69,11 @@ class TemplatesController extends AppController {
 					'conditions' => array('id' => $tagArray)
 				));
 
-				foreach($oldTags as $k => $oT) {
+				foreach ($oldTags as $k => $oT) {
 					if (!in_array($oT['Tag'], $newTags)) $this->TemplateTag->delete($oT['TemplateTag']['id']);
 				}
 
-				foreach($newTags as $k => $nT) {
+				foreach ($newTags as $k => $nT) {
 					if (!in_array($nT['Tag'], $oldTags)) {
 						$this->TemplateTag->create();
 						$this->TemplateTag->save(array('TemplateTag' => array('template_id' => $id, 'tag_id' => $nT['Tag']['id'])));
@@ -124,7 +124,7 @@ class TemplatesController extends AppController {
 		));
 		if (empty($template)) throw new NotFoundException('No template with the provided ID exists, or you are not authorised to see it.');
 		$tagArray = array();
-		foreach($template['TemplateTag'] as $tt) {
+		foreach ($template['TemplateTag'] as $tt) {
 			$tagArray[] = $tt;
 		}
 		$this->set('id', $id);
@@ -173,7 +173,7 @@ class TemplatesController extends AppController {
 		$this->autoRender = false;
 		$this->request->onlyAllow('ajax');
 		$orderedElements = $this->request->data;
-		foreach($orderedElements as &$e) {
+		foreach ($orderedElements as &$e) {
 			$e = ltrim($e, 'id_');
 		}
 		$extractedIds = array();
@@ -334,7 +334,7 @@ class TemplatesController extends AppController {
 				$attributes = json_decode($this->request->data['Template']['attributes'], true);
 				$this->loadModel('Attribute');
 				$fails = 0;
-				foreach($attributes as $k => &$attribute) {
+				foreach ($attributes as $k => &$attribute) {
 					if (isset($attribute['data']) && preg_match('/^[a-zA-Z0-9]{12}$/', $attribute['data'])) {
 						$file = new File(APP . 'tmp/files/' . $attribute['data']);
 						$content = $file->read();

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -452,7 +452,7 @@ class UsersController extends AppController {
 			if (!array_key_exists($this->request->data['User']['role_id'], $syncRoles)) $this->request->data['User']['server_id'] = 0;
 			$fields = array();
 			foreach (array_keys($this->request->data['User']) as $field) {
-				if($field != 'password') array_push($fields, $field);
+				if ($field != 'password') array_push($fields, $field);
 			}
 			// TODO Audit, __extralog, fields get orig
 			$fieldsOldValues = array();
@@ -501,7 +501,7 @@ class UsersController extends AppController {
 				$c = 0;
 				foreach ($fields as $field) {
 					if (isset($fieldsOldValues[$c]) && $fieldsOldValues[$c] != $fieldsNewValues[$c]) {
-						if($field != 'confirm_password') {
+						if ($field != 'confirm_password') {
 							$fieldsResultStr = $fieldsResultStr . ', ' . $field . ' (' . $fieldsOldValues[$c] . ') => (' . $fieldsNewValues[$c] . ')';
 						}
 					}
@@ -610,7 +610,7 @@ class UsersController extends AppController {
 				$this->Session->delete('Message.auth');
 			}
 			// don't display "invalid user" before first login attempt
-			if($this->request->is('post')) {
+			if ($this->request->is('post')) {
 				$this->Session->setFlash(__('Invalid username or password, try again'));
 			}
 			// populate the DB with the first role (site admin) if it's empty
@@ -793,7 +793,7 @@ class UsersController extends AppController {
 		$paletteTool = new ColourPaletteTool();
 		$colours = $paletteTool->createColourPalette(count($sigTypes));
 		$typeDb = array();
-		foreach($sigTypes as $k => $type) {
+		foreach ($sigTypes as $k => $type) {
 			$typeDb[$type] = $colours[$k];
 		}
 		$this->set('typeDb', $typeDb);

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -828,11 +828,11 @@ class UsersController extends AppController {
 		$modelId = $this->Auth->user('id');
 		if ($action == 'login') {
 			$description = "User (" . $this->Auth->user('id') . "): " . $this->data['User']['email'];
-		} elseif ($action == 'logout') {
+		} else if ($action == 'logout') {
 			$description = "User (" . $this->Auth->user('id') . "): " . $this->Auth->user('email');
-		} elseif ($action == 'edit') {
+		} else if ($action == 'edit') {
 			$description = "User (" . $this->User->id . "): " . $this->data['User']['email'];
-		} elseif ($action == 'change_pw') {
+		} else if ($action == 'change_pw') {
 			$description = "User (" . $this->User->id . "): " . $this->data['User']['email'];
 			$fieldsResult = "Password changed.";
 		}
@@ -869,7 +869,7 @@ class UsersController extends AppController {
 		foreach ($array as $key => $val) {
 			if (is_array($val)) {
 				$result[$key] = arrayCopy($val);
-			} elseif (is_object($val)) {
+			} else if (is_object($val)) {
 				$result[$key] = clone $val;
 			} else {
 				$result[$key] = $val;

--- a/app/Controller/WhitelistsController.php
+++ b/app/Controller/WhitelistsController.php
@@ -31,7 +31,7 @@ class WhitelistsController extends AppController {
  * @return void
  */
 	public function admin_add() {
-		if(!$this->userRole['perm_regexp_access']) $this->redirect(array('controller' => 'regexp', 'action' => 'index', 'admin' => false));
+		if (!$this->userRole['perm_regexp_access']) $this->redirect(array('controller' => 'regexp', 'action' => 'index', 'admin' => false));
 		$this->AdminCrud->adminAdd();
 	}
 
@@ -41,7 +41,7 @@ class WhitelistsController extends AppController {
  * @return void
  */
 	public function admin_index() {
-		if(!$this->userRole['perm_regexp_access']) $this->redirect(array('controller' => 'whitelists', 'action' => 'index', 'admin' => false));
+		if (!$this->userRole['perm_regexp_access']) $this->redirect(array('controller' => 'whitelists', 'action' => 'index', 'admin' => false));
 		$this->AdminCrud->adminIndex();
 	}
 
@@ -53,7 +53,7 @@ class WhitelistsController extends AppController {
  * @throws NotFoundException
  */
 	public function admin_edit($id = null) {
-		if(!$this->userRole['perm_regexp_access']) $this->redirect(array('controller' => 'whitelists', 'action' => 'index', 'admin' => false));
+		if (!$this->userRole['perm_regexp_access']) $this->redirect(array('controller' => 'whitelists', 'action' => 'index', 'admin' => false));
 		$this->AdminCrud->adminEdit($id);
 	}
 
@@ -66,7 +66,7 @@ class WhitelistsController extends AppController {
  * @throws NotFoundException
  */
 	public function admin_delete($id = null) {
-		if(!$this->userRole['perm_regexp_access']) $this->redirect(array('controller' => 'whitelists', 'action' => 'index', 'admin' => false));
+		if (!$this->userRole['perm_regexp_access']) $this->redirect(array('controller' => 'whitelists', 'action' => 'index', 'admin' => false));
 		$this->AdminCrud->adminDelete($id);
 	}
 

--- a/app/Lib/Network/Email/SmimeTransport.php
+++ b/app/Lib/Network/Email/SmimeTransport.php
@@ -61,7 +61,7 @@ class SmimeTransport extends AbstractTransport {
 				$msg = 'Could not send email: ' . isset($error['message']) ? $error['message'] : 'unknown';
 				throw new SocketException($msg);
 			}
-		} elseif (!@mail($to, $subject, $message, $headers, $params)) {
+		} else if (!@mail($to, $subject, $message, $headers, $params)) {
 			$error = error_get_last();
 			$msg = 'Could not send email: ' . isset($error['message']) ? $error['message'] : 'unknown';
 			//@codingStandardsIgnoreEnd

--- a/app/Lib/Tools/FinancialTool.php
+++ b/app/Lib/Tools/FinancialTool.php
@@ -154,7 +154,7 @@ class FinancialTool {
 		$d1 = hash("sha256", substr($decoded,0,21), true);
 		$d2 = hash("sha256", $d1, true);
 
-		if(substr_compare($decoded, $d2, 21, 4)) {
+		if (substr_compare($decoded, $d2, 21, 4)) {
 			return false;
 		}
 		return true;
@@ -164,8 +164,8 @@ class FinancialTool {
 		$alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
 		$out = array_fill(0, 25, 0);
-		for($i=0;$i<strlen($input);$i++) {
-			if(($p=strpos($alphabet, $input[$i]))===false) {
+		for ($i=0;$i<strlen($input);$i++) {
+			if (($p=strpos($alphabet, $input[$i]))===false) {
 				return false;
 			}
 			$c = $p;
@@ -175,13 +175,13 @@ class FinancialTool {
 				$c /= 256;
 				$c = (int)$c;
 			}
-			if($c != 0) {
+			if ($c != 0) {
 				return false;
 			}
 		}
 
 		$result = "";
-		foreach($out as $val) {
+		foreach ($out as $val) {
 			$result .= chr($val);
 		}
 

--- a/app/Lib/Tools/FinancialTool.php
+++ b/app/Lib/Tools/FinancialTool.php
@@ -146,7 +146,7 @@ class FinancialTool {
 
 	// based on the php implementation of the BTC address validation example from
 	// http://rosettacode.org/wiki/Bitcoin/address_validation
-	public function validateBTC($address){
+	public function validateBTC($address) {
 		if (strlen($address) < 26 || strlen($address) > 35) return false;
 		$decoded = $this->__decodeBase58($address);
 		if ($decoded === false) return false;
@@ -154,7 +154,7 @@ class FinancialTool {
 		$d1 = hash("sha256", substr($decoded,0,21), true);
 		$d2 = hash("sha256", $d1, true);
 
-		if(substr_compare($decoded, $d2, 21, 4)){
+		if(substr_compare($decoded, $d2, 21, 4)) {
 			return false;
 		}
 		return true;
@@ -164,8 +164,8 @@ class FinancialTool {
 		$alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
 		$out = array_fill(0, 25, 0);
-		for($i=0;$i<strlen($input);$i++){
-			if(($p=strpos($alphabet, $input[$i]))===false){
+		for($i=0;$i<strlen($input);$i++) {
+			if(($p=strpos($alphabet, $input[$i]))===false) {
 				return false;
 			}
 			$c = $p;
@@ -175,13 +175,13 @@ class FinancialTool {
 				$c /= 256;
 				$c = (int)$c;
 			}
-			if($c != 0){
+			if($c != 0) {
 				return false;
 			}
 		}
 
 		$result = "";
-		foreach($out as $val){
+		foreach($out as $val) {
 			$result .= chr($val);
 		}
 

--- a/app/Lib/Tools/SyncTool.php
+++ b/app/Lib/Tools/SyncTool.php
@@ -5,7 +5,7 @@ class SyncTool {
 	public function setupHttpSocket($server = null) {
 		$params = array();
 		App::uses('HttpSocket', 'Network/Http');
-		if(!empty($server)) {
+		if (!empty($server)) {
 			if ($server['Server']['cert_file']) $params['ssl_cafile'] = APP . "files" . DS . "certs" . DS . $server['Server']['id'] . '.pem';
 			if ($server['Server']['self_signed']) $params['ssl_allow_self_signed'] = $server['Server']['self_signed'];
 		}

--- a/app/Lib/Tools/XMLConverterTool.php
+++ b/app/Lib/Tools/XMLConverterTool.php
@@ -139,7 +139,7 @@ class XMLConverterTool {
 				} else {
 					$event['Event']['RelatedEvent'][$key]['Event'][0]['Org'][0] = $event['Event']['RelatedEvent'][$key]['Org'];
 					$event['Event']['RelatedEvent'][$key]['Event'][0]['Orgc'][0] = $event['Event']['RelatedEvent'][$key]['Orgc'];
-					unset ($event['Event']['RelatedEvent'][$key]['Org'], $event['Event']['RelatedEvent'][$key]['Orgc']);
+					unset($event['Event']['RelatedEvent'][$key]['Org'], $event['Event']['RelatedEvent'][$key]['Orgc']);
 				}
 				unset($temp);
 			}

--- a/app/Lib/Tools/XMLConverterTool.php
+++ b/app/Lib/Tools/XMLConverterTool.php
@@ -93,7 +93,7 @@ class XMLConverterTool {
 					}
 				}
 				if (isset($event['Event']['Attribute'][$key]['ShadowAttribute'])) {
-					foreach($event['Event']['Attribute'][$key]['ShadowAttribute'] as $skey => $svalue) {
+					foreach ($event['Event']['Attribute'][$key]['ShadowAttribute'] as $skey => $svalue) {
 						$this->__sanitizeField($event['Event']['Attribute'][$key]['ShadowAttribute'][$skey]['value']);
 						$this->__sanitizeField($event['Event']['Attribute'][$key]['ShadowAttribute'][$skey]['comment']);
 						$event['Event']['Attribute'][$key]['ShadowAttribute'][$skey]['Org'] = array(0 => $event['Event']['Attribute'][$key]['ShadowAttribute'][$skey]['Org']);
@@ -119,7 +119,7 @@ class XMLConverterTool {
 		unset($event['Event']['RelatedAttribute']);
 		if (isset($event['Event']['ShadowAttribute'])) {
 			// remove invalid utf8 characters for the xml parser
-			foreach($event['Event']['ShadowAttribute'] as $key => $value) {
+			foreach ($event['Event']['ShadowAttribute'] as $key => $value) {
 				$this->__sanitizeField($event['Event']['ShadowAttribute'][$key]['value']);
 				$this->__sanitizeField($event['Event']['ShadowAttribute'][$key]['comment']);
 				$event['Event']['ShadowAttribute'][$key]['Org'] = array(0 => $event['Event']['ShadowAttribute'][$key]['Org']);

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -57,7 +57,7 @@ class AppModel extends Model {
 	// add special cases where the upgrade does more than just update the DB
 	// this could become useful in the future
 	public function updateMISP($command) {
-		switch($command) {
+		switch ($command) {
 			case '2.4.20':
 				$this->updateDatabase($command);
 				$this->ShadowAttribute = ClassRegistry::init('ShadowAttribute');

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -1371,7 +1371,7 @@ class Attribute extends AppModel {
 
 		if ($eventId !== false) {
 			$conditions['AND'][] = array('Event.id' => $eventId);
-		} elseif ($tags !== false) {
+		} else if ($tags !== false) {
 			// If we sent any tags along, load the associated tag names for each attribute
 			$tag = ClassRegistry::init('Tag');
 			$args = $this->dissectArgs($tags);

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -619,7 +619,7 @@ class Attribute extends AppModel {
 	public function runValidation($value, $type) {
 		$returnValue = false;
 		// check data validation
-		switch($type) {
+		switch ($type) {
 			case 'md5':
 			case 'imphash':
 			case 'sha1':
@@ -902,7 +902,7 @@ class Attribute extends AppModel {
 
 	// do some last second modifications before the validation
 	public function modifyBeforeValidation($type, $value) {
-		switch($type) {
+		switch ($type) {
 			case 'md5':
 			case 'sha1':
 			case 'sha224':
@@ -1679,7 +1679,7 @@ class Attribute extends AppModel {
 			if (isset($result['multi'])) {
 				$temp = $attribute;
 				$attribute = array();
-				foreach($result['multi'] as $k => $r) {
+				foreach ($result['multi'] as $k => $r) {
 					$attribute['multi'][] = $temp;
 					$attribute['multi'][$k]['type'] = $r['type'];
 					$attribute['multi'][$k]['value'] = $r['value'];

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -357,7 +357,7 @@ class Event extends AppModel {
 		// analysis - setting correct vars
 		// TODO refactor analysis into an Enum (in the database)
 		if (isset($this->data['Event']['analysis'])) {
-			switch($this->data['Event']['analysis']){
+			switch($this->data['Event']['analysis']) {
 			    case 'Initial':
 			        $this->data['Event']['analysis'] = 0;
 			        break;
@@ -1787,7 +1787,7 @@ class Event extends AppModel {
 
 		if ($data['Event']['distribution'] == 4) {
 			$sg = $this->SharingGroup->captureSG($data['Event']['SharingGroup'], $user);
-			if ($sg===false){
+			if ($sg===false) {
 				$sg = 0;
 				$data['Event']['distribution'] = 0;
 			}

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1072,7 +1072,7 @@ class Event extends AppModel {
 		$response = $HttpSocket->post($uri, json_encode($uuidList), $request);
 		if ($response->isOk()) {
 			return(json_decode($response->body, true));
-		} elseif ($response->code == '405') {
+		} else if ($response->code == '405') {
 			// HACKY: without correct permission, the returning null causes Fallback for < 2.4.7 instances
 			// which queries every event, for proposal, which it doesn't have permission for
 			return array();
@@ -1650,10 +1650,10 @@ class Event extends AppModel {
 				if ('url' == $attribute['type']) {
 					$line = str_ireplace("http","hxxp", $line);
 				}
-				elseif ('email-src' == $attribute['type'] or 'email-dst' == $attribute['type']) {
+				else if ('email-src' == $attribute['type'] or 'email-dst' == $attribute['type']) {
 					$line = str_replace("@","[at]", $line);
 				}
-				elseif ('hostname' == $attribute['type'] or 'domain' == $attribute['type'] or 'ip-src' == $attribute['type'] or 'ip-dst' == $attribute['type']) {
+				else if ('hostname' == $attribute['type'] or 'domain' == $attribute['type'] or 'ip-src' == $attribute['type'] or 'ip-dst' == $attribute['type']) {
 					$line = str_replace(".","[.]", $line);
 				}
 

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -952,7 +952,7 @@ class Event extends AppModel {
 					if ($attribute['distribution'] == 2) {
 						$attribute['distribution'] = 1;
 					}
-					unset ($event['Attribute'][$key]['SharingGroup'], $event['Attribute'][$key]['sharing_group_id']);
+					unset($event['Attribute'][$key]['SharingGroup'], $event['Attribute'][$key]['sharing_group_id']);
 					if ($attribute['distribution'] == 4) {
 						unset($event['Event']['Attribute'][$key]);
 						continue;
@@ -1318,7 +1318,7 @@ class Event extends AppModel {
 			// unset empty event tags that got added because the tag wasn't exportable
 			if (!empty($event['EventTag'])) {
 				foreach ($event['EventTag'] as $k => &$eventTag) {
-					if (empty($eventTag['Tag'])) unset ($event['EventTag'][$k]);
+					if (empty($eventTag['Tag'])) unset($event['EventTag'][$k]);
 				}
 				$event['EventTag'] = array_values($event['EventTag']);
 			}
@@ -1792,7 +1792,7 @@ class Event extends AppModel {
 				$data['Event']['distribution'] = 0;
 			}
 			$data['Event']['sharing_group_id'] = $sg;
-			unset ($data['Event']['SharingGroup']);
+			unset($data['Event']['SharingGroup']);
 		}
 		if (isset($data['Event']['Attribute'])) {
 			foreach ($data['Event']['Attribute'] as $k => &$a) {
@@ -1807,7 +1807,7 @@ class Event extends AppModel {
 		// The options here are either by passing an organisation object along or simply passing a string along
 		if (isset($data['Event']['Orgc'])) {
 			$data['Event']['orgc_id'] = $this->Orgc->captureOrg($data['Event']['Orgc'], $user);
-			unset ($data['Event']['Orgc']);
+			unset($data['Event']['Orgc']);
 		} else if (isset($data['Event']['orgc'])) {
 			$data['Event']['orgc_id'] = $this->Orgc->captureOrg($data['Event']['orgc'], $user);
 			unset($data['Event']['orgc']);
@@ -1817,13 +1817,13 @@ class Event extends AppModel {
 		if (isset($data['Event']['EventTag'])) {
 			if (isset($data['Event']['EventTag']['id'])) {
 				$temp = $data['Event']['EventTag'];
-				unset ($data['Event']['EventTag']);
+				unset($data['Event']['EventTag']);
 				$data['Event']['EventTag'][0] = $temp;
 			}
 			$eventTags = array();
 			foreach ($data['Event']['EventTag'] as $k => $tag) {
 				$eventTags[] = array('tag_id' => $this->EventTag->Tag->captureTag($data['Event']['EventTag'][$k]['Tag'], $user));
-				unset ($data['Event']['EventTag'][$k]);
+				unset($data['Event']['EventTag'][$k]);
 			}
 			$data['Event']['EventTag'] = $eventTags;
 		}
@@ -1892,7 +1892,7 @@ class Event extends AppModel {
 			unset($this->Attribute->validate['event_id']); // otherwise gives bugs because event_id is not set
 			unset($this->Attribute->validate['value']['uniqueValue']); // unset this - we are saving a new event, there are no values to compare against and event_id is not set in the attributes
 		}
-		unset ($data['Event']['id']);
+		unset($data['Event']['id']);
 		if (isset($data['Event']['published']) && $data['Event']['published'] && $user['Role']['perm_publish'] == false) $data['Event']['published'] = false;
 		if (isset($data['Event']['uuid'])) {
 			// check if the uuid already exists
@@ -1927,7 +1927,7 @@ class Event extends AppModel {
 			if (isset($data['Event']['Attribute'])) {
 				foreach ($data['Event']['Attribute'] as $k => &$attribute) {
 					$attribute['event_id'] = $this->id;
-					unset ($attribute['id']);
+					unset($attribute['id']);
 					$this->Attribute->create();
 					if (!$this->Attribute->save($attribute, array('fieldList' => $fieldList['Attribute']))) {
 						$validationErrors['Attribute'][$k] = $this->Attribute->validationErrors;
@@ -1987,7 +1987,7 @@ class Event extends AppModel {
 						if (!$this->SharingGroup->checkIfAuthorised($user, $data['Event']['sharing_group_id'])) return(array('error' => 'Event could not be saved: Invalid sharing group or you don\'t have access to that sharing group.'));
 					} else {
 						$data['Event']['sharing_group_id'] = $this->SharingGroup->captureSG($data['Event']['SharingGroup'], $user);
-						unset ($data['Event']['SharingGroup']);
+						unset($data['Event']['SharingGroup']);
 						if ($data['Event']['sharing_group_id'] === false) return (array('error' => 'Event could not be saved: User not authorised to create the associated sharing group.'));
 					}
 				}
@@ -2513,7 +2513,7 @@ class Event extends AppModel {
 				else $xmlArray = $this->__updateXMLArray220($xmlArray);
 			}
 		}
-		unset ($xmlArray['response']['xml_version']);
+		unset($xmlArray['response']['xml_version']);
 		if ($response) return $xmlArray;
 		else return $xmlArray['response'];
 	}
@@ -2688,7 +2688,7 @@ class Event extends AppModel {
 		foreach ($event['Event'] as $k => $v) {
 			if (is_array($v)) {
 				$event[$k] = $v;
-				unset ($event['Event'][$k]);
+				unset($event['Event'][$k]);
 			}
 		}
 		$filterType = false;
@@ -2704,7 +2704,7 @@ class Event extends AppModel {
 		$correlatedShadowAttributes = isset($event['RelatedShadowAttribute']) ? array_keys($event['RelatedShadowAttribute']) : array();
 		foreach ($event['Attribute'] as $attribute) {
 			if ($filterType && !in_array($filterType, array('proposal', 'correlation', 'warning'))) if (!in_array($attribute['type'], $this->Attribute->typeGroupings[$filterType])) continue;
-			if (isset($attribute['distribution']) && $attribute['distribution'] != 4) unset ($attribute['SharingGroup']);
+			if (isset($attribute['distribution']) && $attribute['distribution'] != 4) unset($attribute['SharingGroup']);
 			$attribute['objectType'] = 0;
 			if (!empty($attribute['ShadowAttribute'])) $attribute['hasChildren'] = 1;
 			else $attribute['hasChildren'] = 0;

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -357,7 +357,7 @@ class Event extends AppModel {
 		// analysis - setting correct vars
 		// TODO refactor analysis into an Enum (in the database)
 		if (isset($this->data['Event']['analysis'])) {
-			switch($this->data['Event']['analysis']) {
+			switch ($this->data['Event']['analysis']) {
 			    case 'Initial':
 			        $this->data['Event']['analysis'] = 0;
 			        break;
@@ -1353,7 +1353,7 @@ class Event extends AppModel {
 				// If a shadowattribute can be linked to an attribute, link it to it then remove it from the event
 				// This is to differentiate between proposals that were made to an attribute for modification and between proposals for new attributes
 				foreach ($event['ShadowAttribute'] as $k => &$sa) {
-					if(!empty($sa['old_id'])) {
+					if (!empty($sa['old_id'])) {
 						if ($sa['old_id'] == $attribute['id']) {
 							$results[$eventKey]['Attribute'][$key]['ShadowAttribute'][] = $sa;
 							unset($results[$eventKey]['ShadowAttribute'][$k]);
@@ -1367,7 +1367,7 @@ class Event extends AppModel {
 			// remove proposals to attributes that we cannot see
 			// if the shadow attribute wasn't moved within an attribute before, this is the case
 			foreach ($event['ShadowAttribute'] as $k => &$sa) {
-				if(!empty($sa['old_id'])) unset($event['ShadowAttribute'][$k]);
+				if (!empty($sa['old_id'])) unset($event['ShadowAttribute'][$k]);
 			}
 		}
 		return $results;
@@ -1797,7 +1797,7 @@ class Event extends AppModel {
 		if (isset($data['Event']['Attribute'])) {
 			foreach ($data['Event']['Attribute'] as $k => &$a) {
 				unset($data['Event']['Attribute']['id']);
-				if(isset($a['distribution']) && $a['distribution'] == 4) {
+				if (isset($a['distribution']) && $a['distribution'] == 4) {
 					$data['Event']['Attribute'][$k]['sharing_group_id'] = $this->SharingGroup->captureSG($data['Event']['Attribute'][$k]['SharingGroup'], $user);
 					unset($data['Event']['Attribute'][$k]['SharingGroup']);
 				}
@@ -2253,7 +2253,7 @@ class Event extends AppModel {
 		if ($passAlong) $conditions[] = array('Server.id !=' => $passAlong);
 		$servers = $this->Server->find('all', array('conditions' => $conditions));
 		// iterate over the servers and upload the event
-		if(empty($servers))
+		if (empty($servers))
 			return true;
 
 		$uploaded = true;

--- a/app/Model/EventDelegation.php
+++ b/app/Model/EventDelegation.php
@@ -92,7 +92,7 @@ class EventDelegation extends AppModel {
 		);
 		$objectsWithAttachments = array('Attribute', 'ShadowAttribute');
 		$objectsToRearrange = array('Attribute', 'ShadowAttribute', 'EventTag');
-		unset ($event['Event']['id']);
+		unset($event['Event']['id']);
 		foreach ($objects as $object_type => $fields) {
 			foreach ($event[$object_type] as &$object) {
 				// append attachment

--- a/app/Model/Organisation.php
+++ b/app/Model/Organisation.php
@@ -95,7 +95,7 @@ class Organisation extends AppModel{
 		return true;
 	}
 
-	public function beforeDelete($cascade = false){
+	public function beforeDelete($cascade = false) {
 		if ($this->User->find('count', array('conditions' => array('User.org_id' => $this->id))) != 0) return false;
 		if ($this->Event->find('count', array('conditions' => array('OR' => array('Event.org_id' => $this->id, 'Event.orgc_id' => $this->id)))) != 0) return false;
 		return true;

--- a/app/Model/Post.php
+++ b/app/Model/Post.php
@@ -84,7 +84,7 @@ class Post extends AppModel {
 		$temp = $this->findAllByThreadId($post['Post']['thread_id'],array('user_id'));
 		foreach ($temp as $tempElement) {
 			$user = $this->User->findById($tempElement['Post']['user_id'], array('email', 'gpgkey', 'certif_public', 'contactalert', 'id'));
-			if(!empty($user) && $user['User']['id'] != $user_id && !in_array($user, $orgMembers)) {
+			if (!empty($user) && $user['User']['id'] != $user_id && !in_array($user, $orgMembers)) {
 				array_push($orgMembers, $user);
 			}
 		}

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1188,7 +1188,7 @@ class Server extends AppModel {
 								$event['Event']['distribution'] = '1';
 							}
 							// Distribution
-							switch($event['Event']['distribution']) {
+							switch ($event['Event']['distribution']) {
 								case 1:
 								case 'This community only': // backwards compatibility
 									// if community only, downgrade to org only after pull
@@ -1312,7 +1312,7 @@ class Server extends AppModel {
 							$temp = $proposals['ShadowAttribute'];
 							$proposals['ShadowAttribute'] = array(0 => $temp);
 						}
-						foreach($proposals['ShadowAttribute'] as &$proposal) {
+						foreach ($proposals['ShadowAttribute'] as &$proposal) {
 							$oldsa = $shadowAttribute->findOldProposal($proposal);
 							$proposal['event_id'] = $eid;
 							if (!$oldsa || $oldsa['timestamp'] < $proposal['timestamp']) {
@@ -1651,7 +1651,7 @@ class Server extends AppModel {
 				// event_id is null when we are doing a push
 				$ids = $this->getEventIdsFromServer($server, true, $HttpSocket);
 				// error return strings or ints or throw exceptions
-				if(!is_array($ids)) return false;
+				if (!is_array($ids)) return false;
 				$conditions = array('uuid' => $ids);
 			} else {
 				$conditions = array('id' => $event_id);
@@ -2437,7 +2437,7 @@ class Server extends AppModel {
 	public function proxyDiagnostics(&$diagnostic_errors) {
 		$proxyStatus = 0;
 		$proxy = Configure::read('Proxy');
-		if(!empty($proxy['host'])) {
+		if (!empty($proxy['host'])) {
 			App::uses('SyncTool', 'Tools');
 			$syncTool = new SyncTool();
 			try {
@@ -2446,7 +2446,7 @@ class Server extends AppModel {
 			} catch (Exception $e) {
 				$proxyStatus = 2;
 			}
-			if(empty($proxyResponse) || $proxyResponse->code > 399) {
+			if (empty($proxyResponse) || $proxyResponse->code > 399) {
 				$proxyStatus = 2;
 			}
 		} else {

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1611,7 +1611,7 @@ class Server extends AppModel {
 
 		foreach ($eventIds as $k => $event) {
 			if (empty($this->eventFilterPushableServers($event, array($server)))) {
-				unset ($eventIds[$k]);
+				unset($eventIds[$k]);
 				continue;
 			}
 			unset($eventIds[$k]['Event']['id']);

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1134,7 +1134,7 @@ class Server extends AppModel {
 			if (!empty($eventIds)) {
 				$eventIds = array_reverse($eventIds);
 			}
-		} elseif ("update" === $technique) {
+		} else if ("update" === $technique) {
 			$eventIds = $this->getEventIdsFromServer($server, false, null, true, true);
 			if ($eventIds === 403) {
 				return array (1, null);
@@ -1146,10 +1146,10 @@ class Server extends AppModel {
 					'recursive' => -1,
 			));
 			$eventIds = array_intersect($eventIds, $local_event_ids);
-		} elseif ("incremental" === $technique) {
+		} else if ("incremental" === $technique) {
 			// TODO incremental pull
 			return array (3, null);
-		} elseif (is_numeric($technique)) {
+		} else if (is_numeric($technique)) {
 			$eventIds[] = intval($technique);
 			// if we are downloading a single event, don't fetch all proposals
 			$conditions = array('Event.id' => $technique);
@@ -1486,10 +1486,10 @@ class Server extends AppModel {
 		if ("full" == $technique) {
 			$eventid_conditions_key = 'Event.id >';
 			$eventid_conditions_value = 0;
-		} elseif ("incremental" == $technique) {
+		} else if ("incremental" == $technique) {
 			$eventid_conditions_key = 'Event.id >';
 			$eventid_conditions_value = $this->data['Server']['lastpushedid'];
-		} elseif (true == $technique) {
+		} else if (true == $technique) {
 			$eventid_conditions_key = 'Event.id';
 			$eventid_conditions_value = intval($technique);
 		} else {
@@ -2010,7 +2010,7 @@ class Server extends AppModel {
 				$pubSubTool->killService();
 				return true;
 			}
-		} elseif (!Configure::read('Plugin.ZeroMQ_enable')) {
+		} else if (!Configure::read('Plugin.ZeroMQ_enable')) {
 			// If we are changing any other ZeroMQ settings but the feature is disabled, don't reload the service
 			return true;
 		}
@@ -2684,7 +2684,7 @@ class Server extends AppModel {
 					// in case we have something in the db with a missing org, let's hop over that
 					if ($t[$rule['table']][$rule['old']] !== '') {
 						if ($k == 'local' && !in_array($t[$rule['table']][$rule['old']], $orgs[$k])) $orgs[$k][] = $t[$rule['table']][$rule['old']];
-						elseif ($k == 'external' && !in_array($t[$rule['table']][$rule['old']], $orgs['local']) && !in_array($t[$rule['table']][$rule['old']], $orgs[$k])) $orgs[$k][] = $t[$rule['table']][$rule['old']];
+						else if ($k == 'external' && !in_array($t[$rule['table']][$rule['old']], $orgs['local']) && !in_array($t[$rule['table']][$rule['old']], $orgs[$k])) $orgs[$k][] = $t[$rule['table']][$rule['old']];
 					} else {
 						$this->Log->create();
 						$this->Log->save(array(

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1457,7 +1457,7 @@ class Server extends AppModel {
 			if ($response->code == '403') {
 				return 403;
 			}
-			} catch (SocketException $e){
+			} catch (SocketException $e) {
 			// FIXME refactor this with clean try catch over all http functions
 				return $e->getMessage();
 			}
@@ -2410,7 +2410,7 @@ class Server extends AppModel {
 				try {
 					$gpgStatus = 0;
 					$signed = $gpg->sign('test', Crypt_GPG::SIGN_MODE_CLEAR);
-				} catch (Exception $e){
+				} catch (Exception $e) {
 					$gpgStatus = 4;
 				}
 			}

--- a/app/Model/SharingGroup.php
+++ b/app/Model/SharingGroup.php
@@ -371,7 +371,7 @@ class SharingGroup extends AppModel {
 				return $existingSG['SharingGroup']['id'];
 			}
 		}
-		unset ($sg['Organisation']);
+		unset($sg['Organisation']);
 
 		if (isset($sg['SharingGroupOrg']['id'])) {
 			$temp = $sg['SharingGroupOrg'];
@@ -381,7 +381,7 @@ class SharingGroup extends AppModel {
 		foreach ($sg['SharingGroupOrg'] as $k => $org) {
 			if (isset($org['Organisation'][0])) $org['Organisation'] = $org['Organisation'][0];
 			$sg['SharingGroupOrg'][$k]['org_id'] = $this->Organisation->captureOrg($org['Organisation'], $user, $force);
-			unset ($sg['SharingGroupOrg'][$k]['Organisation']);
+			unset($sg['SharingGroupOrg'][$k]['Organisation']);
 			if ($force) {
 				// we are editing not creating here
 				$temp = $this->SharingGroupOrg->find('first', array(
@@ -414,7 +414,7 @@ class SharingGroup extends AppModel {
 		foreach ($sg['SharingGroupServer'] as $k => $server) {
 			if (isset($server[0])) $server = $server[0];
 			$sg['SharingGroupServer'][$k]['server_id'] = $this->SharingGroupServer->Server->captureServer($server['Server'], $user, $force);
-			if ($sg['SharingGroupServer'][$k]['server_id'] === false) unset ($sg['SharingGroupServer'][$k]);
+			if ($sg['SharingGroupServer'][$k]['server_id'] === false) unset($sg['SharingGroupServer'][$k]);
 			else {
 				if ($force) {
 					// we are editing not creating here

--- a/app/Model/SharingGroup.php
+++ b/app/Model/SharingGroup.php
@@ -74,7 +74,7 @@ class SharingGroup extends AppModel {
 		return true;
 	}
 
-	public function beforeDelete($cascade = false){
+	public function beforeDelete($cascade = false) {
 		$countEvent = $this->Event->find('count', array(
 				'recursive' => -1,
 				'conditions' => array('sharing_group_id' => $this->id)
@@ -357,7 +357,7 @@ class SharingGroup extends AppModel {
 					$attributes = array('name', 'releasability', 'description', 'created', 'modified');
 					$different = false;
 					foreach ($attributes as &$a) {
-						if (!in_array($a, array('created', 'modified')) && $editedSG[$a] !== $sg[$a]){
+						if (!in_array($a, array('created', 'modified')) && $editedSG[$a] !== $sg[$a]) {
 							$different = true;
 						}
 						$editedSG[$a] = $sg[$a];

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -332,7 +332,7 @@ class User extends AppModel {
 		// certif_public is entered
 
 		// Check if $check is a x509 certificate
-		if (openssl_x509_read($check['certif_public'])){
+		if (openssl_x509_read($check['certif_public'])) {
 			try {
 				App::uses('Folder', 'Utility');
 				$dir = APP . 'tmp' . DS . 'SMIME';
@@ -346,7 +346,7 @@ class User extends AppModel {
 				fclose($fp);
 				$msg_test_encrypted = tempnam($dir, 'SMIME');
 				// encrypt it
-				if (openssl_pkcs7_encrypt($msg_test, $msg_test_encrypted, $check['certif_public'], null, 0, OPENSSL_CIPHER_AES_256_CBC)){
+				if (openssl_pkcs7_encrypt($msg_test, $msg_test_encrypted, $check['certif_public'], null, 0, OPENSSL_CIPHER_AES_256_CBC)) {
 					$parse = openssl_x509_parse($check['certif_public']);
 					// Valid certificate ?
 					$now = new DateTime("now");
@@ -354,7 +354,7 @@ class User extends AppModel {
 					$validTo_time_t = new DateTime("@$validTo_time_t_epoch");
 					if ($validTo_time_t > $now) {
 						// purposes smimeencrypt ?
-						if (($parse['purposes'][5][0] == 1) and ($parse['purposes'][5][2] == 'smimeencrypt')){
+						if (($parse['purposes'][5][0] == 1) and ($parse['purposes'][5][2] == 'smimeencrypt')) {
 							return true;
 						} else {
 							return 'This certificate cannot be used to encrypt email';
@@ -365,7 +365,7 @@ class User extends AppModel {
 				} else {
 					return false;
 				}
-			} catch (Exception $e){
+			} catch (Exception $e) {
 				$this->log($e->getMessage());
 			}
 			unlink($msg_test);
@@ -504,7 +504,7 @@ class User extends AppModel {
 					if ($sortedKeys['noEncrypt']) $results[$user['User']['id']][2] .= ' Found ' . $sortedKeys['noEncrypt'] . ' subkey(s) that are sign only.';
 					$results[$user['User']['id']][0] = true;
 				}
-			} catch (Exception $e){
+			} catch (Exception $e) {
 				$results[$user['User']['id']][2] = $e->getMessage();
 				$results[$user['User']['id']][0] = true;
 			}
@@ -536,15 +536,15 @@ class User extends AppModel {
 				fclose($fp);
 				$msg_test_encrypted = tempnam($dir, 'SMIME');
 				// encrypt it
-				if (openssl_pkcs7_encrypt($msg_test, $msg_test_encrypted, $certif_public, null, 0, OPENSSL_CIPHER_AES_256_CBC)){
+				if (openssl_pkcs7_encrypt($msg_test, $msg_test_encrypted, $certif_public, null, 0, OPENSSL_CIPHER_AES_256_CBC)) {
 					$parse = openssl_x509_parse($certif_public);
 					// Valid certificate ?
 					$now = new DateTime("now");
 					$validTo_time_t_epoch = $parse['validTo_time_t'];
 					$validTo_time_t = new DateTime("@$validTo_time_t_epoch");
-					if ($validTo_time_t > $now){
+					if ($validTo_time_t > $now) {
 						// purposes smimeencrypt ?
-						if (($parse['purposes'][5][0] == 1) && ($parse['purposes'][5][2] == 'smimeencrypt')){
+						if (($parse['purposes'][5][0] == 1) && ($parse['purposes'][5][2] == 'smimeencrypt')) {
 						} else {
 							// openssl_pkcs7_encrypt good -- Model/User purposes is NOT GOOD'
 							$results[$user['User']['id']][0] = true;
@@ -558,7 +558,7 @@ class User extends AppModel {
 					$results[$user['User']['id']][0] = true;
 				}
 				$results[$user['User']['id']][1] = $user['User']['email'];
-			} catch (Exception $e){
+			} catch (Exception $e) {
 				$this->log($e->getMessage());
 			}
 			unlink($msg_test);
@@ -771,7 +771,7 @@ class User extends AppModel {
 				if (empty(Configure::read('SMIME.key_sign')) || !is_readable(Configure::read('SMIME.key_sign'))) $canSign = false;
 				if ($canSign) {
 					$signed = tempnam($dir, 'SMIME');
-					if (openssl_pkcs7_sign($msg, $signed, 'file://'.Configure::read('SMIME.cert_public_sign'), array('file://'.Configure::read('SMIME.key_sign'), Configure::read('SMIME.password')), array(), PKCS7_TEXT)){
+					if (openssl_pkcs7_sign($msg, $signed, 'file://'.Configure::read('SMIME.cert_public_sign'), array('file://'.Configure::read('SMIME.key_sign'), Configure::read('SMIME.password')), array(), PKCS7_TEXT)) {
 						$fp = fopen($signed, "r");
 						$bodySigned = fread($fp, filesize($signed));
 						fclose($fp);
@@ -792,7 +792,7 @@ class User extends AppModel {
 				}
 				$msg_signed_encrypted = tempnam($dir, 'SMIME');
 				// encrypt it
-				if (openssl_pkcs7_encrypt($msg_signed, $msg_signed_encrypted, $user['User']['certif_public'], $headers_smime, 0, OPENSSL_CIPHER_AES_256_CBC)){
+				if (openssl_pkcs7_encrypt($msg_signed, $msg_signed_encrypted, $user['User']['certif_public'], $headers_smime, 0, OPENSSL_CIPHER_AES_256_CBC)) {
 					$fp = fopen($msg_signed_encrypted, 'r');
 					$bodyEncSig = fread($fp, filesize($msg_signed_encrypted));
 					fclose($fp);

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -823,7 +823,7 @@ class User extends AppModel {
 				$Email->replyTo($replyToUser['User']['email']);
 				if (!empty($replyToUser['User']['gpgkey'])) {
 					$Email->attachments(array('gpgkey.asc' => array('data' => $replyToUser['User']['gpgkey'])));
-				} elseif (!empty($replyToUser['User']['certif_public'])) {
+				} else if (!empty($replyToUser['User']['certif_public'])) {
 					$Email->attachments(array($replyToUser['User']['email'] . '.pem' => array('data' => $replyToUser['User']['certif_public'])));
 				}
 				$replyToLog = 'from ' . $replyToUser['User']['email'];

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -553,7 +553,7 @@ class User extends AppModel {
 						// openssl_pkcs7_encrypt good -- Model/User expired;
 						$results[$user['User']['id']][0] = true;
 					}
-				} else{
+				} else {
 					// openssl_pkcs7_encrypt NOT good -- Model/User
 					$results[$user['User']['id']][0] = true;
 				}

--- a/app/Plugin/Assets/models/behaviors/LogableBehavior.php
+++ b/app/Plugin/Assets/models/behaviors/LogableBehavior.php
@@ -171,7 +171,7 @@ class LogableBehavior extends ModelBehavior {
 		if ($params[$this->settings[$Model->alias]['classField']]) {
 			if (isset($this->schema[$this->settings[$Model->alias]['classField']])) {
 				$options['conditions'][$this->settings[$Model->alias]['classField']] = $params[$this->settings[$Model->alias]['classField']];
-			} elseif (isset($this->schema['description'])) {
+			} else if (isset($this->schema['description'])) {
 				$options['conditions']['description LIKE '] = $params[$this->settings[$Model->alias]['classField']] . '%';
 			} else {
 				return FALSE;
@@ -248,20 +248,20 @@ class LogableBehavior extends ModelBehavior {
 					$result[$key]['Log']['event'] .= ' edited ' . $one['change'] . ' of ' . low($one[$this->settings[$Model->alias]['classField']]) . '(id ' . $one[$this->settings[$Model->alias]['foreignKey']] . ')';
 
 		//	' at '.$one['created'];
-				} elseif ($one['action'] == 'add') {
+				} else if ($one['action'] == 'add') {
 					$result[$key]['Log']['event'] .= ' added a ' . low($one[$this->settings[$Model->alias]['classField']]) . '(id ' . $one[$this->settings[$Model->alias]['foreignKey']] . ')';
-				} elseif ($one['action'] == 'delete') {
+				} else if ($one['action'] == 'delete') {
 					$result[$key]['Log']['event'] .= ' deleted the ' . low($one[$this->settings[$Model->alias]['classField']]) . '(id ' . $one[$this->settings[$Model->alias]['foreignKey']] . ')';
 				}
 
-			} elseif (isset($one[$this->settings[$Model->alias]['classField']]) && isset($one['action']) && isset($one[$this->settings[$Model->alias]['foreignKey']])) { // have model,model_id and action
+			} else if (isset($one[$this->settings[$Model->alias]['classField']]) && isset($one['action']) && isset($one[$this->settings[$Model->alias]['foreignKey']])) { // have model,model_id and action
 				if ($one['action'] == 'edit') {
 					$result[$key]['Log']['event'] .= ' edited ' . low($one[$this->settings[$Model->alias]['classField']]) . '(id ' . $one[$this->settings[$Model->alias]['foreignKey']] . ')';
 
 		//	' at '.$one['created'];
-				} elseif ($one['action'] == 'add') {
+				} else if ($one['action'] == 'add') {
 					$result[$key]['Log']['event'] .= ' added a ' . low($one[$this->settings[$Model->alias]['classField']]) . '(id ' . $one[$this->settings[$Model->alias]['foreignKey']] . ')';
-				} elseif ($one['action'] == 'delete') {
+				} else if ($one['action'] == 'delete') {
 					$result[$key]['Log']['event'] .= ' deleted the ' . low($one[$this->settings[$Model->alias]['classField']]) . '(id ' . $one[$this->settings[$Model->alias]['foreignKey']] . ')';
 				}
 			} else { // only description field exist
@@ -382,7 +382,7 @@ class LogableBehavior extends ModelBehavior {
 		}
 		if (isset($this->settings[$Model->alias]['skip']['add']) && $this->settings[$Model->alias]['skip']['add'] && $created) {
 			return true;
-		} elseif (isset($this->settings[$Model->alias]['skip']['edit']) && $this->settings[$Model->alias]['skip']['edit'] && !$created) {
+		} else if (isset($this->settings[$Model->alias]['skip']['edit']) && $this->settings[$Model->alias]['skip']['edit'] && !$created) {
 			return true;
 		}
 		$keys = array_keys($Model->data[$Model->alias]);
@@ -392,7 +392,7 @@ class LogableBehavior extends ModelBehavior {
 		}
 		if ($Model->id) {
 			$id = $Model->id;
-		} elseif ($Model->insertId) {
+		} else if ($Model->insertId) {
 			$id = $Model->insertId;
 		}
 		if (isset($this->schema[$this->settings[$Model->alias]['foreignKey']])) {
@@ -473,9 +473,9 @@ class LogableBehavior extends ModelBehavior {
 
 		if ($title !== NULL) {
 			$logData['Log']['title'] = $title;
-		} elseif ($Model->displayField == $Model->primaryKey) {
+		} else if ($Model->displayField == $Model->primaryKey) {
 			$logData['Log']['title'] = $Model->alias . ' (' . $Model->id . ')';
-		} elseif (isset($Model->data[$Model->alias][$Model->displayField])) {
+		} else if (isset($Model->data[$Model->alias][$Model->displayField])) {
 			$logData['Log']['title'] = $Model->data[$Model->alias][$Model->displayField];
 		} else {
 			$logData['Log']['title'] = $Model->field($Model->displayField);
@@ -489,14 +489,14 @@ class LogableBehavior extends ModelBehavior {
 		if (isset($this->schema[$this->settings[$Model->alias]['foreignKey']]) && !isset($logData['Log'][$this->settings[$Model->alias]['foreignKey']])) {
 			if ($Model->id) {
 				$logData['Log'][$this->settings[$Model->alias]['foreignKey']] = $Model->id;
-			} elseif ($Model->insertId) {
+			} else if ($Model->insertId) {
 				$logData['Log'][$this->settings[$Model->alias]['foreignKey']] = $Model->insertId;
 			}
 		}
 
 		if (!isset($this->schema['action'])) {
 			unset($logData['Log']['action']);
-		} elseif (isset($Model->logableAction) && !empty($Model->logableAction)) {
+		} else if (isset($Model->logableAction) && !empty($Model->logableAction)) {
 			$logData['Log']['action'] = implode(',', $Model->logableAction); // . ' ' . $logData['Log']['action'];
 			unset($Model->logableAction);
 		}

--- a/app/Plugin/CertAuth/Controller/Component/Auth/CertificateAuthenticate.php
+++ b/app/Plugin/CertAuth/Controller/Component/Auth/CertificateAuthenticate.php
@@ -54,22 +54,22 @@ class CertificateAuthenticate extends BaseAuthenticate
         self::$ca = self::$client = false;
 
         // this means the client certificate is valid — check nginx/apache configuration
-        if(isset($_SERVER['SSL_CLIENT_VERIFY']) && $_SERVER['SSL_CLIENT_VERIFY']=='SUCCESS') {
+        if (isset($_SERVER['SSL_CLIENT_VERIFY']) && $_SERVER['SSL_CLIENT_VERIFY']=='SUCCESS') {
 
-            if(isset($_SERVER['SSL_CLIENT_I_DN'])) {
+            if (isset($_SERVER['SSL_CLIENT_I_DN'])) {
                 $CA = self::parse($_SERVER['SSL_CLIENT_I_DN'], Configure::read('CertAuth.mapCa'));
 
                 // only valid CAs, if this was configured
-                if($ca=Configure::read('CertAuth.ca')) {
+                if ($ca=Configure::read('CertAuth.ca')) {
                     $k = Configure::read('CertAuth.caId');
-                    if(!$k) $k = 'CN';
+                    if (!$k) $k = 'CN';
                     $id = (isset($CA[$k]))?($CA[$k]):(false);
 
-                    if(!$id) {
+                    if (!$id) {
                         $CA = false;
-                    } else if(is_array($ca)) {
-                        if(!in_array($id, $ca)) $CA = false;
-                    } else if($ca!=$id) {
+                    } else if (is_array($ca)) {
+                        if (!in_array($id, $ca)) $CA = false;
+                    } else if ($ca!=$id) {
                         $CA = false;
                     }
                     unset($id, $k);
@@ -78,7 +78,7 @@ class CertificateAuthenticate extends BaseAuthenticate
                 unset($CA, $ca);
             }
 
-            if(self::$ca && isset($_SERVER['SSL_CLIENT_S_DN'])) {
+            if (self::$ca && isset($_SERVER['SSL_CLIENT_S_DN'])) {
                 self::$client = self::parse($_SERVER['SSL_CLIENT_S_DN'], Configure::read('CertAuth.map'));
             }
         }
@@ -95,11 +95,11 @@ class CertificateAuthenticate extends BaseAuthenticate
     private static function parse($s, $map=null)
     {
         $r=array();
-        foreach(preg_split('#/#', $s, null, PREG_SPLIT_NO_EMPTY) as $v) {
-            if($p=strpos($v, '=')) {
+        foreach (preg_split('#/#', $s, null, PREG_SPLIT_NO_EMPTY) as $v) {
+            if ($p=strpos($v, '=')) {
                 $k = substr($v, 0, $p);
-                if($map) {
-                    if(isset($map[$k])) {
+                if ($map) {
+                    if (isset($map[$k])) {
                         $k = $map[$k];
                     } else {
                         unset($p, $v, $k);
@@ -116,21 +116,21 @@ class CertificateAuthenticate extends BaseAuthenticate
     // to enable stateless authentication
     public function getUser(CakeRequest $request)
     {
-        if(is_null(self::$user)) {
-            if(self::$client) {
+        if (is_null(self::$user)) {
+            if (self::$client) {
                 self::$user = self::$client;
 
                 $sync = Configure::read('CertAuth.syncUser');
 
-                if($sync) {
+                if ($sync) {
                     self::getRestUser();
                 }
 
                 // find and fill user with model
                 $cn = Configure::read('CertAuth.userModel');
-                if($cn) {
+                if ($cn) {
                     $k = Configure::read('CertAuth.userModelKey');
-                    if($k) {
+                    if ($k) {
                         $q = array($k=>self::$user[$k]);
                     } else {
                         $q = self::$user;
@@ -140,30 +140,30 @@ class CertificateAuthenticate extends BaseAuthenticate
                         'conditions' => $q,
                         'recursive' => false
                     ));
-                    if($U) {
-                        if($sync) {
+                    if ($U) {
+                        if ($sync) {
                             $write = array();
-                            foreach(self::$user as $k=>$v) {
-                                if(array_key_exists($k, $U[$cn]) && trim($U[$cn][$k])!=trim($v)) {
+                            foreach (self::$user as $k=>$v) {
+                                if (array_key_exists($k, $U[$cn]) && trim($U[$cn][$k])!=trim($v)) {
                                     $write[] = $k;
                                     $U[$cn][$k] = trim($v);
                                 }
                                 unset($k, $v);
                             }
-                            if($write && !$User->save($U[$cn], true, $write)) {
+                            if ($write && !$User->save($U[$cn], true, $write)) {
                                 CakeLog::write('alert', 'Could not update model at database with RestAPI data.');
                             }
                             unset($write);
                         }
                         self::$user = $U[$cn];
-                    } else if($sync) {
+                    } else if ($sync) {
                         $User->create();
                         $d = Configure::read('CertAuth.userDefaults');
-                        if($d && is_array($d)) {
+                        if ($d && is_array($d)) {
                             self::$user += $d;
                         }
                         unset($d);
-                        if($User->save(self::$user, true, array_keys(self::$user))) {
+                        if ($User->save(self::$user, true, array_keys(self::$user))) {
                             $U = $User->read();
                             self::$user = $U[$cn];
                         } else {
@@ -199,14 +199,14 @@ class CertificateAuthenticate extends BaseAuthenticate
      */
     public function getRestUser($options=null, $user=null)
     {
-        if(is_null($options)) {
+        if (is_null($options)) {
             $options = Configure::read('CertAuth.restApi');
         }
-        if(!is_null($user)) {
+        if (!is_null($user)) {
             self::$user = $user;
         }
 
-        if(!isset($options['url'])) {
+        if (!isset($options['url'])) {
             return null;
         }
 
@@ -217,9 +217,9 @@ class CertificateAuthenticate extends BaseAuthenticate
             'header'=>"Accept: application/json\r\n"
           ),
         );
-        if(isset($options['headers'])) {
-            foreach($options['headers'] as $k=>$v) {
-                if(is_int($k)) {
+        if (isset($options['headers'])) {
+            foreach ($options['headers'] as $k=>$v) {
+                if (is_int($k)) {
                     $req['header'] .= "{$v}\r\n";
                 } else {
                     $req['header'] .= "{$k}: {$v}\r\n";
@@ -229,9 +229,9 @@ class CertificateAuthenticate extends BaseAuthenticate
         }
 
         $url = $options['url'];
-        if(isset($options['param'])) {
-            foreach($options['param'] as $k=>$v) {
-                if(isset(self::$user[$v])) {
+        if (isset($options['param'])) {
+            foreach ($options['param'] as $k=>$v) {
+                if (isset(self::$user[$v])) {
                     $url .= ((strpos($url, '?'))?('&'):('?'))
                         . $k . '=' . urlencode(self::$user[$v]);
                 }
@@ -240,13 +240,13 @@ class CertificateAuthenticate extends BaseAuthenticate
         }
         $ctx = stream_context_create($req);
         $a   = file_get_contents($url, false, $ctx);
-        if(!$a) return null;
+        if (!$a) return null;
 
         $A = json_decode($a, true);
-        if(!isset($A['data'][0])) return false;
-        if(isset($options['map'])) {
-            foreach($options['map'] as $k=>$v) {
-                if(isset($A['data'][0][$k])) {
+        if (!isset($A['data'][0])) return false;
+        if (isset($options['map'])) {
+            foreach ($options['map'] as $k=>$v) {
+                if (isset($A['data'][0][$k])) {
                     self::$user[$v] = $A['data'][0][$k];
                 }
                 unset($k, $v);
@@ -260,13 +260,13 @@ class CertificateAuthenticate extends BaseAuthenticate
 
     public static function ca()
     {
-        if(is_null(self::$ca)) new CertificateAuthenticate();
+        if (is_null(self::$ca)) new CertificateAuthenticate();
         return self::$ca;
     }
 
     public static function client()
     {
-        if(is_null(self::$client)) new CertificateAuthenticate();
+        if (is_null(self::$client)) new CertificateAuthenticate();
         return self::$client;
     }
 

--- a/app/Plugin/SysLog/Lib/SysLog.php
+++ b/app/Plugin/SysLog/Lib/SysLog.php
@@ -76,7 +76,7 @@ class SysLog {
         $priority = LOG_INFO;
         if ($type == 'error' || $type == 'warning') {
             $priority = LOG_ERR;
-        } elseif (in_array($type, $debugTypes)) {
+        } else if (in_array($type, $debugTypes)) {
             $priority = LOG_DEBUG;
         }
         $output = date('Y-m-d H:i:s') . ' ' . ucfirst($type) . ': ' . $message . "\n";

--- a/app/Plugin/SysLogLogable/Model/Behavior/SysLogLogableBehavior.php
+++ b/app/Plugin/SysLogLogable/Model/Behavior/SysLogLogableBehavior.php
@@ -10,7 +10,7 @@ class SysLogLogableBehavior extends LogableBehavior {
 		}
 		if (isset($this->settings[$Model->alias]['skip']['add']) && $this->settings[$Model->alias]['skip']['add'] && $created) {
 			return true;
-		} elseif (isset($this->settings[$Model->alias]['skip']['edit']) && $this->settings[$Model->alias]['skip']['edit'] && !$created) {
+		} else if (isset($this->settings[$Model->alias]['skip']['edit']) && $this->settings[$Model->alias]['skip']['edit'] && !$created) {
 			return true;
 		}
 		$keys = array_keys($Model->data[$Model->alias]);
@@ -20,7 +20,7 @@ class SysLogLogableBehavior extends LogableBehavior {
 		}
 		if ($Model->id) {
 			$id = $Model->id;
-		} elseif ($Model->insertId) {
+		} else if ($Model->insertId) {
 			$id = $Model->insertId;
 		}
 		if (isset($this->schema[$this->settings[$Model->alias]['foreignKey']])) {
@@ -103,9 +103,9 @@ class SysLogLogableBehavior extends LogableBehavior {
 	function _saveLog(&$Model, $logData, $title = null) {
 		if ($title !== NULL) {
 			$logData['Log']['title'] = $title;
-		} elseif ($Model->displayField == $Model->primaryKey) {
+		} else if ($Model->displayField == $Model->primaryKey) {
 			$logData['Log']['title'] = $Model->alias . ' (' . $Model->id . ')';
-		} elseif (isset($Model->data[$Model->alias][$Model->displayField])) {
+		} else if (isset($Model->data[$Model->alias][$Model->displayField])) {
 			if (($Model->alias == "User") && ($logData['Log']['action'] != 'edit')) {
 				$logData['Log']['title'] = 'User (' . $Model->data[$Model->alias][$Model->primaryKey] . '): ' . $Model->data[$Model->alias][$Model->displayField];
 			} else {
@@ -123,13 +123,13 @@ class SysLogLogableBehavior extends LogableBehavior {
 		if (isset($this->schema[$this->settings[$Model->alias]['foreignKey']]) && !isset($logData['Log'][$this->settings[$Model->alias]['foreignKey']])) {
 			if ($Model->id) {
 				$logData['Log'][$this->settings[$Model->alias]['foreignKey']] = $Model->id;
-			} elseif ($Model->insertId) {
+			} else if ($Model->insertId) {
 				$logData['Log'][$this->settings[$Model->alias]['foreignKey']] = $Model->insertId;
 			}
 		}
 		if (!isset($this->schema['action'])) {
 			unset($logData['Log']['action']);
-		} elseif (isset($Model->logableAction) && !empty($Model->logableAction)) {
+		} else if (isset($Model->logableAction) && !empty($Model->logableAction)) {
 			$logData['Log']['action'] = implode(',', $Model->logableAction); // . ' ' . $logData['Log']['action'];
 			unset($Model->logableAction);
 		}

--- a/app/Plugin/magic_tools/models/behaviors/orphans_protectable.php
+++ b/app/Plugin/magic_tools/models/behaviors/orphans_protectable.php
@@ -36,7 +36,7 @@ class OrphansProtectableBehavior extends ModelBehavior {
    * @return boolean
    */
   function beforeDelete(&$model, $cascade) {
-    if($cascade) return true;
+    if ($cascade) return true;
     return !$Model->wouldLeaveOrphanedRecordsBehind();
   }
 
@@ -49,17 +49,17 @@ class OrphansProtectableBehavior extends ModelBehavior {
 	function wouldLeaveOrphanedRecordsBehind(&$model) {
 	  $possibleOrphans = array();
 
-	  foreach($Model->hasMany as $model => $settings) {
+	  foreach ($Model->hasMany as $model => $settings) {
 	    // Is relationship is dependent?
-      if($settings['dependent']) { // Yes! Possible orphans are deleted, too!
+      if ($settings['dependent']) { // Yes! Possible orphans are deleted, too!
         // Do nothing
       } else { // No! Possible orphans should be protected!
         // Is there a possible orphan for this relation?
         $Model->{$model}->recursive = -1;
         $objects = $Model->{$model}->find('all', array('conditions' => array($settings['className'].'.'.$settings['foreignKey'] => $Model->id), 'order' => 'id asc'));
-        if(count($objects) > 0) { // Yes, there is at least one possible orphan!
+        if (count($objects) > 0) { // Yes, there is at least one possible orphan!
           $objectIds = array();
-          foreach($objects as $object) {
+          foreach ($objects as $object) {
             $objectIds[] = $object[$model]['id'];
           }
           $possibleOrphans[$model] = $objectIds;
@@ -68,7 +68,7 @@ class OrphansProtectableBehavior extends ModelBehavior {
     }
 
     // Would orphans be left behind?
-    if(count($possibleOrphans) > 0) { // Yes! Create deletion error message!
+    if (count($possibleOrphans) > 0) { // Yes! Create deletion error message!
       $Model->_deletionError = $Model->createDeletionError($possibleOrphans);
       return true;
     } else { // No!
@@ -95,7 +95,7 @@ class OrphansProtectableBehavior extends ModelBehavior {
 	 */
 	function createDeletionError(&$model, $possibleOrphans) {
 	  $errorParts = array();
-    foreach($possibleOrphans as $model => $ids) {
+    foreach ($possibleOrphans as $model => $ids) {
       $count = count($ids);
       $modelName = $count > 1 ? Inflector::pluralize($model) : $model;
       $errorParts[] = $count.' '.__($modelName, true).' (ID: '.$Model->createDeletionErrorIds($model, $ids).')';
@@ -113,8 +113,8 @@ class OrphansProtectableBehavior extends ModelBehavior {
 	 */
 	function createDeletionErrorIds(&$model, $orphanModel, $ids) {
 	  $messageParts = array();
-	  if($Model->orphansProtectableOptions['htmlError']) {
-	    foreach($ids as $id) {
+	  if ($Model->orphansProtectableOptions['htmlError']) {
+	    foreach ($ids as $id) {
 	      $messageParts[] = '<a href="'.Inflector::pluralize(strtolower($orphanModel)).'/view/'.$id.'">'.$id.'</a>'; // TODO: Noch unschÃ¶n! --zivi-muh
 	    }
 	  } else {

--- a/app/Plugin/magic_tools/models/behaviors/orphans_protectable.php
+++ b/app/Plugin/magic_tools/models/behaviors/orphans_protectable.php
@@ -51,7 +51,7 @@ class OrphansProtectableBehavior extends ModelBehavior {
 
 	  foreach($Model->hasMany as $model => $settings) {
 	    // Is relationship is dependent?
-      if($settings['dependent']){ // Yes! Possible orphans are deleted, too!
+      if($settings['dependent']) { // Yes! Possible orphans are deleted, too!
         // Do nothing
       } else { // No! Possible orphans should be protected!
         // Is there a possible orphan for this relation?

--- a/app/View/Attributes/add.ctp
+++ b/app/View/Attributes/add.ctp
@@ -78,7 +78,7 @@
 		?>
 		</div>
 	</fieldset>
-	<p style="color:red;font-weight:bold;display:none;<?php if(isset($ajax) && $ajax) echo "text-align:center;"?>" id="warning-message">Warning: You are about to share data that is of a sensitive nature (Attribution / targeting data). Make sure that you are authorised to share this.</p>
+	<p style="color:red;font-weight:bold;display:none;<?php if (isset($ajax) && $ajax) echo "text-align:center;"?>" id="warning-message">Warning: You are about to share data that is of a sensitive nature (Attribution / targeting data). Make sure that you are authorised to share this.</p>
 	<?php if ($ajax): ?>
 		<div class="overlay_spacing">
 			<table>
@@ -104,7 +104,7 @@
 	<div id="confirmation_box" class="confirmation_box"></div>
 </div>
 <?php
-	if(!$ajax) {
+	if (!$ajax) {
 		$event['Event']['id'] = $this->request->data['Attribute']['event_id'];
 		$event['Event']['published'] = $published;
 		echo $this->element('side_menu', array('menuList' => 'event', 'menuItem' => 'addAttribute', 'event' => $event));

--- a/app/View/Attributes/index.ctp
+++ b/app/View/Attributes/index.ctp
@@ -94,7 +94,7 @@ foreach ($attributes as $attribute):
 			}
 			if ('attachment' == $attribute['Attribute']['type'] || 'malware-sample' == $attribute['Attribute']['type']) {
 				?><a href="<?php echo $baseurl;?>/attributes/download/<?php echo $attribute['Attribute']['id'];?>"><?php echo $sigDisplay; ?></a><?php
-			} elseif ('link' == $attribute['Attribute']['type']) {
+			} else if ('link' == $attribute['Attribute']['type']) {
 				?><a href="<?php echo h($attribute['Attribute']['value']);?>"><?php echo $sigDisplay; ?></a><?php
 			} else {
 				echo $sigDisplay;

--- a/app/View/Attributes/json/rest_search.ctp
+++ b/app/View/Attributes/json/rest_search.ctp
@@ -1,7 +1,7 @@
 <?php
 $jsonArray = array();
 foreach ($results as $k => $v) {
-	unset (
+	unset(
 			$results[$k]['Event'],
 			$results[$k]['Attribute']['value1'],
 			$results[$k]['Attribute']['value2']

--- a/app/View/Attributes/json/return_attributes.ctp
+++ b/app/View/Attributes/json/return_attributes.ctp
@@ -1,7 +1,7 @@
 <?php
 $jsonArray = array();
 foreach ($results as $k => $v) {
-	unset (
+	unset(
 			$results[$k]['value1'],
 			$results[$k]['value2']
 	);

--- a/app/View/Attributes/rest_search.ctp
+++ b/app/View/Attributes/rest_search.ctp
@@ -1,7 +1,7 @@
 <?php
 $xmlArray = array();
 foreach ($results as $k => $v) {
-	unset (
+	unset(
 			$results[$k]['Event'],
 			$results[$k]['Attribute']['value1'],
 			$results[$k]['Attribute']['value2']

--- a/app/View/Attributes/return_attributes.ctp
+++ b/app/View/Attributes/return_attributes.ctp
@@ -1,7 +1,7 @@
 <?php
 $xmlArray = array();
 foreach ($results as $k => $v) {
-	unset (
+	unset(
 			$results[$k]['value1'],
 			$results[$k]['value2']
 	);

--- a/app/View/Attributes/xml/rest_search.ctp
+++ b/app/View/Attributes/xml/rest_search.ctp
@@ -1,7 +1,7 @@
 <?php
 $xmlArray = array();
 foreach ($results as $k => $v) {
-	unset (
+	unset(
 			$results[$k]['Event'],
 			$results[$k]['Attribute']['value1'],
 			$results[$k]['Attribute']['value2']

--- a/app/View/Attributes/xml/return_attributes.ctp
+++ b/app/View/Attributes/xml/return_attributes.ctp
@@ -1,7 +1,7 @@
 <?php
 $xmlArray = array();
 foreach ($results as $k => $v) {
-	unset (
+	unset(
 			$results[$k]['value1'],
 			$results[$k]['value2']
 	);

--- a/app/View/Elements/eventattribute.ctp
+++ b/app/View/Elements/eventattribute.ctp
@@ -160,7 +160,7 @@
 			<th class="actions">Actions</th>
 		</tr>
 		<?php
-			foreach($event['objects'] as $k => $object):
+			foreach ($event['objects'] as $k => $object):
 				$extra = '';
 				$extra2 = '';
 				$extra3 = '';
@@ -381,7 +381,7 @@
 					<td class="short <?php echo $extra;?>">
 						<span id="sightingForm_<?php echo h($object['id']);?>">
 						<?php
-							if($object['objectType'] == 0):
+							if ($object['objectType'] == 0):
 								echo $this->Form->create('Sighting', array('id' => 'Sighting_' . $object['id'], 'url' => '/sightings/add/' . $object['id'], 'style' => 'display:none;'));
 								echo $this->Form->end();
 						?>

--- a/app/View/Elements/eventattribute.ctp
+++ b/app/View/Elements/eventattribute.ctp
@@ -268,18 +268,18 @@
 													echo $this->Html->link($filenameHash[0], array('controller' => $t, 'action' => 'download', $object['id']));
 												}
 												if (isset($filenameHash[1])) echo ' | ' . $filenameHash[1];
-											} elseif (strpos($object['type'], '|') !== false) {
+											} else if (strpos($object['type'], '|') !== false) {
 												$filenameHash = explode('|', $object['value']);
 												echo h($filenameHash[0]);
 												if (isset($filenameHash[1])) echo ' | ' . $filenameHash[1];
-											} elseif ('vulnerability' == $object['type']) {
+											} else if ('vulnerability' == $object['type']) {
 												if (! is_null(Configure::read('MISP.cveurl'))) {
 													$cveUrl = Configure::read('MISP.cveurl');
 												} else {
 													$cveUrl = "http://www.google.com/search?q=";
 												}
 												echo $this->Html->link($sigDisplay, $cveUrl . $sigDisplay, array('target' => '_blank'));
-											} elseif ('link' == $object['type']) {
+											} else if ('link' == $object['type']) {
 												echo $this->Html->link($sigDisplay, $sigDisplay);
 											} else if ('text' == $object['type']) {
 												$sigDisplay = str_replace("\r", '', h($sigDisplay));

--- a/app/View/Elements/footer.ctp
+++ b/app/View/Elements/footer.ctp
@@ -7,14 +7,14 @@
 				$gpgpath = ROOT.DS.APP_DIR.DS.WEBROOT_DIR.DS.'gpg.asc';
 				if (file_exists($gpgpath) && is_file($gpgpath)){ ?>
 					<span>Download: <?php echo $this->Html->link('PGP/GPG key', $this->webroot.'gpg.asc');?></span>
-				<?php }else{ ?>
+				<?php } else { ?>
 					<span>Could not locate the PGP/GPG public key.</span>
 				<?php }
 				if (Configure::read('SMIME.enabled')):
 					$smimepath = ROOT.DS.APP_DIR.DS.WEBROOT_DIR.DS.'public_certificate.pem';
 					if (file_exists($smimepath) && is_file($smimepath)){ ?>
 						<span>Download: <?php echo $this->Html->link('SMIME certificate', $this->webroot.'public_certificate.pem');?></span>
-					<?php }else{ ?>
+					<?php } else { ?>
 						<span>Could not locate SMIME certificate.</span>
 					<?php }
 				endif;

--- a/app/View/Elements/footer.ctp
+++ b/app/View/Elements/footer.ctp
@@ -5,14 +5,14 @@
 			<div class="pull-left footerText" style="float:left;position:absolute;padding-top:12px;z-index:2;">
 				<?php
 				$gpgpath = ROOT.DS.APP_DIR.DS.WEBROOT_DIR.DS.'gpg.asc';
-				if(file_exists($gpgpath) && is_file($gpgpath)){ ?>
+				if (file_exists($gpgpath) && is_file($gpgpath)){ ?>
 					<span>Download: <?php echo $this->Html->link('PGP/GPG key', $this->webroot.'gpg.asc');?></span>
 				<?php }else{ ?>
 					<span>Could not locate the PGP/GPG public key.</span>
 				<?php }
 				if (Configure::read('SMIME.enabled')):
 					$smimepath = ROOT.DS.APP_DIR.DS.WEBROOT_DIR.DS.'public_certificate.pem';
-					if(file_exists($smimepath) && is_file($smimepath)){ ?>
+					if (file_exists($smimepath) && is_file($smimepath)){ ?>
 						<span>Download: <?php echo $this->Html->link('SMIME certificate', $this->webroot.'public_certificate.pem');?></span>
 					<?php }else{ ?>
 						<span>Could not locate SMIME certificate.</span>

--- a/app/View/Elements/global_menu.ctp
+++ b/app/View/Elements/global_menu.ctp
@@ -108,7 +108,7 @@
 					</li>
 					<?php endif;?>
 
-					<?php if($isAdmin || $isSiteAdmin): ?>
+					<?php if ($isAdmin || $isSiteAdmin): ?>
 					<li class="dropdown">
 						<a class="dropdown-toggle" data-toggle="dropdown" href="#">
 							Administration
@@ -125,10 +125,10 @@
 							<?php endif;?>
 							<li class="divider"></li>
 							<li><a href="<?php echo $baseurl;?>/admin/roles/index">List Roles</a></li>
-							<?php if($isSiteAdmin): ?>
+							<?php if ($isSiteAdmin): ?>
 							<li><a href="<?php echo $baseurl;?>/admin/roles/add">Add Role</a></li>
 							<?php endif; ?>
-							<?php if($isSiteAdmin): ?>
+							<?php if ($isSiteAdmin): ?>
 								<li class="divider"></li>
 								<li><a href="<?php echo $baseurl;?>/pages/display/administration">Administrative tools</a></li>
 								<li><a href="<?php echo $baseurl;?>/servers/serverSettings">Server settings</a></li>
@@ -153,7 +153,7 @@
 					</li>
 					<?php endif; ?>
 
-					<?php if($isAclAudit): ?>
+					<?php if ($isAclAudit): ?>
 					<li class="dropdown">
 						<a class="dropdown-toggle" data-toggle="dropdown" href="#">
 							Audit

--- a/app/View/Elements/histogram.ctp
+++ b/app/View/Elements/histogram.ctp
@@ -28,7 +28,7 @@
 		<?php foreach ($typeDb as $type => $colour): ?>
 			<div class="membersList-histogram-legend-line">
 				<div class="membersList-histogram-legend-box" style="background-color:<?php echo $colour; ?>">&nbsp;</div>
-				<div style="display: inline-block;<?php if (in_array($type, $selectedTypes)) echo 'font-weight:bold';?>" onClick='toggleHistogramType("<?php echo $type; ?>", [<?php foreach($selectedTypes as $t) echo '"' . $t . '", ' ?>]);'><?php echo $type;?></div>
+				<div style="display: inline-block;<?php if (in_array($type, $selectedTypes)) echo 'font-weight:bold';?>" onClick='toggleHistogramType("<?php echo $type; ?>", [<?php foreach ($selectedTypes as $t) echo '"' . $t . '", ' ?>]);'><?php echo $type;?></div>
 			</div>
 		<?php
 			endforeach;

--- a/app/View/Elements/templateElements/populateTemplateAttribute.ctp
+++ b/app/View/Elements/templateElements/populateTemplateAttribute.ctp
@@ -64,7 +64,7 @@
 			}
 		?>
 		</div>
-		<div class="error-message populateTemplateErrorField" <?php if(!isset($errors[$element_id])) echo 'style="display:none;"';?>>
+		<div class="error-message populateTemplateErrorField" <?php if (!isset($errors[$element_id])) echo 'style="display:none;"';?>>
 			<?php echo 'Error: ' . $errors[$element_id]; ?>
 		</div>
 	</div>

--- a/app/View/Elements/templateElements/populateTemplateDescription.ctp
+++ b/app/View/Elements/templateElements/populateTemplateDescription.ctp
@@ -14,7 +14,7 @@
 	<div class="left" style="float:left;">Tags automatically assigned:</div>
 	<div class="right" style="float:left;">
 		<?php
-			foreach($templateData['TemplateTag'] as $tag) {
+			foreach ($templateData['TemplateTag'] as $tag) {
 				echo $this->element('ajaxTemplateTag', array('editable' => 'no', 'tag' => array('Tag' => $tag['Tag'])));
 			}
 		?>

--- a/app/View/Elements/templateElements/populateTemplateFile.ctp
+++ b/app/View/Elements/templateElements/populateTemplateFile.ctp
@@ -16,7 +16,7 @@
 		<div class="input file" id="file_container_<?php echo $element_id;?>">
 		</div>
 		<iframe id="iframe_<?php echo $element_id; ?>" src="/templates/uploadFile/<?php echo $element_id; ?>/<?php echo ($element['batch'] ? 'yes' : 'no'); ?>" style="border:0px;height:30px;width:100%;overflow:hidden;" scrolling="no"></iframe>
-		<div class="error-message populateTemplateErrorField" <?php if(!isset($errors[$element_id])) echo 'style="display:none;"';?>>
+		<div class="error-message populateTemplateErrorField" <?php if (!isset($errors[$element_id])) echo 'style="display:none;"';?>>
 			<?php echo 'Error: ' . $errors[$element_id]; ?>
 		</div>
 	</div>

--- a/app/View/Events/index.ctp
+++ b/app/View/Events/index.ctp
@@ -119,7 +119,7 @@
 
 		</tr>
 		<?php foreach ($events as $event): ?>
-		<tr <?php if($event['Event']['distribution'] == 0) echo 'class = "privateRed"'?>>
+		<tr <?php if ($event['Event']['distribution'] == 0) echo 'class = "privateRed"'?>>
 			<td class="short" ondblclick="document.location.href ='<?php echo $baseurl."/events/view/".$event['Event']['id'];?>'">
 				<?php
 				if ($event['Event']['published'] == 1) {

--- a/app/View/Events/index.ctp
+++ b/app/View/Events/index.ctp
@@ -214,7 +214,7 @@
 				<?php
 				if (0 == $event['Event']['published'] && ($isSiteAdmin || ($isAclPublish && $event['Event']['orgc_id'] == $me['org_id'])))
 					echo $this->Form->postLink('', array('action' => 'alert', $event['Event']['id']), array('class' => 'icon-download-alt', 'title' => 'Publish Event'), 'Are you sure this event is complete and everyone should be informed?');
-				elseif (0 == $event['Event']['published']) echo 'Not published';
+				else if (0 == $event['Event']['published']) echo 'Not published';
 
 				if ($isSiteAdmin || ($isAclModify && $event['Event']['user_id'] == $me['id']) || ($isAclModifyOrg && $event['Event']['orgc_id'] == $me['org_id'])) {
 				?>

--- a/app/View/Events/json/rest_search.ctp
+++ b/app/View/Events/json/rest_search.ctp
@@ -22,7 +22,7 @@ foreach ($results as $result) {
 		unset($result['Event']['Attribute'][$key]['value2']);
 	}
 	// remove invalid utf8 characters for the xml parser
-	foreach($result['Event']['ShadowAttribute'] as $key => $value) {
+	foreach ($result['Event']['ShadowAttribute'] as $key => $value) {
 		$result['Event']['ShadowAttribute'][$key]['value'] = preg_replace ('/[^\x{0009}\x{000a}\x{000d}\x{0020}-\x{D7FF}\x{E000}-\x{FFFD}]+/u', ' ', $result['Event']['ShadowAttribute'][$key]['value']);
 	}
 

--- a/app/View/Events/proposal_event_index.ctp
+++ b/app/View/Events/proposal_event_index.ctp
@@ -37,7 +37,7 @@
 			</th>
 		</tr>
 		<?php foreach ($events as $event):?>
-		<tr <?php if($event['Event']['distribution'] == 0) echo 'class = "privateRed"'?>>
+		<tr <?php if ($event['Event']['distribution'] == 0) echo 'class = "privateRed"'?>>
 			<td class="short" onclick="document.location.href ='<?php echo $baseurl."/events/view/".$event['Event']['id'];?>'">
 				<?php
 				if ($event['Event']['published'] == 1) {

--- a/app/View/Events/resolved_attributes.ctp
+++ b/app/View/Events/resolved_attributes.ctp
@@ -144,7 +144,7 @@
 		foreach ($options as $group) {
 			foreach ($group as $k => $element) {
 				$temp = $group;
-				unset ($temp[$k]);
+				unset($temp[$k]);
 				if (!isset($optionsRearranged[$element])) $optionsRearranged[$element] = array();
 				$optionsRearranged[$element] = array_merge($optionsRearranged[$element], $temp);
 			}

--- a/app/View/Events/view.ctp
+++ b/app/View/Events/view.ctp
@@ -78,7 +78,7 @@
 				<dt>Contributors</dt>
 				<dd>
 					<?php
-						foreach($contributors as $k => $entry) {
+						foreach ($contributors as $k => $entry) {
 							if (Configure::read('MISP.showorg') || $isAdmin) {
 								?>
 									<a href="<?php echo $baseurl."/logs/event_index/".$event['Event']['id'].'/'.h($entry);?>" style="margin-right:2px;text-decoration: none;">
@@ -125,7 +125,7 @@
 					&nbsp;
 				</dd>
 				<dt>Distribution</dt>
-				<dd <?php if($event['Event']['distribution'] == 0) echo 'class = "privateRedText"';?> title = "<?php echo h($distributionDescriptions[$event['Event']['distribution']]['formdesc'])?>">
+				<dd <?php if ($event['Event']['distribution'] == 0) echo 'class = "privateRedText"';?> title = "<?php echo h($distributionDescriptions[$event['Event']['distribution']]['formdesc'])?>">
 					<?php
 						if ($event['Event']['distribution'] == 4):
 					?>
@@ -148,7 +148,7 @@
 				<dd style="word-wrap: break-word;">
 						<span id="eventSightingCount" class="bold sightingsCounter" data-toggle="popover" data-trigger="hover" data-content="<?php echo $sightingPopover; ?>"><?php echo count($event['Sighting']); ?></span>
 						(<span id="eventOwnSightingCount" class="green bold sightingsCounter" data-toggle="popover" data-trigger="hover" data-content="<?php echo $sightingPopover; ?>"><?php echo isset($ownSightings) ? count($ownSightings) : 0; ?></span>)
-						<?php if(!Configure::read('Plugin.Sightings_policy')) echo '- restricted to own organisation only.'; ?>
+						<?php if (!Configure::read('Plugin.Sightings_policy')) echo '- restricted to own organisation only.'; ?>
 				</dd>
 				<?php endif;
 					if (!empty($delegationRequest)):

--- a/app/View/Events/view_graph.ctp
+++ b/app/View/Events/view_graph.ctp
@@ -184,7 +184,7 @@ function update() {
 		.attr("dy", ".35em")
 		.attr("fill", function(d) {
 			if (d.type == "event") {
-				if(d.expanded == 1) {
+				if (d.expanded == 1) {
 					return "#0000ff";
 				} else {
 					return "#ff0000";

--- a/app/View/Feeds/preview_event.ctp
+++ b/app/View/Feeds/preview_event.ctp
@@ -125,7 +125,7 @@
 					<th title="<?php echo $attrDescriptions['signature']['desc'];?>"><?php echo $this->Paginator->sort('to_ids', 'IDS');?></th>
 				</tr>
 			    <?php
-					foreach($event['objects'] as $k => $object):
+					foreach ($event['objects'] as $k => $object):
 				?>
 					<tr id = "<?php echo 'Attribute_' . $object['uuid'] . '_tr'; ?>">
 						<td class="short"><?php echo (isset($object['timestamp'])) ? date('Y-m-d', $object['timestamp']) : '&nbsp'; ?></td>

--- a/app/View/Helper/CommandHelper.php
+++ b/app/View/Helper/CommandHelper.php
@@ -4,7 +4,7 @@ App::uses('AppHelper', 'View/Helper');
 //this helper simply replaces quotes between [QUOTE][/QUOTE] with div tags.
 
 	class CommandHelper extends AppHelper {
-		public function convertQuotes($string){
+		public function convertQuotes($string) {
 			$string = str_ireplace('[QUOTE]', '<div class="quote">', $string);
 			$string = str_ireplace('[/QUOTE]', '</div>', $string);
 			$matches = array();

--- a/app/View/Regexp/admin_add.ctp
+++ b/app/View/Regexp/admin_add.ctp
@@ -20,7 +20,7 @@
 	</div>
 	<div class="input clear">	</div>
 	<?php
-		foreach($types as $key => $type) {
+		foreach ($types as $key => $type) {
 			echo $this->Form->input($key, array(
 				'checked' => false,
 				'label' => $type,

--- a/app/View/Regexp/admin_edit.ctp
+++ b/app/View/Regexp/admin_edit.ctp
@@ -22,14 +22,14 @@
 	<div class="input clear">	</div>
 	<?php
 		if ($all) {
-			foreach($types as $key => $type) {
+			foreach ($types as $key => $type) {
 				echo $this->Form->input($key, array(
 				'checked' => $value[$key],
 				'label' => $type,
 				));
 			}
 		} else {
-			foreach($types as $key => $type) {
+			foreach ($types as $key => $type) {
 				echo $this->Form->input($key, array(
 					'checked' => $value[$key],
 					'label' => $type,

--- a/app/View/Roles/view.ctp
+++ b/app/View/Roles/view.ctp
@@ -22,7 +22,7 @@
 		foreach ($role['Role'] as $k => $item):
 			if (substr($k, 0, 5) === 'perm_' && !in_array($k, array('perm_add', 'perm_modify', 'perm_modify_org', 'perm_publish', 'perm_full'))):
 				$nameParts = explode('_', $k);
-				unset ($nameParts[0]);
+				unset($nameParts[0]);
 				foreach ($nameParts as &$p) $p = ucfirst($p);
 				$name = implode(' ', $nameParts);
 				?>

--- a/app/View/Servers/preview_event.ctp
+++ b/app/View/Servers/preview_event.ctp
@@ -51,7 +51,7 @@
 					&nbsp;
 				</dd>
 				<dt>Distribution</dt>
-				<dd <?php if($event['Event']['distribution'] == 0) echo 'class = "privateRedText"';?> title = "<?php echo h($distributionDescriptions[$event['Event']['distribution']]['formdesc'])?>">
+				<dd <?php if ($event['Event']['distribution'] == 0) echo 'class = "privateRedText"';?> title = "<?php echo h($distributionDescriptions[$event['Event']['distribution']]['formdesc'])?>">
 					<?php
 						if ($event['Event']['distribution'] == 4):
 					?>
@@ -151,7 +151,7 @@
 					<th title="<?php echo $attrDescriptions['distribution']['desc'];?>"><?php echo $this->Paginator->sort('distribution');?></th>
 				</tr>
 			    <?php
-					foreach($event['objects'] as $k => $object):
+					foreach ($event['objects'] as $k => $object):
 						$extra = $extra2 = $extra3 = '';
 						$currentType = 'denyForm';
 						if ($object['objectType'] == 0 ) {

--- a/app/View/Servers/preview_index.ctp
+++ b/app/View/Servers/preview_index.ctp
@@ -81,7 +81,7 @@
 
 		</tr>
 		<?php if (!empty($events)) foreach ($events as $event): ?>
-		<tr <?php if($event['Event']['distribution'] == 0) echo 'class = "privateRed"'?>>
+		<tr <?php if ($event['Event']['distribution'] == 0) echo 'class = "privateRed"'?>>
 			<td class="short" ondblclick="document.location.href ='<?php echo $eventViewURL . h($event['Event']['id']);?>'">
 				<?php
 				if ($event['Event']['published'] == 1) {

--- a/app/View/Servers/server_settings.ctp
+++ b/app/View/Servers/server_settings.ctp
@@ -11,7 +11,7 @@
 			echo $this->element('healthElements/diagnostics');
 		} else if ($tab == 'workers') {
 			echo $this->element('healthElements/workers');
-		} else if($tab == 'files') {
+		} else if ($tab == 'files') {
 			echo $this->element('healthElements/files');
 		} else {
 			echo $this->element('healthElements/overview');

--- a/app/View/ShadowAttributes/add.ctp
+++ b/app/View/ShadowAttributes/add.ctp
@@ -44,7 +44,7 @@
 		?>
 	</div>
 	</fieldset>
-	<p style="color:red;font-weight:bold;display:none;<?php if($ajax) echo 'text-align:center;'; ?>" id="warning-message">Warning: You are about to share data that is of a classified nature (Attribution / targeting data). Make sure that you are authorised to share this.</p>
+	<p style="color:red;font-weight:bold;display:none;<?php if ($ajax) echo 'text-align:center;'; ?>" id="warning-message">Warning: You are about to share data that is of a classified nature (Attribution / targeting data). Make sure that you are authorised to share this.</p>
 	<?php if (isset($ajax) && $ajax): ?>
 		<div class="overlay_spacing">
 			<table>
@@ -53,7 +53,7 @@
 					<span id="submitButton" class="btn btn-primary" onClick="submitPopoverForm('<?php echo $event_id;?>', 'propose')">Propose</span>
 				</td>
 				<td style="width:540px;">
-					<p style="color:red;font-weight:bold;display:none;<?php if(isset($ajax) && $ajax) echo "text-align:center;"?>" id="warning-message">Warning: You are about to share data that is of a sensitive nature (Attribution / targeting data). Make sure that you are authorised to share this.</p>
+					<p style="color:red;font-weight:bold;display:none;<?php if (isset($ajax) && $ajax) echo "text-align:center;"?>" id="warning-message">Warning: You are about to share data that is of a sensitive nature (Attribution / targeting data). Make sure that you are authorised to share this.</p>
 				</td>
 				<td style="vertical-align:top;">
 					<span class="btn btn-inverse" id="cancel_attribute_add">Cancel</span>

--- a/app/View/ShadowAttributes/edit.ctp
+++ b/app/View/ShadowAttributes/edit.ctp
@@ -49,7 +49,7 @@
 					<span id="submitButton" class="btn btn-primary" onClick="submitPopoverForm('<?php echo $event_id;?>', 'propose')">Propose</span>
 				</td>
 				<td style="width:540px;">
-					<p style="color:red;font-weight:bold;display:none;<?php if(isset($ajax) && $ajax) echo "text-align:center;"?>" id="warning-message">Warning: You are about to share data that is of a sensitive nature (Attribution / targeting data). Make sure that you are authorised to share this.</p>
+					<p style="color:red;font-weight:bold;display:none;<?php if (isset($ajax) && $ajax) echo "text-align:center;"?>" id="warning-message">Warning: You are about to share data that is of a sensitive nature (Attribution / targeting data). Make sure that you are authorised to share this.</p>
 				</td>
 				<td style="vertical-align:top;">
 					<span class="btn btn-inverse" id="cancel_attribute_add">Cancel</span>

--- a/app/View/ShadowAttributes/xml/get_proposals_by_uuid.ctp
+++ b/app/View/ShadowAttributes/xml/get_proposals_by_uuid.ctp
@@ -5,9 +5,9 @@ $xmlArray = array();
 //
 if (isset($proposal['ShadowAttribute']['id'])) {
 	$temp = $proposal['ShadowAttribute'];
-	unset ($proposal['ShadowAttribute']);
+	unset($proposal['ShadowAttribute']);
 	$proposal['ShadowAttribute'][0] = $temp;
-	unset ($temp);
+	unset($temp);
 }
 $xmlArray['response']['ShadowAttribute'] = array();
 foreach ($proposal as &$temp) {

--- a/app/View/TemplateElements/ajax/ajaxIndex.ctp
+++ b/app/View/TemplateElements/ajax/ajaxIndex.ctp
@@ -1,13 +1,13 @@
 <div id="ajaxTemplateElementsIndex">
 	<h2>Template Elements</h2>
-	<ul <?php if($mayModify): ?> id="sortable" <?php endif; ?> style="list-style:none; margin:0px;">
+	<ul <?php if ($mayModify): ?> id="sortable" <?php endif; ?> style="list-style:none; margin:0px;">
 				<?php
 				foreach ($elements as $k => $element):
 					echo $this->element('templateElements/templateRow' . ucfirst($element['TemplateElement']['element_definition']), array('element' => $element, 'element_id' => $element['TemplateElement']['id']));
 				endforeach;
 			?>
 	</ul>
-	<?php if($mayModify): ?>
+	<?php if ($mayModify): ?>
 	<div id="AddTemplateElementDiv" class="addTemplateElement useCursorPointer" onClick="templateAddElementClicked(<?php echo $id; ?>);">+</div>
 	<?php endif; ?>
 </div>

--- a/app/View/Users/admin_filter_user_index.ctp
+++ b/app/View/Users/admin_filter_user_index.ctp
@@ -22,7 +22,7 @@
 						'div' => false
 				));
 
-				foreach($differentFilters as $b) {
+				foreach ($differentFilters as $b) {
 					echo $this->Form->input('search' . $b, array(
 						'options' => array('' => 'Any', '0' => 'No', '1' => 'Yes'),
 						'class' => 'input',
@@ -32,7 +32,7 @@
 					));
 				}
 
-				foreach($simpleFilters as $t) {
+				foreach ($simpleFilters as $t) {
 					if ($t == 'role') {
 						echo $this->Form->input('search' . $t, array(
 								'options' => array($roles),

--- a/app/View/Users/statistics.ctp
+++ b/app/View/Users/statistics.ctp
@@ -45,7 +45,7 @@
 	<ul class="inline">
 	<li id="org-all"  class="btn btn btn.active qet" style="margin-right:5px;" onClick="updateCalendar('all')">All organisations</li>
 	<?php
-		foreach($orgs as $org): ?>
+		foreach ($orgs as $org): ?>
 			<li id="org-<?php echo h($org['Organisation']['name']);?>"  class="btn btn btn.active qet" style="margin-right:5px;" onClick="updateCalendar('<?php echo h($org['Organisation']['name']);?>')">
 				<?php echo h($org['Organisation']['name']);?>
 			</li>


### PR DESCRIPTION
replaces #1208 

this PR aims to achieve a consistent coding convention regarding spaces/brackets.
it applies the way it was already done in most parts of the code to the other parts.

commands:

```
# add space before opening curly brackets
egrep -rlI "\){( |/|$)" | grep "\.php" | while read file; do sed -i -r 's|\)\{( .*\|/.*)?$|) {\1|g' $file; done
# add space after keywords if/for/foreach/while/switch/catch
egrep -rlI "\s(if|for|foreach|while|switch|catch)\(" | egrep "\.(php|ctp)" | while read file; do sed -i -r 's|(\s+)(if\|for\|foreach\|while\|switch\|catch)\(|\1\2 (|g' $file; done
# remove space after unset before opening brace
grep -rlI "unset (" | while read file; do sed -i "s|unset (|unset(|" $file; done
# use consistent spacing around else/elseif
egrep -rlI "} ?else{" | egrep "\.(php|ctp)" | while read file; do sed -i -r "s|\} ?else\{|} else {|" $file; done
egrep -rlI "\selseif \(" | egrep "\.(php|ctp)" | while read file; do sed -i -r "s|(\s+)elseif \(|\1else if (|" $file; done
```

two exceptions are made from the last command to not break special if/endif syntax.
