### PR TITLE
fix: specify correct&specific branches in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "app/Lib/cakephp"]
 	path = app/Lib/cakephp
 	url = https://github.com/cakephp/cakephp.git
-	branch = 2.7
+	branch = 2.x
 [submodule "PyMISP"]
 	path = PyMISP
 	url = https://github.com/MISP/PyMISP.git
@@ -9,6 +9,8 @@
 [submodule "app/files/taxonomies"]
 	path = app/files/taxonomies
 	url = https://github.com/MISP/misp-taxonomies.git
+	branch = master
 [submodule "app/files/warninglists"]
 	path = app/files/warninglists
 	url = https://github.com/MISP/misp-warninglists.git
+	branch = master


### PR DESCRIPTION
as discussed with @iglocska on gitter:
this PR corrects the branch setting in the .gitmodules file.
the branch "2.7" doesn't exist (at least anymore) in cakephp repo, it has to be "2.x"
also, this adds the branches to  taxonomies and warninglist repos, just to be sure.

it might be possible, that no installation that was simply updated with git uses cake php 2.8 yet, because of this wrong branch setting.
also, one that got installed with 2.8.3 still uses that and not the current 2.8.5, because it wont update because of the wrong branch.

this might also fix #1345 and allow us to reintroduce the reverted #1341 
