### PR TITLE
remove obsolete uuid() wrapper

### DIFF
--- a/app/Console/Command/UserInitShell.php
+++ b/app/Console/Command/UserInitShell.php
@@ -35,7 +35,7 @@ class UserInitShell extends AppShell {
 					'name' => !empty(Configure::read('MISP.org')) ? Configure::read('MISP.org') : 'ADMIN',
 					'description' => 'Automatically generated admin organisation',
 					'type' => 'ADMIN',
-					'uuid' => $this->Organisation->generateUuid(),
+					'uuid' => CakeText::uuid(),
 					'local' => 1
 			));
 			$this->Organisation->save($org);

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -479,7 +479,7 @@ class AppController extends Controller {
 			));
 			foreach ($attributes as $k => $attribute) {
 				if ($k > 0) {
-					$attribute['Attribute']['uuid'] = $this->Attribute->generateUuid();
+					$attribute['Attribute']['uuid'] = CakeText::uuid();
 					$this->Attribute->save($attribute);
 					$counter++;
 				}

--- a/app/Controller/Component/IOCImportComponent.php
+++ b/app/Controller/Component/IOCImportComponent.php
@@ -180,7 +180,7 @@ class IOCImportComponent extends Component {
 				if (!in_array($condensed, $duplicateFilter)) {
 					$this->saved_uuids[] = $attribute['uuid'];
 					$duplicateFilter[] = $condensed;
-					$attribute['uuid'] = $this->Attribute->generateUuid();
+					$attribute['uuid'] = CakeText::uuid();
 				} else unset($event['Attribute'][$k]);
 			}
 		}
@@ -192,7 +192,7 @@ class IOCImportComponent extends Component {
 		// Add a special attribute that captures the basic data about the .ioc such as the ioc-s uuid, info, long info, author, etc.
 		// Define the fields used in the global iocinfo variable.
 		foreach ($this->iocinfo as $k => $v) {
-			if (isset($event[$v])) $event['Attribute'][] = array('uuid' => $this->Attribute->generateUuid(), 'category' => 'Other', 'type' => 'comment', 'event_id' => $id, 'value' => $v . ': ' . $event[$v], 'to_ids' => $this->typeToIdsSettings['comment'], 'distribution' => $this->distribution, 'comment' => 'OpenIOC import from file ' . $filename);
+			if (isset($event[$v])) $event['Attribute'][] = array('uuid' => CakeText::uuid(), 'category' => 'Other', 'type' => 'comment', 'event_id' => $id, 'value' => $v . ': ' . $event[$v], 'to_ids' => $this->typeToIdsSettings['comment'], 'distribution' => $this->distribution, 'comment' => 'OpenIOC import from file ' . $filename);
 		}
 
 		// attach the graph to the event

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -1955,7 +1955,7 @@ class EventsController extends AppController {
 			// add the original openIOC file as an attachment
 			$saveEvent['Attribute'][] = array(
 				'category' => 'External analysis',
-				'uuid' =>  $this->Event->generateUuid(),
+				'uuid' =>  CakeText::uuid(),
 				'type' => 'attachment',
 				'value' => $this->data['Event']['submittedioc']['name'],
 				'to_ids' => false,
@@ -2543,7 +2543,7 @@ class EventsController extends AppController {
 			'org_id' => $this->Auth->user('org_id'),
 			'orgc_id' => $this->Auth->user('org_id'),
 			'timestamp' => $ts,
-			'uuid' => $this->Event->generateUuid(),
+			'uuid' => CakeText::uuid(),
 			'user_id' => $this->Auth->user('id'),
 		));
 		$default['Event']['info'] = 'A junk event for load testing';
@@ -2564,7 +2564,7 @@ class EventsController extends AppController {
 						'value1' => $value,
 						'value2' => '',
 						'comment' => '',
-						'uuid' => $this->Event->generateUuid(),
+						'uuid' => CakeText::uuid(),
 						'timestamp' => $ts,
 				);
 			}

--- a/app/Controller/OrganisationsController.php
+++ b/app/Controller/OrganisationsController.php
@@ -117,7 +117,7 @@ class OrganisationsController extends AppController {
 	}
 
 	public function admin_generateuuid() {
-		$this->set('uuid', $this->Organisation->generateUuid());
+		$this->set('uuid', CakeText::uuid());
 		$this->set('_serialize', array('uuid'));
 	}
 

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -642,7 +642,7 @@ class UsersController extends AppController {
 						'name' => !empty(Configure::read('MISP.org')) ? Configure::read('MISP.org') : 'ADMIN',
 						'description' => 'Automatically generated admin organisation',
 						'type' => 'ADMIN',
-						'uuid' => $this->User->Organisation->generateUuid(),
+						'uuid' => CakeText::uuid(),
 						'local' => 1,
 						'sector' => '',
 						'nationality' => ''

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -481,15 +481,6 @@ class AppModel extends Model {
 		return $version_array;
 	}
 
-	// wrapper for UUID generation, compatible with cakephp <= 2.6 and cakephp and cakephp >= 2.7
-	public function generateUuid() {
-		$version = Configure::version();
-		$version = explode('.', $version);
-		if (intval($version[0]) <= 2 && intval($version[1]) < 7) $uuid = String::uuid();
-		else $uuid = CakeText::uuid();
-		return $uuid;
-	}
-
 	// alternative to the build in notempty/notblank validation functions, compatible with cakephp <= 2.6 and cakephp and cakephp >= 2.7
 	public function valueNotEmpty($value) {
 		$field = array_keys($value);

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -528,7 +528,7 @@ class Attribute extends AppModel {
 		}
 		// generate UUID if it doesn't exist
 		if (empty($this->data['Attribute']['uuid'])) {
-			$this->data['Attribute']['uuid'] = $this->generateUuid();
+			$this->data['Attribute']['uuid'] = CakeText::uuid();
 		}
 		// generate timestamp if it doesn't exist
 		if (empty($this->data['Attribute']['timestamp'])) {

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -362,7 +362,7 @@ class Event extends AppModel {
 
 		// generate UUID if it doesn't exist
 		if (empty($this->data['Event']['uuid'])) {
-			$this->data['Event']['uuid'] = $this->generateUuid();
+			$this->data['Event']['uuid'] = CakeText::uuid();
 		}
 		// generate timestamp if it doesn't exist
 		if (empty($this->data['Event']['timestamp'])) {

--- a/app/Model/Organisation.php
+++ b/app/Model/Organisation.php
@@ -86,7 +86,7 @@ class Organisation extends AppModel{
 	public function beforeValidate($options = array()) {
 		parent::beforeValidate();
 		if (empty($this->data['Organisation']['uuid']) && (isset($this->data['Organisation']['local']) && $this->data['Organisation']['local'])) {
-			$this->data['Organisation']['uuid'] = $this->generateUuid();
+			$this->data['Organisation']['uuid'] = CakeText::uuid();
 		}
 		$date = date('Y-m-d H:i:s');
 		if (!isset($this->data['Organisation']['date_created']) || empty($this->data['Organisation']['date_created'])) $this->data['Organisation']['date_created'] = $date;
@@ -175,7 +175,7 @@ class Organisation extends AppModel{
 		if (empty($existingOrg)) {
 			$this->create();
 			$organisation = array(
-					'uuid' => $this->generateUuid(),
+					'uuid' =>CakeText::uuid(),
 					'name' => $name,
 					'local' => $local,
 					'created_by' => $user_id

--- a/app/Model/ShadowAttribute.php
+++ b/app/Model/ShadowAttribute.php
@@ -320,7 +320,7 @@ class ShadowAttribute extends AppModel {
 
 		// generate UUID if it doesn't exist
 		if (empty($this->data['ShadowAttribute']['uuid'])) {
-			$this->data['ShadowAttribute']['uuid'] = $this->generateUuid();
+			$this->data['ShadowAttribute']['uuid'] = CakeText::uuid();
 		}
 
 		// always return true, otherwise the object cannot be saved

--- a/app/Model/SharingGroup.php
+++ b/app/Model/SharingGroup.php
@@ -55,7 +55,7 @@ class SharingGroup extends AppModel {
 	public function beforeValidate($options = array()) {
 		parent::beforeValidate();
 		if (empty($this->data['SharingGroup']['uuid'])) {
-			$this->data['SharingGroup']['uuid'] = $this->generateUuid();
+			$this->data['SharingGroup']['uuid'] = CakeText::uuid();
 		}
 		$date = date('Y-m-d H:i:s');
 		if (empty($this->data['SharingGroup']['date_created'])) {


### PR DESCRIPTION
#### What does it do?

this removes an ancient generateUuid() wrapper from AppModel.php, because this wrapper does nothing else than calling CakeText::uuid() for every case, because String::uuid() is only an alias for the other function (String class extends CakeText and changes nothing and is deprecated, too)
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
