### PR TITLE
changing the loading bar update interval from 1000 to 3000 (as it is …

### DIFF
--- a/app/View/Events/export.ctp
+++ b/app/View/Events/export.ctp
@@ -14,7 +14,7 @@
 					if (id != -1 && progress < 100 && modified != "N/A") {
 						queryTask(k, i);
 					}
-				}, 1000);
+				}, 3000);
 		}
 		function editMessage(id, text) {
 			document.getElementById("message" + id).innerHTML = text;


### PR DESCRIPTION
#### What does it do?

In the event\export: it changes the loading bar update time from 1000 to 3000. This decreases the requests number. In the Jobs list it is already 3000. 
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [X] Minor
- [ ] Patch

…also in the jobs list);
