### PR TITLE
Bug fixing on shibboleth auth. DB group loading and missing email bug…

### DIFF
--- a/app/Plugin/ShibbAuth/Controller/Component/Auth/ApacheShibbAuthenticate.php
+++ b/app/Plugin/ShibbAuth/Controller/Component/Auth/ApacheShibbAuthenticate.php
@@ -73,6 +73,8 @@ class ApacheShibbAuthenticate extends BaseAuthenticate {
         $groupRoleMatching = Configure::read('ApacheShibbAuth.GroupRoleMatching');
 
         // Get user values
+        if(!isset($_SERVER[$mailTag])) return false;
+
         $mispUsername = $_SERVER[$mailTag];
 
         //Change username column for email (username in shibboleth attributes corresponds to the email in MISPs DB)
@@ -194,7 +196,11 @@ class ApacheShibbAuthenticate extends BaseAuthenticate {
     public function checkOrganization($org, $user)
     {
         $orgModel = ClassRegistry::init('Organisation');
-        $orgAux = $orgModel->find($org);
+        $orgAux = $orgModel->find('first', array(
+                'fields' => array('Organisation.id'),
+                'conditions' => array('name' => $org),
+            )
+        );
         $orgId = $orgAux['id'];
         if ($orgAux == null) {
             $organisations = new Organisation();


### PR DESCRIPTION
#### What does it do?

It fixes two bugs in the shibboleth authentication plugin.  The first one concerns the loading of groups from database, previously it was always returning null due to bad query sintax. Also checking for missing email is implemented, if shibboleth does not return an email authentication will fail, previously it failed due to sql exception.
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
