### PR TITLE
fix: submodule updates: force overwrite

### DIFF
--- a/INSTALL/UPDATE.txt
+++ b/INSTALL/UPDATE.txt
@@ -18,9 +18,7 @@ git checkout tags/$(git describe --tags `git rev-list --tags --max-count=1`)
 # 2. Update CakePHP to the latest supported version (if for some reason it doesn't get updated automatically with git submodule)
 
 cd /var/www/MISP
-rm -rf app/Lib/cakephp/
-git submodule init
-git submodule update
+git submodule update --init --force
 
 
 # 3. Update Mitre's STIX and its dependencies

--- a/INSTALL/UPGRADE.txt
+++ b/INSTALL/UPGRADE.txt
@@ -14,8 +14,7 @@ git checkout tags/$(git describe --tags `git rev-list --tags --max-count=1`)
 # 3. Update CakePHP to the latest supported version
 cd /var/www/MISP
 rm -rf app/Lib/cakephp/
-git submodule init
-git submodule update
+git submodule update --init --force
 
 # 4. delete everything from MISP's cache directory to get rid of the cached models
 find /var/www/MISP/app/tmp/cache/ -type f -not -name 'empty' -delete


### PR DESCRIPTION
this changes the update/upgrade documentation to combine two submodule commands and adds "--force" so local changes are alway overwritten (these can be for example file permission (chmod) changes)

this fixes #1368 which results of the problem during the update process
