### PR TITLE
chg: cleanup Sighting.php

### DIFF
--- a/app/Model/Sighting.php
+++ b/app/Model/Sighting.php
@@ -1,6 +1,13 @@
 <?php
+
 App::uses('AppModel', 'Model');
-class Sighting extends AppModel{
+
+/**
+ * Sighting Model
+ *
+ */
+class Sighting extends AppModel {
+
 	public $useTable = 'sightings';
 	public $recursive = -1;
 	public $actsAs = array(
@@ -36,7 +43,7 @@ class Sighting extends AppModel{
 		return true;
 	}
 
-	public function attachToEvent(&$event, &$user, $eventOnly = false) {
+	public function attachToEvent(&$event, &$user) {
 		$ownEvent = false;
 		if ($user['Role']['perm_site_admin'] || $event['Event']['org_id'] == $user['org_id']) $ownEvent = true;
 		$conditions = array('Sighting.event_id' => $event['Event']['id']);


### PR DESCRIPTION
#### What does it do?

cleans up Sighting.php a little, including removal of a obsolete function parameter
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
