### PR TITLE
Allow delegation when unpublishedprivate is set

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -301,6 +301,7 @@ class AppController extends Controller {
 			$this->set('isAclModify', $role['perm_modify']);
 			$this->set('isAclModifyOrg', $role['perm_modify_org']);
 			$this->set('isAclPublish', $role['perm_publish']);
+			$this->set('isAclDelegate', $role['perm_delegate']);
 			$this->set('isAclSync', $role['perm_sync']);
 			$this->set('isAclAdmin', $role['perm_admin']);
 			$this->set('isAclAudit', $role['perm_audit']);

--- a/app/Controller/Component/ACLComponent.php
+++ b/app/Controller/Component/ACLComponent.php
@@ -68,7 +68,7 @@ class ACLComponent extends Component {
 			),
 			'eventDelegations' => array(
 					'acceptDelegation' => array('perm_add'),
-					'delegateEvent' => array('perm_add'),
+					'delegateEvent' => array('perm_delegate'),
 					'deleteDelegation' => array('perm_add'),
 					'view' => array('*'),
 			),

--- a/app/Controller/EventDelegationsController.php
+++ b/app/Controller/EventDelegationsController.php
@@ -35,7 +35,7 @@ class EventDelegationsController extends AppController {
 				'fields' => array('Event.id', 'Event.orgc_id', 'Event.distribution')
 		));
 		if (!$this->_isSiteAdmin() && $this->Auth->user('org_id') !== $event['Event']['orgc_id']) throw new MethodNotAllowedException('You are not authorised to do that.');
-		if ($event['Event']['distribution'] != 0) throw new MethodNotAllowedException('Only events with the distribution setting "Your Organisation Only" can be delegated.');
+		if (!Configure::read('MISP.unpublishedprivate') && $event['Event']['distribution'] != 0) throw new MethodNotAllowedException('Only events with the distribution setting "Your Organisation Only" can be delegated.');
 		$existingDelegations = $this->EventDelegation->find('first', array('conditions' => array('event_id' => $id), 'recursive' => -1));
 		if (!empty($existingDelegations)) throw new MethodNotAllowedException('This event already has a pending delegation request. Please revoke that before creating a new request.');
 		if ($this->request->is('Post')) {

--- a/app/View/Elements/side_menu.ctp
+++ b/app/View/Elements/side_menu.ctp
@@ -53,7 +53,7 @@
 					<li<?php echo $publishButtons; ?> class="publishButtons"><a href="#" onClick="publishPopup('<?php echo h($event['Event']['id']); ?>', 'alert')">Publish Event</a></li>
 					<li<?php echo $publishButtons; ?> class="publishButtons"><a href="#" onClick="publishPopup('<?php echo h($event['Event']['id']); ?>', 'publish')">Publish (no email)</a></li>
 					<?php if (Configure::read('MISP.delegation')):?>
-						<?php if (isset($event['Event']['distribution']) && (!isset($delegationRequest) || !$delegationRequest) && $event['Event']['distribution'] == 0 && ($isSiteAdmin || (isset($mayPublish) && $mayPublish))): ?>
+						<?php if ((Configure::read('MISP.unpublishedprivate') || (isset($event['Event']['distribution']) && $event['Event']['distribution'] == 0)) && (!isset($delegationRequest) || !$delegationRequest) && ($isSiteAdmin || (isset($isAclDelegate) && $isAclDelegate))): ?>
 								<li id='lidelegateEvent'><a href="#" onClick="delegatePopup('<?php echo h($event['Event']['id']); ?>');">Delegate Publishing</a></li>
 						<?php endif;?>
 						<?php if (isset($delegationRequest) && $delegationRequest && ($isSiteAdmin || ($isAclPublish && ($me['org_id'] == $delegationRequest['EventDelegation']['org_id'] || $me['org_id'] == $delegationRequest['EventDelegation']['requester_org_id'])))): ?>


### PR DESCRIPTION
#### What does it do?
- Allow delegation when unpublishedprivate is set
- Use perm_delegate instead of perm_publish for delegation

perm_delegate will be added to the role matrix in 2.4.49
#### Questions
- [x] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
