### PR TITLE
Create categories array, if only one category given

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -3623,6 +3623,9 @@ class EventsController extends AppController {
 					if (!is_array($r['types'])) {
 						$r['types'] = array($r['types']);
 					}
+					if (!is_array($r['categories'])) {
+						$r['categories'] = array($r['categories']);
+					}
 					foreach ($r['values'] as &$value) {
 						if (!is_array($r['values']) || !isset($r['values'][0])) {
 							$r['values'] = array($r['values']);


### PR DESCRIPTION
#### What does it do?

Handles categories from returning module values as the values and types. If only one category given and it is not in an array, create an array with that value.
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
- [x] On our test environment
  #### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
