### PR TITLE
Add support to export an OpenIOC file via API

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -52,7 +52,7 @@ class AppController extends Controller {
 	// Used for _isAutomation(), a check that returns true if the controller & action combo matches an action that is a non-xml and non-json automation method
 	// This is used to allow authentication via headers for methods not covered by _isRest() - as that only checks for JSON and XML formats
 	public $automationArray = array(
-		'events' => array('csv', 'nids', 'hids', 'xml', 'restSearch', 'stix', 'updateGraph'),
+		'events' => array('csv', 'nids', 'hids', 'xml', 'restSearch', 'stix', 'updateGraph', 'downloadOpenIOCEvent'),
 		'attributes' => array('text', 'downloadAttachment', 'returnAttributes', 'restSearch', 'rpz'),
 	);
 

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -2503,16 +2503,16 @@ class EventsController extends AppController {
 		}
 		$this->layout = 'text/default';
 
-	if ($key != 'download'){
-		$user = $this->checkAuthUser($key);
-		if (!$user){
-			throw new UnauthorizedException('This authentication key is not authorized to be used for exports. Contact your administrator.');
+		if ($key != 'download'){
+			$user = $this->checkAuthUser($key);
+			if (!$user){
+				throw new UnauthorizedException('This authentication key is not authorized to be used for exports. Contact your administrator.');
+			}
+		} else {
+			if (!$this->Auth->user('id')){
+				throw new UnauthorizedException('You have to be logged in to do that.');
+			}
 		}
-	} else {
-		if (!$this->Auth->user('id')){
-			throw new UnauthorizedException('You have to be logged in to do that.');
-		}
-	}
 
 		// get the event if it exists and load it together with its attributes
 		$this->Event->id = $eventid;

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -2502,17 +2502,17 @@ class EventsController extends AppController {
 			$this->header('Content-Disposition: download; filename="misp.openIOC' . $eventid . '.ioc"');
 		}
 		$this->layout = 'text/default';
-        
-         if ($key != 'download'){
-            $user = $this->checkAuthUser($key);
-            if (!$user){
-                throw new UnauthorizedException('This authentication key is not authorized to be used for exports. Contact your administrator.');
-            }
-        } else {
-            if (!$this->Auth->user('id')){
-                throw new UnauthorizedException('You have to be logged in to do that.');
-            }
-        }
+
+	if ($key != 'download'){
+		$user = $this->checkAuthUser($key);
+		if (!$user){
+			throw new UnauthorizedException('This authentication key is not authorized to be used for exports. Contact your administrator.');
+		}
+	} else {
+		if (!$this->Auth->user('id')){
+			throw new UnauthorizedException('You have to be logged in to do that.');
+		}
+	}
 
 		// get the event if it exists and load it together with its attributes
 		$this->Event->id = $eventid;

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -2492,7 +2492,7 @@ class EventsController extends AppController {
 		return $this->response;
 	}
 
-	public function downloadOpenIOCEvent($eventid) {
+	public function downloadOpenIOCEvent($key, $eventid) {
 		// return a downloadable text file called misp.openIOC.<eventId>.ioc for individual events
 		// TODO implement mass download of all events - maybe in a zip file?
 		$this->response->type('text');	// set the content type
@@ -2502,6 +2502,17 @@ class EventsController extends AppController {
 			$this->header('Content-Disposition: download; filename="misp.openIOC' . $eventid . '.ioc"');
 		}
 		$this->layout = 'text/default';
+        
+         if ($key != 'download'){
+            $user = $this->checkAuthUser($key);
+            if (!$user){
+                throw new UnauthorizedException('This authentication key is not authorized to be used for exports. Contact your administrator.');
+            }
+        } else {
+            if (!$this->Auth->user('id')){
+                throw new UnauthorizedException('You have to be logged in to do that.');
+            }
+        }
 
 		// get the event if it exists and load it together with its attributes
 		$this->Event->id = $eventid;
@@ -3139,7 +3150,7 @@ class EventsController extends AppController {
 					'checkbox_default' => true
 			),
 			'openIOC' => array(
-					'url' => '/events/downloadOpenIOCEvent/' . $id,
+					'url' => '/events/downloadOpenIOCEvent/download/' . $id,
 					'text' => 'OpenIOC (all indicators marked to IDS)',
 					'requiresPublished' => true,
 					'checkbox' => false,


### PR DESCRIPTION
#### What does it do?

Fixes `#607` .... partially. With these changes you can at least download a single event's OpenIOC file. It does not implement global exports or exports based on filters/tags.

Make a request with your auth key to https://<misp_host>/events/downloadOpenIOCEvent/download/<event_id> and you'll receive your OpenIOC file.
#### Questions
- [ ] Does it require a DB change? 
  No.
- [ ] Are you using it in production? 
  Yes
- [ ] Does it require a change in the API (PyMISP for example)?
  Kind of? It shouldn't break anything, it just allows for API requests to download OpenIOC files.
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
