### PR TITLE
openIOC import issue / fileAccess class not found / Update EventsController.php

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -1902,6 +1902,7 @@ class EventsController extends AppController {
 	public function _addIOCFile($id) {
 		if (!empty($this->data) && $this->data['Event']['submittedioc']['size'] > 0 &&
 				is_uploaded_file($this->data['Event']['submittedioc']['tmp_name'])) {
+			App::uses('FileAccess', 'Tools');
 			$iocData = FileAccess::readFromFile($this->data['Event']['submittedioc']['tmp_name'], $this->data['Event']['submittedioc']['size']);
 
 			// write


### PR DESCRIPTION
Hello guys,

I (re)installed MISP ona new Debian 8.5. Everything was working well except when I tried to upload some openioc files.

I got this error log:

_2016-07-06 11:48:07 Error: Fatal Error (1): Class 'FileAccess' not found in [/var/www/MISP/app/Controller/EventsController.php, line 1905]
2016-07-06 11:48:07 Error: [InternalErrorException] Internal Server Error
Request URL: /events/addIOC/1
Stack Trace:
#0 /var/www/MISP/app/Lib/cakephp/lib/Cake/Error/ErrorHandler.php(213): ErrorHandler::handleFatalError(1, 'Class 'FileAcce...', '/var/www/MISP/a...', 1905)
#1 [internal function]: ErrorHandler::handleError(1, 'Class 'FileAcce...', '/var/www/MISP/a...', 1905, Array)
#2 /var/www/MISP/app/Lib/cakephp/lib/Cake/Core/App.php(970): call_user_func('ErrorHandler::h...', 1, 'Class 'FileAcce...', '/var/www/MISP/a...', 1905, Array)
#3 /var/www/MISP/app/Lib/cakephp/lib/Cake/Core/App.php(943): App::_checkFatalError()
#4 [internal function]: App::shutdown()
#5 {main}_

To fix it, I just add App::uses('FileAccess', 'Tools'); line 1905.

Hope it will help some others users.

CheYen
