### PR TITLE
chg: dont depend on MySQL-result-format of select-count()

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -2562,9 +2562,9 @@ class Server extends AppModel {
 			$sessionCount = 'N/A';
 			return 2;
 		}
-		$sql = 'SELECT COUNT(id) FROM cake_sessions WHERE expires < ' . time() . ';';
+		$sql = 'SELECT COUNT(id) AS session_count FROM cake_sessions WHERE expires < ' . time() . ';';
 		$sqlResult = $this->query($sql);
-		if (isset($sqlResult[0][0])) $sessionCount = $sqlResult[0][0]['COUNT(id)'];
+		if (isset($sqlResult[0][0])) $sessionCount = $sqlResult[0][0]['session_count'];
 		else {
 			$sessionCount = 'Error';
 			return 3;


### PR DESCRIPTION
#### What does it do?

this PR removes another MySQL-dependency, is a followup to #1437
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
