### PR TITLE
fix: clarification on menu

### DIFF
--- a/app/View/Elements/side_menu.ctp
+++ b/app/View/Elements/side_menu.ctp
@@ -184,7 +184,7 @@
 				case 'admin':
 					if ($menuItem === 'editUser' || $menuItem === 'viewUser'): ?>
 					<li id='liviewUser'><?php echo $this->Html->link('View User', array('controller' => 'users', 'action' => 'view', 'admin' => true, h($id))); ?> </li>
-					<li><a href="#/" onClick="initiatePasswordReset('<?php echo h($id); ?>');">Send Credentials</a></li>
+					<li><a href="#/" onClick="initiatePasswordReset('<?php echo h($id); ?>');">Reset Password</a></li>
 					<li id='lieditUser'><?php echo $this->Html->link('Edit User', array('controller' => 'users', 'action' => 'edit', 'admin' => true, h($id))); ?> </li>
 					<li><?php echo $this->Form->postLink('Delete User', array('admin' => true, 'action' => 'delete', h($id)), null, __('Are you sure you want to delete # %s? It is highly recommended to never delete users but to disable them instead.', h($id)));?></li>
 					<li class="divider"></li>


### PR DESCRIPTION
Change menu 'Send Credentials' by 'Reset Password' on User's administration page.
The functionality is to reset the password, not simply send credentials :speak_no_evil:
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
