### PR TITLE
fixing the "TLP:AMBER hardcoded in email subject" issue #1107

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1484,7 +1484,7 @@ class Event extends AppModel {
 		} else {
 			$subject = '';
 		}
-		$subject = "[" . Configure::read('MISP.org') . " MISP] Event " . $id . " - " . $subject . $event[0]['ThreatLevel']['name'] . " - TLP Amber";
+		$subject = "[" . Configure::read('MISP.org') . " MISP] Event " . $id . " - " . $subject . $event[0]['ThreatLevel']['name'] . " - ".Configure::read('MISP.email_subject_TLP_string');
 
 		// Initialise the Job class if we have a background process ID
 		// This will keep updating the process's progress bar
@@ -1677,7 +1677,7 @@ class Event extends AppModel {
 		$bodyevent .= $bodyTempOther;	// append the 'other' attribute types to the bottom.
 		$result = true;
 		foreach ($orgMembers as &$reporter) {
-			$subject = "[" . Configure::read('MISP.org') . " MISP] Need info about event " . $id . " - TLP Amber";
+			$subject = "[" . Configure::read('MISP.org') . " MISP] Need info about event " . $id . " - ".Configure::read('MISP.email_subject_TLP_string');
 			$result = $this->User->sendEmail($reporter, $bodyevent, $body, $subject, $user) && $result;
 		}
 		return $result;

--- a/app/Model/Post.php
+++ b/app/Model/Post.php
@@ -111,7 +111,7 @@ class Post extends AppModel {
 		$bodyDetail .= "The following message was added: \n";
 		$bodyDetail .= "\n";
 		$bodyDetail .= $message . "\n";
-		$subject = "[" . Configure::read('MISP.org') . " MISP] New post in discussion " . $post['Post']['thread_id'] . " - TLP Amber";
+		$subject = "[" . Configure::read('MISP.org') . " MISP] New post in discussion " . $post['Post']['thread_id'] . " - ".Configure::read('MISP.email_subject_TLP_string');
 		foreach ($orgMembers as &$recipient) {
 			$this->User->sendEmail($recipient, $bodyDetail, $body, $subject);
 		}

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -272,6 +272,14 @@ class Server extends AppModel {
 							'test' => 'testBool',
 							'type' => 'boolean',
 					),
+					'email_subject_TLP_string' => array(
+						'level' => 0,
+						'description' => 'This is the TLP string in alert e-mail sent when an event is published.',
+						'value' => '',
+						'errorMessage' => '',
+						'test' => 'testForEmpty',
+						'type' => 'string',
+					),
 					'sync' => array(
 							'level' => 3,
 							'description' => 'This setting is deprecated and can be safely removed.',


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:
- One Pull Request per fix/feature/change/...
- Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
- Always make sure it is mergeable in the default branch (as of today 2016-06-03: branch 2.4)
- Please make sure Travis CI works on this request, or update the test cases if needed
- Any major changes adding a functionality should be disabled by default in the config
#### What does it do?

It fixes the "TLP:AMBER hardcoded in email subject" issue `#<1107>`
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [x] Minor
- [ ] Patch
