### PR TITLE
new filename regex & separate functions

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -667,4 +667,8 @@ class AppController extends Controller {
 		$this->Session->setFlash('Caches cleared.');
 		$this->redirect(array('controller' => 'servers', 'action' => 'serverSettings', 'diagnostics'));
 	}
+
+	public function checkFilename($filename) {
+		return preg_match('@^([a-z0-9_.]+[a-z0-9_.\- ]*[a-z0-9_.\-]|[a-z0-9_.])+$@i', $filename);
+	}
 }

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -1938,8 +1938,8 @@ class EventsController extends AppController {
 			$rootDir = APP . "files" . DS . $id . DS;
 			App::uses('Folder', 'Utility');
 			$dir = new Folder($rootDir, true);
-			if (!preg_match('@^[\w\-, .]+\.[A-Za-z0-9_]{2,4}$@', $this->data['Event']['submittedgfi']['name'])) {
-				throw new Exception ('Filename not allowed');
+			if (!$this->checkFilename($this->data['Event']['submittedgfi']['name'])) {
+				throw new Exception ('Filename not allowed.');
 			}
 			$zipFile = new File($rootDir . $this->data['Event']['submittedgfi']['name']);
 			$result = $zipFile->write($zipData);
@@ -1966,6 +1966,10 @@ class EventsController extends AppController {
 	public function _addIOCFile($id) {
 		if (!empty($this->data) && $this->data['Event']['submittedioc']['size'] > 0 &&
 				is_uploaded_file($this->data['Event']['submittedioc']['tmp_name'])) {
+			if (!$this->checkFilename($this->data['Event']['submittedioc']['name'])) {
+				throw new Exception ('Filename not allowed.');
+			}
+
 			App::uses('FileAccessTool', 'Tools');
 			$fileAccessTool = new FileAccessTool();
 			$iocData = $fileAccessTool->readFromFile($this->data['Event']['submittedioc']['tmp_name'], $this->data['Event']['submittedioc']['size']);
@@ -1975,9 +1979,6 @@ class EventsController extends AppController {
 			App::uses('Folder', 'Utility');
 			$dir = new Folder($rootDir . 'ioc', true);
 			$destPath = $rootDir . 'ioc';
-			if (!preg_match('@^[\w\-, .]+\.[A-Za-z0-9_]{2,4}$@', $this->data['Event']['submittedioc']['name'])) {
-				throw new Exception ('Filename not allowed');
-			}
 			App::uses('File', 'Utility');
 			$iocFile = new File($destPath . DS . $this->data['Event']['submittedioc']['name']);
 			$result = $iocFile->write($iocData);
@@ -2888,8 +2889,8 @@ class EventsController extends AppController {
 						App::uses('FileAccessTool', 'Tools');
 						$tmpdir = Configure::read('MISP.tmpdir') ? Configure::read('MISP.tmpdir') : '/tmp';
 						$tempFile = explode('|', $attribute['data']);
-						if (!preg_match('/^\w+$/i', $tempFile[0])) {
-							throw new MethodNotAllowedException('Invalid filename, stop tampering with it.');
+						if (!$this->checkFilename($tempFile[0])) {
+							throw new Exception('Invalid filename.');
 						}
 						$attribute['data'] = (new FileAccessTool())->readFromFile($tmpdir . '/' . $tempFile[0], $tempFile[1]);
 						unlink($tmpdir . '/' . $tempFile[0]);

--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -552,6 +552,9 @@ class ServersController extends AppController {
 			App::uses('File', 'Utility');
 			App::uses('Folder', 'Utility');
 			App::uses('FileAccessTool', 'Tools');
+			if (!$this->checkFilename($server['Server']['submitted_cert']['name'])) {
+				throw new Exception ('Filename not allowed');
+			}
 			$file = new File($server['Server']['submitted_cert']['name']);
 			$ext = $file->ext();
 			if (($ext != 'pem') || !$server['Server']['submitted_cert']['size'] > 0) {
@@ -564,7 +567,6 @@ class ServersController extends AppController {
 
 			$destpath = APP . "files" . DS . "certs" . DS;
 			$dir = new Folder(APP . "files" . DS . "certs", true);
-			if (!preg_match('@^[\w\-, .]+\.[A-Za-z0-9_]{2,4}$@', $server['Server']['submitted_cert']['name'])) throw new Exception ('Filename not allowed');
 			$pemfile = new File($destpath . $id . '.' . $ext);
 			$result = $pemfile->write($pemData);
 			$s = $this->Server->read(null, $id);

--- a/app/Controller/TemplatesController.php
+++ b/app/Controller/TemplatesController.php
@@ -333,7 +333,7 @@ class TemplatesController extends AppController {
 				$this->loadModel('Attribute');
 				$fails = 0;
 				foreach ($attributes as $k => &$attribute) {
-					if (isset($attribute['data']) && preg_match('/^[a-zA-Z0-9]{12}$/', $attribute['data'])) {
+					if (isset($attribute['data']) && $this->checkFilename($attribute['data'])) {
 						$file = new File(APP . 'tmp/files/' . $attribute['data']);
 						$content = $file->read();
 						$attribute['data'] = base64_encode($content);
@@ -376,7 +376,7 @@ class TemplatesController extends AppController {
 			// filename checks
 			foreach ($this->request->data['Template']['file'] as $k => $file) {
 				if ($file['size'] > 0 && $file['error'] == 0) {
-					if (preg_match('@^[\w\-. ]+$@', $file['name'])) { // filename regex
+					if ($this->checkFilename($file['name'])) {
 						$fn = $this->Template->generateRandomFileName();
 						move_uploaded_file($file['tmp_name'], APP . 'tmp/files/' . $fn);
 						$filenames[] = $file['name'];
@@ -406,7 +406,7 @@ class TemplatesController extends AppController {
 		if (!$this->request->is('post')) throw new MethodNotAllowedException('This action is restricted to accepting POST requests only.');
 		if (!$this->request->is('ajax')) throw new MethodNotAllowedException('This action is only accessible through AJAX.');
 		$this->autoRender = false;
-		if (preg_match('/^[a-zA-Z0-9]{12}$/', $filename)) { // filename regex
+		if ($this->checkFilename($filename)) {
 			$file = new File(APP . 'tmp/files/' . $filename);
 			if ($file->exists()) {
 				$file->delete();

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -687,4 +687,8 @@ class AppModel extends Model {
 		));
 		return $delegations;
 	}
+
+	public function checkFilename($filename) {
+		return preg_match('@^([a-z0-9_.]+[a-z0-9_.\- ]*[a-z0-9_.\-]|[a-z0-9_.])+$@i', $filename);
+	}
 }

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -1654,7 +1654,7 @@ class Attribute extends AppModel {
 			$element['to_ids'] = 0;
 		}
 		foreach ($files as $file) {
-			if (!preg_match('@^[\w\-. ]+$@', $file['filename'])) { // filename regex
+			if (!$this->checkFilename($file['filename'])) {
 				$errors = 'Filename not allowed.';
 				continue;
 			}

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1956,7 +1956,7 @@ class Server extends AppModel {
 
 	public function testForPath($value) {
 		if ($value === '') return true;
-		if (preg_match('/^[a-z0-9\-_:/]+$/i', $value)) return true;
+		if (preg_match('@^\/?(([a-z0-9_.]+[a-z0-9_.\- ]*[a-z0-9_.\-]|[a-z0-9_.])+\/?)+$@i', $value)) return true;
 		return 'Invalid characters in the path.';
 	}
 
@@ -2171,7 +2171,7 @@ class Server extends AppModel {
 	// never come here directly, always go through a secondary check like testForTermsFile in order to also pass along the expected file path
 	private function __testForFile($value, $path) {
 		if ($this->testForEmpty($value) !== true) return $this->testForEmpty($value);
-		if (!preg_match('/^[\w, \-_]+(\.)?[A-Za-z0-9]+$/', $value)) return 'Invalid filename. Valid filenames can only include characters between a-z, A-Z or 0-9. They can also include - and _ and can optionally have an extension.';
+		if (!$this->checkFilename($value)) return 'Invalid filename.';
 		$file = $path . DS . $value;
 		if (!file_exists($file)) return 'Could not find the specified file. Make sure that it is uploaded into the following directory: ' . $path;
 		return true;


### PR DESCRIPTION
#### What does it do?

following #1471 i discussed the topic on gitter with @iglocska 

the result are these regexes, one with slashes (if a whole path is checked) and one without.
we dont allow colons or commas anymore, but can be easily reintroduced if someone has trouble.

```
@^([a-z0-9_.]+[a-z0-9_.\- ]*[a-z0-9_.\-]|[a-z0-9_.])+$@i
@^\/?(([a-z0-9_.]+[a-z0-9_.\- ]*[a-z0-9_.\-]|[a-z0-9_.])+\/?)+$@i
```

also, the regex is now in only 3 places, one function for Model, one for Controller and the single path check. before it was in 10 places.
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
