### PR TITLE
Overwrite cached json exports instead of appending

### DIFF
--- a/app/Console/Command/EventShell.php
+++ b/app/Console/Command/EventShell.php
@@ -85,7 +85,7 @@ class EventShell extends AppShell
 		}
 		App::uses('JSONConverterTool', 'Tools');
 		$converter = new JSONConverterTool();
-		$file->append('{"response":[');
+		$file->write('{"response":[');
 		foreach ($eventIds as $k => $eventId) {
 			$result = $this->Event->fetchEvent($user, array('eventid' => $eventId['Event']['id'], 'includeAttachments' => Configure::read('MISP.cached_attachments')));
 			$file->append($converter->event2JSON($result[0]));


### PR DESCRIPTION
#### What does it do?

Fixes #1439
#### Questions
- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
