### PR TITLE
installation instructions for MISP on Ubuntu 16.04

### DIFF
--- a/INSTALL/INSTALL.ubuntu1604.txt
+++ b/INSTALL/INSTALL.ubuntu1604.txt
@@ -1,0 +1,269 @@
+INSTALLATION INSTRUCTIONS
+------------------------- for ubuntu 16.04-server
+
+1/ Minimal Ubuntu install
+-------------------------
+
+# Install a minimal Ubuntu 16.04-server system with the software:
+- OpenSSH server
+
+# install postfix, there will be some questions.
+sudo apt-get install postfix
+# Postfix Configuration: Satellite system
+# change the relay server later with:
+sudo postconf -e 'relayhost = example.com'
+sudo postfix reload
+
+# Make sure your system is up2date:
+sudo apt-get update
+sudo apt-get upgrade
+
+
+2/ Install LAMP & dependencies
+------------------------------
+Once the system is installed you can perform the following steps:
+
+# Install the dependencies: (some might already be installed)
+sudo apt-get install curl gcc git gnupg-agent make python openssl redis-server sudo vim zip
+
+# Install MariaDB (a MySQL fork/alternative)
+sudo apt-get install mariadb-client mariadb-server
+
+# Secure the MariaDB installation (especially by setting a strong root password)
+sudo mysql_secure_installation
+
+# Install Apache2
+sudo apt-get install apache2 apache2-doc apache2-utils
+
+# Enable modules, settings, and default of SSL in Apache
+sudo a2dismod status
+sudo a2enmod ssl rewrite
+sudo a2dissite 000-default
+sudo a2ensite default-ssl
+
+# Install PHP and dependencies
+sudo apt-get install libapache2-mod-php php php-cli php-crypt-gpg php-dev php-json php-mysql php-opcache php-readline php-redis
+
+# Apply all changes
+sudo systemctl restart apache2
+
+
+3/ MISP code
+------------
+# Download MISP using git in the /var/www/ directory.
+sudo mkdir /var/www/MISP
+sudo chown www-data:www-data /var/www/MISP
+sudo -u www-data git clone https://github.com/MISP/MISP.git /var/www/MISP
+cd /var/www/MISP
+
+# Make git ignore filesystem permission differences
+sudo -u www-data git config core.filemode false
+
+# install Mitre's STIX and its dependencies by running the following commands:
+sudo apt-get install python-dev python-pip libxml2-dev libxslt1-dev zlib1g-dev
+cd /var/www/MISP/app/files/scripts
+sudo -u www-data git clone https://github.com/CybOXProject/python-cybox.git
+sudo -u www-data git clone https://github.com/STIXProject/python-stix.git
+cd /var/www/MISP/app/files/scripts/python-cybox
+sudo -u www-data git checkout v2.1.0.12
+sudo python setup.py install
+cd /var/www/MISP/app/files/scripts/python-stix
+sudo -u www-data git checkout v1.1.1.4
+sudo python setup.py install
+
+
+4/ CakePHP
+-----------
+# CakePHP is included as a submodule of MISP, execute the following commands to let git fetch it:
+cd /var/www/MISP
+sudo -u www-data git submodule init
+sudo -u www-data git submodule update
+
+# Once done, install CakeResque along with its dependencies if you intend to use the built in background jobs:
+cd /var/www/MISP/app
+sudo -u www-data wget https://getcomposer.org/download/1.1.2/composer.phar -O composer.phar
+sudo -u www-data php composer.phar require kamisama/cake-resque:4.1.2
+sudo -u www-data php composer.phar config vendor-dir Vendor
+sudo -u www-data php composer.phar install
+
+# Enable CakeResque with php-redis
+sudo phpenmod redis
+
+# To use the scheduler worker for scheduled tasks, do the following:
+sudo -u www-data cp -fa /var/www/MISP/INSTALL/setup/config.php /var/www/MISP/app/Plugin/CakeResque/Config/config.php
+
+
+5/ Set the permissions
+----------------------
+
+# Check if the permissions are set correctly using the following commands:
+sudo chown -R www-data:www-data /var/www/MISP
+sudo chmod -R 750 /var/www/MISP
+sudo chmod -R g+ws /var/www/MISP/app/tmp
+sudo chmod -R g+ws /var/www/MISP/app/files
+sudo chmod -R g+ws /var/www/MISP/app/files/scripts/tmp
+
+
+6/ Create a database and user
+-----------------------------
+# Enter the mysql shell
+sudo mysql -u root -p
+
+MariaDB [(none)]> create database misp;
+MariaDB [(none)]> grant usage on *.* to misp@localhost identified by 'XXXXdbpasswordhereXXXXX';
+MariaDB [(none)]> grant all privileges on misp.* to misp@localhost;
+MariaDB [(none)]> flush privileges;
+MariaDB [(none)]> exit
+
+# Import the empty MISP database from MYSQL.sql
+sudo -u www-data sh -c "mysql -u misp -p misp < /var/www/MISP/INSTALL/MYSQL.sql"
+# enter the password you set previously
+
+
+7/ Apache configuration
+-----------------------
+# Now configure your apache server with the DocumentRoot /var/www/MISP/app/webroot/
+# A sample vhost can be found in /var/www/MISP/INSTALL/apache.misp.ubuntu
+
+sudo cp /var/www/MISP/INSTALL/apache.misp.ssl /etc/apache2/sites-available/misp-ssl.conf
+
+# Be aware that the configuration files for apache 2.4 and up have changed.
+# The configuration file has to have the .conf extension in the sites-available directory
+# For more information, visit http://httpd.apache.org/docs/2.4/upgrading.html
+
+# If a valid SSL certificate is not already created for the server, create a self-signed certificate:
+openssl req -newkey rsa:4096 -days 365 -nodes -x509 \
+-subj "/C=<Country>/ST=<State>/L=<Locality>/O=<Organization>/OU=<Organizational Unit Name>/CN=<QDN.here>/emailAddress=admin@<your.FQDN.here>" \
+-keyout /etc/ssl/private/misp.local.key -out /etc/ssl/private/misp.local.crt
+
+# Otherwise, copy the SSLCertificateFile, SSLCertificateKeyFile, and SSLCertificateChainFile to /etc/ssl/private/. (Modify path and config to fit your environment)
+
+============================================= Begin sample working SSL config for MISP
+<VirtualHost <IP, FQDN, or *>:80>
+        ServerName <your.FQDN.here>
+
+        Redirect permanent / https://<your.FQDN.here>
+
+        LogLevel warn
+        ErrorLog /var/log/apache2/misp.local_error.log
+        CustomLog /var/log/apache2/misp.local_access.log combined
+        ServerSignature Off
+</VirtualHost>
+
+<VirtualHost <IP, FQDN, or *>:443>
+        ServerAdmin admin@<your.FQDN.here>
+        ServerName <your.FQDN.here>
+        DocumentRoot /var/www/MISP/app/webroot
+        <Directory /var/www/MISP/app/webroot>
+                Options -Indexes
+                AllowOverride all
+                Order allow,deny
+                allow from all
+        </Directory>
+
+        SSLEngine On
+        SSLCertificateFile /etc/ssl/private/misp.local.crt
+        SSLCertificateKeyFile /etc/ssl/private/misp.local.key
+#        SSLCertificateChainFile /etc/ssl/private/misp-chain.crt
+
+        LogLevel warn
+        ErrorLog /var/log/apache2/misp.local_error.log
+        CustomLog /var/log/apache2/misp.local_access.log combined
+        ServerSignature Off
+</VirtualHost>
+============================================= End sample working SSL config for MISP
+
+# activate new vhost
+sudo a2dissite default-ssl
+sudo a2ensite misp-ssl
+
+# Restart apache
+sudo systemctl restart apache2
+
+
+8/ MISP configuration
+---------------------
+# There are 4 sample configuration files in /var/www/MISP/app/Config that need to be copied
+sudo -u www-data cp -a /var/www/MISP/app/Config/bootstrap.default.php /var/www/MISP/app/Config/bootstrap.php
+sudo -u www-data cp -a /var/www/MISP/app/Config/database.default.php /var/www/MISP/app/Config/database.php
+sudo -u www-data cp -a /var/www/MISP/app/Config/core.default.php /var/www/MISP/app/Config/core.php
+sudo -u www-data cp -a /var/www/MISP/app/Config/config.default.php /var/www/MISP/app/Config/config.php
+
+# Configure the fields in the newly created files:
+sudo -u www-data vim /var/www/MISP/app/Config/database.php
+# login, port, password, database
+
+# Important! Change the salt key in /var/www/MISP/app/Config/config.php
+# The salt key must be a string at least 32 bytes long.
+# The admin user account will be generated on the first login, make sure that the salt is changed before you create that user
+# If you forget to do this step, and you are still dealing with a fresh installation, just alter the salt,
+# delete the user from mysql and log in again using the default admin credentials (admin@admin.test / admin)
+
+# Change base url in config.php
+sudo -u www-data vim /var/www/MISP/app/Config/config.php
+# example: 'baseurl' => 'https://<your.FQDN.here>',
+# alternatively, you can leave this field empty if you would like to use relative pathing in MISP
+# 'baseurl' => '',
+
+# and make sure the file permissions are still OK
+sudo chown -R www-data:www-data /var/www/MISP/app/Config
+sudo chmod -R 750 /var/www/MISP/app/Config
+
+# Generate a GPG encryption key.
+sudo -u www-data mkdir /var/www/MISP/.gnupg
+sudo chmod 700 /var/www/MISP/.gnupg
+sudo -u www-data gpg --homedir /var/www/MISP/.gnupg --gen-key
+# The email address should match the one set in the config.php / set in the configuration menu in the administration menu configuration file
+
+# And export the public key to the webroot
+sudo -u www-data sh -c "gpg --homedir /var/www/MISP/.gnupg --export --armor YOUR-KEYS-EMAIL-HERE > /var/www/MISP/app/webroot/gpg.asc"
+
+# To make the background workers start on boot
+sudo chmod +x /var/www/MISP/app/Console/worker/start.sh
+sudo vim /etc/rc.local
+# Add the following line before the last line (exit 0). Make sure that you replace www-data with your apache user:
+sudo -u www-data bash /var/www/MISP/app/Console/worker/start.sh
+
+# Now log in using the webinterface:
+# The default user/pass = admin@admin.test/admin
+
+# Using the server settings tool in the admin interface (Administration -> Server Settings), set MISP up to your preference
+# It is especially vital that no critical issues remain!
+# start the workers by navigating to the workers tab and clicking restart all workers
+
+# Don't forget to change the email, password and authentication key after installation.
+
+# Once done, have a look at the diagnostics
+
+# If any of the directories that MISP uses to store files is not writeable to the apache user, change the permissions
+# you can do this by running the following commands:
+
+chmod -R 750 /var/www/MISP/<directory path with an indicated issue>
+chown -R www-data:www-data /var/www/MISP/<directory path with an indicated issue>
+
+# Make sure that the STIX libraries and GnuPG work as intended, if not, refer to INSTALL.txt's paragraphs dealing with these two items
+
+# If anything goes wrong, make sure that you check MISP's logs for errors:
+# /var/www/MISP/app/tmp/logs/error.log
+# /var/www/MISP/app/tmp/logs/resque-worker-error.log
+# /var/www/MISP/app/tmp/logs/resque-scheduler-error.log
+# /var/www/MISP/app/tmp/logs/resque-2015-01-01.log // where the actual date is the current date
+
+
+Recommended actions
+-------------------
+- By default CakePHP exposes its name and version in email headers. Apply a patch to remove this behavior.
+
+- You should really harden your OS
+- You should really harden the configuration of Apache
+- You should really harden the configuration of MySQL/MariaDB
+- Keep your software up2date (OS, MISP, CakePHP and everything else)
+- Log and audit
+
+
+Optional features
+-------------------
+# MISP has a new pub/sub feature, using ZeroMQ. To enable it, simply run the following command
+pip install pyzmq
+# ZeroMQ depends on the Python client for Redis
+pip install redis


### PR DESCRIPTION
this adds detailed installation instructions for MISP on Ubuntu 16.04 "Xenial"

the instructions are based on those for Ubuntu 14.04 and parts of it on #1195 by @infde6

improvements to both base-instruction-documents:
- use SSL by default
- don't install not-in-use php-packages
- don't depend on root shell, use sudo most of the time

instructions have been tested, although i obviously didn't test every other feature of MISP
