### PR TITLE
fix: doc: use php5-redis package instead of pecl for deb7/ubu14

### DIFF
--- a/INSTALL/INSTALL.debian7.txt
+++ b/INSTALL/INSTALL.debian7.txt
@@ -26,8 +26,9 @@ Once the system is installed you can perform the following steps as root:
 # Because vim is just so practical
 apt-get install vim
 
+# Note that the php5-redis package in Debian oldstable (wheezy) only exists in the backports repository: http://backports.debian.org/Instructions/
 # Install the dependencies:
-apt-get install gcc zip php-pear git redis-server make python-dev python-pip libxml2-dev libxslt1-dev zlib1g-dev php5-dev libapache2-mod-php5 php5-mysql php5-json curl
+apt-get install gcc zip php-pear git redis-server make python-dev python-pip libxml2-dev libxslt1-dev zlib1g-dev php5-dev libapache2-mod-php5 php5-mysql php5-json php5-redis curl
 pear install Crypt_GPG    # we need version >1.3.0
 #if you are using a proxy do:
 pear config-set http_proxy http://username:password@yourproxy:80
@@ -80,14 +81,8 @@ php composer.phar require kamisama/cake-resque:4.1.2
 php composer.phar config vendor-dir Vendor
 php composer.phar install
 
-# CakeResque normally uses phpredis to connect to redis, but it has a (buggy) fallback connector through Redisent. It is highly advised to install phpredis
-pecl install redis
-apt-get install php5-redis
-# Note that the php5-redis package in Debian oldstable (wheezy) only exists in the backports repository: http://backports.debian.org/Instructions/
-# After installing it, enable it in your php.ini file
-vim /etc/php5/apache2/php.ini
-# add the following line:
-extension=redis.so
+# Enable CakeResque with php5-redis
+sudo php5enmod redis
 
 # To use the scheduler worker for scheduled tasks, do the following:
 cp -fa /var/www/MISP/INSTALL/setup/config.php /var/www/MISP/app/Plugin/CakeResque/Config/config.php

--- a/INSTALL/INSTALL.ubuntu1404.txt
+++ b/INSTALL/INSTALL.ubuntu1404.txt
@@ -27,7 +27,7 @@ Once the system is installed you can perform the following steps as root:
 apt-get install vim
 
 # Install the dependencies:
-apt-get install gcc zip php-pear git redis-server make python-dev python-pip libxml2-dev libxslt1-dev zlib1g-dev php5-dev libapache2-mod-php5 php5-mysql php5-json curl gnupg-agent
+apt-get install gcc zip php-pear git redis-server make python-dev python-pip libxml2-dev libxslt1-dev zlib1g-dev php5-dev libapache2-mod-php5 php5-mysql php5-json php5-redis curl gnupg-agent
 pear install Crypt_GPG    # we need version >1.3.0
 
 3/ MISP code
@@ -73,14 +73,8 @@ php composer.phar require kamisama/cake-resque:4.1.2
 php composer.phar config vendor-dir Vendor
 php composer.phar install
 
-# CakeResque normally uses phpredis to connect to redis, but it has a (buggy) fallback connector through Redisent. It is highly advised to install phpredis
-pecl install redis
-apt-get install php5-redis
-# Note that the php5-redis package in Debian oldstable (wheezy) only exists in the backports repository: http://backports.debian.org/Instructions/
-# After installing it, enable it in your php.ini file
-vim /etc/php5/apache2/php.ini
-# add the following line:
-extension=redis.so
+# Enable CakeResque with php5-redis
+sudo php5enmod redis
 
 # To use the scheduler worker for scheduled tasks, do the following:
 cp -fa /var/www/MISP/INSTALL/setup/config.php /var/www/MISP/app/Plugin/CakeResque/Config/config.php


### PR DESCRIPTION
this updates documentation to use the distribution-packaged version of the php redis extension on Debian 7 and Ubuntu 14.04, too.

also fixes #1274, at least for ubuntu
