### PR TITLE
remove some obsolete FIXME notes

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -497,7 +497,6 @@ class Attribute extends AppModel {
 		// delete attachments from the disk
 		$this->read(); // first read the attribute from the db
 		if ($this->typeIsAttachment($this->data['Attribute']['type'])) {
-			// FIXME secure this filesystem access/delete by not allowing to change directories or go outside of the directory container.
 			// only delete the file if it exists
 			$filepath = APP . "files" . DS . $this->data['Attribute']['event_id'] . DS . $this->data['Attribute']['id'];
 			$file = new File($filepath);
@@ -1136,7 +1135,7 @@ class Attribute extends AppModel {
 		$destpath = $rootDir . DS . $this->getID(); // id of the new attribute in the database
 		$file = new File($destpath);
 		$zipfile = new File($destpath . '.zip');
-		$fileInZip = new File($rootDir . DS . $extraPath . $filename); // FIXME do sanitization of the filename
+		$fileInZip = new File($rootDir . DS . $extraPath . $filename);
 
 		// zip and password protect the malware files
 		if ($malware) {

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -319,7 +319,6 @@ class Event extends AppModel {
 		// delete all of the event->tag combinations that involve the deleted event
 		$this->EventTag->deleteAll(array('event_id' => $this->id));
 
-		// FIXME secure this filesystem access/delete by not allowing to change directories or go outside of the directory container.
 		// only delete the file if it exists
 		$filepath = APP . "files" . DS . $this->id;
 		App::uses('Folder', 'Utility');

--- a/app/Model/ShadowAttribute.php
+++ b/app/Model/ShadowAttribute.php
@@ -262,7 +262,6 @@ class ShadowAttribute extends AppModel {
 		if (isset($this->data['ShadowAttribute']['deleted']) && $this->data['ShadowAttribute']['deleted']) {
 			$sa = $this->find('first', array('conditions' => array('ShadowAttribute.id' => $this->data['ShadowAttribute']['id']), 'recursive' => -1, 'fields' => array('ShadowAttribute.id', 'ShadowAttribute.event_id', 'ShadowAttribute.type')));
 			if ($this->typeIsAttachment($sa['ShadowAttribute']['type'])) {
-				// FIXME secure this filesystem access/delete by not allowing to change directories or go outside of the directory container.
 				// only delete the file if it exists
 				$filepath = APP . "files" . DS . 'shadow' . DS . $sa['ShadowAttribute']['event_id'] . DS . $sa['ShadowAttribute']['id'];
 				$file = new File($filepath);
@@ -290,7 +289,6 @@ class ShadowAttribute extends AppModel {
 		// delete attachments from the disk
 		$this->read(); // first read the attribute from the db
 		if ($this->typeIsAttachment($this->data['ShadowAttribute']['type'])) {
-			// FIXME secure this filesystem access/delete by not allowing to change directories or go outside of the directory container.
 			// only delete the file if it exists
 			$filepath = APP . "files" . DS . 'shadow' . DS . $this->data['ShadowAttribute']['event_id'] . DS . $this->data['ShadowAttribute']['id'];
 			$file = new File($filepath);
@@ -442,7 +440,7 @@ class ShadowAttribute extends AppModel {
 		$destpath = $rootDir . DS . $this->getID(); // id of the new attribute in the database
 		$file = new File($destpath);
 		$zipfile = new File($destpath . '.zip');
-		$fileInZip = new File($rootDir . DS . $extraPath . $filename); // FIXME do sanitization of the filename
+		$fileInZip = new File($rootDir . DS . $extraPath . $filename);
 
 		// zip and password protect the malware files
 		if ($malware) {


### PR DESCRIPTION
this PR removes some comments containing FIXME notes about checking filenames and paths.

i have checked the variables that are being combined and asked @iglocska about some of them, if they can be trusted (as in: they aren't user input), and there don't seem to be issues, so the comments are obsolete.
