### PR TITLE
rename findTags() to findEventIdsByTagNames()

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -1247,8 +1247,8 @@ class AttributesController extends AppController {
 						else $include[] = $tagname;
 					}
 					$this->loadModel('Tag');
-					if (!empty($include)) $conditions['AND'][] = array('OR' => array('Attribute.event_id' => $this->Tag->findTags($include)));
-					if (!empty($exclude)) $conditions['AND'][] = array('Attribute.event_id !=' => $this->Tag->findTags($exclude));
+					if (!empty($include)) $conditions['AND'][] = array('OR' => array('Attribute.event_id' => $this->Tag->findEventIdsByTagNames($include)));
+					if (!empty($exclude)) $conditions['AND'][] = array('Attribute.event_id !=' => $this->Tag->findEventIdsByTagNames($exclude));
 				}
 				if ($type != 'ALL') {
 					$conditions['Attribute.type ='] = $type;

--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -69,17 +69,16 @@ class Tag extends AppModel {
 		$acceptIds = array();
 		$rejectIds = array();
 		if (!empty($accept)) {
-			$acceptIds = $this->findTags($accept);
+			$acceptIds = $this->findEventIdsByTagNames($accept);
 			if (empty($acceptIds)) $acceptIds[] = -1;
 		}
 		if (!empty($reject)) {
-			$rejectIds = $this->findTags($reject);
+			$rejectIds = $this->findEventIdsByTagNames($reject);
 		}
 		return array($acceptIds, $rejectIds);
 	}
 
-	// find all of the event Ids that belong to tags with certain names
-	public function findTags($array) {
+	public function findEventIdsByTagNames($array) {
 		$ids = array();
 		foreach ($array as $a) {
 			$conditions['OR'][] = array('LOWER(name) like' => strtolower($a));
@@ -87,7 +86,6 @@ class Tag extends AppModel {
 		$params = array(
 				'recursive' => 1,
 				'contain' => 'EventTag',
-				//'fields' => array('id', 'name'),
 				'conditions' => $conditions
 		);
 		$result = $this->find('all', $params);


### PR DESCRIPTION
#### What does it do?

renames a functio  findTags() to a more descriptive name findEventIdsByTagNames()
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
