### PR TITLE
filename regex changes

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -1938,7 +1938,7 @@ class EventsController extends AppController {
 			$rootDir = APP . "files" . DS . $id . DS;
 			App::uses('Folder', 'Utility');
 			$dir = new Folder($rootDir, true);
-			if (!preg_match('@^[\w-,\s,\.]+\.[A-Za-z0-9_]{2,4}$@', $this->data['Event']['submittedgfi']['name'])) {
+			if (!preg_match('@^[\w\-, .]+\.[A-Za-z0-9_]{2,4}$@', $this->data['Event']['submittedgfi']['name'])) {
 				throw new Exception ('Filename not allowed');
 			}
 			$zipFile = new File($rootDir . $this->data['Event']['submittedgfi']['name']);
@@ -1975,7 +1975,7 @@ class EventsController extends AppController {
 			App::uses('Folder', 'Utility');
 			$dir = new Folder($rootDir . 'ioc', true);
 			$destPath = $rootDir . 'ioc';
-			if (!preg_match('@^[\w-,\s,\.]+\.[A-Za-z0-9_]{2,4}$@', $this->data['Event']['submittedioc']['name'])) {
+			if (!preg_match('@^[\w\-, .]+\.[A-Za-z0-9_]{2,4}$@', $this->data['Event']['submittedioc']['name'])) {
 				throw new Exception ('Filename not allowed');
 			}
 			App::uses('File', 'Utility');
@@ -2888,7 +2888,7 @@ class EventsController extends AppController {
 						App::uses('FileAccessTool', 'Tools');
 						$tmpdir = Configure::read('MISP.tmpdir') ? Configure::read('MISP.tmpdir') : '/tmp';
 						$tempFile = explode('|', $attribute['data']);
-						if (!preg_match('/^[a-z0-9]*$/i', $tempFile[0])) {
+						if (!preg_match('/^\w+$/i', $tempFile[0])) {
 							throw new MethodNotAllowedException('Invalid filename, stop tampering with it.');
 						}
 						$attribute['data'] = (new FileAccessTool())->readFromFile($tmpdir . '/' . $tempFile[0], $tempFile[1]);

--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -564,7 +564,7 @@ class ServersController extends AppController {
 
 			$destpath = APP . "files" . DS . "certs" . DS;
 			$dir = new Folder(APP . "files" . DS . "certs", true);
-			if (!preg_match('@^[\w-,\s,\.]+\.[A-Za-z0-9_]{2,4}$@', $server['Server']['submitted_cert']['name'])) throw new Exception ('Filename not allowed');
+			if (!preg_match('@^[\w\-, .]+\.[A-Za-z0-9_]{2,4}$@', $server['Server']['submitted_cert']['name'])) throw new Exception ('Filename not allowed');
 			$pemfile = new File($destpath . $id . '.' . $ext);
 			$result = $pemfile->write($pemData);
 			$s = $this->Server->read(null, $id);

--- a/app/Controller/TemplatesController.php
+++ b/app/Controller/TemplatesController.php
@@ -381,7 +381,7 @@ class TemplatesController extends AppController {
 			// filename checks
 			foreach ($this->request->data['Template']['file'] as $k => $file) {
 				if ($file['size'] > 0 && $file['error'] == 0) {
-					if (preg_match('@^[\w\-. ]+$@', $file['name'])) {
+					if (preg_match('@^[\w\-. ]+$@', $file['name'])) { // filename regex
 						$fn = $this->Template->generateRandomFileName();
 						move_uploaded_file($file['tmp_name'], APP . 'tmp/files/' . $fn);
 						$filenames[] =$file['name'];
@@ -420,7 +420,7 @@ class TemplatesController extends AppController {
 		if (!$this->request->is('post')) throw new MethodNotAllowedException('This action is restricted to accepting POST requests only.');
 		if (!$this->request->is('ajax')) throw new MethodNotAllowedException('This action is only accessible through AJAX.');
 		$this->autoRender = false;
-		if (preg_match('/^[a-zA-Z0-9]{12}$/', $filename)) {
+		if (preg_match('/^[a-zA-Z0-9]{12}$/', $filename)) { // filename regex
 			$file = new File(APP . 'tmp/files/' . $filename);
 			if ($file->exists()) {
 				$file->delete();

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -1654,7 +1654,7 @@ class Attribute extends AppModel {
 			$element['to_ids'] = 0;
 		}
 		foreach ($files as $file) {
-			if (!preg_match('@^[\w\-. ]+$@', $file['filename'])) {
+			if (!preg_match('@^[\w\-. ]+$@', $file['filename'])) { // filename regex
 				$errors = 'Filename not allowed.';
 				continue;
 			}

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1956,7 +1956,7 @@ class Server extends AppModel {
 
 	public function testForPath($value) {
 		if ($value === '') return true;
-		if (preg_match('/^[a-z0-9\-\_\:\/]+$/i', $value)) return true;
+		if (preg_match('/^[a-z0-9\-_:/]+$/i', $value)) return true;
 		return 'Invalid characters in the path.';
 	}
 
@@ -2164,7 +2164,7 @@ class Server extends AppModel {
 	// never come here directly, always go through a secondary check like testForTermsFile in order to also pass along the expected file path
 	private function __testForFile($value, $path) {
 		if ($this->testForEmpty($value) !== true) return $this->testForEmpty($value);
-		if (!preg_match('/^[\w,\s-]+(\.)?[A-Za-z0-9]+$/', $value)) return 'Invalid filename. Valid filenames can only include characters between a-z, A-Z or 0-9. They can also include - and _ and can optionally have an extension.';
+		if (!preg_match('/^[\w, \-_]+(\.)?[A-Za-z0-9]+$/', $value)) return 'Invalid filename. Valid filenames can only include characters between a-z, A-Z or 0-9. They can also include - and _ and can optionally have an extension.';
 		$file = $path . DS . $value;
 		if (!file_exists($file)) return 'Could not find the specified file. Make sure that it is uploaded into the following directory: ' . $path;
 		return true;


### PR DESCRIPTION
#### What does it do?

**this is NOT a finished PR yet, it's content should be the base for a discussion.**

it is about regexes that check for filenames.

what it does so far:
- fix obvious errors in regexes (double chars, not quoted hyphen, quote chars that dont have to be quoted, replace \s by single space, + instead of *
- it marks other filename regexes, that don't have obvious errors, with a comment to have them hilighted in this PR

the questions for discussion are:
- why are there many different regexes for a filename, couldn't we reduce that to one?
- why allow some underscores, some commas, one a colon?
- why have some restrictions regarding the file extensions, others not?
- why do some allow the filename even starting with a space?
- why does one limit the length, all others don't?

my suggestion for a common regex would be:
`@^[\w_.,:]+[\w_.,\-: ]*[\w_.,\-:]+$@`
that wouldn't allow files to start with a hyphen or space and to end with a space.
additionally, a check for <=255 characters?
what this suggested regex would allow _less_ for some of the current cases:
- no tabs
- no start with space or hyphen
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
