### PR TITLE
Using custom comments for module return values/attributes

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -3667,6 +3667,12 @@ class EventsController extends AppController {
 				}
 				$resultArray = array_merge($resultArray, $freetextResults);
 			}
+			if(isset($result['comment']) && $result['comment'] != "") {
+				$importComment = $result['comment'];
+			}
+			else {
+				$importComment = 'Enriched via the ' . $module . ' module';
+			}
 			$typeCategoryMapping = array();
 			foreach ($this->Event->Attribute->categoryDefinitions as $k => $cat) {
 				foreach ($cat['types'] as $type) {
@@ -3681,13 +3687,14 @@ class EventsController extends AppController {
 				);
 				$result['related'] = $this->Event->Attribute->fetchAttributes($this->Auth->user(), $options);
 			}
+
 			$this->set('event', array('Event' => $attribute[0]['Event']));
 			$this->set('resultArray', $resultArray);
 			$this->set('typeList', array_keys($this->Event->Attribute->typeDefinitions));
 			$this->set('defaultCategories', $this->Event->Attribute->defaultCategories);
 			$this->set('typeCategoryMapping', $typeCategoryMapping);
 			$this->set('title', 'Enrichment Results');
-			$this->set('importComment', 'Enriched via the ' . $module . ' module');
+			$this->set('importComment', $importComment);
 			$this->render('resolved_attributes');
 		}
 	}


### PR DESCRIPTION
#### What does it do?

Enables custom comments (instead of `Enriched via...`) when using enrichment modules.

``` python
    r = {'results': [
                        {
                            'types': ['ip-src', 'ip-dst'],
                            'values': ['1.1.1.1', '2.2.2.2'],
                            'categories': ['Payload delivery', 'Network activity']
                        },
                        {
                            'types': ['filename'],
                            'values': ['test1.exe', 'test2.exe'],
                            'categories': ['Payload installation']
                        },
                    ],
         'comment': 'This is a custom comment.'}
```

If there's no comment set, the default comment is used. No changes in the template, because I think the comments should always be editable.
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
- [x] Using it on test server at the moment  
#### Release Type:
- [ ] Major
- [ ] Minor
- [x] Patch
