### PR TITLE
issue 1289 - Cache jobs do not update the date modified once completed.

### DIFF
--- a/app/Console/Command/EventShell.php
+++ b/app/Console/Command/EventShell.php
@@ -60,6 +60,7 @@ class EventShell extends AppShell
 		}
 		$this->Job->saveField('progress', 100);
 		$this->Job->saveField('message', 'Job done.');
+		$this->Job->saveField('date_modified', date("y-m-d H:i:s"));
 		$file->append('<xml_version>' . $this->Event->mispVersion . '</xml_version>');
 		$file->append('</response>' . PHP_EOL);
 		$file->close();
@@ -110,6 +111,7 @@ class EventShell extends AppShell
 		$file->close();
 		$this->Job->saveField('progress', '100');
 		$this->Job->saveField('message', 'Job done.');
+		$this->Job->saveField('date_modified', date("y-m-d H:i:s"));
 	}
 
 	public function cacherpz() {
@@ -148,6 +150,7 @@ class EventShell extends AppShell
 		$file->close();
 		$this->Job->saveField('progress', '100');
 		$this->Job->saveField('message', 'Job done.');
+		$this->Job->saveField('date_modified', date("y-m-d H:i:s"));
 	}
 
 	public function cachecsv() {
@@ -184,6 +187,7 @@ class EventShell extends AppShell
 		$file->close();
 		$this->Job->saveField('progress', '100');
 		$this->Job->saveField('message', 'Job done.');
+		$this->Job->saveField('date_modified', date("y-m-d H:i:s"));
 	}
 
 	public function cachetext() {
@@ -210,6 +214,7 @@ class EventShell extends AppShell
 		}
 		$this->Job->saveField('progress', 100);
 		$this->Job->saveField('message', 'Job done.');
+		$this->Job->saveField('date_modified', date("y-m-d H:i:s"));
 	}
 
 	public function cachenids() {
@@ -243,6 +248,7 @@ class EventShell extends AppShell
 		$file->close();
 		$this->Job->saveField('progress', '100');
 		$this->Job->saveField('message', 'Job done.');
+		$this->Job->saveField('date_modified', date("y-m-d H:i:s"));
 	}
 
 	public function alertemail() {
@@ -254,6 +260,7 @@ class EventShell extends AppShell
 		$result = $this->Event->sendAlertEmail($eventId, $user, $processId);
 		$job['Job']['progress'] = 100;
 		$job['Job']['message'] = 'Emails sent.';
+		//$job['Job']['date_modified'] = date("y-m-d H:i:s");
 		$this->Job->save($job);
 	}
 
@@ -268,6 +275,7 @@ class EventShell extends AppShell
 		$user = $this->User->getAuthUser($userId);
 		$result = $this->Event->sendContactEmail($id, $message, $all, array('User' => $user), $isSiteAdmin);
 		$this->Job->saveField('progress', '100');
+		//$this->Job->saveField('date_modified', date("y-m-d H:i:s"));
 		if ($result != true) $this->Job->saveField('message', 'Job done.');
 	}
 
@@ -282,6 +290,7 @@ class EventShell extends AppShell
 		$result = $this->Post->sendPostsEmail($userId, $postId, $eventId, $title, $message);
 		$job['Job']['progress'] = 100;
 		$job['Job']['message'] = 'Emails sent.';
+		//$job['Job']['date_modified'] = date("y-m-d H:i:s");
 		$this->Job->save($job);
 	}
 
@@ -345,6 +354,7 @@ class EventShell extends AppShell
 		$this->Event->Behaviors->unload('SysLogLogable.SysLogLogable');
 		$result = $this->Event->publish($id, $passAlong);
 		$job['Job']['progress'] = 100;
+		//$job['Job']['date_modified'] = date("y-m-d H:i:s");
 		if ($result) {
 			$job['Job']['message'] = 'Event published.';
 		} else {


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:
#### What does it do?

It fixes an existing issue, `#<1289>` 
I also added the "finish" time to the contactemail(), publish(), postsemail() and alertemail(), where they are also missing. 
For the moment the lines are commented out as it's not part of the issue. I can commit again w/ the lines not commented. Or create a different PR for that. 
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [X] Minor
- [ ] Patch

I also added this to the contactemail(), publish(), postsemail() and alertemail(). But it's commented out as it's not part of the issue. I can commit it again w/ the lines uncommented.
