### PR TITLE
Push events to server with push rules on non-exportable tags

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1554,7 +1554,7 @@ class Server extends AppModel {
 				$fails = array();
 				$lowestfailedid = null;
 				foreach ($eventUUIDsFiltered as $k => $eventUuid) {
-					$event = $this->Event->fetchEvent($user, array('event_uuid' => $eventUuid, 'includeAttachments' => true));
+					$event = $this->Event->fetchEvent($user, array('event_uuid' => $eventUuid, 'includeAttachments' => true, 'includeAllTags' => true));
 					$event = $event[0];
 					$event['Event']['locked'] = true;
 					$result = $this->Event->uploadEventToServer(


### PR DESCRIPTION
#### What does it do?

It fixes a bug where a push to a server with a push rule based on a non-exportable tag would never happen. Using includeAllTags is safe because __updateEventForSync() called by restfulEventToServer() filters out the non-exportable tags just before the REST HTTP call.
#### Questions
- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
