### PR TITLE
chg: remove duplicate array item

### DIFF
--- a/app/Console/Command/UserInitShell.php
+++ b/app/Console/Command/UserInitShell.php
@@ -22,8 +22,7 @@ class UserInitShell extends AppShell {
 					'perm_regexp_access' => 1,
 					'perm_sharing_group' => 1,
 					'perm_tagger' => 1,
-					'perm_template' => 1,
-					'perm_site_admin' => 1
+					'perm_template' => 1
 			));
 			$this->Role->save($siteAdmin);
 		}


### PR DESCRIPTION
#### What does it do?

removes duplicate array item "perm_site_admin = 1" from UserInitShell.php
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
