### PR TITLE
Less mysql dependency

### DIFF
--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -748,7 +748,7 @@ class UsersController extends AppController {
 		$this->loadModel('Attribute');
 		$conditions = array();
 		if ($selected) $conditions[] = array('Attribute.type' => $selectedTypes, 'Attribute.deleted' => false);
-		$fields = array('Event.orgc_id', 'Attribute.type', 'count(Attribute.type) as `num_types`');
+		$fields = array('Event.orgc_id', 'Attribute.type', 'COUNT(Attribute.type) AS num_types');
 		$params = array('recursive' => 0,
 				'fields' => $fields,
 				'group' => array('Attribute.type', 'Event.orgc_id'),

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -156,11 +156,11 @@ class AppModel extends Model {
 				$sql = 'ALTER TABLE `events` ADD UNIQUE (uuid);';
 				break;
 			case 'cleanSessionTable':
-				$sql = 'DELETE FROM `cake_sessions` WHERE `expires` < ' . time() . ';';
+				$sql = 'DELETE FROM cake_sessions WHERE expires < ' . time() . ';';
 				$clean = false;
 				break;
 			case 'destroyAllSessions':
-				$sql = 'DELETE FROM `cake_sessions`;';
+				$sql = 'DELETE FROM cake_sessions;';
 				$clean = false;
 				break;
 			case 'addIPLogging':

--- a/app/Model/Bruteforce.php
+++ b/app/Model/Bruteforce.php
@@ -9,11 +9,11 @@ App::uses('Sanitize', 'Utility');
 class Bruteforce extends AppModel {
 
 	public function insert($ip, $username) {
-		$expire = Configure::read('SecureAuth.expire');
+		$expire = time() + Configure::read('SecureAuth.expire');
 		// sanitize fields
 		$ip = Sanitize::clean($ip);
 		$username = Sanitize::clean($username);
-		$this->query("INSERT INTO bruteforces (ip, username, `expire`) VALUES ('$ip', '$username', TIMESTAMPADD(SECOND, $expire, NOW()));");
+		$this->query("INSERT INTO bruteforces (ip, username, `expire`) VALUES ('$ip', '$username', '$expire');");
 		if ($this->isBlacklisted($ip, $username)) {
 			$this->Log = ClassRegistry::init('Log');
 			$this->Log->create();

--- a/app/Model/Bruteforce.php
+++ b/app/Model/Bruteforce.php
@@ -13,7 +13,7 @@ class Bruteforce extends AppModel {
 		// sanitize fields
 		$ip = Sanitize::clean($ip);
 		$username = Sanitize::clean($username);
-		$this->query("INSERT INTO `bruteforces` (`ip` , `username` , `expire` ) VALUES ('$ip', '$username', TIMESTAMPADD(SECOND,$expire, NOW()));");
+		$this->query("INSERT INTO bruteforces (ip, username, `expire`) VALUES ('$ip', '$username', TIMESTAMPADD(SECOND, $expire, NOW()));");
 		if ($this->isBlacklisted($ip, $username)) {
 			$this->Log = ClassRegistry::init('Log');
 			$this->Log->create();
@@ -29,7 +29,7 @@ class Bruteforce extends AppModel {
 	}
 
 	public function clean() {
-		$this->query("DELETE FROM `bruteforces` WHERE `expire`<=NOW();");
+		$this->query("DELETE FROM bruteforces WHERE `expire` <= NOW();");
 	}
 
 	public function isBlacklisted($ip,$username) {

--- a/app/Model/Organisation.php
+++ b/app/Model/Organisation.php
@@ -204,7 +204,7 @@ class Organisation extends AppModel{
 		if (!$logFile->create()) throw new MethodNotAllowedException('Merge halted because the log file (default location: /var/www/MISP/app/tmp/logs/merges/[old_org_id]_[new_org_id]_timestamp.log) could not be created. This is most likely a permission issue, make sure that MISP can write to the logs directory and try again.');
 		$backupFile = new File($dirPath . DS . 'merge_' . $currentOrg['Organisation']['id'] . '_' . $targetOrg['Organisation']['id'] . '_' . time() . '.sql');
 		if (!$backupFile->create()) throw new MethodNotAllowedException('Merge halted because the backup script file (default location: /var/www/MISP/app/tmp/logs/merges/[old_org_id]_[new_org_id]_timestamp.sql) could not be created. This is most likely a permission issue, make sure that MISP can write to the logs directory and try again.');
-		$backupFile->append('INSERT INTO `organisations` (`' . implode('`, `', array_keys($currentOrg['Organisation'])) . '`) VALUES (\'' . implode('\', \'', array_values($currentOrg['Organisation'])) . '\');' . PHP_EOL);
+		$backupFile->append('INSERT INTO organisations (`' . implode('`, `', array_keys($currentOrg['Organisation'])) . '`) VALUES (\'' . implode('\', \'', array_values($currentOrg['Organisation'])) . '\');' . PHP_EOL);
 		$this->Log->create();
 		$this->Log->save(array(
 				'org' => $user['Organisation']['name'],

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -2553,7 +2553,7 @@ class Server extends AppModel {
 			$sessionCount = 'N/A';
 			return 2;
 		}
-		$sql = 'SELECT COUNT(id) FROM `cake_sessions` WHERE `expires` < ' . time() . ';';
+		$sql = 'SELECT COUNT(id) FROM cake_sessions WHERE expires < ' . time() . ';';
 		$sqlResult = $this->query($sql);
 		if (isset($sqlResult[0][0])) $sessionCount = $sqlResult[0][0]['COUNT(id)'];
 		else {
@@ -2742,8 +2742,8 @@ class Server extends AppModel {
 			$this->Job->saveField('progress', 10);
 			$this->Job->saveField('message', 'Starting the migration of the database to 2.4');
 		}
-		$this->query('UPDATE `roles` SET `perm_template` = 1 WHERE `perm_site_admin` = 1 OR `perm_admin` = 1');
-		$this->query('UPDATE `roles` SET `perm_sharing_group` = 1 WHERE `perm_site_admin` = 1 OR `perm_sync` = 1');
+		$this->query('UPDATE roles SET perm_template = 1 WHERE perm_site_admin = 1 OR perm_admin = 1');
+		$this->query('UPDATE roles SET perm_sharing_group = 1 WHERE perm_site_admin = 1 OR perm_sync = 1');
 		$orgs = array('local' => array(), 'external' => array());
 		$captureRules = array(
 				'events_org' => array('table' => 'events', 'old' => 'org', 'new' => 'org_id'),
@@ -2849,9 +2849,9 @@ class Server extends AppModel {
 		// will result in the same visibility, etc. Once events / attributes get put into a sharing group this will get recorrelated anyway
 		// Also by unsetting the org field after the move the changes we ensure that these correlations won't get hit again by the script if we rerun it
 		// and that we don't accidentally "upgrade" a 2.4 correlation
-		$this->query('UPDATE `correlations` SET `distribution` = 1, `a_distribution` = 1 WHERE `org` != "" AND `private` = 0');
+		$this->query('UPDATE correlations SET distribution = 1, a_distribution = 1 WHERE org != "" AND private = 0');
 		foreach ($orgMapping as $old => $new) {
-			$this->query('UPDATE `correlations` SET `org_id` = "' . $new . '", `org` = "" WHERE `org` = "' . $old . '";');
+			$this->query('UPDATE correlations SET org_id = "' . $new . '", org = "" WHERE org = "' . $old . '";');
 		}
 		if (Configure::read('MISP.background_jobs') && $jobId) {
 			$this->Job->saveField('progress', 60);

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -918,7 +918,7 @@ class User extends AppModel {
 	
 	public function getMembersCount() {
 		// for Organizations List
-		$fields = array('org_id', 'count(User.id) as `num_members`');
+		$fields = array('org_id', 'COUNT(User.id) AS num_members');
 		$params = array(
 				'fields' => $fields,
 				'recursive' => -1,


### PR DESCRIPTION
#### What does it do?

this PR removes some dependency on MySQL-specifics
- remove backticks where no keyword-escaping is necessary
- remove mysql-only function TIMESTAMPADD from a query
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
