### PR TITLE
chg: only show API/authkey to user with API key rights, fixes #1311

### DIFF
--- a/app/Controller/Component/ACLComponent.php
+++ b/app/Controller/Component/ACLComponent.php
@@ -328,6 +328,7 @@ class ACLComponent extends Component {
 					'logout' => array('*'),
 					'attributehistogram' => array('*'),
 					'resetauthkey' => array('*'),
+					'request_API' => array('*'),
 					'routeafterlogin' => array('*'),
 					'statistics' => array('*'),
 					'terms' => array('*'),

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -56,7 +56,7 @@ class UsersController extends AppController {
 	}
 
 	public function request_API(){
-		$responsibleAdmin = $this->User->findAdminsResponsibleForUser($this->Auth->user('id'));
+		$responsibleAdmin = $this->User->findAdminsResponsibleForUser($this->Auth->user());
 		$message = "Something went wrong, please try again later.";
 		if(isset($responsibleAdmin['email']) && !empty($responsibleAdmin['email'])){
 			$subject = "[MISP ".Configure::read('MISP.org')."] User requesting API access";

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -936,27 +936,17 @@ class User extends AppModel {
 		return $usersPerOrg;
 	}
 
-	public function findAdminsResponsibleForUser($id){
-		$userOrg = $this->find('first', array(
-			'conditions' => array(
-				'User.id' => $id,
-			),
-			'contain' => array(
-				'Organisation' => array('fields' => array('id')),
-			),
-			'fields' => array('Organisation.id')
-		));
-
+	public function findAdminsResponsibleForUser($user){
 		$admin = $this->find('first', array(
 			'recursive' => -1,
 			'conditions' => array(
 				'Role.perm_site_admin' => 0,
 				'Role.perm_admin' => 1,
 				'User.disabled' => 0,
-				'User.org_id' => $userOrg['Organisation']['id']
+				'User.org_id' => $user['org_id']
 			),
 			'contain' => array(
-				'Role' => array('fields' => array('perm_admin'))
+				'Role' => array('fields' => array('perm_admin', 'perm_site_admin'))
 			),
 			'fields' => array('User.id', 'User.email', 'User.org_id')
 		));

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -951,12 +951,11 @@ class User extends AppModel {
 			'recursive' => -1,
 			'conditions' => array(
 				'Role.perm_site_admin' => 0,
+				'Role.perm_admin' => 1,
 				'User.disabled' => 0,
-				'User.org_id' => $userOrg['Organisation']['id'],
-				'Role.perm_admin' => 1
+				'User.org_id' => $userOrg['Organisation']['id']
 			),
 			'contain' => array(
-				'Organisation' => array('fields' => array('id')),
 				'Role' => array('fields' => array('perm_admin'))
 			),
 			'fields' => array('User.id', 'User.email', 'User.org_id')
@@ -969,7 +968,6 @@ class User extends AppModel {
 					'User.disabled' => 0,
 				),
 				'contain' => array(
-					'Organisation' => array('fields' => array('id')),
 					'Role' => array('fields' => array('perm_site_admin'))
 				),
 				'fields' => array('User.id', 'User.email', 'User.org_id')

--- a/app/View/Users/request__a_p_i.ctp
+++ b/app/View/Users/request__a_p_i.ctp
@@ -1,0 +1,5 @@
+<div class="message2user"><br />
+	<div><?php echo $message; ?></div>
+	<br />
+	<span class="btn btn-inverse" onClick="cancelPrompt();" style="float:right;">Close</span>
+</div>

--- a/app/View/Users/view.ctp
+++ b/app/View/Users/view.ctp
@@ -34,9 +34,13 @@
 		<dt><?php echo __('Authkey'); ?></dt>
 		<dd>
 			<?php
-				echo h($user['User']['authkey']);
-				if (!Configure::read('MISP.disableUserSelfManagement') || $isAdmin) {
-					echo '(' . $this->Html->link('reset', array('controller' => 'users', 'action' => 'resetauthkey', $user['User']['id'])) . ')';
+				if ($user['Role']['perm_auth']) {
+					echo h($user['User']['authkey']);
+					if (!Configure::read('MISP.disableUserSelfManagement') || $isAdmin) {
+						echo '(' . $this->Html->link('reset', array('controller' => 'users', 'action' => 'resetauthkey', $user['User']['id'])) . ')';
+					}
+				} else {
+					echo "<a onclick='requestAPIAccess()' style='cursor: pointer;'>Request API access</a>";
 				}
 			?>
 			&nbsp;

--- a/app/View/Users/view.ctp
+++ b/app/View/Users/view.ctp
@@ -40,7 +40,7 @@
 						echo '(' . $this->Html->link('reset', array('controller' => 'users', 'action' => 'resetauthkey', $user['User']['id'])) . ')';
 					}
 				} else {
-					echo "<a onclick='requestAPIAccess()' style='cursor: pointer;'>Request API access</a>";
+					echo "<a onclick=\"requestAPIAccess()\" style=\"cursor:pointer;\">Request API access</a>";
 				}
 			?>
 			&nbsp;

--- a/app/webroot/css/main.css
+++ b/app/webroot/css/main.css
@@ -1600,6 +1600,9 @@ a.discrete {
     background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
 }
 
+#confirmation_box .message2user div{text-align: center;}
+#confirmation_box .message2user .btn{margin: -1em 0.6em 0.6em;}
+
 @-webkit-keyframes rotation {
    from {-webkit-transform: rotate(0deg);}
    to {-webkit-transform: rotate(359deg);}

--- a/app/webroot/js/misp2.4.50.js
+++ b/app/webroot/js/misp2.4.50.js
@@ -2495,9 +2495,7 @@ $(".queryPopover").click(function() {
 });
 
 function requestAPIAccess() {
-	var destination = 'users';
-	var action = 'request_API';
-	url = "/" + destination + "/" + action + "/";
+	url = "/users/request_API/";
 	$.ajax({
 		type:"get",
 		url:url,

--- a/app/webroot/js/misp2.4.50.js
+++ b/app/webroot/js/misp2.4.50.js
@@ -60,6 +60,11 @@ function cancelPrompt() {
 	$("#confirmation_box").empty();
 }
 
+function showPrompt(){
+	$("#confirmation_box").fadeIn();
+	$("#gray_out").fadeIn();
+}
+
 function submitDeletion(context_id, action, type, id) {
 	var context = 'event';
 	if (type == 'template_elements') context = 'template';
@@ -2489,3 +2494,23 @@ $(".queryPopover").click(function() {
 	});
 });
 
+function requestAPIAccess() {
+	var destination = 'users';
+	var action = 'request_API';
+	url = "/" + destination + "/" + action + "/";
+	$.ajax({
+		type:"get",
+		url:url,
+		beforeSend: function (XMLHttpRequest) {
+			$(".loading").show();
+		},
+		success:function (data) {
+			$("#confirmation_box").html(data);
+			showPrompt();
+			$(".loading").hide();
+		},
+		error:function() {
+			showMessage('fail', 'Something went wrong - could not request API access.');
+		}
+	});
+}


### PR DESCRIPTION
#### What does it do?

It changes showing the API key behavior, not shown for users where it is not enabled. 
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
