### PR TITLE
Add install procedure for current version of ZeroMQ

### DIFF
--- a/INSTALL/INSTALL.debian8.txt
+++ b/INSTALL/INSTALL.debian8.txt
@@ -267,7 +267,35 @@ Recommended actions
 
 Optional features
 -------------------
-# MISP has a new pub/sub feature, using ZeroMQ. To enable it, simply run the following command
-sudo pip install pyzmq
+# MISP has a new pub/sub feature, using ZeroMQ. To enable it, simply run the following commands
+
 # ZeroMQ depends on the Python client for Redis
 sudo pip install redis
+
+# Debian has an ancient version of ZeroMQ, so manually install a current version
+
+## Install ZeroMQ and prerequisites
+sudo apt-get install pkg-config
+cd /usr/local/src/
+sudo git clone git://github.com/jedisct1/libsodium.git
+cd libsodium
+sudo ./autogen.sh
+sudo ./configure
+sudo make check
+sudo make
+sudo make install
+sudo ldconfig
+cd /usr/local/src/
+sudo wget https://archive.org/download/zeromq_4.1.5/zeromq-4.1.5.tar.gz
+sudo tar -xvf zeromq-4.1.5.tar.gz
+cd zeromq-4.1.5/
+sudo ./autogen.sh
+sudo ./configure
+sudo make check
+sudo make
+sudo make install
+sudo ldconfig
+
+## install pyzmq
+sudo pip install pyzmq
+


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:
- One Pull Request per fix/feature/change/...
- Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
- Always make sure it is mergeable in the default branch (as of today 2016-06-03: branch 2.4)
- Please make sure Travis CI works on this request, or update the test cases if needed
- Any major changes adding a functionality should be disabled by default in the config
#### What does it do?

If it fixes an existing issue, please use github syntax: `#<IssueID>`
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch

Debian 8 has an ancient version of ZeroMQ which is not compatible with the latest pyzmq on PyPI. Manually installing the current ZeroMQ release is a viable workaround.
