### PR TITLE
exceptions in _readGfiXml()

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -2135,7 +2135,9 @@ class EventsController extends AppController {
 					if ((string)$key == 'index') $index = (string)$val;
 				}
 			}
-			// TODO: what if the xml parsing didn't return any filename? $index would be unset
+			if (!isset($index) || !is_numeric($index)) {
+				throw new Exception('The GFI sandbox xml file seems to be malformed, at least one process with stored_files hasn\'t got a valid numeric index attribute.');
+			}
 			$actualFile = $rootDir . DS . 'Analysis' . DS . 'proc_' . $index . DS . 'modified_files' . DS . $actualFileName;
 			$extraPath = 'Analysis' . DS . 'proc_' . $index . DS . 'modified_files' . DS;
 			$file = new File($actualFile);

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -2080,14 +2080,13 @@ class EventsController extends AppController {
 		}
 
 		// Payload delivery -- malware-sample
+		$realFileName = '';
 		$results = $parsedXml->xpath('/analysis');
 		foreach ($results as $result) {
 			foreach ($result[0]->attributes() as $key => $val) {
 				if ((string)$key == 'filename') $realFileName = (string)$val;
 			}
 		}
-		// TODO: what if the xml parsing didn't return any filename? $realFileName would be unset
-		$realMalware = $realFileName;
 		$rootDir = APP . "files" . DS . $id . DS;
 		$malware = $rootDir . DS . 'sample';
 		$this->Event->Attribute->uploadAttachment($malware,	$realFileName,	true, $id, null, '', $this->Event->data['Event']['uuid'] . '-sample', $dist, true);

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -2076,7 +2076,7 @@ class EventsController extends AppController {
 				$dist .= Configure::read('MISP.default_attribute_distribution');
 			}
 		} else {
-			// TODO: need a default value for $dist or throw an exception
+			throw new Exception('Couldn\'t read "MISP.default_attribute_distribution".');
 		}
 
 		// Payload delivery -- malware-sample


### PR DESCRIPTION
this PR makes sure that malformed (perhaps intentionally) xml files lead to exceptions where necessary and necessary default values are always set.

as valid gfi xml files seem to always use integers as process index ids, is_numeric() is called so there is nothing else - especially nothing like "../../../", which might lead to files being created in directories where they shouldn't be.
