### PR TITLE
Fix CertAuth plugin

### DIFF
--- a/app/Config/config.default.php
+++ b/app/Config/config.default.php
@@ -78,7 +78,7 @@ $config = array (
     'restApi'       => array(        // API parameters
       'url'         => 'https://example.com/data/users',  // URL to query
       'headers'     => array(),                           // additional headers, used for authentication
-      'param'       => array( 'email' => 'email'),        // query parameters to add to the URL, mapped to User properties
+      'param'       => array( 'email' => 'email' ),       // query parameters to add to the URL, mapped to User properties
       'map'         =>  array(                            // maps REST result to the User properties
         'uid'       => 'nids_sid',
         'team'      => 'org',
@@ -86,7 +86,7 @@ $config = array (
         'pgp_public'=> 'gpgkey',
       ),
     ),
-    'userDefaults'  => array ( 'role_id' => 3),           // default attributes for new users
+    'userDefaults'  => array ( 'role_id' => 3 ),          // default attributes for new users
   ),
   */
   // Warning: The following is a 3rd party contribution and still untested (including security) by the MISP-project team.

--- a/app/Config/config.default.php
+++ b/app/Config/config.default.php
@@ -86,6 +86,7 @@ $config = array (
         'pgp_public'=> 'gpgkey',
       ),
     ),
+    'userDefaults'  => array ( 'role_id' => 3),           // default attributes for new users
   ),
   */
   // Warning: The following is a 3rd party contribution and still untested (including security) by the MISP-project team.

--- a/app/Plugin/CertAuth/Controller/Component/Auth/CertificateAuthenticate.php
+++ b/app/Plugin/CertAuth/Controller/Component/Auth/CertificateAuthenticate.php
@@ -155,7 +155,7 @@ class CertificateAuthenticate extends BaseAuthenticate
                             }
                             unset($write);
                         }
-                        self::$user = $U[$cn];
+                        self::$user = $User->getAuthUser($U[$cn]['id']);
                     } else if ($sync) {
                         $User->create();
                         $d = Configure::read('CertAuth.userDefaults');
@@ -165,7 +165,7 @@ class CertificateAuthenticate extends BaseAuthenticate
                         unset($d);
                         if ($User->save(self::$user, true, array_keys(self::$user))) {
                             $U = $User->read();
-                            self::$user = $U[$cn];
+                            self::$user = $User->getAuthUser($U[$cn]['id']);
                         } else {
                             CakeLog::write('alert', 'Could not insert model at database from RestAPI data.');
                         }

--- a/app/Plugin/CertAuth/README.md
+++ b/app/Plugin/CertAuth/README.md
@@ -37,9 +37,10 @@ Configure::write('CertAuth',
         'email'     => 'email',
       ),
     ),
+    'userDefaults'  => array ( 'role_id' => 3 ),          // default attributes for new users
   )
 );
 ```
 
-
+If you set *syncUser* to *true* and *restApi.url* to *null*, new users will be created with the defaults defined by *userDefaults* without the need for a REST server.
 

--- a/app/Plugin/CertAuth/README.md
+++ b/app/Plugin/CertAuth/README.md
@@ -37,8 +37,8 @@ Configure::write('CertAuth',
         'email'     => 'email',
       ),
     ),
-  ),
-));
+  )
+);
 ```
 
 


### PR DESCRIPTION
#### What does it do?

The CertAuth plugin returned an user object that was missing the ['Role'], ['Organization'] and ['Server'] elements. This PR fixes that. It also adds documentation for the userDefaults feature.

In my testing the CertAuth configuration was never written to config.php and actually removed when present there. So I used the documentation from README.md and placed it in bootstrap.php instead. Perhaps the example CertAuth configuration in config.default.php should be moved to bootstrap.default.php
#### Questions
- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
