### PR TITLE
change of boolean datatype handling #2

### DIFF
--- a/app/Console/Command/Task/RolesTask.php
+++ b/app/Console/Command/Task/RolesTask.php
@@ -13,12 +13,12 @@ class RolesTask extends Shell {
 
 		$roles = ClassRegistry::init('Role');
 		$roles->create();
-		$roles->save(array('Role' => array('name' => 'admin', 'perm_add' => true, 'perm_modify' => true, 'perm_publish' => true, 'perm_full' => true, 'perm_sync' => true, 'perm_audit' => true, 'perm_auth' =>true)));
+		$roles->save(array('Role' => array('name' => 'admin', 'perm_add' => 1, 'perm_modify' => 1, 'perm_publish' => 1, 'perm_full' => 1, 'perm_sync' => 1, 'perm_audit' => 1, 'perm_auth' => 1)));
 		$roles->create();
-		$roles->save(array('Role' => array('name' => 'org_admin', 'perm_add' => true, 'perm_modify' => true, 'perm_publish' => false, 'perm_full' => false, 'perm_sync' => true, 'perm_audit' => true, 'perm_auth' =>true)));
+		$roles->save(array('Role' => array('name' => 'org_admin', 'perm_add' => 1, 'perm_modify' => 1, 'perm_publish' => 0, 'perm_full' => 0, 'perm_sync' => 1, 'perm_audit' => 1, 'perm_auth' => 1)));
 		$roles->create();
-		$roles->save(array('Role' => array('name' => 'User', 'perm_add' => true, 'perm_modify' => true, 'perm_publish' => false, 'perm_full' => false, 'perm_sync' => true, 'perm_audit' => true, 'perm_auth' =>false)));
+		$roles->save(array('Role' => array('name' => 'User', 'perm_add' => 1, 'perm_modify' => 1, 'perm_publish' => 0, 'perm_full' => 0, 'perm_sync' => 1, 'perm_audit' => 1, 'perm_auth' => 0)));
 		$roles->create();
-		$roles->save(array('Role' => array('name' => 'Sync', 'perm_add' => true, 'perm_modify' => true, 'perm_publish' => true, 'perm_full' => false, 'perm_sync' => true, 'perm_audit' => true, 'perm_auth' =>true)));
+		$roles->save(array('Role' => array('name' => 'Sync', 'perm_add' => 1, 'perm_modify' => 1, 'perm_publish' => 1, 'perm_full' => 0, 'perm_sync' => 1, 'perm_audit' => 1, 'perm_auth' => 1)));
 	}
 }

--- a/app/Controller/OrganisationsController.php
+++ b/app/Controller/OrganisationsController.php
@@ -223,7 +223,7 @@ class OrganisationsController extends AppController {
 			));
 			$orgs['external'] = $this->Organisation->find('all', array(
 					'fields' => array('id', 'name', 'uuid'),
-					'conditions' => array('Organisation.id !=' => $id, 'Organisation.local' => false),
+					'conditions' => array('Organisation.id !=' => $id, 'Organisation.local' => 0),
 					'order' => 'lower(Organisation.name) ASC'
 			));
 			foreach (array('local', 'external') as $type) {

--- a/app/Controller/SharingGroupsController.php
+++ b/app/Controller/SharingGroupsController.php
@@ -165,8 +165,8 @@ class SharingGroupsController extends AppController {
 
 	public function index($passive = false) {
 		if ($passive === 'true') $passive = true;
-		if ($passive === true) $this->paginate['conditions'][] = array('SharingGroup.active' => false);
-		else $this->paginate['conditions'][] = array('SharingGroup.active' => true);
+		if ($passive === true) $this->paginate['conditions'][] = array('SharingGroup.active' => 0);
+		else $this->paginate['conditions'][] = array('SharingGroup.active' => 1);
 		$result = $this->paginate();
 		// check if the current user can modify or delete the SG
 		foreach ($result as $k => $sg) {

--- a/app/Controller/TaxonomiesController.php
+++ b/app/Controller/TaxonomiesController.php
@@ -95,7 +95,7 @@ class TaxonomiesController extends AppController {
 				'recursive' => -1,
 				'conditions' => array('Taxonomy.id' => $id),
 		));
-		$taxonomy['Taxonomy']['enabled'] = false;
+		$taxonomy['Taxonomy']['enabled'] = 0;
 		$this->Taxonomy->save($taxonomy);
 		$this->Log = ClassRegistry::init('Log');
 		$this->Log->create();

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -747,7 +747,7 @@ class UsersController extends AppController {
 		// What org posted what type of attribute
 		$this->loadModel('Attribute');
 		$conditions = array();
-		if ($selected) $conditions[] = array('Attribute.type' => $selectedTypes, 'Attribute.deleted' => false);
+		if ($selected) $conditions[] = array('Attribute.type' => $selectedTypes, 'Attribute.deleted' => 0);
 		$fields = array('Event.orgc_id', 'Attribute.type', 'COUNT(Attribute.type) AS num_types');
 		$params = array('recursive' => 0,
 				'fields' => $fields,
@@ -883,7 +883,7 @@ class UsersController extends AppController {
 			$conditions = array();
 			if (!$this->_isSiteAdmin()) $conditions = array('org_id' => $this->Auth->user('org_id'));
 			if ($this->request->data['User']['recipient'] != 1) $conditions['id'] = $this->request->data['User']['recipientEmailList'];
-			$conditions['AND'][] = array('User.disabled' => false);
+			$conditions['AND'][] = array('User.disabled' => 0);
 			$users = $this->User->find('all', array('recursive' => -1, 'order' => array('email ASC'), 'conditions' => $conditions));
 			$this->request->data['User']['message'] = $this->User->adminMessageResolve($this->request->data['User']['message']);
 			$failures = '';
@@ -908,7 +908,7 @@ class UsersController extends AppController {
 		}
 		$conditions = array();
 		if (!$this->_isSiteAdmin()) $conditions = array('org_id' => $this->Auth->user('org_id'));
-		$conditions['User.disabled'] = false;
+		$conditions['User.disabled'] = 0;
 		$temp = $this->User->find('all', array('recursive' => -1, 'fields' => array('id', 'email'), 'order' => array('email ASC'), 'conditions' => $conditions));
 		$emails = array();
 		// save all the emails of the users and set it for the dropdown list in the form
@@ -983,8 +983,8 @@ class UsersController extends AppController {
 		$stats[0] = $this->User->Event->find('count', null);
 		$stats[1] = $this->User->Event->find('count', array('conditions' => array('Event.timestamp >' => $this_month)));
 
-		$stats[2] = $this->User->Event->Attribute->find('count', array('conditions' => array('Attribute.deleted' => false)));
-		$stats[3] = $this->User->Event->Attribute->find('count', array('conditions' => array('Attribute.timestamp >' => $this_month, 'Attribute.deleted' => false)));
+		$stats[2] = $this->User->Event->Attribute->find('count', array('conditions' => array('Attribute.deleted' => 0)));
+		$stats[3] = $this->User->Event->Attribute->find('count', array('conditions' => array('Attribute.timestamp >' => $this_month, 'Attribute.deleted' => 0)));
 
 		$this->loadModel('Correlation');
 		$this->Correlation->recursive = -1;

--- a/app/Controller/WarninglistsController.php
+++ b/app/Controller/WarninglistsController.php
@@ -106,10 +106,10 @@ class WarninglistsController extends AppController {
 		$currentState = $this->Warninglist->find('first', array('conditions' => array('id' => $id), 'recursive' => -1));
 		if (empty($currentState)) return new CakeResponse(array('body'=> json_encode(array('saved' => false, 'errors' => 'Warninglist not found.')), 'status' => 200));
 		if ($currentState['Warninglist']['enabled']) {
-			$currentState['Warninglist']['enabled'] = false;
+			$currentState['Warninglist']['enabled'] = 0;
 			$message = 'disabled';
 		} else {
-			$currentState['Warninglist']['enabled'] = true;
+			$currentState['Warninglist']['enabled'] = 1;
 			$message = 'enabled';
 		}
 		if ($this->Warninglist->save($currentState)) {
@@ -123,6 +123,8 @@ class WarninglistsController extends AppController {
 		$this->Warninglist->id = $id;
 		debug($id);
 		if (!$this->Warninglist->exists()) throw new NotFoundException('Invalid Warninglist.');
+		// DBMS interoperability: convert boolean false to integer 0 so cakephp doesn't try to insert an empty string into the database
+		if ($enable === false) $enable = 0;
 		$this->Warninglist->saveField('enabled', $enable);
 		$this->Session->setFlash('Warninglist enabled');
 		$this->redirect(array('controller' => 'warninglists', 'action' => 'view', $id));

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -66,13 +66,13 @@ class AppModel extends Model {
 			case '2.4.25':
 				$this->updateDatabase($command);
 				$newFeeds = array(
-					array('provider' => 'CIRCL', 'name' => 'CIRCL OSINT Feed', 'url' => 'https://www.circl.lu/doc/misp/feed-osint', 'enabled' => false),
+					array('provider' => 'CIRCL', 'name' => 'CIRCL OSINT Feed', 'url' => 'https://www.circl.lu/doc/misp/feed-osint', 'enabled' => 0),
 				);
 				$this->__addNewFeeds($newFeeds);
 				break;
 			case '2.4.27':
 				$newFeeds = array(
-					array('provider' => 'Botvrij.eu', 'name' => 'The Botvrij.eu Data','url' => 'http://www.botvrij.eu/data/feed-osint', 'enabled' => false)
+					array('provider' => 'Botvrij.eu', 'name' => 'The Botvrij.eu Data','url' => 'http://www.botvrij.eu/data/feed-osint', 'enabled' => 0)
 				);
 				$this->__addNewFeeds($newFeeds);
 				break;

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -1645,13 +1645,13 @@ class Attribute extends AppModel {
 	private function __resolveElementFile($element, $files) {
 		$attributes = array();
 		$errors = null;
-		$element['complex'] = false;
+		$element['complex'] = 0;
 		if ($element['malware']) {
 			$element['type'] = 'malware-sample';
-			$element['to_ids'] = true;
+			$element['to_ids'] = 1;
 		} else {
 			$element['type'] = 'attachment';
-			$element['to_ids'] = false;
+			$element['to_ids'] = 0;
 		}
 		foreach ($files as $file) {
 			if (!preg_match('@^[\w\-. ]+$@', $file['filename'])) {
@@ -1882,7 +1882,7 @@ class Attribute extends AppModel {
 		$date = new DateTime();
 		$attribute['Attribute']['timestamp'] = $date->getTimestamp();
 		if ($this->save($attribute['Attribute'])) {
-			$attribute['Event']['published'] = false;
+			$attribute['Event']['published'] = 0;
 			$attribute['Event']['timestamp'] = $date->getTimestamp();
 			$this->Event->save($attribute['Event']);
 			return true;

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1845,7 +1845,7 @@ class Event extends AppModel {
 			unset($this->Attribute->validate['value']['uniqueValue']); // unset this - we are saving a new event, there are no values to compare against and event_id is not set in the attributes
 		}
 		unset($data['Event']['id']);
-		if (isset($data['Event']['published']) && $data['Event']['published'] && $user['Role']['perm_publish'] == false) $data['Event']['published'] = false;
+		if (isset($data['Event']['published']) && $data['Event']['published'] && $user['Role']['perm_publish'] == 0) $data['Event']['published'] = 0;
 		if (isset($data['Event']['uuid'])) {
 			// check if the uuid already exists
 			$existingEventCount = $this->find('count', array('conditions' => array('Event.uuid' => $data['Event']['uuid'])));
@@ -1967,8 +1967,8 @@ class Event extends AppModel {
 		} else {
 			return (array('error' => 'Event could not be saved: Could not find the local event.'));
 		}
-		if (isset($data['Event']['published']) && $data['Event']['published'] && !$user['Role']['perm_publish']) $data['Event']['published'] = false;
-		if (!isset($data['Event']['published'])) $data['Event']['published'] = false;
+		if (isset($data['Event']['published']) && $data['Event']['published'] && !$user['Role']['perm_publish']) $data['Event']['published'] = 0;
+		if (!isset($data['Event']['published'])) $data['Event']['published'] = 0;
 		$fieldList = array(
 				'Event' => array('date', 'threat_level_id', 'analysis', 'info', 'published', 'uuid', 'distribution', 'timestamp', 'sharing_group_id'),
 				'Attribute' => array('event_id', 'category', 'type', 'value', 'value1', 'value2', 'to_ids', 'uuid', 'revision', 'distribution', 'timestamp', 'comment', 'sharing_group_id', 'deleted')
@@ -2260,7 +2260,7 @@ class Event extends AppModel {
 			$pubSubTool = new PubSubTool();
 			$hostOrg = $this->Org->find('first', array('conditions' => array('name' => Configure::read('MISP.org')), 'fields' => array('id')));
 			if (!empty($hostOrg)) {
-				$user = array('org_id' => $hostOrg['Org']['id'], 'Role' => array('perm_sync' => false, 'perm_site_admin' => false), 'Organisation' => $hostOrg['Org']);
+				$user = array('org_id' => $hostOrg['Org']['id'], 'Role' => array('perm_sync' => 0, 'perm_site_admin' => 0), 'Organisation' => $hostOrg['Org']);
 				$fullEvent = $this->fetchEvent($user, array('eventid' => $id));
 				if (!empty($fullEvent)) $pubSubTool->publishEvent($fullEvent[0]);
 			}

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1321,7 +1321,7 @@ class Server extends AppModel {
 							}
 						} else {
 							$tempUser = $user;
-							$tempUser['Role']['perm_site_admin'] = false;
+							$tempUser['Role']['perm_site_admin'] = 0;
 							$result = $eventModel->_edit($event, $tempUser, $existingEvent['Event']['id'], $jobId);
 							if ($result === true) $successes[] = $eventId;
 							else if (isset($result['error'])) $fails[$eventId] = $result['error'];

--- a/app/Model/ShadowAttribute.php
+++ b/app/Model/ShadowAttribute.php
@@ -193,7 +193,7 @@ class ShadowAttribute extends AppModel {
 				$this->data['ShadowAttribute']['value2'] = '';
 			}
 		}
-		if (!isset($this->data['ShadowAttribute']['deleted'])) $this->data['ShadowAttribute']['deleted'] = false;
+		if (!isset($this->data['ShadowAttribute']['deleted'])) $this->data['ShadowAttribute']['deleted'] = 0;
 		if ($this->data['ShadowAttribute']['deleted']) $this->__beforeDeleteCorrelation($this->data['ShadowAttribute']);
 		return true;
 	}

--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -65,10 +65,10 @@ class Warninglist extends AppModel{
 	}
 
 	private function __updateList($list, $current) {
-		$list['enabled'] = false;
+		$list['enabled'] = 0;
 		$warninglist = array();
 		if (!empty($current)) {
-			if ($current['Warninglist']['enabled']) $list['enabled'] = true;
+			if ($current['Warninglist']['enabled']) $list['enabled'] = 1;
 			$this->deleteAll(array('Warninglist.id' => $current['Warninglist']['id']));
 		}
 		$fieldsToSave = array('name', 'version', 'description', 'type', 'enabled');
@@ -100,7 +100,7 @@ class Warninglist extends AppModel{
 	}
 
 	public function fetchForEventView() {
-		$warninglists = $this->find('all', array('contain' => array('WarninglistType'), 'conditions' => array('enabled' => true)));
+		$warninglists = $this->find('all', array('contain' => array('WarninglistType'), 'conditions' => array('enabled' => 1)));
 		if (empty($warninglists)) return array();
 		foreach ($warninglists as $k => &$t) {
 			$t['values'] = $this->WarninglistEntry->find('list', array(


### PR DESCRIPTION
#### What does it do?

this PR is a followup to #1364 , especially ff7a7de

let me quote the relevent part of the older PRs text:

> because MySQL has no "bool" datatype, tinyint(1) is used and therefore booleans have to be casted to integers 1/0. in some parts of the MISP-code, the integers are used while in others, the booleans are used.
> this can lead to problems with the cakephp ORM wrapper, which (sometimes?) casts a "false" to "" (empty string) instead of 0, which works with MySQL, but isn't clean and doesn't work with other DBMS like PostgreSQL.
> 
> therefore, this PR changes many true/false booleans used for sql queries to their 1/0 integer counterparts.
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
