### PR TITLE
change in SELtype, httpd_sys_content_rw_t does not exists

### DIFF
--- a/INSTALL/INSTALL.centos7.txt
+++ b/INSTALL/INSTALL.centos7.txt
@@ -167,13 +167,13 @@ mysql -u misp -p misp < INSTALL/MYSQL.sql
 cp /var/www/MISP/INSTALL/apache.misp.centos7 /etc/httpd/conf.d/misp.conf
 
 # Since SELinux is enabled, we need to allow httpd to write to certain directories
-chcon -t httpd_sys_content_rw_t /var/www/MISP/app/files
-chcon -t httpd_sys_content_rw_t /var/www/MISP/app/files/terms
-chcon -t httpd_sys_content_rw_t /var/www/MISP/app/files/scripts/tmp
-chcon -t httpd_sys_content_rw_t /var/www/MISP/app/Plugin/CakeResque/tmp
-chcon -R -t httpd_sys_content_rw_t /var/www/MISP/app/tmp
-chcon -R -t httpd_sys_content_rw_t /var/www/MISP/app/webroot/img/orgs
-chcon -R -t httpd_sys_content_rw_t /var/www/MISP/app/webroot/img/custom
+chcon -t httpd_sys_rw_content_t /var/www/MISP/app/files
+chcon -t httpd_sys_rw_content_t /var/www/MISP/app/files/terms
+chcon -t httpd_sys_rw_content_t /var/www/MISP/app/files/scripts/tmp
+chcon -t httpd_sys_rw_content_t /var/www/MISP/app/Plugin/CakeResque/tmp
+chcon -R -t httpd_sys_rw_content_t /var/www/MISP/app/tmp
+chcon -R -t httpd_sys_rw_content_t /var/www/MISP/app/webroot/img/orgs
+chcon -R -t httpd_sys_rw_content_t /var/www/MISP/app/webroot/img/custom
 
 # Allow httpd to connect to the redis server and php-fpm over tcp/ip
 setsebool -P httpd_can_network_connect on
@@ -210,7 +210,7 @@ cp -a config.default.php config.php
 
 # If you want to be able to change configuration parameters from the webinterface:
 chown apache:apache /var/www/MISP/app/Config/config.php
-chcon -t httpd_sys_content_rw_t /var/www/MISP/app/Config/config.php
+chcon -t httpd_sys_rw_content_t /var/www/MISP/app/Config/config.php
 
 # Generate a GPG encryption key.
 # If the following command gives an error message, try it as root from the console


### PR DESCRIPTION
#### What does it do?

In the Installation manual for CentOS 7 there it is said to change the SELinux type to httpd_sys_content_rw_t. However I was getting some errors, checked on my system and that type does not exists, however httpd_sys_rw_content_t does, therefore I change the installation manual.
#### Questions
- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
