### PR TITLE
additional chars in mail address regex

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -758,7 +758,7 @@ class Attribute extends AppModel {
 			case 'target-email':
 			case 'whois-registrant-email':
 				// we don't use the native function to prevent issues with partial email addresses
-				if (preg_match("#^[A-Z0-9._&%+-]*@[A-Z0-9.\-_]+\.[A-Z]{2,}$#i", $value)) {
+				if (preg_match("#^[A-Z0-9._&%+-=~]*@[A-Z0-9.\-_]+\.[A-Z]{2,}$#i", $value)) {
 					$returnValue = true;
 				} else {
 					$returnValue = 'Email address has an invalid format. Please double check the value or select type "other".';


### PR DESCRIPTION
fixes #1344 and adds also "~" as a possible character of a mail address.
there are even more according to RFC, but i haven't seen them in the wild so i didn't add them.
