### PR TITLE
Centralize CIDR checks

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -1190,7 +1190,7 @@ class AttributesController extends AppController {
 							}
 
 							// check for an IPv4 address and subnet in CIDR notation (e.g. 127.0.0.1/8)
-							if (preg_match('@^((\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.){3}(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])(\/(\d|[12]\d|3[012]))$@', $saveWord)) {
+							if ($this->Cidr->checkCIDR($saveWord, 4)) {
 								$cidrresults = $this->Cidr->CIDR($saveWord);
 								foreach ($cidrresults as $result) {
 									$result = strtolower($result);
@@ -1595,7 +1595,8 @@ class AttributesController extends AppController {
 				foreach ($elements as $v) {
 					if (empty($v)) continue;
 					if (substr($v, 0, 1) == '!') {
-						if ($parameters[$k] === 'value' && preg_match('@^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(\d|[1-2]\d|3[0-2]))$@', substr($v, 1))) {
+						// check for an IPv4 address and subnet in CIDR notation (e.g. 127.0.0.1/8)
+						if ($parameters[$k] === 'value' && $this->Cidr->checkCIDR(substr($v, 1), 4)) {
 							$cidrresults = $this->Cidr->CIDR(substr($v, 1));
 							foreach ($cidrresults as $result) {
 								$subcondition['AND'][] = array('Attribute.value NOT LIKE' => $result);
@@ -1614,7 +1615,8 @@ class AttributesController extends AppController {
 							$subcondition['AND'][] = array('Attribute.' . $parameters[$k] . ' NOT LIKE' => '%'.substr($v, 1).'%');
 						}
 					} else {
-						if ($parameters[$k] === 'value' && preg_match('@^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(\d|[1-2]\d|3[0-2]))$@', $v)) {
+						// check for an IPv4 address and subnet in CIDR notation (e.g. 127.0.0.1/8)
+						if ($parameters[$k] === 'value' && $this->Cidr->checkCIDR($v, 4)) {
 							$cidrresults = $this->Cidr->CIDR($v);
 							foreach ($cidrresults as $result) {
 								$subcondition['OR'][] = array('Attribute.value LIKE' => $result);

--- a/app/Controller/Component/CidrComponent.php
+++ b/app/Controller/Component/CidrComponent.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * CIDR conversion tool
- */
-
 class CidrComponent extends Component {
 	public function CIDR($cidr) {
 		list($address, $prefix) = explode('/', $cidr, 2);
@@ -39,5 +35,22 @@ class CidrComponent extends Component {
 			if ($length < 3) $results[$i] .= '.%';
 		}
 		return $results;
+	}
+
+	public function checkCIDR($cidr, $ipVersion) {
+		if (strpos($cidr, '/') === FALSE || substr_count($cidr, '/') !== 1) {
+			return false;
+		}
+		list($net, $maskbits) = explode('/', $cidr);
+		if (!is_numeric($maskbits) || $maskbits < 0) {
+			return false;
+		}
+		if ($ipVersion == 4) {
+			return ($maskbits <= 32) && filter_var($net, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4);
+		} else if ($ipVersion == 6) {
+			return ($maskbits <= 128) && filter_var($net, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6);
+		} else {
+			throw new InvalidArgumentException('checkCIDR does only support IPv4 & IPv6');
+		}
 	}
 }

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -2376,7 +2376,7 @@ class EventsController extends AppController {
 						if ($v == '') continue;
 						if (substr($v, 0, 1) == '!') {
 							// check for an IPv4 address and subnet in CIDR notation (e.g. 127.0.0.1/8)
-							if ($parameters[$k] === 'value' && preg_match('@^((\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.){3}(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])(\/(\d|[12]\d|3[012]))$@', substr($v, 1))) {
+							if ($parameters[$k] === 'value' && $this->Cidr->checkCIDR(substr($v, 1), 4)) {
 								$cidrresults = $this->Cidr->CIDR(substr($v, 1));
 								foreach ($cidrresults as $result) {
 									$subcondition['AND'][] = array('Attribute.value NOT LIKE' => $result);
@@ -2398,7 +2398,7 @@ class EventsController extends AppController {
 							}
 						} else {
 							// check for an IPv4 address and subnet in CIDR notation (e.g. 127.0.0.1/8)
-							if ($parameters[$k] === 'value' && preg_match('@^((\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.){3}(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])(\/(\d|[12]\d|3[012]))$@', $v)) {
+							if ($parameters[$k] === 'value' && $this->Cidr->checkCIDR($v, 4)) {
 								$cidrresults = $this->Cidr->CIDR($v);
 								foreach ($cidrresults as $result) {
 									if (!empty($result)) $subcondition['OR'][] = array('Attribute.value LIKE' => $result);


### PR DESCRIPTION
#### What does it do?

moves the check for valid ip/mask combinations to one single central function
(and doesn't use preg_match anymore for this)
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
