### PR TITLE
SSO plugin (Shibboleth based). Instructions to enable and configure i…

### DIFF
--- a/app/Config/bootstrap.default.php
+++ b/app/Config/bootstrap.default.php
@@ -127,7 +127,7 @@ CakePlugin::load('UrlCache');
  * It's also necessary to configure the plugin — for more information, please read app/Plugin/CertAuth/reame.md
  */
 // CakePlugin::load('CertAuth');
-
+// CakePlugin::load('ShibbAuth');
 /**
  * You can attach event listeners to the request lifecyle as Dispatcher Filter . By Default CakePHP bundles two filters:
  *

--- a/app/Config/config.default.php
+++ b/app/Config/config.default.php
@@ -7,6 +7,7 @@ $config = array (
     'salt' => '',
     'cipherSeed' => '',
     //'auth'=>array('CertAuth.Certificate'), // additional authentication methods
+    //'auth'=>array('ShibbAuth.ApacheShibb'),
   ),
   'MISP' =>
   array (
@@ -87,6 +88,24 @@ $config = array (
       ),
     ),
     'userDefaults'  => array ( 'role_id' => 3 ),          // default attributes for new users
+  ),
+  */
+  /*
+   'ApacheShibbAuth' =>                      // Configuration for shibboleth authentication
+    array(
+         'apacheEnv' => 'REMOTE_USER',        // If proxy variable = HTTP_REMOTE_USER
+         'ssoAuth' => 'AUTH_TYPE',
+         'MailTag' => 'EMAIL_TAG',
+         'OrgTag' => 'FEDERATION_TAG',
+         'GroupTag' => 'GROUP_TAG',
+         'GroupSeparator' => ';',
+         'GroupRoleMatching' => array(                // 3:User, 1:admin. May be good to set "1" for the first user
+               'group_three' => 3,
+               'group_two' => 2,
+               'group_one' => 1,
+          ),
+         'DefaultRoleId' => 3,
+         'DefaultOrg' => 'DEFAULT_ORG',
   ),
   */
   // Warning: The following is a 3rd party contribution and still untested (including security) by the MISP-project team.

--- a/app/Plugin/ShibbAuth/Controller/Component/Auth/ApacheShibbAuthenticate.php
+++ b/app/Plugin/ShibbAuth/Controller/Component/Auth/ApacheShibbAuthenticate.php
@@ -1,0 +1,145 @@
+<?php
+
+App::uses('BaseAuthenticate', 'Controller/Component/Auth');
+
+/*
+ * custom class for Apache-based authentication
+ *
+ * User for ApacheAuthenticate you can pass in settings to which fields, model and additional conditions
+ * are used. See FormAuthenticate::$settings for more information.
+ * TODO: clarification needed, text almost the same as in lib/Cake/Controller/Component/Auth/FormAuthenticate.php
+ *
+ * CakePHP version 2.8.5
+ *
+ * @package       Controller.Component.Auth
+ * @since 2.0
+ * @see ApacheAuthComponent::$authenticate
+ */
+
+class ApacheShibbAuthenticate extends BaseAuthenticate {
+
+
+    /**
+     * Authentication class
+     *
+     * Configuration in app/Config/Config.php is:
+     *
+     * 'ApacheShibbAuth' =>                      // Configuration for shibboleth authentication
+     *     array(
+     *      'apacheEnv' => 'REMOTE_USER',        // If proxy variable = HTTP_REMOTE_USER
+     *      'ssoAuth' => 'AUTH_TYPE',            // NOT to modify
+     *      'MailTag' => 'EMAIL_TAG',
+     *      'OrgTag' => 'FEDERATION_TAG',
+     *      'GroupTag' => 'GROUP_TAG',
+     *      'GroupSeparator' => ';',
+     *      'GroupRoleMatching' => array(                // 3:User, 1:admin. May be good to set "1" for the first user
+     *          'group_three' => '3',
+     *          'group_two' => 2,
+     *          'group_one' => 1,
+     *       ),
+     *      'DefaultRoleId' => 3,
+     *      'DefaultOrg' => 'MY_ORG',
+     * ),
+     * @param CakeRequest $request The request that contains login information.
+     * @param CakeResponse $response Unused response object.
+     * @return mixed False on login failure. An array of User data on success.
+     */
+
+
+    public function authenticate(CakeRequest $request, CakeResponse $response)
+    {
+        return self::$this->getUser($request);
+    }
+
+    /**
+     * @return array|bool
+     */
+    public function getUser(CakeRequest $request)
+    {
+        // Get Default parameters
+        $roleId = Configure::read('ApacheShibbAuth.DefaultRoleId');
+        $org = Configure::read('ApacheShibbAuth.DefaultOrg');
+        // Get tags from SSO config
+        $mailTag = Configure::read('ApacheShibbAuth.MailTag');
+        $orgTag = Configure::read('ApacheShibbAuth.OrgTag');
+        $groupTag = Configure::read('ApacheShibbAuth.GroupTag');
+        $groupRoleMatching = Configure::read('ApacheShibbAuth.GroupRoleMatching');
+
+        // Get user values
+        $mispUsername = $_SERVER[$mailTag];
+
+        //Change username column for email (username in shibboleth attributes corresponds to the email in MISPs DB)
+        $this->settings['fields'] = array('username' => 'email');
+
+        // Find user with real username (mail)
+        $user = $this->_findUser($mispUsername);
+
+        //Obtain default org. If not, org keeps the default value
+        if (isset($_SERVER[$orgTag])) {
+            $org = $_SERVER[$orgTag];
+        }
+
+        //Check if the list
+        $roleChanged = false;
+        if (isset($_SERVER[$groupTag])) {
+            $groupSeparator = Configure::read('ApacheShibbAuth.GroupSeparator');
+            $groupList = explode($groupSeparator, $_SERVER[$groupTag]);
+            //Check user roles and egroup match and update if needed
+            foreach ($groupList as $group) {
+                $roleVal = $groupRoleMatching[$group];
+                if ($roleVal <= $roleId) {
+                    $roleId = $roleVal;
+                    $roleChanged = true;
+                }
+            }
+        }
+        // Database model object
+        $userModel = ClassRegistry::init($this->settings['userModel']);
+
+        if ($user) { // User already exists
+            if ($roleChanged && $user['role_id'] != $roleId) {
+                $user['role_id'] = $roleId; // Different role either increase or decrease permissions
+                $userUpdatedData = array('User' => $user);
+                $userModel->set(array(
+                    'role_id' => $roleId,
+                    'id' => $user['id'],
+                )); // Update the user
+                $userModel->save($userUpdatedData, false);
+            }
+            return $user;
+        }
+        // insert user in database if not existent
+        //Generate random password
+        $password = $this->randPasswordGen(40);
+        // create user
+        $userData = array('User' => array(
+            'email' => $mispUsername,
+            'org_id' => $org,
+            'password' => $password, //Since it is done via shibboleth the password will be a random 40 character string
+            'confirm_password' => $password,
+            'authkey' => $userModel->generateAuthKey(),
+            'nids_sid' => 4000000,
+            'newsread' => date('Y-m-d'),
+            'role_id' => $roleId,
+            'change_pw' => 0
+        ));
+
+        // save user
+        $userModel->save($userData, false);
+
+        return $this->_findUser(
+            $mispUsername
+        );
+    }
+
+    private function randPasswordGen($len){
+        $result = "";
+        $chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\$_?!-0123456789";
+        $charArray = str_split($chars);
+        for($i = 0; $i < $len; $i++){
+            $randItem = array_rand($charArray);
+            $result .= "".$charArray[$randItem];
+        }
+        return $result;
+    }
+}

--- a/app/Plugin/ShibbAuth/README.md
+++ b/app/Plugin/ShibbAuth/README.md
@@ -1,0 +1,50 @@
+#Client SSO Authentication (Shibboleth based) for CakePHP
+
+This plugin enables CakePHP applications to use Single Sing-On to authenticate its users. It gets the information given by Apache environment variables.
+
+
+## Usage
+
+Enable the plugin at bootstrap.php:
+
+```php
+CakePlugin::load('ShibbAuth');
+```
+
+And configure it at config.php:
+
+Uncomment the following line to enable SSO authorization
+```php
+'auth'=>array('ShibbAuth.ApacheShibb'),
+```
+
+And configure it. apacheEnv ans ssoAuth are parametert that come by default which values should not be changed unless
+it is explicitly needed. MailTag, OrgTag and GroupTag are the string that represent the key for the values needed by the plugin.
+For example if you are using ADFS OrgTag will be ADFS_FEDERATION, GroupTag will be ADFS_GROUP, etc. meaning the key for the values needed.
+DefaultRoleId and DefaultOrg are values that come by default just in case they are not defined or obtained from the environment variables.
+The GroupRoleMatching is an array that allows the definition and correlation between groups and roles in MISP, being them updated
+if the groups are updated (i.e. a user that was admin and their groups changed inside the organization will have his role changed in MISP
+upon the next login being now user or org admin respectively). The GroupSeparator is the character used to separate the different groups
+in the list given by apache.
+
+```php
+'ApacheShibbAuth' =>                      // Configuration for shibboleth authentication
+    array(
+   	     'apacheEnv' => 'REMOTE_USER',        // If proxy variable = HTTP_REMOTE_USER
+         'ssoAuth' => 'AUTH_TYPE',
+         'MailTag' => 'EMAIL_TAG',
+         'OrgTag' => 'FEDERATION_TAG',
+	     'GroupTag' => 'GROUP_TAG',
+	     'GroupSeparator' => ';',
+         'GroupRoleMatching' => array(                // 3:User, 1:admin. May be good to set "1" for the first user
+               'group_three' => '3',
+	           'group_two' => 2,
+	           'group_one' => 1,
+          ),
+         'DefaultRoleId' => 3,
+         'DefaultOrg' => 'DEFAULT_ORG',
+    ),
+```
+
+
+


### PR DESCRIPTION
#### What does it do?

Single Sing-On authentication integration via Plugin (following the same structure than the CertAuth plugin. 
As a summary, the plugin will take the values from the environment variables (given by apache after login-in in via SSO) and authenticate the user (creating it if it does not exists)
#### Questions
- [ ] Does it require a DB change? No
- [ ] Are you using it in production? No, development
- [ ] Does it require a change in the API (PyMISP for example)? No
#### Release Type:
- [ ] Major
- [X] Minor
- [] Patch
