### PR TITLE
remove several usages of App::import() in favor of App::uses()

### DIFF
--- a/app/Console/Command/Task/RoleIdTask.php
+++ b/app/Console/Command/Task/RoleIdTask.php
@@ -1,5 +1,5 @@
 <?php
-App::import('Controller', 'Users');
+App::uses('UsersController', 'Controller');
 
 class RoleIdTask extends Shell {
 

--- a/app/Console/Command/Task/RoleToAroAcoTask.php
+++ b/app/Console/Command/Task/RoleToAroAcoTask.php
@@ -1,5 +1,5 @@
 <?php
-App::import('Controller', 'Roles');
+App::uses('RolesController', 'Controller');
 
 class RoleToAroAcoTask extends Shell {
 

--- a/app/Console/Command/Task/RolesTask.php
+++ b/app/Console/Command/Task/RolesTask.php
@@ -1,5 +1,5 @@
 <?php
-App::import('Controller', 'Roles');
+App::uses('RolesController', 'Controller');
 
 class RolesTask extends Shell {
 

--- a/app/Console/Command/Task/UsersTask.php
+++ b/app/Console/Command/Task/UsersTask.php
@@ -1,5 +1,5 @@
 <?php
-App::import('Controller', 'Users');
+App::uses('UsersController', 'Controller');
 
 class UsersTask extends Shell {
 

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1,7 +1,6 @@
 <?php
 App::uses('AppModel', 'Model');
 App::uses('CakeEmail', 'Network/Email');
-App::import('Controller', 'Attributes');
 Configure::load('config'); // This is needed to load GnuPG.bodyonlyencrypted
 /**
  * Event Model
@@ -1797,7 +1796,7 @@ class Event extends AppModel {
 	 */
 	public function _add(&$data, $fromXml, $user, $org_id = 0, $passAlong = null, $fromPull = false, $jobId = null, &$created_id = 0, &$validationErrors = array()) {
 		if ($jobId) {
-			App::import('Component','Auth');
+			App::uses('AuthComponent', 'Controller/Component');
 		}
 		if (Configure::read('MISP.enableEventBlacklisting') && isset($data['Event']['uuid'])) {
 			$event = $this->find('first', array(

--- a/app/Plugin/Assets/models/behaviors/LogableBehavior.php
+++ b/app/Plugin/Assets/models/behaviors/LogableBehavior.php
@@ -111,7 +111,7 @@ class LogableBehavior extends ModelBehavior {
 			$this->UserModel = $Model;
 		}
 		$this->schema = $this->Log->schema();
-		App::import('Component', 'Auth');
+		App::uses('AuthComponent', 'Controller/Component');
 		$this->user[$this->settings[$Model->alias]['userModel']] = AuthComponent::user();
 	}
 

--- a/app/Plugin/SysLogLogable/Model/Behavior/SysLogLogableBehavior.php
+++ b/app/Plugin/SysLogLogable/Model/Behavior/SysLogLogableBehavior.php
@@ -273,7 +273,7 @@ class SysLogLogableBehavior extends LogableBehavior {
 			$this->UserModel = $Model;
 		}
 		$this->schema = $this->Log->schema();
-		App::import('Component', 'Auth');
+		App::uses('AuthComponent', 'Controller/Component');
 		$user = AuthComponent::user();
 		if (!empty($user)) $this->user[$this->settings[$Model->alias]['userModel']] = AuthComponent::user();
 		else $this->user['User'] = array('email' => 'SYSTEM', 'Organisation' => array('name' => 'SYSTEM'), 'id' => 0);


### PR DESCRIPTION
#### What does it do?

this PR replaces the usages of App::import() by App::uses(), which is recommended in cakephp 2.x

in app/Model/Event.php it even removes an import of the AttributesController as i couldn't find out why a AttributesCONTROLLER should be imported into the EventModel - and i didn't find any usage of it.

but maybe i overlooked something, so please have a close second look on this PR before merging.
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
