### PR TITLE
change of boolean datatype handling

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -15,7 +15,7 @@ class AttributesController extends AppController {
 	public $paginate = array(
 			'limit' => 60,
 			'maxLimit' => 9999, // LATER we will bump here on a problem once we have more than 9999 events
-			'conditions' => array('AND' => array('Event.id >' => 0, 'Attribute.deleted' => false))
+			'conditions' => array('AND' => array('Event.id >' => 0, 'Attribute.deleted' => 0))
 	);
 
 	public $helpers = array('Js' => array('Jquery'));
@@ -857,7 +857,7 @@ class AttributesController extends AppController {
 	public function delete($id = null, $hard = false) {
 		$this->set('id', $id);
 		$conditions = array('id' => $id);
-		if (!$hard) $conditions['deleted'] = false;
+		if (!$hard) $conditions['deleted'] = 0;
 		$attribute = $this->Attribute->find('first', array(
 				'conditions' => $conditions,
 				'recursive' => -1,
@@ -983,7 +983,7 @@ class AttributesController extends AppController {
 
 			// remove the published flag from the event
 			$result['Event']['timestamp'] = $date->getTimestamp();
-			$result['Event']['published'] = false;
+			$result['Event']['published'] = 0;
 			$this->Attribute->Event->save($result, array('fieldList' => array('published', 'timestamp', 'info')));
 			return true;
 		} else {
@@ -1336,7 +1336,7 @@ class AttributesController extends AppController {
 						$conditions['AND'][] = $temp;
 					}
 				}
-				$conditions['AND'][] = array('Attribute.deleted' => false);
+				$conditions['AND'][] = array('Attribute.deleted' => 0);
 				if ($this->request->data['Attribute']['alternate']) {
 					$events = $this->searchAlternate($conditions);
 					$this->set('events', $events);

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -133,7 +133,7 @@ class EventsController extends AppController {
 				$includeQuery['conditions']['OR'][] = array('lower(Attribute.value1) LIKE' => $i);
 				$includeQuery['conditions']['OR'][] = array('lower(Attribute.value2) LIKE' => $i);
 			}
-			$includeQuery['conditions']['AND'][] = array('Attribute.deleted' => false);
+			$includeQuery['conditions']['AND'][] = array('Attribute.deleted' => 0);
 			$includeHits = $this->Event->Attribute->find('all', $includeQuery);
 
 			// convert it into an array that uses the event ID as a key
@@ -153,7 +153,7 @@ class EventsController extends AppController {
 				$excludeQuery['conditions']['OR'][] = array('lower(Attribute.value1) LIKE' => $e);
 				$excludeQuery['conditions']['OR'][] = array('lower(Attribute.value2) LIKE' => $e);
 			}
-			$excludeQuery['conditions']['AND'][] = array('Attribute.deleted' => false);
+			$excludeQuery['conditions']['AND'][] = array('Attribute.deleted' => 0);
 			$excludeHits = $this->Event->Attribute->find('all', $excludeQuery);
 
 			// convert it into an array that uses the event ID as a key
@@ -189,7 +189,7 @@ class EventsController extends AppController {
 		$conditions = array(
 			'AND' => array(
 				'OR' => $subconditions,
-				'deleted' => false
+				'deleted' => 0
 			)
 		);
 		$attributeHits = $this->Event->Attribute->fetchAttributes($this->Auth->user(), array(
@@ -689,7 +689,7 @@ class EventsController extends AppController {
 	public function viewEventAttributes($id, $all = false) {
 		$conditions = array('eventid' => $id);
 		if (isset($this->params['named']['deleted']) && $this->params['named']['deleted']) {
-			$conditions['deleted'] = true;
+			$conditions['deleted'] = 1;
 		}
 		$results = $this->Event->fetchEvent($this->Auth->user(), $conditions);
 		if (empty($results)) throw new NotFoundException('Invalid event');
@@ -874,7 +874,7 @@ class EventsController extends AppController {
 			$conditions['includeAttachments'] = true;
 		}
 		if (isset($this->params['named']['deleted']) && $this->params['named']['deleted']) {
-			$conditions['deleted'] = true;
+			$conditions['deleted'] = 1;
 		}
 		$results = $this->Event->fetchEvent($this->Auth->user(), $conditions);
 		if (empty($results)) throw new NotFoundException('Invalid event');

--- a/app/Controller/ShadowAttributesController.php
+++ b/app/Controller/ShadowAttributesController.php
@@ -66,7 +66,7 @@ class ShadowAttributesController extends AppController {
 				'recursive' => -1,
 				'conditions' => array(
 					'ShadowAttribute.id' => $id,
-					'deleted' => false
+					'deleted' => 0
 				),
 			)
 		);
@@ -225,7 +225,7 @@ class ShadowAttributesController extends AppController {
 					'recursive' => -1,
 					'conditions' => array(
 						'ShadowAttribute.id' => $id,
-						'deleted' => false
+						'deleted' => 0
 					),
 				)
 			);

--- a/app/Controller/TemplatesController.php
+++ b/app/Controller/TemplatesController.php
@@ -29,14 +29,14 @@ class TemplatesController extends AppController {
 	public function index() {
 		$conditions = array();
 		if (!$this->_isSiteAdmin()) {
-			$conditions['OR'] = array('org' => $this->Auth->user('Organisation')['name'], 'share' => true);
+			$conditions['OR'] = array('org' => $this->Auth->user('Organisation')['name'], 'share' => 1);
 		}
 		if (!$this->_isSiteAdmin()) {
 			$this->paginate = Set::merge($this->paginate,array(
 					'conditions' =>
 					array("OR" => array(
 							array('org' => $this->Auth->user('Organisation')['name']),
-							array('share' => true),
+							array('share' => 1),
 			))));
 		}
 		$this->set('list', $this->paginate());
@@ -231,7 +231,7 @@ class TemplatesController extends AppController {
 
 		$conditions = array();
 		if (!$this->_isSiteAdmin) {
-			$conditions['OR'] = array('Template.org' => $this->Auth->user('Organisation')['name'], 'Template.share' => true);
+			$conditions['OR'] = array('Template.org' => $this->Auth->user('Organisation')['name'], 'Template.share' => 1);
 		}
 		$templates = $this->Template->find('all', array(
 				'recursive' => -1,

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -41,7 +41,7 @@ class Attribute extends AppModel {
  * @var array
  */
 	public $virtualFields = array(
-			'value' => 'IF (Attribute.value2="", Attribute.value1, CONCAT(Attribute.value1, "|", Attribute.value2))',
+			'value' => "CASE WHEN Attribute.value2 = '' THEN Attribute.value1 ELSE CONCAT(Attribute.value1, '|', Attribute.value2) END",
 	); // TODO hardcoded
 
 /**

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -416,7 +416,7 @@ class Attribute extends AppModel {
 			'fields' => '',
 			'order' => '',
 			'counterCache' => 'attribute_count',
-			'counterScope' => array('Attribute.deleted' => false)
+			'counterScope' => array('Attribute.deleted' => 0)
 		),
 		'SharingGroup' => array(
 				'className' => 'SharingGroup',
@@ -570,7 +570,7 @@ class Attribute extends AppModel {
 				'Attribute.type' => $type,
 				'Attribute.category' => $category,
 				'Attribute.value' => $value,
-				'Attribute.deleted' => false
+				'Attribute.deleted' => 0
 		);
 		if (isset($this->data['Attribute']['id'])) {
 			$conditions['Attribute.id !='] = $this->data['Attribute']['id'];
@@ -1492,7 +1492,7 @@ class Attribute extends AppModel {
 					'conditions' => array('id' => $id),
 					'order' => array()
 			));
-			$attributes = $this->find('all', array('recursive' => -1, 'conditions' => array('Attribute.event_id' => $id, 'Attribute.deleted' => false), 'order' => array()));
+			$attributes = $this->find('all', array('recursive' => -1, 'conditions' => array('Attribute.event_id' => $id, 'Attribute.deleted' => 0), 'order' => array()));
 			foreach ($attributes as $k => $attribute) {
 				$this->__afterSaveCorrelation($attribute['Attribute'], true, $event);
 				$attributeCount++;
@@ -1765,7 +1765,7 @@ class Attribute extends AppModel {
 		if (isset($options['conditions'])) $params['conditions']['AND'][] = $options['conditions'];
 		if (isset($options['order'])) $params['order'] = $options['order'];
 		else ($params['order'] = array());
-		if (!$user['Role']['perm_sync'] || !isset($options['deleted']) || !$options['deleted']) $params['conditions']['AND']['Attribute.deleted'] = false;
+		if (!$user['Role']['perm_sync'] || !isset($options['deleted']) || !$options['deleted']) $params['conditions']['AND']['Attribute.deleted'] = 0;
 		if (isset($options['group'])) $params['group'] = $options['group'];
 		if (Configure::read('MISP.unpublishedprivate')) $params['conditions']['AND'][] = array('OR' => array('Event.published' => 1, 'Event.orgc_id' => $user['org_id']));
 		$results = $this->find('all', $params);
@@ -1869,7 +1869,7 @@ class Attribute extends AppModel {
 			}
 		}
 		unset($attribute['Attribute']['timestamp']);
-		$attribute['Attribute']['deleted'] = false;
+		$attribute['Attribute']['deleted'] = 0;
 		$date = new DateTime();
 		$attribute['Attribute']['timestamp'] = $date->getTimestamp();
 		if ($this->save($attribute['Attribute'])) {

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1173,11 +1173,11 @@ class Event extends AppModel {
 				$conditionsAttributes['AND'][] = array(
 					'OR' => array(
 						'(SELECT events.org_id FROM events WHERE events.id = Attribute.event_id)' => $user['org_id'],
-						'Attribute.deleted' => false
+						'Attribute.deleted' => 0
 					)
 				);
 			}
-		} else $conditionsAttributes['AND']['Attribute.deleted'] = false;
+		} else $conditionsAttributes['AND']['Attribute.deleted'] = 0;
 
 		if ($options['idList'] && !$options['tags']) {
 			$conditions['AND'][] = array('Event.id' => $options['idList']);

--- a/app/Model/Role.php
+++ b/app/Model/Role.php
@@ -81,28 +81,28 @@ class Role extends AppModel {
 	public function beforeSave($options = array()) {
 		switch ($this->data['Role']['permission']) {
 			case '0':
-				$this->data['Role']['perm_add'] = false;
-				$this->data['Role']['perm_modify'] = false;
-				$this->data['Role']['perm_modify_org'] = false;
-				$this->data['Role']['perm_publish'] = false;
+				$this->data['Role']['perm_add'] = 0;
+				$this->data['Role']['perm_modify'] = 0;
+				$this->data['Role']['perm_modify_org'] = 0;
+				$this->data['Role']['perm_publish'] = 0;
 				break;
 			case '1':
-				$this->data['Role']['perm_add'] = true;
-				$this->data['Role']['perm_modify'] = true; // SHOULD BE true
-				$this->data['Role']['perm_modify_org'] = false;
-				$this->data['Role']['perm_publish'] = false;
+				$this->data['Role']['perm_add'] = 1;
+				$this->data['Role']['perm_modify'] = 1; // SHOULD BE true
+				$this->data['Role']['perm_modify_org'] = 0;
+				$this->data['Role']['perm_publish'] = 0;
 				break;
 			case '2':
-				$this->data['Role']['perm_add'] = true;
-				$this->data['Role']['perm_modify'] = true;
-				$this->data['Role']['perm_modify_org'] = true;
-				$this->data['Role']['perm_publish'] = false;
+				$this->data['Role']['perm_add'] = 1;
+				$this->data['Role']['perm_modify'] = 1;
+				$this->data['Role']['perm_modify_org'] = 1;
+				$this->data['Role']['perm_publish'] = 0;
 				break;
 			case '3':
-				$this->data['Role']['perm_add'] = true;
-				$this->data['Role']['perm_modify'] = true; // ?
-				$this->data['Role']['perm_modify_org'] = true; // ?
-				$this->data['Role']['perm_publish'] = true;
+				$this->data['Role']['perm_add'] = 1;
+				$this->data['Role']['perm_modify'] = 1; // ?
+				$this->data['Role']['perm_modify_org'] = 1; // ?
+				$this->data['Role']['perm_publish'] = 1;
 				break;
 			default:
 				break;

--- a/app/Model/Role.php
+++ b/app/Model/Role.php
@@ -60,7 +60,7 @@ class Role extends AppModel {
  */
 
 	public $virtualFields = array(
-		'permission' => "IF (Role.perm_add && Role.perm_modify && Role.perm_publish, '3', IF (Role.perm_add && Role.perm_modify_org, '2', IF (Role.perm_add, '1', '0')))",
+		'permission' => "CASE WHEN (Role.perm_add + Role.perm_modify + Role.perm_publish = 3) THEN '3' WHEN (Role.perm_add + Role.perm_modify_org = 2) THEN '2' WHEN (Role.perm_add = 1) THEN '1' ELSE '0' END",
 	);
 
 	public $permFlags = array(

--- a/app/Model/ShadowAttribute.php
+++ b/app/Model/ShadowAttribute.php
@@ -62,7 +62,7 @@ class ShadowAttribute extends AppModel {
  * @var array
  */
 	public $virtualFields = array(
-			'value' => 'IF (ShadowAttribute.value2="", ShadowAttribute.value1, CONCAT(ShadowAttribute.value1, "|", ShadowAttribute.value2))',
+			'value' => "CASE WHEN ShadowAttribute.value2 = '' THEN ShadowAttribute.value1 ELSE CONCAT(ShadowAttribute.value1, '|', ShadowAttribute.value2) END",
 	); // TODO hardcoded
 
 /**

--- a/app/Model/ShadowAttribute.php
+++ b/app/Model/ShadowAttribute.php
@@ -223,7 +223,7 @@ class ShadowAttribute extends AppModel {
 											'Attribute.value2' => $cV
 									),
 									'Attribute.type !=' => $this->Event->Attribute->nonCorrelatingTypes,
-									'Attribute.deleted' => false
+									'Attribute.deleted' => 0
 							),
 					),
 					'recursive => -1',

--- a/app/Model/Taxonomy.php
+++ b/app/Model/Taxonomy.php
@@ -61,10 +61,10 @@ class Taxonomy extends AppModel{
 	}
 
 	private function __updateVocab(&$vocab, &$current, $skipUpdateFields = array()) {
-		$enabled = false;
+		$enabled = 0;
 		$taxonomy = array();
 		if (!empty($current)) {
-			if ($current['Taxonomy']['enabled']) $enabled = true;
+			if ($current['Taxonomy']['enabled']) $enabled = 1;
 			$this->deleteAll(array('Taxonomy.namespace' => $current['Taxonomy']['namespace']));
 		}
 		$taxonomy['Taxonomy'] = array('namespace' => $vocab['namespace'], 'description' => $vocab['description'], 'version' => $vocab['version'], 'enabled' => $enabled);
@@ -234,7 +234,7 @@ class Taxonomy extends AppModel{
 		$recursive = -1;
 		if (isset($options['full']) && $options['full']) $recursive = 2;
 		$conditions = array();
-		if (isset($options['enabled']) && $options['enabled']) $conditions[] = array('Taxonomy.enabled' => true);
+		if (isset($options['enabled']) && $options['enabled']) $conditions[] = array('Taxonomy.enabled' => 1);
 		$temp =  $this->find('all',  array(
 			'recursive' => $recursive,
 			'conditions' => $conditions

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -90,7 +90,7 @@ class User extends AppModel {
 			'boolean' => array(
 				'rule' => array('boolean'),
 				//'message' => 'Your custom message here',
-				'allowEmpty' => true,
+				//'allowEmpty' => false,
 				'required' => false,
 				//'last' => false, // Stop validation after this rule
 				//'on' => 'create', // Limit validation to 'create' or 'update' operations
@@ -100,7 +100,7 @@ class User extends AppModel {
 				'boolean' => array(
 						'rule' => array('boolean'),
 						//'message' => 'Your custom message here',
-						'allowEmpty' => true,
+						//'allowEmpty' => false,
 						'required' => false,
 						//'last' => false, // Stop validation after this rule
 						//'on' => 'create', // Limit validation to 'create' or 'update' operations

--- a/app/View/Tags/add.ctp
+++ b/app/View/Tags/add.ctp
@@ -11,6 +11,7 @@
 		<div class="clear"></div>
 	<?php
 		echo $this->Form->input('exportable', array(
+			'type' => 'checkbox', 'checked' => true
 		));
 	?>
 	</fieldset>

--- a/app/View/Tags/edit.ctp
+++ b/app/View/Tags/edit.ctp
@@ -8,10 +8,11 @@
 		echo $this->Form->input('colour', array(
 		));
 	?>
-	<div class="clear"></div>
+		<div class="clear"></div>
 	<?php
 		echo $this->Form->input('exportable', array(
-	));
+			'type' => 'checkbox'
+		));
 	?>
 	</fieldset>
 <?php

--- a/app/View/Templates/add.ctp
+++ b/app/View/Templates/add.ctp
@@ -42,6 +42,7 @@
 		));
 		echo $this->Form->input('share', array(
 			'label' => 'Share this template with others',
+			'type' => 'checkbox'
 		));
 	?>
 	</fieldset>

--- a/app/View/Templates/edit.ctp
+++ b/app/View/Templates/edit.ctp
@@ -42,6 +42,7 @@
 		));
 		echo $this->Form->input('share', array(
 			'label' => 'Share this template with others',
+			'type' => 'checkbox'
 		));
 	?>
 	</fieldset>

--- a/app/View/Users/admin_add.ctp
+++ b/app/View/Users/admin_add.ctp
@@ -63,8 +63,8 @@
 		<div class="clear"><span onClick="lookupPGPKey('UserEmail');" class="btn btn-inverse" style="margin-bottom:10px;">Fetch GPG key</span></div>
 	<?php
 		if (Configure::read('SMIME.enabled')) echo $this->Form->input('certif_public', array('label' => 'Public certificate (Encryption -- PEM format)', 'div' => 'clear', 'class' => 'input-xxlarge'));
-		echo $this->Form->input('autoalert', array('label' => 'Receive alerts when events are published'));
-		echo $this->Form->input('contactalert', array('label' => 'Receive alerts from "contact reporter" requests'));
+		echo $this->Form->input('autoalert', array('label' => 'Receive alerts when events are published', 'type' => 'checkbox'));
+		echo $this->Form->input('contactalert', array('label' => 'Receive alerts from "contact reporter" requests', 'type' => 'checkbox'));
 	?>
 		<div class="clear"></div>
 	<?php

--- a/app/View/Users/admin_edit.ctp
+++ b/app/View/Users/admin_edit.ctp
@@ -64,8 +64,8 @@
 		if (Configure::read('SMIME.enabled')) echo $this->Form->input('certif_public', array('label' => 'SMIME Public certificate (PEM format)', 'div' => 'clear', 'class' => 'input-xxlarge'));
 		echo $this->Form->input('termsaccepted', array('label' => 'Terms accepted'));
 		echo $this->Form->input('change_pw', array('type' => 'checkbox', 'label' => 'Change Password'));
-		echo $this->Form->input('autoalert', array('label' => 'Receive alerts when events are published'));
-		echo $this->Form->input('contactalert', array('label' => 'Receive alerts from "contact reporter" requests'));
+		echo $this->Form->input('autoalert', array('label' => 'Receive alerts when events are published', 'type' => 'checkbox'));
+		echo $this->Form->input('contactalert', array('label' => 'Receive alerts from "contact reporter" requests', 'type' => 'checkbox'));
 
 		echo $this->Html->link('Reset Auth Key', array('controller' => 'users', 'action' => 'resetauthkey', $currentId));
 	?>

--- a/app/View/Users/edit.ctp
+++ b/app/View/Users/edit.ctp
@@ -16,8 +16,8 @@
 			<div class="clear"><span onClick="lookupPGPKey('UserEmail');" class="btn btn-inverse" style="margin-bottom:10px;">Fetch GPG key</span></div>
 		<?php
 		if (Configure::read('SMIME.enabled')) echo $this->Form->input('certif_public', array('label' => 'SMIME Public certificate (PEM format)', 'div' => 'clear', 'class' => 'input-xxlarge'));
-		echo $this->Form->input('autoalert', array('label' => 'Receive alerts when events are published'));
-		echo $this->Form->input('contactalert', array('label' => 'Receive alerts from "contact reporter" requests'));
+		echo $this->Form->input('autoalert', array('label' => 'Receive alerts when events are published', 'type' => 'checkbox'));
+		echo $this->Form->input('contactalert', array('label' => 'Receive alerts from "contact reporter" requests', 'type' => 'checkbox'));
 	?>
 	</fieldset>
 <?php echo $this->Form->button(__('Submit'), array('class' => 'btn btn-primary'));


### PR DESCRIPTION
the commits in this PR change the way, booleans and related things are handled by MISP.

because MySQL has no "bool" datatype, tinyint(1) is used and therefore booleans have to be casted to integers 1/0. in some parts of the MISP-code, the integers are used while in others, the booleans are used.
this can lead to problems with the cakephp ORM wrapper, which (sometimes?) casts a "false" to "" (empty string) instead of 0, which works with MySQL, but isn't clean and doesn't work with other DBMS like PostgreSQL.

therefore, this PR changes many true/false booleans used for sql queries to their 1/0 integer counterparts.
it also changes some $virtualFields sql statements to work with this.
third, it sets input type checkbox explicitly for some boolean input fields, so these input fields don't depend on type-guessing, because this won't work with PostgreSQL as it doesn't have the "tinyint(1)" datatype.

a second test of this by someone else before merging would be good.

these changes are also mandatory for the basic postgresql support ( #1363 )
