### PR TITLE
Update INSTALL.centos7.txt

### DIFF
--- a/INSTALL/INSTALL.centos7.txt
+++ b/INSTALL/INSTALL.centos7.txt
@@ -45,6 +45,8 @@ pear channel-update pear.php.net
 
 pear install Crypt_GPG    # we need version >1.3.0
 
+NOTE: if using rh-php56 the command needs to be run through its terminal: /usr/bin/scl enable rh-php56 "pear list | grep Crypt_GPG"
+
 # GPG needs lots of entropy, haveged provides entropy
 yum install haveged
 systemctl enable haveged.service
@@ -110,6 +112,8 @@ pecl install redis-2.2.8
 echo "extension=redis.so" > /etc/opt/rh/rh-php56/php-fpm.d/redis.ini
 ln -s ../php-fpm.d/redis.ini /etc/opt/rh/rh-php56/php.d/99-redis.ini
 systemctl restart rh-php56-php-fpm.service
+
+Note: if using rh-php56 redis needs to be installed through its terminal: /usr/bin/scl enable rh-php56  "pecl install redis-2.2.8"
 
 # If you have not yet set a timezone in php.ini
 echo 'date.timezone = "Europe/Amsterdam"' > /etc/opt/rh/rh-php56/php-fpm.d/timezone.ini


### PR DESCRIPTION
#### What does it do?

Some libraries and packages (Crypt_GPG and redis) were told to be install through pear and pecl, however if using php 5.6 they have to be installed opening a bash for php56, if not it will not recognized them, failing and giving warnings in some features of MISP (workers, diganostics, etc)
#### Questions
- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
