### PR TITLE
chg: improve fopen/fread/fwrite handling via Lib

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -1831,12 +1831,8 @@ class EventsController extends AppController {
 	public function _addGfiZip($id) {
 		if (!empty($this->data) && $this->data['Event']['submittedgfi']['size'] > 0 &&
 				is_uploaded_file($this->data['Event']['submittedgfi']['tmp_name'])) {
-			$tmpFileHandle = fopen($this->data['Event']['submittedgfi']['tmp_name'], "rb");
-			if ($tmpFileHandle === FALSE) {
-				throw new Exception('An error has occured while attempting to access the GFI sandbox .zip file.');
-			}
-			$zipData = fread($tmpFileHandle, $this->data['Event']['submittedgfi']['size']);
-			fclose($tmpFileHandle);
+			App::uses('FileAccess', 'Tools');
+			$zipData = FileAccess::readFromFile($this->data['Event']['submittedgfi']['tmp_name'], $this->data['Event']['submittedgfi']['size']);
 
 			// write
 			$rootDir = APP . "files" . DS . $id . DS;
@@ -1860,12 +1856,7 @@ class EventsController extends AppController {
 			// open the xml
 			$xmlFileName = 'analysis.xml';
 			$xmlFilePath = $rootDir . DS . 'Analysis' . DS . $xmlFileName;
-			$xmlFileHandle = fopen($xmlFilePath, "rb");
-			if ($xmlFileHandle === FALSE) {
-				throw new Exception('An error has occured while attempting to access the GFI sandbox XML analysis file.');
-			}
-			$xmlFileData = fread($xmlFileHandle, filesize($xmlFilePath));
-			fclose($xmlFileHandle);
+			$xmlFileData = FileAccess::readFromFile($xmlFilePath);
 
 			// read XML
 			$this->_readGfiXML($xmlFileData, $id);
@@ -1875,12 +1866,7 @@ class EventsController extends AppController {
 	public function _addIOCFile($id) {
 		if (!empty($this->data) && $this->data['Event']['submittedioc']['size'] > 0 &&
 				is_uploaded_file($this->data['Event']['submittedioc']['tmp_name'])) {
-			$tmpFileHandle = fopen($this->data['Event']['submittedioc']['tmp_name'], "rb");
-			if ($tmpFileHandle === FALSE) {
-				throw new Exception('An error has occured while attempting to access the IOC file.');
-			}
-			$iocData = fread($tmpFileHandle, $this->data['Event']['submittedioc']['size']);
-			fclose($tmpFileHandle);
+			$iocData = FileAccess::readFromFile($this->data['Event']['submittedioc']['tmp_name'], $this->data['Event']['submittedioc']['size']);
 
 			// write
 			$rootDir = APP . "files" . DS . $id . DS;
@@ -1896,12 +1882,7 @@ class EventsController extends AppController {
 
 			// open the xml
 			$xmlFilePath = $destPath . DS . $this->data['Event']['submittedioc']['name'];
-			$xmlFileHandle = fopen($xmlFilePath, "rb");
-			if ($xmlFileHandle === FALSE) {
-				throw new Exception('An error has occured while attempting to access the IOC file.');
-			}
-			$xmlFileData = fread($xmlFileHandle, $this->data['Event']['submittedioc']['size']);
-			fclose($xmlFileHandle);
+			$xmlFileData = FileAccess::readFromFile($xmlFilePath, $this->data['Event']['submittedioc']['size']);
 
 			// Load event and populate the event data
 			$this->Event->id = $id;
@@ -1967,12 +1948,8 @@ class EventsController extends AppController {
 	}
 
 	public function _addMISPExportFile($ext, $take_ownership = false) {
-		$fileHandle = fopen($this->data['Event']['submittedfile']['tmp_name'], "rb");
-		if ($fileHandle === FALSE) {
-			throw new Exception('An error has occured while attempting to access the submitted file.');
-		}
-		$data = fread($fileHandle, $this->data['Event']['submittedfile']['size']);
-		fclose($fileHandle);
+		App::uses('FileAccess', 'Tools');
+		$data = FileAccess::readFromFile($this->data['Event']['submittedfile']['tmp_name'], $this->data['Event']['submittedfile']['size']);
 
 		if ($ext == 'xml') {
 			App::uses('Xml', 'Utility');

--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -537,14 +537,17 @@ class ServersController extends AppController {
 			$ext = '';
 			App::uses('File', 'Utility');
 			App::uses('Folder', 'Utility');
+			App::uses('FileAccess', 'Tools');
 			$file = new File($server['Server']['submitted_cert']['name']);
 			$ext = $file->ext();
 			if (($ext != 'pem') || !$server['Server']['submitted_cert']['size'] > 0) {
 				$this->Session->setFlash('Incorrect extension or empty file.');
 				$this->redirect(array('action' => 'index'));
 			}
-			$pemData = fread(fopen($server['Server']['submitted_cert']['tmp_name'], "r"),
-					$server['Server']['submitted_cert']['size']);
+
+			// read pem file data
+			$pemData = FileAccess::readFromFile($server['Server']['submitted_cert']['name'], $server['Server']['submitted_cert']['size']);
+
 			$destpath = APP . "files" . DS . "certs" . DS;
 			$dir = new Folder(APP . "files" . DS . "certs", true);
 			if (!preg_match('@^[\w-,\s,\.]+\.[A-Za-z0-9_]{2,4}$@', $server['Server']['submitted_cert']['name'])) throw new Exception ('Filename not allowed');

--- a/app/Lib/Tools/FileAccess.php
+++ b/app/Lib/Tools/FileAccess.php
@@ -1,0 +1,41 @@
+<?php
+
+class FileAccess {
+	private static $__fileErrorMsgPrefix = 'An error has occured while attempting to ';
+
+	public static function createTempFile($dir, $prefix = 'MISP') {
+		$tempFile = tempnam($dir, $prefix);
+		self::checkForFalse($tempFile, 'create a temporary file in path "' . $dir);
+		return $tempFile;
+	}
+
+	public static function readFromFile($file, $fileSize = -1) {
+		self::checkForFalse($file, 'create file "' . $file);
+		$fileHandle = fopen($file, 'rb');
+		self::checkForFalse($fileHandle, 'access file "' . $file);
+		if ($fileSize === -1) {
+			$fileSize = filesize($file);
+			self::checkForFalse($fileHandle, 'get filesize from file "' . $file);
+		}
+		$readResult = fread($fileHandle, $fileSize);
+		self::checkForFalse($fileHandle, 'read from file "' . $file);
+		fclose($fileHandle);
+		return $readResult;
+	}
+
+	public static function writeToFile($file, $content) {
+		self::checkForFalse($file, 'create file "' . $file);
+		$fileHandle = fopen($file, 'wb');
+		self::checkForFalse($fileHandle, 'access file "' . $file);
+		$writeResult = fwrite($fileHandle, $content);
+		self::checkForFalse($writeResult, 'write to file "' . $file);
+		fclose($fileHandle);
+		return $file;
+	}
+
+	private static function checkForFalse($result, $errorMsgPart) {
+		if ($result === false) {
+			throw new Exception(self::$__fileErrorMsgPrefix . $errorMsgPart . '".');
+		}
+	}
+}

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -335,16 +335,14 @@ class User extends AppModel {
 		if (openssl_x509_read($check['certif_public'])) {
 			try {
 				App::uses('Folder', 'Utility');
+				App::uses('FileAccess', 'Tools');
 				$dir = APP . 'tmp' . DS . 'SMIME';
 				if (!file_exists($dir)) {
 					if (!mkdir($dir, 0750, true)) throw new MethodNotAllowedException('The SMIME temp directory is not writeable (app/tmp/SMIME).');
 				}
-				$msg_test = tempnam($dir, 'SMIME');
-				$fp = fopen($msg_test, "w");
-				$test = 'test';
-				fwrite($fp, $test);
-				fclose($fp);
-				$msg_test_encrypted = tempnam($dir, 'SMIME');
+				$tempFile = FileAccess::createTempFile($dir, 'SMIME');
+				$msg_test = FileAccess::writeToFile($tempFile, 'test');
+				$msg_test_encrypted = FileAccess::createTempFile($dir, 'SMIME');
 				// encrypt it
 				if (openssl_pkcs7_encrypt($msg_test, $msg_test_encrypted, $check['certif_public'], null, 0, OPENSSL_CIPHER_AES_256_CBC)) {
 					unlink($msg_test);
@@ -529,16 +527,14 @@ class User extends AppModel {
 			$certif_public = $user['User']['certif_public'];
 			try {
 				App::uses('Folder', 'Utility');
+				App::uses('FileAccess', 'Tools');
 				$dir = APP . 'tmp' . DS . 'SMIME';
 				if (!file_exists($dir)) {
 					if (!mkdir($dir, 0750, true)) throw new MethodNotAllowedException('The SMIME temp directory is not writeable (app/tmp/SMIME).');
 				}
-				$msg_test = tempnam($dir, 'SMIME');
-				$fp = fopen($msg_test, "w");
-				$test = 'test';
-				fwrite($fp, $test);
-				fclose($fp);
-				$msg_test_encrypted = tempnam($dir, 'SMIME');
+				$tempFile = FileAccess::createTempFile($dir, 'SMIME');
+				$msg_test = FileAccess::writeToFile($tempFile, 'test');
+				$msg_test_encrypted = FileAccess::createTempFile($dir, 'SMIME');
 				// encrypt it
 				if (openssl_pkcs7_encrypt($msg_test, $msg_test_encrypted, $certif_public, null, 0, OPENSSL_CIPHER_AES_256_CBC)) {
 					$parse = openssl_x509_parse($certif_public);
@@ -760,25 +756,22 @@ class User extends AppModel {
 			try {
 				$prependedBody = 'Content-Transfer-Encoding: 7bit' . PHP_EOL . 'Content-Type: text/plain;' . PHP_EOL . '    charset=us-ascii' . PHP_EOL . PHP_EOL . $body;
 				App::uses('Folder', 'Utility');
+				App::uses('FileAccess', 'Tools');
 				$dir = APP . 'tmp' . DS . 'SMIME';
 				if (!file_exists($dir)) {
 					if (!mkdir($dir, 0750, true)) throw new MethodNotAllowedException('The SMIME temp directory is not writeable (app/tmp/SMIME).');
 				}
 				// save message to file
-				$msg = tempnam($dir, 'SMIME');
-				$fp = fopen($msg, "w");
-				fwrite($fp, $prependedBody);
-				fclose($fp);
+				$tempFile = FileAccess::createTempFile($dir, 'SMIME');
+				$msg = FileAccess::writeToFile($tempFile, $prependedBody);
 				$headers_smime = array("To" => $user['User']['email'], "From" => Configure::read('MISP.email'), "Subject" => $subject);
 				$canSign = true;
 				if (empty(Configure::read('SMIME.cert_public_sign')) || !is_readable(Configure::read('SMIME.cert_public_sign'))) $canSign = false;
 				if (empty(Configure::read('SMIME.key_sign')) || !is_readable(Configure::read('SMIME.key_sign'))) $canSign = false;
 				if ($canSign) {
-					$signed = tempnam($dir, 'SMIME');
+					$signed = FileAccess::createTempFile($dir, 'SMIME');
 					if (openssl_pkcs7_sign($msg, $signed, 'file://'.Configure::read('SMIME.cert_public_sign'), array('file://'.Configure::read('SMIME.key_sign'), Configure::read('SMIME.password')), array(), PKCS7_TEXT)) {
-						$fp = fopen($signed, "r");
-						$bodySigned = fread($fp, filesize($signed));
-						fclose($fp);
+						$bodySigned = FileAccess::readFromFile($signed);
 						unlink($msg);
 						unlink($signed);
 					} else {
@@ -787,19 +780,15 @@ class User extends AppModel {
 						throw new Exception('Failed while attempting to sign the SMIME message.');
 					}
 					// save message to file
-					$msg_signed = tempnam($dir, 'SMIME');
-					$fp = fopen($msg_signed, "w");
-					fwrite($fp, $bodySigned);
-					fclose($fp);
+					$tempFile = FileAccess::createTempFile($dir, 'SMIME');
+					$msg_signed = FileAccess::writeToFile($tempFile, $bodySigned);
 				} else {
 					$msg_signed = $msg;
 				}
-				$msg_signed_encrypted = tempnam($dir, 'SMIME');
+				$msg_signed_encrypted = FileAccess::createTempFile($dir, 'SMIME');
 				// encrypt it
 				if (openssl_pkcs7_encrypt($msg_signed, $msg_signed_encrypted, $user['User']['certif_public'], $headers_smime, 0, OPENSSL_CIPHER_AES_256_CBC)) {
-					$fp = fopen($msg_signed_encrypted, 'r');
-					$bodyEncSig = fread($fp, filesize($msg_signed_encrypted));
-					fclose($fp);
+					$bodyEncSig = FileAccess::readFromFile($msg_signed_encrypted);
 					unlink($msg_signed);
 					unlink($msg_signed_encrypted);
 					$parts = explode("\n\n", $bodyEncSig);


### PR DESCRIPTION
introduces better (if there even was any) error handling to fopen/fread/fwrite.

using a separate private function in two of the three files to reduce code redundancy.
