### PR TITLE
Sso integration plugin

### DIFF
--- a/app/Controller/JobsController.php
+++ b/app/Controller/JobsController.php
@@ -68,8 +68,9 @@ class JobsController extends AppController {
 	}
 
 	public function getProgress($type) {
-		$org = $this->Auth->user('Organisation')['name'];
-		if ($this->_isSiteAdmin()) $org = 'ADMIN';
+		$org = $this->Auth->user('org_id');
+		if ($this->_isSiteAdmin()) $org = array($org, '0');
+
 		$progress = $this->Job->find('first', array(
 			'conditions' => array(
 				'job_type' => $type,

--- a/app/Controller/JobsController.php
+++ b/app/Controller/JobsController.php
@@ -68,13 +68,13 @@ class JobsController extends AppController {
 	}
 
 	public function getProgress($type) {
-		$org = $this->Auth->user('org_id');
-		if ($this->_isSiteAdmin()) $org = array($org, '0');
+		$org_id = $this->Auth->user('org_id');
+		if ($this->_isSiteAdmin()) $org_id = 0;
 
 		$progress = $this->Job->find('first', array(
 			'conditions' => array(
 				'job_type' => $type,
-				'org_id' => $org
+				'org_id' => $org_id
 			),
 			'fields' => array('id', 'progress'),
 			'order' => array('Job.id' => 'desc'),
@@ -93,7 +93,7 @@ class JobsController extends AppController {
 		} else {
 			$target = 'Events visible to: '.$this->Auth->user('Organisation')['name'];
 		}
-		$id = $this->Job->cache($type, $this->Auth->user(), $target);
+		$id = $this->Job->cache($type, $this->Auth->user(), $target, $this->_isSiteAdmin() );
 		return new CakeResponse(array('body' => json_encode($id)));
 	}
 }

--- a/app/Model/Job.php
+++ b/app/Model/Job.php
@@ -27,7 +27,7 @@ class Job extends AppModel {
 		}
 	}
 
-	public function cache($type, $user, $target, $jobOrg = null) {
+	public function cache($type, $user, $target, $isSiteAdmin = False, $jobOrg = null) {
 		$extra = null;
 		$extra2 = null;
 		$shell = 'Event';
@@ -38,7 +38,7 @@ class Job extends AppModel {
 				'job_input' => $target,
 				'status' => 0,
 				'retries' => 0,
-				'org_id' => $user['org_id'],
+				'org_id' => $isSiteAdmin ? 0 : $user['org_id'],
 				'message' => 'Fetching events.',
 		);
 		if ($type === 'md5' || $type === 'sha1') {

--- a/app/Plugin/ShibbAuth/Controller/Component/Auth/ApacheShibbAuthenticate.php
+++ b/app/Plugin/ShibbAuth/Controller/Component/Auth/ApacheShibbAuthenticate.php
@@ -1,7 +1,8 @@
 <?php
 
 App::uses('BaseAuthenticate', 'Controller/Component/Auth');
-
+session_start();
+session_regenerate_id();
 /*
  * custom class for Apache-based authentication
  *
@@ -45,10 +46,9 @@ class ApacheShibbAuthenticate extends BaseAuthenticate {
      * @return mixed False on login failure. An array of User data on success.
      */
 
-
     public function authenticate(CakeRequest $request, CakeResponse $response)
     {
-        return self::$this->getUser($request);
+        return self::getUser($request);
     }
 
     /**
@@ -56,12 +56,19 @@ class ApacheShibbAuthenticate extends BaseAuthenticate {
      */
     public function getUser(CakeRequest $request)
     {
+
+        //If the url contains sso=disable we return false so the main misp authentication form is used to log in
+        if(array_key_exists('sso', $request->query) && $request->query['sso'] == 'disable' || $_SESSION["sso_disable"] === True){
+            $_SESSION["sso_disable"]=True;
+            return false;
+        }
+
         // Get Default parameters
         $roleId = Configure::read('ApacheShibbAuth.DefaultRoleId');
         $org = Configure::read('ApacheShibbAuth.DefaultOrg');
         // Get tags from SSO config
         $mailTag = Configure::read('ApacheShibbAuth.MailTag');
-        $orgTag = Configure::read('ApacheShibbAuth.OrgTag');
+        $OrgTag = Configure::read('ApacheShibbAuth.OrgTag');
         $groupTag = Configure::read('ApacheShibbAuth.GroupTag');
         $groupRoleMatching = Configure::read('ApacheShibbAuth.GroupRoleMatching');
 
@@ -75,40 +82,25 @@ class ApacheShibbAuthenticate extends BaseAuthenticate {
         $user = $this->_findUser($mispUsername);
 
         //Obtain default org. If not, org keeps the default value
-        if (isset($_SERVER[$orgTag])) {
-            $org = $_SERVER[$orgTag];
+        if (isset($_SERVER[$OrgTag])) {
+            $org = $_SERVER[$OrgTag];
         }
+        //Check if the organization exits and create it if not
+        $org = $this->checkOrganization($org, $user);
 
-        //Check if the list
-        $roleChanged = false;
-        if (isset($_SERVER[$groupTag])) {
-            $groupSeparator = Configure::read('ApacheShibbAuth.GroupSeparator');
-            $groupList = explode($groupSeparator, $_SERVER[$groupTag]);
-            //Check user roles and egroup match and update if needed
-            foreach ($groupList as $group) {
-                $roleVal = $groupRoleMatching[$group];
-                if ($roleVal <= $roleId) {
-                    $roleId = $roleVal;
-                    $roleChanged = true;
-                }
-            }
-        }
+        //Get user role from its list of groups
+        list($roleChanged, $roleId) = $this->getUserRoleFromGroup($groupTag, $groupRoleMatching, $roleId);
+
         // Database model object
         $userModel = ClassRegistry::init($this->settings['userModel']);
 
         if ($user) { // User already exists
-            if ($roleChanged && $user['role_id'] != $roleId) {
-                $user['role_id'] = $roleId; // Different role either increase or decrease permissions
-                $userUpdatedData = array('User' => $user);
-                $userModel->set(array(
-                    'role_id' => $roleId,
-                    'id' => $user['id'],
-                )); // Update the user
-                $userModel->save($userUpdatedData, false);
-            }
+            $user = $this->updateUserRole($roleChanged, $user, $roleId, $userModel);
+            $user = $this->updateUserOrg($org, $user, $userModel);
             return $user;
         }
-        // insert user in database if not existent
+
+        //Insert user in database if not existent
         //Generate random password
         $password = $this->randPasswordGen(40);
         // create user
@@ -141,5 +133,90 @@ class ApacheShibbAuthenticate extends BaseAuthenticate {
             $result .= "".$charArray[$randItem];
         }
         return $result;
+    }
+
+    /**
+     * @param $roleChanged
+     * @param $user
+     * @param $roleId
+     * @param $userModel
+     * @return mixed
+     */
+    public function updateUserRole($roleChanged, $user, $roleId, $userModel)
+    {
+        if ($roleChanged && $user['role_id'] != $roleId) {
+            $user['role_id'] = $roleId; // Different role either increase or decrease permissions
+            $userUpdatedData = array('User' => $user);
+            $userModel->set(array(
+                'role_id' => $roleId,
+                'id' => $user['id'],
+            )); // Update the user
+            $userModel->save($userUpdatedData, false);
+            return $user;
+        }
+        return $user;
+    }
+
+    /**
+     * @param $groupTag
+     * @param $groupRoleMatching
+     * @param $roleId
+     * @return array
+     */
+    public function getUserRoleFromGroup($groupTag, $groupRoleMatching, $roleId)
+    {
+        //Check the role mapping to get the user's role level and update it if needed
+        $roleChanged = false;
+        if (isset($_SERVER[$groupTag])) {
+            $groupSeparator = Configure::read('ApacheShibbAuth.GroupSeparator');
+            $groupList = explode($groupSeparator, $_SERVER[$groupTag]);
+            //Check user roles and egroup match and update if needed
+            foreach ($groupList as $group) {
+                //TODO: Can be optimized inverting the search group and using only array_key_exists
+                if (array_key_exists($group, $groupRoleMatching)) { //In case there is an group not defined in the config.php file
+                    $roleVal = $groupRoleMatching[$group];
+                    if ($roleVal <= $roleId) {
+                        $roleId = $roleVal;
+                        $roleChanged = true;
+                    }
+                }
+            }
+            return array($roleChanged, $roleId);
+        }
+        return array($roleChanged, $roleId);
+    }
+
+    /**
+     * @param $org
+     * @param $user
+     * @return array|bool|int|mixed|string
+     */
+    public function checkOrganization($org, $user)
+    {
+        $orgModel = ClassRegistry::init('Organisation');
+        $orgAux = $orgModel->find($org);
+        $orgId = $orgAux['id'];
+        if ($orgAux == null) {
+            $organisations = new Organisation();
+            $orgUserId = 1; //By default created by the admin
+            if ($user) $orgUserId = $user['id'];
+            $orgId = $organisations->createOrgFromName($org, $orgUserId, 0); //Created with local set to 0 by default
+        }
+        return $orgId;
+    }
+
+    private function updateUserOrg($org, $user, $userModel)
+    {
+        if ($user['org_id'] != $org) {
+            $user['org_id'] = $org; // Different role either increase or decrease permissions
+            $userUpdatedData = array('User' => $user);
+            $userModel->set(array(
+                'org_id' => $org,
+                'id' => $user['id'],
+            )); // Update the user
+            $userModel->save($userUpdatedData, false);
+            return $user;
+        }
+        return $user;
     }
 }


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:
#### What does it do?

Minor changes in ShibbolethAuthentication plugin: an organization is created if the one given by the environment variables / default in config.php does not exists. Session and get parameter added in case it is needed to be disable upon login. 

Bug fix: Jobs were being displayed as queued on export. That was due to the query in "getProcess" comparing organization name to organization id. Also the creation of the process was taking org_id from the user ignoring if it is an admin or not (line 41 in Job.php) now it checks if isSiteAdmin puts org_id to 0, if not, it is put to org_id.
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [X ] Minor
- [X] Patch
