### PR TITLE
replace exec unzip by ZipArchive class

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -1853,12 +1853,17 @@ class EventsController extends AppController {
 			$result = $zipFile->write($zipData);
 			if (!$result) $this->Session->setFlash(__('Problem with writing the zip file. Please report to administrator.'));
 
-			// extract zip
-			$execRetval = '';
-			$execOutput = array();
-			exec("unzip " . $zipFile->path . ' -d ' . $rootDir, $execOutput, $execRetval);
-			if ($execRetval != 0) {	// not EXIT_SUCCESS
-				throw new Exception('An error has occured while attempting to unzip the GFI sandbox .zip file. We apologise for the inconvenience.');
+			// extract
+			$zip = new ZipArchive();
+			$res = $zip->open($zipFile->path);
+			if ($res === TRUE) {
+				$res2 = $zip->extractTo($rootDir);
+				if ($res2 === FALSE) {
+					throw new Exception('An error has occured while attempting to unzip the GFI sandbox .zip file.');
+				}
+				$zip->close();
+			} else {
+				throw new Exception('An error ("'.$res.'") has occured while attempting to open the GFI sandbox .zip file.');
 			}
 
 			// open the xml


### PR DESCRIPTION
as using exec() or similar functions that directly call shell commands always carries security problems, these should be replaced by native solutions.
as a first step, this PR replaces the exec("unzip...") in EventsController.php by using the ZipArchive class that is available when PHP is compiled with --enable-zip

this is untested, because i
a) don't have an example GFI sandbox file
b) don't have any experience with CentOS (to know if they have zip enabled in their PHP packages)

therefore, testing and feedback would be appreciated.

afterwards, i intend to also convert the other zip-execs
