### PR TITLE
FileAccess cleanup/consistency

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -1927,9 +1927,9 @@ class EventsController extends AppController {
 	public function _addGfiZip($id) {
 		if (!empty($this->data) && $this->data['Event']['submittedgfi']['size'] > 0 &&
 				is_uploaded_file($this->data['Event']['submittedgfi']['tmp_name'])) {
-			App::uses('FileAccess', 'Tools');
-			$fileAccess = new FileAccess();
-			$zipData = $fileAccess->readFromFile($this->data['Event']['submittedgfi']['tmp_name'], $this->data['Event']['submittedgfi']['size']);
+			App::uses('FileAccessTool', 'Tools');
+			$fileAccessTool = new FileAccessTool();
+			$zipData = $fileAccessTool->readFromFile($this->data['Event']['submittedgfi']['tmp_name'], $this->data['Event']['submittedgfi']['size']);
 
 			// write
 			$rootDir = APP . "files" . DS . $id . DS;
@@ -1953,7 +1953,7 @@ class EventsController extends AppController {
 			// open the xml
 			$xmlFileName = 'analysis.xml';
 			$xmlFilePath = $rootDir . DS . 'Analysis' . DS . $xmlFileName;
-			$xmlFileData = $fileAccess->readFromFile($xmlFilePath);
+			$xmlFileData = $fileAccessTool->readFromFile($xmlFilePath);
 
 			// read XML
 			$this->_readGfiXML($xmlFileData, $id);
@@ -1963,9 +1963,9 @@ class EventsController extends AppController {
 	public function _addIOCFile($id) {
 		if (!empty($this->data) && $this->data['Event']['submittedioc']['size'] > 0 &&
 				is_uploaded_file($this->data['Event']['submittedioc']['tmp_name'])) {
-			App::uses('FileAccess', 'Tools');
-			$fileAccess = new FileAccess();
-			$iocData = $fileAccess->readFromFile($this->data['Event']['submittedioc']['tmp_name'], $this->data['Event']['submittedioc']['size']);
+			App::uses('FileAccessTool', 'Tools');
+			$fileAccessTool = new FileAccessTool();
+			$iocData = $fileAccessTool->readFromFile($this->data['Event']['submittedioc']['tmp_name'], $this->data['Event']['submittedioc']['size']);
 
 			// write
 			$rootDir = APP . "files" . DS . $id . DS;
@@ -1982,7 +1982,7 @@ class EventsController extends AppController {
 
 			// open the xml
 			$xmlFilePath = $destPath . DS . $this->data['Event']['submittedioc']['name'];
-			$xmlFileData = $fileAccess->readFromFile($xmlFilePath, $this->data['Event']['submittedioc']['size']);
+			$xmlFileData = $fileAccessTool->readFromFile($xmlFilePath, $this->data['Event']['submittedioc']['size']);
 
 			// Load event and populate the event data
 			$this->Event->id = $id;
@@ -2048,8 +2048,8 @@ class EventsController extends AppController {
 	}
 
 	public function _addMISPExportFile($ext, $take_ownership = false) {
-		App::uses('FileAccess', 'Tools');
-		$data = (new FileAccess())->readFromFile($this->data['Event']['submittedfile']['tmp_name'], $this->data['Event']['submittedfile']['size']);
+		App::uses('FileAccessTool', 'Tools');
+		$data = (new FileAccessTool())->readFromFile($this->data['Event']['submittedfile']['tmp_name'], $this->data['Event']['submittedfile']['size']);
 
 		if ($ext == 'xml') {
 			App::uses('Xml', 'Utility');
@@ -2882,13 +2882,13 @@ class EventsController extends AppController {
 					if ($attribute['type'] == 'ip-src/ip-dst') {
 						$types = array('ip-src', 'ip-dst');
 					} else if ($attribute['type'] == 'malware-sample') {
-						App::uses('FileAccess', 'Tools');
+						App::uses('FileAccessTool', 'Tools');
 						$tmpdir = Configure::read('MISP.tmpdir') ? Configure::read('MISP.tmpdir') : '/tmp';
 						$tempFile = explode('|', $attribute['data']);
 						if (!preg_match('/^[a-z0-9]*$/i', $tempFile[0])) {
 							throw new MethodNotAllowedException('Invalid filename, stop tampering with it.');
 						}
-						$attribute['data'] = (new FileAccess())->readFromFile($tmpdir . '/' . $tempFile[0], $tempFile[1]);
+						$attribute['data'] = (new FileAccessTool())->readFromFile($tmpdir . '/' . $tempFile[0], $tempFile[1]);
 						unlink($tmpdir . '/' . $tempFile[0]);
 						$result = $this->Event->Attribute->handleMaliciousBase64($id, $attribute['value'], $attribute['data'], array('md5', 'sha1', 'sha256'), $objectType == 'ShadowAttribute' ? true : false);
 						if (!$result['success']) {
@@ -3735,11 +3735,11 @@ class EventsController extends AppController {
 				);
 				$result['related'] = $this->Event->Attribute->fetchAttributes($this->Auth->user(), $options);
 				if (isset($result['data'])) {
-					App::uses('FileAccess', 'Tools');
-					$fileAccess = new FileAccess();
+					App::uses('FileAccessTool', 'Tools');
+					$fileAccessTool = new FileAccessTool();
 					$tmpdir = Configure::read('MISP.tmpdir') ? Configure::read('MISP.tmpdir') : '/tmp';
-					$tempFile = $fileAccess->createTempFile($tmpdir, $prefix = 'MISP');
-					$fileAccess->writeToFile($tempFile, $result['data']);
+					$tempFile = $fileAccessTool->createTempFile($tmpdir, $prefix = 'MISP');
+					$fileAccessTool->writeToFile($tempFile, $result['data']);
 					$result['data'] = basename($tempFile) . '|' . filesize($tempFile);
 				}
 			}
@@ -3795,8 +3795,8 @@ class EventsController extends AppController {
 						$tmpfile = new File($fileupload['tmp_name']);
 						if ((isset($fileupload['error']) && $fileupload['error'] == 0) || (!empty($fileupload['tmp_name']) && $fileupload['tmp_name'] != 'none') && is_uploaded_file($tmpfile->path)) {
 							$filename = basename($fileupload['name']);
-							App::uses('FileAccess', 'Tools');
-							$modulePayload['data'] = (new FileAccess())->readFromFile($fileupload['tmp_name'], $fileupload['size']);
+							App::uses('FileAccessTool', 'Tools');
+							$modulePayload['data'] = (new FileAccessTool())->readFromFile($fileupload['tmp_name'], $fileupload['size']);
 						} else {
 							$fail = 'Invalid file upload.';
 						}

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -1928,7 +1928,8 @@ class EventsController extends AppController {
 		if (!empty($this->data) && $this->data['Event']['submittedgfi']['size'] > 0 &&
 				is_uploaded_file($this->data['Event']['submittedgfi']['tmp_name'])) {
 			App::uses('FileAccess', 'Tools');
-			$zipData = FileAccess::readFromFile($this->data['Event']['submittedgfi']['tmp_name'], $this->data['Event']['submittedgfi']['size']);
+			$fileAccess = new FileAccess();
+			$zipData = $fileAccess->readFromFile($this->data['Event']['submittedgfi']['tmp_name'], $this->data['Event']['submittedgfi']['size']);
 
 			// write
 			$rootDir = APP . "files" . DS . $id . DS;
@@ -1952,7 +1953,7 @@ class EventsController extends AppController {
 			// open the xml
 			$xmlFileName = 'analysis.xml';
 			$xmlFilePath = $rootDir . DS . 'Analysis' . DS . $xmlFileName;
-			$xmlFileData = FileAccess::readFromFile($xmlFilePath);
+			$xmlFileData = $fileAccess->readFromFile($xmlFilePath);
 
 			// read XML
 			$this->_readGfiXML($xmlFileData, $id);
@@ -1963,7 +1964,8 @@ class EventsController extends AppController {
 		if (!empty($this->data) && $this->data['Event']['submittedioc']['size'] > 0 &&
 				is_uploaded_file($this->data['Event']['submittedioc']['tmp_name'])) {
 			App::uses('FileAccess', 'Tools');
-			$iocData = FileAccess::readFromFile($this->data['Event']['submittedioc']['tmp_name'], $this->data['Event']['submittedioc']['size']);
+			$fileAccess = new FileAccess();
+			$iocData = $fileAccess->readFromFile($this->data['Event']['submittedioc']['tmp_name'], $this->data['Event']['submittedioc']['size']);
 
 			// write
 			$rootDir = APP . "files" . DS . $id . DS;
@@ -1980,7 +1982,7 @@ class EventsController extends AppController {
 
 			// open the xml
 			$xmlFilePath = $destPath . DS . $this->data['Event']['submittedioc']['name'];
-			$xmlFileData = FileAccess::readFromFile($xmlFilePath, $this->data['Event']['submittedioc']['size']);
+			$xmlFileData = $fileAccess->readFromFile($xmlFilePath, $this->data['Event']['submittedioc']['size']);
 
 			// Load event and populate the event data
 			$this->Event->id = $id;
@@ -2047,7 +2049,7 @@ class EventsController extends AppController {
 
 	public function _addMISPExportFile($ext, $take_ownership = false) {
 		App::uses('FileAccess', 'Tools');
-		$data = FileAccess::readFromFile($this->data['Event']['submittedfile']['tmp_name'], $this->data['Event']['submittedfile']['size']);
+		$data = (new FileAccess())->readFromFile($this->data['Event']['submittedfile']['tmp_name'], $this->data['Event']['submittedfile']['size']);
 
 		if ($ext == 'xml') {
 			App::uses('Xml', 'Utility');
@@ -2886,7 +2888,7 @@ class EventsController extends AppController {
 						if (!preg_match('/^[a-z0-9]*$/i', $tempFile[0])) {
 							throw new MethodNotAllowedException('Invalid filename, stop tampering with it.');
 						}
-						$attribute['data'] = FileAccess::readFromFile($tmpdir . '/' . $tempFile[0], $tempFile[1]);
+						$attribute['data'] = (new FileAccess())->readFromFile($tmpdir . '/' . $tempFile[0], $tempFile[1]);
 						unlink($tmpdir . '/' . $tempFile[0]);
 						$result = $this->Event->Attribute->handleMaliciousBase64($id, $attribute['value'], $attribute['data'], array('md5', 'sha1', 'sha256'), $objectType == 'ShadowAttribute' ? true : false);
 						if (!$result['success']) {
@@ -3734,9 +3736,10 @@ class EventsController extends AppController {
 				$result['related'] = $this->Event->Attribute->fetchAttributes($this->Auth->user(), $options);
 				if (isset($result['data'])) {
 					App::uses('FileAccess', 'Tools');
+					$fileAccess = new FileAccess();
 					$tmpdir = Configure::read('MISP.tmpdir') ? Configure::read('MISP.tmpdir') : '/tmp';
-					$tempFile = FileAccess::createTempFile($tmpdir, $prefix = 'MISP');
-					FileAccess::writeToFile($tempFile, $result['data']);
+					$tempFile = $fileAccess->createTempFile($tmpdir, $prefix = 'MISP');
+					$fileAccess->writeToFile($tempFile, $result['data']);
 					$result['data'] = basename($tempFile) . '|' . filesize($tempFile);
 				}
 			}
@@ -3793,7 +3796,7 @@ class EventsController extends AppController {
 						if ((isset($fileupload['error']) && $fileupload['error'] == 0) || (!empty($fileupload['tmp_name']) && $fileupload['tmp_name'] != 'none') && is_uploaded_file($tmpfile->path)) {
 							$filename = basename($fileupload['name']);
 							App::uses('FileAccess', 'Tools');
-							$modulePayload['data'] = FileAccess::readFromFile($fileupload['tmp_name'], $fileupload['size']);
+							$modulePayload['data'] = (new FileAccess())->readFromFile($fileupload['tmp_name'], $fileupload['size']);
 						} else {
 							$fail = 'Invalid file upload.';
 						}

--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -560,7 +560,7 @@ class ServersController extends AppController {
 			}
 
 			// read pem file data
-			$pemData = FileAccess::readFromFile($server['Server']['submitted_cert']['tmp_name'], $server['Server']['submitted_cert']['size']);
+			$pemData = (new FileAccess())->readFromFile($server['Server']['submitted_cert']['tmp_name'], $server['Server']['submitted_cert']['size']);
 
 			$destpath = APP . "files" . DS . "certs" . DS;
 			$dir = new Folder(APP . "files" . DS . "certs", true);

--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -551,7 +551,7 @@ class ServersController extends AppController {
 			$ext = '';
 			App::uses('File', 'Utility');
 			App::uses('Folder', 'Utility');
-			App::uses('FileAccess', 'Tools');
+			App::uses('FileAccessTool', 'Tools');
 			$file = new File($server['Server']['submitted_cert']['name']);
 			$ext = $file->ext();
 			if (($ext != 'pem') || !$server['Server']['submitted_cert']['size'] > 0) {
@@ -560,7 +560,7 @@ class ServersController extends AppController {
 			}
 
 			// read pem file data
-			$pemData = (new FileAccess())->readFromFile($server['Server']['submitted_cert']['tmp_name'], $server['Server']['submitted_cert']['size']);
+			$pemData = (new FileAccessTool())->readFromFile($server['Server']['submitted_cert']['tmp_name'], $server['Server']['submitted_cert']['size']);
 
 			$destpath = APP . "files" . DS . "certs" . DS;
 			$dir = new Folder(APP . "files" . DS . "certs", true);

--- a/app/Lib/Tools/FileAccess.php
+++ b/app/Lib/Tools/FileAccess.php
@@ -1,41 +1,41 @@
 <?php
 
 class FileAccess {
-	private static $__fileErrorMsgPrefix = 'An error has occured while attempting to ';
+	private $__fileErrorMsgPrefix = 'An error has occured while attempting to ';
 
-	public static function createTempFile($dir, $prefix = 'MISP') {
+	public function createTempFile($dir, $prefix = 'MISP') {
 		$tempFile = tempnam($dir, $prefix);
-		self::__checkForFalse($tempFile, 'create a temporary file in path "' . $dir);
+		$this->__checkForFalse($tempFile, 'create a temporary file in path "' . $dir);
 		return $tempFile;
 	}
 
-	public static function readFromFile($file, $fileSize = -1) {
-		self::__checkForFalse($file, 'create file "' . $file);
+	public function readFromFile($file, $fileSize = -1) {
+		$this->__checkForFalse($file, 'create file "' . $file);
 		$fileHandle = fopen($file, 'rb');
-		self::__checkForFalse($fileHandle, 'access file "' . $file);
+		$this->__checkForFalse($fileHandle, 'access file "' . $file);
 		if ($fileSize === -1) {
 			$fileSize = filesize($file);
-			self::__checkForFalse($fileHandle, 'get filesize from file "' . $file);
+			$this->__checkForFalse($fileHandle, 'get filesize from file "' . $file);
 		}
 		$readResult = fread($fileHandle, $fileSize);
-		self::__checkForFalse($fileHandle, 'read from file "' . $file);
+		$this->__checkForFalse($fileHandle, 'read from file "' . $file);
 		fclose($fileHandle);
 		return $readResult;
 	}
 
-	public static function writeToFile($file, $content) {
-		self::__checkForFalse($file, 'create file "' . $file);
+	public function writeToFile($file, $content) {
+		$this->__checkForFalse($file, 'create file "' . $file);
 		$fileHandle = fopen($file, 'wb');
-		self::__checkForFalse($fileHandle, 'access file "' . $file);
+		$this->__checkForFalse($fileHandle, 'access file "' . $file);
 		$writeResult = fwrite($fileHandle, $content);
-		self::__checkForFalse($writeResult, 'write to file "' . $file);
+		$this->__checkForFalse($writeResult, 'write to file "' . $file);
 		fclose($fileHandle);
 		return $file;
 	}
 
-	private static function __checkForFalse($result, $errorMsgPart) {
+	private function __checkForFalse($result, $errorMsgPart) {
 		if ($result === false) {
-			throw new MethodNotAllowedException(self::$__fileErrorMsgPrefix . $errorMsgPart . '".');
+			throw new MethodNotAllowedException($this->__fileErrorMsgPrefix . $errorMsgPart . '".');
 		}
 	}
 }

--- a/app/Lib/Tools/FileAccessTool.php
+++ b/app/Lib/Tools/FileAccessTool.php
@@ -1,6 +1,6 @@
 <?php
 
-class FileAccess {
+class FileAccessTool {
 	private $__fileErrorMsgPrefix = 'An error has occured while attempting to ';
 
 	public function createTempFile($dir, $prefix = 'MISP') {

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -337,13 +337,14 @@ class User extends AppModel {
 			try {
 				App::uses('Folder', 'Utility');
 				App::uses('FileAccess', 'Tools');
+				$fileAccess = new FileAccess();
 				$dir = APP . 'tmp' . DS . 'SMIME';
 				if (!file_exists($dir)) {
 					if (!mkdir($dir, 0750, true)) throw new MethodNotAllowedException('The SMIME temp directory is not writeable (app/tmp/SMIME).');
 				}
-				$tempFile = FileAccess::createTempFile($dir, 'SMIME');
-				$msg_test = FileAccess::writeToFile($tempFile, 'test');
-				$msg_test_encrypted = FileAccess::createTempFile($dir, 'SMIME');
+				$tempFile = $fileAccess->createTempFile($dir, 'SMIME');
+				$msg_test = $fileAccess->writeToFile($tempFile, 'test');
+				$msg_test_encrypted = $fileAccess->createTempFile($dir, 'SMIME');
 				// encrypt it
 				if (openssl_pkcs7_encrypt($msg_test, $msg_test_encrypted, $check['certif_public'], null, 0, OPENSSL_CIPHER_AES_256_CBC)) {
 					unlink($msg_test);
@@ -528,13 +529,14 @@ class User extends AppModel {
 			try {
 				App::uses('Folder', 'Utility');
 				App::uses('FileAccess', 'Tools');
+				$fileAccess = new FileAccess();
 				$dir = APP . 'tmp' . DS . 'SMIME';
 				if (!file_exists($dir)) {
 					if (!mkdir($dir, 0750, true)) throw new MethodNotAllowedException('The SMIME temp directory is not writeable (app/tmp/SMIME).');
 				}
-				$tempFile = FileAccess::createTempFile($dir, 'SMIME');
-				$msg_test = FileAccess::writeToFile($tempFile, 'test');
-				$msg_test_encrypted = FileAccess::createTempFile($dir, 'SMIME');
+				$tempFile = $fileAccess->createTempFile($dir, 'SMIME');
+				$msg_test = $fileAccess->writeToFile($tempFile, 'test');
+				$msg_test_encrypted = $fileAccess->createTempFile($dir, 'SMIME');
 				// encrypt it
 				if (openssl_pkcs7_encrypt($msg_test, $msg_test_encrypted, $certif_public, null, 0, OPENSSL_CIPHER_AES_256_CBC)) {
 					$parse = openssl_x509_parse($certif_public);
@@ -757,21 +759,22 @@ class User extends AppModel {
 				$prependedBody = 'Content-Transfer-Encoding: 7bit' . PHP_EOL . 'Content-Type: text/plain;' . PHP_EOL . '    charset=us-ascii' . PHP_EOL . PHP_EOL . $body;
 				App::uses('Folder', 'Utility');
 				App::uses('FileAccess', 'Tools');
+				$fileAccess = new FileAccess();
 				$dir = APP . 'tmp' . DS . 'SMIME';
 				if (!file_exists($dir)) {
 					if (!mkdir($dir, 0750, true)) throw new MethodNotAllowedException('The SMIME temp directory is not writeable (app/tmp/SMIME).');
 				}
 				// save message to file
-				$tempFile = FileAccess::createTempFile($dir, 'SMIME');
-				$msg = FileAccess::writeToFile($tempFile, $prependedBody);
+				$tempFile = $fileAccess->createTempFile($dir, 'SMIME');
+				$msg = $fileAccess->writeToFile($tempFile, $prependedBody);
 				$headers_smime = array("To" => $user['User']['email'], "From" => Configure::read('MISP.email'), "Subject" => $subject);
 				$canSign = true;
 				if (empty(Configure::read('SMIME.cert_public_sign')) || !is_readable(Configure::read('SMIME.cert_public_sign'))) $canSign = false;
 				if (empty(Configure::read('SMIME.key_sign')) || !is_readable(Configure::read('SMIME.key_sign'))) $canSign = false;
 				if ($canSign) {
-					$signed = FileAccess::createTempFile($dir, 'SMIME');
+					$signed = $fileAccess->createTempFile($dir, 'SMIME');
 					if (openssl_pkcs7_sign($msg, $signed, 'file://'.Configure::read('SMIME.cert_public_sign'), array('file://'.Configure::read('SMIME.key_sign'), Configure::read('SMIME.password')), array(), PKCS7_TEXT)) {
-						$bodySigned = FileAccess::readFromFile($signed);
+						$bodySigned = $fileAccess->readFromFile($signed);
 						unlink($msg);
 						unlink($signed);
 					} else {
@@ -780,15 +783,15 @@ class User extends AppModel {
 						throw new Exception('Failed while attempting to sign the SMIME message.');
 					}
 					// save message to file
-					$tempFile = FileAccess::createTempFile($dir, 'SMIME');
-					$msg_signed = FileAccess::writeToFile($tempFile, $bodySigned);
+					$tempFile = $fileAccess->createTempFile($dir, 'SMIME');
+					$msg_signed = $fileAccess->writeToFile($tempFile, $bodySigned);
 				} else {
 					$msg_signed = $msg;
 				}
-				$msg_signed_encrypted = FileAccess::createTempFile($dir, 'SMIME');
+				$msg_signed_encrypted = $fileAccess->createTempFile($dir, 'SMIME');
 				// encrypt it
 				if (openssl_pkcs7_encrypt($msg_signed, $msg_signed_encrypted, $user['User']['certif_public'], $headers_smime, 0, OPENSSL_CIPHER_AES_256_CBC)) {
-					$bodyEncSig = FileAccess::readFromFile($msg_signed_encrypted);
+					$bodyEncSig = $fileAccess->readFromFile($msg_signed_encrypted);
 					unlink($msg_signed);
 					unlink($msg_signed_encrypted);
 					$parts = explode("\n\n", $bodyEncSig);

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -336,15 +336,15 @@ class User extends AppModel {
 		if (openssl_x509_read($check['certif_public'])) {
 			try {
 				App::uses('Folder', 'Utility');
-				App::uses('FileAccess', 'Tools');
-				$fileAccess = new FileAccess();
+				App::uses('FileAccessTool', 'Tools');
+				$fileAccessTool = new FileAccessTool();
 				$dir = APP . 'tmp' . DS . 'SMIME';
 				if (!file_exists($dir)) {
 					if (!mkdir($dir, 0750, true)) throw new MethodNotAllowedException('The SMIME temp directory is not writeable (app/tmp/SMIME).');
 				}
-				$tempFile = $fileAccess->createTempFile($dir, 'SMIME');
-				$msg_test = $fileAccess->writeToFile($tempFile, 'test');
-				$msg_test_encrypted = $fileAccess->createTempFile($dir, 'SMIME');
+				$tempFile = $fileAccessTool->createTempFile($dir, 'SMIME');
+				$msg_test = $fileAccessTool->writeToFile($tempFile, 'test');
+				$msg_test_encrypted = $fileAccessTool->createTempFile($dir, 'SMIME');
 				// encrypt it
 				if (openssl_pkcs7_encrypt($msg_test, $msg_test_encrypted, $check['certif_public'], null, 0, OPENSSL_CIPHER_AES_256_CBC)) {
 					unlink($msg_test);
@@ -528,15 +528,15 @@ class User extends AppModel {
 			$certif_public = $user['User']['certif_public'];
 			try {
 				App::uses('Folder', 'Utility');
-				App::uses('FileAccess', 'Tools');
-				$fileAccess = new FileAccess();
+				App::uses('FileAccessTool', 'Tools');
+				$fileAccessTool = new FileAccessTool();
 				$dir = APP . 'tmp' . DS . 'SMIME';
 				if (!file_exists($dir)) {
 					if (!mkdir($dir, 0750, true)) throw new MethodNotAllowedException('The SMIME temp directory is not writeable (app/tmp/SMIME).');
 				}
-				$tempFile = $fileAccess->createTempFile($dir, 'SMIME');
-				$msg_test = $fileAccess->writeToFile($tempFile, 'test');
-				$msg_test_encrypted = $fileAccess->createTempFile($dir, 'SMIME');
+				$tempFile = $fileAccessTool->createTempFile($dir, 'SMIME');
+				$msg_test = $fileAccessTool->writeToFile($tempFile, 'test');
+				$msg_test_encrypted = $fileAccessTool->createTempFile($dir, 'SMIME');
 				// encrypt it
 				if (openssl_pkcs7_encrypt($msg_test, $msg_test_encrypted, $certif_public, null, 0, OPENSSL_CIPHER_AES_256_CBC)) {
 					$parse = openssl_x509_parse($certif_public);
@@ -758,23 +758,23 @@ class User extends AppModel {
 			try {
 				$prependedBody = 'Content-Transfer-Encoding: 7bit' . PHP_EOL . 'Content-Type: text/plain;' . PHP_EOL . '    charset=us-ascii' . PHP_EOL . PHP_EOL . $body;
 				App::uses('Folder', 'Utility');
-				App::uses('FileAccess', 'Tools');
-				$fileAccess = new FileAccess();
+				App::uses('FileAccessTool', 'Tools');
+				$fileAccessTool = new FileAccessTool();
 				$dir = APP . 'tmp' . DS . 'SMIME';
 				if (!file_exists($dir)) {
 					if (!mkdir($dir, 0750, true)) throw new MethodNotAllowedException('The SMIME temp directory is not writeable (app/tmp/SMIME).');
 				}
 				// save message to file
-				$tempFile = $fileAccess->createTempFile($dir, 'SMIME');
-				$msg = $fileAccess->writeToFile($tempFile, $prependedBody);
+				$tempFile = $fileAccessTool->createTempFile($dir, 'SMIME');
+				$msg = $fileAccessTool->writeToFile($tempFile, $prependedBody);
 				$headers_smime = array("To" => $user['User']['email'], "From" => Configure::read('MISP.email'), "Subject" => $subject);
 				$canSign = true;
 				if (empty(Configure::read('SMIME.cert_public_sign')) || !is_readable(Configure::read('SMIME.cert_public_sign'))) $canSign = false;
 				if (empty(Configure::read('SMIME.key_sign')) || !is_readable(Configure::read('SMIME.key_sign'))) $canSign = false;
 				if ($canSign) {
-					$signed = $fileAccess->createTempFile($dir, 'SMIME');
+					$signed = $fileAccessTool->createTempFile($dir, 'SMIME');
 					if (openssl_pkcs7_sign($msg, $signed, 'file://'.Configure::read('SMIME.cert_public_sign'), array('file://'.Configure::read('SMIME.key_sign'), Configure::read('SMIME.password')), array(), PKCS7_TEXT)) {
-						$bodySigned = $fileAccess->readFromFile($signed);
+						$bodySigned = $fileAccessTool->readFromFile($signed);
 						unlink($msg);
 						unlink($signed);
 					} else {
@@ -783,15 +783,15 @@ class User extends AppModel {
 						throw new Exception('Failed while attempting to sign the SMIME message.');
 					}
 					// save message to file
-					$tempFile = $fileAccess->createTempFile($dir, 'SMIME');
-					$msg_signed = $fileAccess->writeToFile($tempFile, $bodySigned);
+					$tempFile = $fileAccessTool->createTempFile($dir, 'SMIME');
+					$msg_signed = $fileAccessTool->writeToFile($tempFile, $bodySigned);
 				} else {
 					$msg_signed = $msg;
 				}
-				$msg_signed_encrypted = $fileAccess->createTempFile($dir, 'SMIME');
+				$msg_signed_encrypted = $fileAccessTool->createTempFile($dir, 'SMIME');
 				// encrypt it
 				if (openssl_pkcs7_encrypt($msg_signed, $msg_signed_encrypted, $user['User']['certif_public'], $headers_smime, 0, OPENSSL_CIPHER_AES_256_CBC)) {
-					$bodyEncSig = $fileAccess->readFromFile($msg_signed_encrypted);
+					$bodyEncSig = $fileAccessTool->readFromFile($msg_signed_encrypted);
 					unlink($msg_signed);
 					unlink($msg_signed_encrypted);
 					$parts = explode("\n\n", $bodyEncSig);


### PR DESCRIPTION
#### What does it do?

to make Tools consistent, this changes FileAccess tool:
- rename to FileAccessTool
- use instantiable class instead of static

where it is only used once, the method is directly called from a new object instad of assigning the object to a variable first. (supported since PHP 5.4)

( related to #1222 )
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
