### PR TITLE
Fix export for non md5/sha1/sha256 types

### DIFF
--- a/app/Model/Job.php
+++ b/app/Model/Job.php
@@ -41,7 +41,7 @@ class Job extends AppModel {
 				'org_id' => $user['Role']['perm_site_admin'] ? 0 : $user['org_id'],
 				'message' => 'Fetching events.',
 		);
-		if ($type === 'md5' || $type === 'sha1' || $type = 'sha256') {
+		if ($type === 'md5' || $type === 'sha1' || $type === 'sha256') {
 			$extra = $type;
 			$type = 'hids';
 		}


### PR DESCRIPTION
#### What does it do?

If fixes an issue where generating exports except md5/sha1/sha256 would actually generate an export for sha256.
#### Questions
- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
