### PR TITLE
fix: dont override type variable

### DIFF
--- a/app/Lib/Tools/ComplexTypeTool.php
+++ b/app/Lib/Tools/ComplexTypeTool.php
@@ -34,9 +34,11 @@ class ComplexTypeTool {
 		if (strpos($input, '|')) {
 			$composite = true;
 			$result = explode('|', $input);
-			if (count($result) != 2) $type = 'other';
-			if (!preg_match("#^.+#", $result[0])) $type = 'other';
-			$type = 'filename|';
+			if (count($result) != 2 || !preg_match("#^.+#", $result[0])) {
+				$type = 'other';
+			} else {
+				$type = 'filename|';
+			}
 			$input = $result[1];
 		}
 		if (strlen($input) == 32 && preg_match("#[0-9a-f]{32}$#", $input)) $type .= 'md5';


### PR DESCRIPTION
the type variable is always overriden by "filename|" even if it was set to "other" before.

i'm not 100% sure if my PR achieves the intended behaviour, but at least it doesn't override something.
please comment if this isn't the intended behaviour.
