### PR TITLE
Install/update doc improvements - releases instead of random commits

### DIFF
--- a/INSTALL/INSTALL.centos7.txt
+++ b/INSTALL/INSTALL.centos7.txt
@@ -59,9 +59,14 @@ systemctl start  redis.service
 # Download MISP using git in the /var/www/ directory.
 cd /var/www/
 git clone https://github.com/MISP/MISP.git
+cd /var/www/MISP
+git checkout tags/$(git describe --tags `git rev-list --tags --max-count=1`)
+# if the last shortcut doesn't work, specify the latest version manually
+# example: git checkout tags/v2.4.XY
+# the message regarding a "detached HEAD state" is expected behaviour
+# (you only have to create a new branch, if you want to change stuff and do a pull request for example)
 
 # Make git ignore filesystem permission differences
-cd /var/www/MISP
 git config core.filemode false
 
 # install Mitre's STIX and its dependencies by running the following commands:

--- a/INSTALL/INSTALL.debian7.txt
+++ b/INSTALL/INSTALL.debian7.txt
@@ -36,8 +36,14 @@ pear config-set http_proxy http://username:password@yourproxy:80
 3/ MISP code
 ------------
 # Download MISP using git in the /var/www/ directory.
-cd /var/www/
-git clone https://github.com/MISP/MISP.git
+mkdir /var/www/MISP
+cd /var/www/MISP
+git clone https://github.com/MISP/MISP.git /var/www/MISP
+git checkout tags/$(git describe --tags `git rev-list --tags --max-count=1`)
+# if the last shortcut doesn't work, specify the latest version manually
+# example: git checkout tags/v2.4.XY
+# the message regarding a "detached HEAD state" is expected behaviour
+# (you only have to create a new branch, if you want to change stuff and do a pull request for example)
 
 # if you are behind a proxy:
 git config --global http.proxy http://username:password@yourproxy:80

--- a/INSTALL/INSTALL.debian8.txt
+++ b/INSTALL/INSTALL.debian8.txt
@@ -55,6 +55,11 @@ sudo mkdir /var/www/MISP
 sudo chown www-data:www-data /var/www/MISP
 cd /var/www/MISP
 sudo -u www-data git clone https://github.com/MISP/MISP.git /var/www/MISP
+sudo -u www-data git checkout tags/$(git describe --tags `git rev-list --tags --max-count=1`)
+# if the last shortcut doesn't work, specify the latest version manually
+# example: git checkout tags/v2.4.XY
+# the message regarding a "detached HEAD state" is expected behaviour
+# (you only have to create a new branch, if you want to change stuff and do a pull request for example)
 
 # Make git ignore filesystem permission differences
 sudo -u www-data git config core.filemode false

--- a/INSTALL/INSTALL.ubuntu1404.txt
+++ b/INSTALL/INSTALL.ubuntu1404.txt
@@ -33,11 +33,17 @@ pear install Crypt_GPG    # we need version >1.3.0
 3/ MISP code
 ------------
 # Download MISP using git in the /var/www/ directory.
-cd /var/www/
-git clone https://github.com/MISP/MISP.git
+mkdir /var/www/MISP
+cd /var/www/MISP
+git clone https://github.com/MISP/MISP.git /var/www/MISP
+git clone https://github.com/MISP/MISP.git /var/www/MISP
+git checkout tags/$(git describe --tags `git rev-list --tags --max-count=1`)
+# if the last shortcut doesn't work, specify the latest version manually
+# example: git checkout tags/v2.4.XY
+# the message regarding a "detached HEAD state" is expected behaviour
+# (you only have to create a new branch, if you want to change stuff and do a pull request for example)
 
 # Make git ignore filesystem permission differences
-cd /var/www/MISP
 git config core.filemode false
 
 # install Mitre's STIX and its dependencies by running the following commands:

--- a/INSTALL/INSTALL.ubuntu1604.txt
+++ b/INSTALL/INSTALL.ubuntu1604.txt
@@ -53,8 +53,13 @@ sudo systemctl restart apache2
 # Download MISP using git in the /var/www/ directory.
 sudo mkdir /var/www/MISP
 sudo chown www-data:www-data /var/www/MISP
-sudo -u www-data git clone https://github.com/MISP/MISP.git /var/www/MISP
 cd /var/www/MISP
+sudo -u www-data git clone https://github.com/MISP/MISP.git /var/www/MISP
+sudo -u www-data git checkout tags/$(git describe --tags `git rev-list --tags --max-count=1`)
+# if the last shortcut doesn't work, specify the latest version manually
+# example: git checkout tags/v2.4.XY
+# the message regarding a "detached HEAD state" is expected behaviour
+# (you only have to create a new branch, if you want to change stuff and do a pull request for example)
 
 # Make git ignore filesystem permission differences
 sudo -u www-data git config core.filemode false

--- a/INSTALL/UPDATE.txt
+++ b/INSTALL/UPDATE.txt
@@ -2,19 +2,26 @@
 # use this between hotfix versions (such as 2.4.3 -> 2.4.13)
 # If you would like to upgrade from a minor version to another, look at the UPGRADE.txt file instead (such as 2.3.142 -> 2.4.13)
 
-# 1. Update the MISP code to the latest hotfix. If a new major version (2.4.x) has been released, refer to UPGRADE.txt instead.
+# 1. Update the MISP code to the latest hotfix. If a new minor or major version (2.4.x) has been released, refer to UPGRADE.txt instead.
 
 As user root, do the following:
 
 cd /var/www/MISP
 git pull
+git checkout tags/$(git describe --tags `git rev-list --tags --max-count=1`)
+# if the last shortcut doesn't work, specify the latest version manually
+# example: git checkout tags/v2.4.XY
+# the message regarding a "detached HEAD state" is expected behaviour
+# (you only have to create a new branch, if you want to change stuff and do a pull request for example)
 
-# 2. Update CakePHP to the latest supported version (if for some reason it doesn't get updated automatically with git submodule
 
-rm -rf /var/www/MISP/app/Lib/cakephp
+# 2. Update CakePHP to the latest supported version (if for some reason it doesn't get updated automatically with git submodule)
+
 cd /var/www/MISP
+rm -rf app/Lib/cakephp/
 git submodule init
 git submodule update
+
 
 # 3. Update Mitre's STIX and its dependencies
 
@@ -25,7 +32,8 @@ cd /var/www/MISP/app/files/scripts/python-stix
 git checkout v1.1.1.4
 python setup.py install
 
-# 4. Update CakeResque and it's dependencies
+
+# 4. Update CakeResque and its dependencies
 
 cd /var/www/MISP/app
 
@@ -41,17 +49,20 @@ php composer.phar update
 # To use the scheduler worker for scheduled tasks, do the following:
 cp -fa /var/www/MISP/INSTALL/setup/config.php /var/www/MISP/app/Plugin/CakeResque/Config/config.php
 
+
 # 5. Make sure all file permissions are set correctly
 
 find /var/www/MISP -type d -exec chmod g=rx {} \;
 chmod -R g+r,o= /var/www/MISP
 chown -R www-data:www-data /var/www/MISP
 
+
 # 6. Restart the CakeResque workers
 
 su - www-data -s /bin/bash -c 'bash /var/www/MISP/app/Console/worker/start.sh'
 
 # You can also do this using the MISP application by navigating to the workers tab in the server settings and clicking on the "Restart all workers" button.
+
 
 # 7. Add any new dependencies that might have been added since you've last updated (shown below)
 

--- a/INSTALL/UPGRADE.txt
+++ b/INSTALL/UPGRADE.txt
@@ -2,26 +2,36 @@
 # it is assumed that the upgrade happens from an up-to-date 2.3 instance
 # It is a good idea to back up your MISP installation and data before upgrading to a new release.
 
-# - git pull the latest version of MISP from https://github.com/MISP/MISP.git
+# 2. git pull the latest version of MISP from https://github.com/MISP/MISP.git
+cd /var/www/MISP
 git pull
-git checkout 2.4
+git checkout tags/$(git describe --tags `git rev-list --tags --max-count=1`)
+# if the last shortcut doesn't work, specify the latest version manually
+# example: git checkout tags/v2.4.XY
+# the message regarding a "detached HEAD state" is expected behaviour
+# (you only have to create a new branch, if you want to change stuff and do a pull request for example)
+
+# 3. Update CakePHP to the latest supported version
+cd /var/www/MISP
+rm -rf app/Lib/cakephp/
 git submodule init
 git submodule update
 
-# delete everything from MISP's cache directory to get rid of the cached models
+# 4. delete everything from MISP's cache directory to get rid of the cached models
 find /var/www/MISP/app/tmp/cache/ -type f -not -name 'empty' -delete
 
-# clear the old submodule cached entry for CakeResque
+# 5. clear the old submodule cached entry for CakeResque
 cd /var/www/MISP
 git rm --cached app/Plugin/CakeResque/
 
-# make sure that your database is backed up
+# 6. make sure that your database is backed up
 mysqldump -u [misp_mysql_user] -p [misp_database] > /home/[my_user]/misp_db_pre_migration.sql
-# upgrade your database with the new tables / fields introduces in 2.4
+
+# 7. upgrade your database with the new tables / fields introduced in 2.4
 cd /var/www/MISP/INSTALL
 mysql -u [misp_mysql_user] -p [misp_database] < upgrade_2.4.sql
 
-# After this run the upgrade script from within the application
+# 8. run the upgrade script from within the application
 # simply navigate to Administration -> Administrative Tools -> "Upgrade to 2.4"
 # Once that has completed successfully run the 2.3->2.4 cleanup script
 # simply navigate to Administration -> Administrative Tools -> "2.3->2.4 cleanup script"


### PR DESCRIPTION
this updates the INSTALL and UPDATE documentation so it uses releases of MISP instead of the latest commit at the time of setting up or updateing the instance.

if someone willingly wants to use a specific commit between releases, he can still do that, but the default should be that only releases (tagged revisions) are used.

this is achieved in this commit by using the latest "tag" in the default branch (2.4.48 in branch 2.4 at the time of writing)
