### PR TITLE
remove some references to variables

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -363,7 +363,7 @@ class AppController extends Controller {
 	private function __convertEmailToName($email) {
 		$name = explode('@', $email);
 		$name = explode('.', $name[0]);
-		foreach ($name as &$temp) $temp = ucfirst($temp);
+		foreach ($name as $key => $value) $name[$key] = ucfirst($value);
 		$name = implode(' ', $name);
 		return $name;
 	}
@@ -582,7 +582,7 @@ class AppController extends Controller {
 		throw new ForbiddenException($message);
 	}
 
-	private function __customAuthentication(&$server) {
+	private function __customAuthentication($server) {
 		$result = false;
 		if (Configure::read('Plugin.CustomAuth_enable')) {
 			$header = Configure::read('Plugin.CustomAuth_header') ? Configure::read('Plugin.CustomAuth_header') : 'Authorization';

--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -1010,36 +1010,36 @@ class AttributesController extends AppController {
 			}
 
 			if ($this->request->data['Attribute']['to_ids'] != 2) {
-				foreach ($attributes as &$attribute) {
-					$attribute['Attribute']['to_ids'] = ($this->request->data['Attribute']['to_ids'] == 0 ? false : true);
+				foreach ($attributes as $key => $attribute) {
+					$attributes[$key]['Attribute']['to_ids'] = ($this->request->data['Attribute']['to_ids'] == 0 ? false : true);
 				}
 			}
 
 			if ($this->request->data['Attribute']['distribution'] != 6) {
-				foreach ($attributes as &$attribute) {
-					$attribute['Attribute']['distribution'] = $this->request->data['Attribute']['distribution'];
+				foreach ($attributes as $key => $attribute) {
+					$attributes[$key]['Attribute']['distribution'] = $this->request->data['Attribute']['distribution'];
 				}
 				if ($this->request->data['Attribute']['distribution'] == 4) {
-					foreach ($attributes as &$attribute) {
-						$attribute['Attribute']['sharing_group_id'] = $this->request->data['Attribute']['sharing_group_id'];
+					foreach ($attributes as $key => $attribute) {
+						$attributes[$key]['Attribute']['sharing_group_id'] = $this->request->data['Attribute']['sharing_group_id'];
 					}
 				} else {
-					foreach ($attributes as &$attribute) {
-						$attribute['Attribute']['sharing_group_id'] = 0;
+					foreach ($attributes as $key => $attribute) {
+						$attributes[$key]['Attribute']['sharing_group_id'] = 0;
 					}
 				}
 			}
 
 			if ($this->request->data['Attribute']['comment'] != null) {
-				foreach ($attributes as &$attribute) {
-					$attribute['Attribute']['comment'] = $this->request->data['Attribute']['comment'];
+				foreach ($attributes as $key => $attribute) {
+					$attributes[$key]['Attribute']['comment'] = $this->request->data['Attribute']['comment'];
 				}
 			}
 
 			$date = new DateTime();
 			$timestamp = $date->getTimestamp();
-			foreach ($attributes as &$attribute) {
-				$attribute['Attribute']['timestamp'] = $timestamp;
+			foreach ($attributes as $key => $attribute) {
+				$attributes[$key]['Attribute']['timestamp'] = $timestamp;
 			}
 
 			if ($this->Attribute->saveMany($attributes)) {
@@ -1074,7 +1074,7 @@ class AttributesController extends AppController {
 		if (empty($servers))
 			return;
 		App::uses('SyncTool', 'Tools');
-		foreach ($servers as &$server) {
+		foreach ($servers as $server) {
 			$syncTool = new SyncTool();
 			$HttpSocket = $syncTool->setupHttpSocket($server);
 			$this->Attribute->deleteAttributeFromServer($uuid, $server, $HttpSocket);
@@ -1339,7 +1339,7 @@ class AttributesController extends AppController {
 						$attributes = $this->Whitelist->removeWhitelistedFromArray($attributes, true);
 					}
 
-					foreach ($attributes as &$attribute) {
+					foreach ($attributes as $attribute) {
 						$attributeIdList[] = $attribute['Attribute']['id'];
 						if (!in_array($attribute['Attribute']['event_id'], $idList)) {
 							$idList[] = $attribute['Attribute']['event_id'];
@@ -1440,8 +1440,8 @@ class AttributesController extends AppController {
 				}
 			}
 		}
-		foreach ($events as &$event) {
-			$event['relevance'] = 100 * $event['to_ids'] / ($event['no_ids'] + $event['to_ids']);
+		foreach ($events as $key => $event) {
+			$events[$key]['relevance'] = 100 * $event['to_ids'] / ($event['no_ids'] + $event['to_ids']);
 		}
 		if (!empty($events)) $events = $this->__subval_sort($events, 'relevance');
 		return $events;
@@ -2026,10 +2026,11 @@ class AttributesController extends AppController {
 			));
 			$results = array('untouched' => count($oldAttributes), 'created' => 0, 'deleted' => 0, 'createdFail' => 0, 'deletedFail' => 0);
 
-			foreach ($newValues as &$value) {
-				$value = trim($value);
+			$newValues = array_map('trim', $newValues);
+
+			foreach ($newValues as $value) {
 				$found = false;
-				foreach ($oldAttributes as &$old) {
+				foreach ($oldAttributes as $old) {
 					if ($value == $old['Attribute']['value']) {
 						$found = true;
 					}
@@ -2052,7 +2053,7 @@ class AttributesController extends AppController {
 				}
 			}
 
-			foreach ($oldAttributes as &$old) {
+			foreach ($oldAttributes as $old) {
 				if (!in_array($old['Attribute']['value'], $newValues)) {
 					if ($this->Attribute->delete($old['Attribute']['id'])) {
 						$results['deleted']++;
@@ -2239,13 +2240,13 @@ class AttributesController extends AppController {
 				throw new Exception('Invalid script.');
 		}
 		$counter = 0;
-		foreach ($replaceConditions as &$rC) {
+		foreach ($replaceConditions as $rC) {
 			$searchPattern = '';
 			if (in_array($rC['condition'], array('endsWith', 'contains'))) $searchPattern .= '%';
 			$searchPattern .= $rC['from'];
 			if (in_array($rC['condition'], array('startsWith', 'contains'))) $searchPattern .= '%';
 			$attributes = $this->Attribute->find('all', array('conditions' => array($rC['search'] => $searchPattern), 'recursive' => -1));
-			foreach ($attributes as &$attribute) {
+			foreach ($attributes as $attribute) {
 				$regex = '/';
 				if (!in_array($rC['condition'], array('startsWith', 'contains'))) $regex .= '^';
 				$regex .= $rC['from'];
@@ -2274,10 +2275,10 @@ class AttributesController extends AppController {
 		$url = Configure::read('Plugin.Enrichment_services_url') ? Configure::read('Plugin.Enrichment_services_url') : $this->Server->serverSettings['Plugin']['Enrichment_services_url']['value'];
 		$port = Configure::read('Plugin.Enrichment_services_port') ? Configure::read('Plugin.Enrichment_services_port') : $this->Server->serverSettings['Plugin']['Enrichment_services_port']['value'];
 		$resultArray = array();
-		foreach ($validTypes as &$type) {
+		foreach ($validTypes as $type) {
 			$options = array();
 			$found = false;
-			foreach ($modules['modules'] as &$temp) {
+			foreach ($modules['modules'] as $temp) {
 				if ($temp['name'] == $type) {
 					$found = true;
 					if (isset($temp['meta']['config'])) {
@@ -2303,7 +2304,7 @@ class AttributesController extends AppController {
 				continue;
 			}
 			if (!empty($result['results'])) {
-				foreach ($result['results'] as &$r) {
+				foreach ($result['results'] as $r) {
 					if (is_array($r['values']) && !empty($r['values'])) {
 						$tempArray = array();
 						foreach ($r['values'] as $k => $v) {

--- a/app/Controller/Component/ACLComponent.php
+++ b/app/Controller/Component/ACLComponent.php
@@ -422,8 +422,8 @@ class ACLComponent extends Component {
 	public function findMissingFunctionNames($content = false) {
 		$results = $this->__findAllFunctions();
 		$missing = array();
-		foreach ($results as $controller => &$functions) {
-			foreach ($functions as &$function) {
+		foreach ($results as $controller => $functions) {
+			foreach ($functions as $function) {
 				if (!isset($this->__aclList[$controller])
 				|| !in_array($function, array_keys($this->__aclList[$controller])))
 					$missing[$controller][] = $function;
@@ -442,7 +442,7 @@ class ACLComponent extends Component {
 			'conditions' => $conditions
 		));
 		if (empty($roles)) throw new NotFoundException('Role not found.');
-		foreach ($roles as &$role) {
+		foreach ($roles as $role) {
 			$urls = $this->__checkRoleAccess($role['Role']);
 			$results[$role['Role']['id']] = array('name' => $role['Role']['name'], 'urls' => $urls);
 		}
@@ -451,7 +451,7 @@ class ACLComponent extends Component {
 
 	private function __checkRoleAccess($role) {
 		$result = array();
-		foreach ($this->__aclList as $controller => &$actions) {
+		foreach ($this->__aclList as $controller => $actions) {
 			$controllerNames = Inflector::variable($controller) == Inflector::underscore($controller) ? array(Inflector::variable($controller)) : array(Inflector::variable($controller), Inflector::underscore($controller));
 			foreach ($controllerNames as $controllerName) {
 				foreach ($actions as $action => $permissions) {

--- a/app/Controller/Component/IOCExportComponent.php
+++ b/app/Controller/Component/IOCExportComponent.php
@@ -6,7 +6,7 @@ class IOCExportComponent extends Component {
 
 	public function buildAll($user, $event) {
 		$this->__buildTop($event);
-		foreach ($event['Attribute'] as &$attribute) {
+		foreach ($event['Attribute'] as $attribute) {
 			$this->__buildAttribute($attribute);
 		}
 		$this->__buildBottom();

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -260,7 +260,7 @@ class EventsController extends AppController {
 		$passedArgs = $this->passedArgs;
 		if (isset($this->request->data)) {
 			if (isset($this->request->data['request'])) $this->request->data = $this->request->data['request'];
-			foreach ($overrideAbleParams as &$oap) {
+			foreach ($overrideAbleParams as $oap) {
 				if (isset($this->request->data['search' . $oap])) $this->request->data[$oap] = $this->request->data['search' . $oap];
 				if (isset($this->request->data[$oap])) $passedArgs['search' . $oap] = $this->request->data[$oap];
 			}
@@ -471,8 +471,8 @@ class EventsController extends AppController {
 								'recursive' => -1,
 								'fields' => array('id', 'name'),
 							));
-							foreach ($threatLevels as &$tl) {
-								$terms[$tl['ThreatLevel']['id']] =$tl['ThreatLevel']['name'];
+							foreach ($threatLevels as $tl) {
+								$terms[$tl['ThreatLevel']['id']] = $tl['ThreatLevel']['name'];
 							}
 						} else if ($searchTerm == 'analysis') {
 							$terms = $this->Event->analysisLevels;
@@ -540,11 +540,11 @@ class EventsController extends AppController {
 			}
 			if (isset($this->paginate['conditions'])) $rules['conditions'] = $this->paginate['conditions'];
 			$events = $this->Event->find('all', $rules);
-			foreach ($events as $k => &$event) {
-				foreach ($event['EventTag'] as $k2 => &$et) {
+			foreach ($events as $k => $event) {
+				foreach ($event['EventTag'] as $k2 => $et) {
 					if (empty($et['Tag'])) unset($events[$k]['EventTag'][$k2]);
 				}
-				$event['EventTag'] = array_values($event['EventTag']);
+				$events[$k]['EventTag'] = array_values($event['EventTag']);
 			}
 			$this->set('events', $events);
 		} else {
@@ -678,7 +678,7 @@ class EventsController extends AppController {
 		}
 		$results = $this->Event->fetchEvent($this->Auth->user(), $conditions);
 		if (empty($results)) throw new NotFoundException('Invalid event');
-		$event = &$results[0];
+		$event = $results[0];
 		$emptyEvent = (!isset($event['Attribute']) || empty($event['Attribute']));
 		$this->set('emptyEvent', $emptyEvent);
 		$params = $this->Event->rearrangeEventForView($event, $this->passedArgs, $all);
@@ -686,13 +686,13 @@ class EventsController extends AppController {
 		// workaround to get the event dates in to the attribute relations
 		$relatedDates = array();
 		if (isset($event['RelatedEvent'])) {
-			foreach ($event['RelatedEvent'] as &$relation) {
+			foreach ($event['RelatedEvent'] as $relation) {
 				$relatedDates[$relation['Event']['id']] = $relation['Event']['date'];
 			}
 			if (isset($event['RelatedAttribute'])) {
-				foreach ($event['RelatedAttribute'] as &$relatedAttribute) {
-					foreach ($relatedAttribute as &$relation) {
-						$relation['date'] = $relatedDates[$relation['id']];
+				foreach ($event['RelatedAttribute'] as $key => $relatedAttribute) {
+					foreach ($relatedAttribute as $key2 => $relation) {
+						$event['RelatedAttribute'][$key][$key2]['date'] = $relatedDates[$relation['id']];
 					}
 				}
 			}
@@ -737,7 +737,7 @@ class EventsController extends AppController {
 			$proposalStatus = false;
 			if (isset($event['ShadowAttribute']) && !empty($event['ShadowAttribute'])) $proposalStatus = true;
 			if (!$proposalStatus && !empty($event['Attribute'])) {
-				foreach ($event['Attribute'] as &$temp) {
+				foreach ($event['Attribute'] as $temp) {
 					if (isset($temp['ShadowAttribute']) && !empty($temp['ShadowAttribute'])) {
 						$proposalStatus = true;
 					}
@@ -768,13 +768,13 @@ class EventsController extends AppController {
 		// workaround to get the event dates in to the attribute relations
 		$relatedDates = array();
 		if (isset($event['RelatedEvent'])) {
-			foreach ($event['RelatedEvent'] as &$relation) {
+			foreach ($event['RelatedEvent'] as $relation) {
 				$relatedDates[$relation['Event']['id']] = $relation['Event']['date'];
 			}
 			if (isset($event['RelatedAttribute'])) {
-				foreach ($event['RelatedAttribute'] as &$relatedAttribute) {
-					foreach ($relatedAttribute as &$relation) {
-						$relation['date'] = $relatedDates[$relation['id']];
+				foreach ($event['RelatedAttribute'] as $key => $relatedAttribute) {
+					foreach ($relatedAttribute as $key2 => $relation) {
+						$event['RelatedAttribute'][$key][$key2]['date'] = $relatedDates[$relation['id']];
 					}
 				}
 			}
@@ -861,7 +861,7 @@ class EventsController extends AppController {
 		if ($this->userRole['perm_admin'] && !$this->_isSiteAdmin() && ($results[0]['Org']['id'] == $this->Auth->user('org_id'))) {
 			$results[0]['User']['email'] = $this->User->field('email', array('id' , $results[0]['Event']['user_id']));
 		}
-		$event = &$results[0];
+		$event = $results[0];
 		if ($this->_isRest()) {
 			$this->set('event', $event);
 		}
@@ -1026,7 +1026,7 @@ class EventsController extends AppController {
 							}
 							// REST users want to see the newly created event
 							$results = $this->Event->fetchEvent($this->Auth->user(), array('eventid' => $created_id));
-							$event = &$results[0];
+							$event = $results[0];
 							if (!empty($validationErrors)) {
 								$event['errors'] = $validationErrors;
 							}
@@ -1185,7 +1185,7 @@ class EventsController extends AppController {
 				if ($result === true) {
 					// REST users want to see the newly created event
 					$results = $this->Event->fetchEvent($this->Auth->user(), array('eventid' => $id));
-					$event = &$results[0];
+					$event = $results[0];
 					$this->set('event', $event);
 					$this->render('view');
 					return true;
@@ -1676,10 +1676,10 @@ class EventsController extends AppController {
 			if (empty($result)) continue;
 			$validEvents++;
 			if ($withAttachment) {
-				foreach ($result[0]['Attribute'] as &$attribute) {
+				foreach ($result[0]['Attribute'] as $key => $attribute) {
 					if ($this->Event->Attribute->typeIsAttachment($attribute['type'])) {
 						$encodedFile = $this->Event->Attribute->base64EncodeAttachment($attribute);
-						$attribute['data'] = $encodedFile;
+						$result[0]['Attribute'][$key]['data'] = $encodedFile;
 					}
 				}
 			}
@@ -1822,7 +1822,7 @@ class EventsController extends AppController {
 				$attributes = $this->Whitelist->removeWhitelistedFromArray($attributes, true);
 			}
 			$list = array();
-			foreach ($attributes as &$attribute) {
+			foreach ($attributes as $attribute) {
 				$list[] = $attribute['Attribute']['id'];
 			}
 			$events = array($eventid);
@@ -2010,7 +2010,7 @@ class EventsController extends AppController {
 		} else {
 			$dataArray = json_decode($data, true);
 			if (isset($dataArray['response'][0])) {
-				foreach ($dataArray['response'] as $k => &$temp) {
+				foreach ($dataArray['response'] as $k => $temp) {
 					$dataArray['Event'][] = $temp['Event'];
 					unset($dataArray['response'][$k]);
 				}
@@ -2237,7 +2237,7 @@ class EventsController extends AppController {
 			$attributes = $this->Whitelist->removeWhitelistedFromArray($attributes, true);
 		}
 		$idList = array();
-		foreach ($attributes as &$attribute) {
+		foreach ($attributes as $attribute) {
 			if (!in_array($attribute['Attribute']['event_id'], $idList)) {
 				$idList[] = $attribute['Attribute']['event_id'];
 			}
@@ -2631,13 +2631,13 @@ class EventsController extends AppController {
 					),
 		));
 		$events = $this->paginate();
-		foreach ($events as $k => &$event) {
+		foreach ($events as $k => $event) {
 			$orgs = array();
 			foreach ($event['ShadowAttribute'] as $sa) {
 				if (!in_array($sa['org_id'], $orgs)) $orgs[] = $sa['org_id'];
 			}
 			$events[$k]['orgArray'] = $orgs;
-			$event['Event']['proposal_count'] = count($event['ShadowAttribute']);
+			$events[$k]['Event']['proposal_count'] = count($event['ShadowAttribute']);
 		}
 		$this->set('events', $events);
 		$this->set('eventDescriptions', $this->Event->fieldDescriptions);
@@ -2781,12 +2781,12 @@ class EventsController extends AppController {
 			App::uses('ComplexTypeTool', 'Tools');
 			$complexTypeTool = new ComplexTypeTool();
 			$resultArray = $complexTypeTool->checkComplexRouter($this->request->data['Attribute']['value'], 'FreeText');
-			foreach ($resultArray as &$r) {
+			foreach ($resultArray as $key => $r) {
 				$temp = array();
 				foreach ($r['types'] as $type) {
 					$temp[$type] = $type;
 				}
-				$r['types'] = $temp;
+				$resultArray[$key]['types'] = $temp;
 			}
 
 			// remove all duplicates
@@ -2795,13 +2795,13 @@ class EventsController extends AppController {
 					if (isset($resultArray[$i]) && $v == $resultArray[$i]) unset($resultArray[$k]);
 				}
 			}
-			foreach ($resultArray as &$result) {
+			foreach ($resultArray as $key => $result) {
 				$options = array(
 					'conditions' => array('OR' => array('Attribute.value1' => $result['value'], 'Attribute.value2' => $result['value'])),
 					'fields' => array('Attribute.type', 'Attribute.category', 'Attribute.value', 'Attribute.comment'),
 					'order' => false
 				);
-				$result['related'] = $this->Event->Attribute->fetchAttributes($this->Auth->user(), $options);
+				$resultArray[$key]['related'] = $this->Event->Attribute->fetchAttributes($this->Auth->user(), $options);
 			}
 			$resultArray = array_values($resultArray);
 			$typeCategoryMapping = array();
@@ -3482,7 +3482,7 @@ class EventsController extends AppController {
 			$current_event_id = count($json['nodes'])-1;
 		}
 		$relatedEvents = array();
-		if (!empty($event[0]['RelatedEvent'])) foreach ($event[0]['RelatedEvent'] as &$re) {
+		if (!empty($event[0]['RelatedEvent'])) foreach ($event[0]['RelatedEvent'] as $re) {
 			$relatedEvents[$re['Event']['id']] = $re;
 		}
 		foreach ($event[0]['Attribute'] as $k => $att) {
@@ -3642,23 +3642,22 @@ class EventsController extends AppController {
 		if (empty($attribute)) throw new MethodNotAllowedException('Attribute not found or you are not authorised to see it.');
 		if ($this->request->is('ajax')) {
 			$this->loadModel('Module');
-			$modules = $this->Module->getEnabledModules();
-			if (!is_array($modules) || empty($modules)) throw new MethodNotAllowedException('No valid enrichment options found for this attribute.');
-			$temp = array();
-			foreach ($modules['modules'] as &$module) {
+			$enabledModules = $this->Module->getEnabledModules();
+			if (!is_array($enabledModules) || empty($enabledModules)) throw new MethodNotAllowedException('No valid enrichment options found for this attribute.');
+			$modules = array();
+			foreach ($enabledModules['modules'] as $module) {
 				if (in_array($attribute[0]['Attribute']['type'], $module['mispattributes']['input'])) {
-					$temp[] = array('name' => $module['name'], 'description' => $module['meta']['description']);
+					$modules[] = array('name' => $module['name'], 'description' => $module['meta']['description']);
 				}
 			}
-			$modules = &$temp;
 			foreach (array('attribute_id', 'modules') as $viewVar) $this->set($viewVar, $$viewVar);
 			$this->render('ajax/enrichmentChoice');
 		} else {
 			$this->loadModel('Module');
-			$modules = $this->Module->getEnabledModules();
-			if (!is_array($modules) || empty($modules)) throw new MethodNotAllowedException('No valid enrichment options found for this attribute.');
+			$enabledModules = $this->Module->getEnabledModules();
+			if (!is_array($enabledModules) || empty($enabledModules)) throw new MethodNotAllowedException('No valid enrichment options found for this attribute.');
 			$options = array();
-			foreach ($modules['modules'] as &$temp) {
+			foreach ($enabledModules['modules'] as $temp) {
 				if ($temp['name'] == $module) {
 					if (isset($temp['meta']['config'])) {
 						foreach ($temp['meta']['config'] as $conf) {
@@ -3687,20 +3686,20 @@ class EventsController extends AppController {
 					$typeCategoryMapping[$type][$k] = $k;
 				}
 			}
-			foreach ($resultArray as &$result) {
+			foreach ($resultArray as $key => $result) {
 				$options = array(
 						'conditions' => array('OR' => array('Attribute.value1' => $result['value'], 'Attribute.value2' => $result['value'])),
 						'fields' => array('Attribute.type', 'Attribute.category', 'Attribute.value', 'Attribute.comment'),
 						'order' => false
 				);
-				$result['related'] = $this->Event->Attribute->fetchAttributes($this->Auth->user(), $options);
+				$resultArray[$key]['related'] = $this->Event->Attribute->fetchAttributes($this->Auth->user(), $options);
 				if (isset($result['data'])) {
 					App::uses('FileAccessTool', 'Tools');
 					$fileAccessTool = new FileAccessTool();
 					$tmpdir = Configure::read('MISP.tmpdir') ? Configure::read('MISP.tmpdir') : '/tmp';
 					$tempFile = $fileAccessTool->createTempFile($tmpdir, $prefix = 'MISP');
 					$fileAccessTool->writeToFile($tempFile, $result['data']);
-					$result['data'] = basename($tempFile) . '|' . filesize($tempFile);
+					$resultArray[$key]['data'] = basename($tempFile) . '|' . filesize($tempFile);
 				}
 			}
 
@@ -3783,13 +3782,13 @@ class EventsController extends AppController {
 							$typeCategoryMapping[$type][$k] = $k;
 						}
 					}
-					foreach ($resultArray as &$result) {
+					foreach ($resultArray as $key => $result) {
 						$options = array(
 								'conditions' => array('OR' => array('Attribute.value1' => $result['value'], 'Attribute.value2' => $result['value'])),
 								'fields' => array('Attribute.type', 'Attribute.category', 'Attribute.value', 'Attribute.comment'),
 								'order' => false
 						);
-						$result['related'] = $this->Event->Attribute->fetchAttributes($this->Auth->user(), $options);
+						$resultArray[$key]['related'] = $this->Event->Attribute->fetchAttributes($this->Auth->user(), $options);
 					}
 					$this->set('event', array('Event' => array('id' => $eventId)));
 					$this->set('resultArray', $resultArray);

--- a/app/Controller/NewsController.php
+++ b/app/Controller/NewsController.php
@@ -26,9 +26,9 @@ class NewsController extends AppController {
 				'conditions' => array('User.id' => $this->Auth->user('id')),
 				'fields' => array('User.newsread')
 		));
-		foreach ($newsItems as &$item) {
-			if ($item['News']['date_created'] > $currentUser['User']['newsread']) $item['News']['new'] = true;
-			else $item['News']['new'] = false;
+		foreach ($newsItems as $key => $item) {
+			if ($item['News']['date_created'] > $currentUser['User']['newsread']) $newsItems[$key]['News']['new'] = true;
+			else $newsItems[$key]['News']['new'] = false;
 		}
 		$this->User->id = $this->Auth->user('id');
 		$this->User->saveField('newsread', time());

--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -658,7 +658,7 @@ class ServersController extends AppController {
 					else $tempArray['general'][] = $result;
 				}
 			}
-			$finalSettings = &$tempArray;
+			$finalSettings = $tempArray;
 			// Diagnostics portion
 			$diagnostic_errors = 0;
 			App::uses('File', 'Utility');
@@ -697,10 +697,10 @@ class ServersController extends AppController {
 
 				);
 
-				foreach ($phpSettings as $setting => &$settingArray) {
-					$settingArray['value'] = ini_get($setting);
-					if ($settingArray['unit']) $settingArray['value'] = intval(rtrim($settingArray['value'], $settingArray['unit']));
-					else $settingArray['value'] = intval($settingArray['value']);
+				foreach ($phpSettings as $setting => $settingArray) {
+					$phpSettings[$setting]['value'] = ini_get($setting);
+					if ($settingArray['unit']) $phpSettings[$setting]['value'] = intval(rtrim($settingArray['value'], $settingArray['unit']));
+					else $phpSettings[$setting]['value'] = intval($settingArray['value']);
 				}
 				$this->set('phpSettings', $phpSettings);
 
@@ -748,8 +748,8 @@ class ServersController extends AppController {
 				$this->set('worker_array', array());
 			}
 			if ($tab == 'download') {
-				foreach ($dumpResults as &$dr) {
-					unset($dr['description']);
+				foreach ($dumpResults as $key => $dr) {
+					unset($dumpResults[$key]['description']);
 				}
 				$dump = array('gpgStatus' => $gpgErrors[$gpgStatus], 'proxyStatus' => $proxyErrors[$proxyStatus], 'zmqStatus' => $zmqStatus, 'stix' => $stix, 'writeableDirs' => $writeableDirs, 'writeableFiles' => $writeableFiles,'finalSettings' => $dumpResults);
 				$this->response->body(json_encode($dump, JSON_PRETTY_PRINT));

--- a/app/Controller/ShadowAttributesController.php
+++ b/app/Controller/ShadowAttributesController.php
@@ -302,7 +302,7 @@ class ShadowAttributesController extends AppController {
 			if (isset($this->request->data['request'])) $this->request->data = $this->request->data['request'];
 			// rearrange the request in case someone didn't RTFM
 			$invalidNames = array('Attribute', 'Proposal');
-			foreach ($invalidNames as &$iN) {
+			foreach ($invalidNames as $iN) {
 				if (isset($this->request->data[$iN]) && !isset($this->request->data['ShadowAttribute'])) {
 					$this->request->data['ShadowAttribute'] = $this->request->data[$iN];
 				}
@@ -625,7 +625,7 @@ class ShadowAttributesController extends AppController {
 			if (isset($this->request->data['request'])) $this->request->data = $this->request->data['request'];
 			// rearrange the request in case someone didn't RTFM
 			$invalidNames = array('Attribute', 'Proposal');
-			foreach ($invalidNames as &$iN) if (isset($this->request->data[$iN]) && !isset($this->request->data['ShadowAttribute'])) $this->request->data['ShadowAttribute'] = $this->request->data[$iN];
+			foreach ($invalidNames as $iN) if (isset($this->request->data[$iN]) && !isset($this->request->data['ShadowAttribute'])) $this->request->data['ShadowAttribute'] = $this->request->data[$iN];
 			if ($attachment) {
 				$fields = array(
 						'static' => array('old_id' => 'Attribute.id', 'uuid' => 'Attribute.uuid', 'event_id' => 'Attribute.event_id', 'event_uuid' => 'Event.uuid', 'event_org_id' => 'Event.orgc_id', 'category' => 'Attribute.category', 'type' => 'Attribute.type'),
@@ -853,10 +853,9 @@ class ShadowAttributesController extends AppController {
 					'EventOrg' => array('fields' => array('uuid', 'name')),
 				)
 		));
-		foreach ($temp as &$t) {
+		foreach ($temp as $key => $t) {
 			if ($this->ShadowAttribute->typeIsAttachment($t['ShadowAttribute']['type'])) {
-				$encodedFile = $this->ShadowAttribute->base64EncodeAttachment($t['ShadowAttribute']);
-				$t['ShadowAttribute']['data'] = $encodedFile;
+				$temp[$key]['ShadowAttribute']['data'] = $this->ShadowAttribute->base64EncodeAttachment($t['ShadowAttribute']);
 			}
 		}
 		if ($temp == null) {
@@ -890,10 +889,9 @@ class ShadowAttributesController extends AppController {
 					),
 			));
 			if (empty($temp)) continue;
-			foreach ($temp as &$t) {
+			foreach ($temp as $key => $t) {
 				if ($this->ShadowAttribute->typeIsAttachment($t['ShadowAttribute']['type'])) {
-					$encodedFile = $this->ShadowAttribute->base64EncodeAttachment($t['ShadowAttribute']);
-					$t['ShadowAttribute']['data'] = $encodedFile;
+					$temp[$key]['ShadowAttribute']['data'] = $this->ShadowAttribute->base64EncodeAttachment($t['ShadowAttribute']);
 				}
 			}
 			$result = array_merge($result, $temp);

--- a/app/Controller/SharingGroupsController.php
+++ b/app/Controller/SharingGroupsController.php
@@ -197,8 +197,8 @@ class SharingGroupsController extends AppController {
 		$this->SharingGroup->read();
 		$sg = $this->SharingGroup->data;
 		if (isset($sg['SharingGroupServer'])) {
-			foreach ($sg['SharingGroupServer'] as &$sgs) {
-				if ($sgs['server_id'] == 0) $sgs['Server'] = array('name' => 'Local instance', 'url' => Configure::read('MISP.baseurl'));
+			foreach ($sg['SharingGroupServer'] as $key => $sgs) {
+				if ($sgs['server_id'] == 0) $sg['SharingGroupServer'][$key]['Server'] = array('name' => 'Local instance', 'url' => Configure::read('MISP.baseurl'));
 			}
 		}
 		if ($sg['SharingGroup']['sync_user_id']) {

--- a/app/Controller/TagsController.php
+++ b/app/Controller/TagsController.php
@@ -32,7 +32,7 @@ class TagsController extends AppController {
 		$this->loadModel('Taxonomy');
 		$taxonomies = $this->Taxonomy->listTaxonomies(array('full' => false, 'enabled' => true));
 		$taxonomyNamespaces = array();
-		if (!empty($taxonomies)) foreach ($taxonomies as &$taxonomy) $taxonomyNamespaces[$taxonomy['namespace']] = $taxonomy;
+		if (!empty($taxonomies)) foreach ($taxonomies as $taxonomy) $taxonomyNamespaces[$taxonomy['namespace']] = $taxonomy;
 		$taxonomyTags = array();
 		$this->Event->recursive = -1;
 		if ($favouritesOnly) {
@@ -44,9 +44,9 @@ class TagsController extends AppController {
 			$this->paginate['conditions']['AND']['Tag.id'] = $tag_id_list;
 		}
 		$paginated = $this->paginate();
-		foreach ($paginated as $k => &$tag) {
+		foreach ($paginated as $k => $tag) {
 			$eventIDs = array();
-			if (empty($tag['EventTag'])) $tag['Tag']['count'] = 0;
+			if (empty($tag['EventTag'])) $paginated[$k]['Tag']['count'] = 0;
 			else {
 				foreach ($tag['EventTag'] as $eventTag) {
 					$eventIDs[] = $eventTag['event_id'];
@@ -65,28 +65,28 @@ class TagsController extends AppController {
 					'fields' => array('Event.id', 'Event.distribution', 'Event.orgc_id'),
 					'conditions' => $conditions
 				));
-				$tag['Tag']['count'] = count($events);
+				$paginated[$k]['Tag']['count'] = count($events);
 			}
-			unset($tag['EventTag']);
+			unset($paginated[$k]['EventTag']);
 			if (!empty($tag['FavouriteTag'])) {
-				foreach ($tag['FavouriteTag'] as &$ft) if ($ft['user_id'] == $this->Auth->user('id')) $tag['Tag']['favourite'] = true;
-				if (!isset($tag['Tag']['favourite'])) $tag['Tag']['favourite'] = false;
-			} else $tag['Tag']['favourite'] = false;
-			unset($tag['FavouriteTag']);
+				foreach ($tag['FavouriteTag'] as $ft) if ($ft['user_id'] == $this->Auth->user('id')) $paginated[$k]['Tag']['favourite'] = true;
+				if (!isset($tag['Tag']['favourite'])) $paginated[$k]['Tag']['favourite'] = false;
+			} else $paginated[$k]['Tag']['favourite'] = false;
+			unset($paginated[$k]['FavouriteTag']);
 			if (!empty($taxonomyNamespaces)) {
 				$taxonomyNamespaceArrayKeys = array_keys($taxonomyNamespaces);
-				foreach ($taxonomyNamespaceArrayKeys as &$tns) {
+				foreach ($taxonomyNamespaceArrayKeys as $tns) {
 					if (substr(strtoupper($tag['Tag']['name']), 0, strlen($tns)) === strtoupper($tns)) {
-						$tag['Tag']['Taxonomy'] = $taxonomyNamespaces[$tns];
+						$paginated[$k]['Tag']['Taxonomy'] = $taxonomyNamespaces[$tns];
 						if (!isset($taxonomyTags[$tns])) $taxonomyTags[$tns] = $this->Taxonomy->getTaxonomyTags($taxonomyNamespaces[$tns]['id'], true);
-						$tag['Tag']['Taxonomy']['expanded'] = $taxonomyTags[$tns][strtoupper($tag['Tag']['name'])];
+						$paginated[$k]['Tag']['Taxonomy']['expanded'] = $taxonomyTags[$tns][strtoupper($tag['Tag']['name'])];
 					}
 				}
 			}
 		}
 		if ($this->_isRest()) {
-			foreach ($paginated as &$tag) {
-				$tag = $tag['Tag'];
+			foreach ($paginated as $key => $tag) {
+				$paginated[$key] = $tag['Tag'];
 			}
 			$this->set('Tag', $paginated);
 			$this->set('_serialize', array('Tag'));
@@ -125,7 +125,7 @@ class TagsController extends AppController {
 		));
 		$orgs = array(0 => 'Unrestricted');
 		if (!empty($temp)) {
-			foreach ($temp as &$org) {
+			foreach ($temp as $org) {
 				$orgs[$org['Organisation']['id']] = $org['Organisation']['name'];
 			}
 		}
@@ -176,7 +176,7 @@ class TagsController extends AppController {
 		));
 		$orgs = array(0 => 'Unrestricted');
 		if (!empty($temp)) {
-			foreach ($temp as &$org) {
+			foreach ($temp as $org) {
 				$orgs[$org['Organisation']['id']] = $org['Organisation']['name'];
 			}
 		}
@@ -293,7 +293,7 @@ class TagsController extends AppController {
 		$favourites = $this->Tag->FavouriteTag->find('count', array('conditions' => array('FavouriteTag.user_id' => $this->Auth->user('id'))));
 		$this->loadModel('Taxonomy');
 		$options = $this->Taxonomy->find('list', array('conditions' => array('enabled' => true), 'fields' => array('namespace'), 'order' => array('Taxonomy.namespace ASC')));
-		foreach ($options as $k => &$option) {
+		foreach ($options as $k => $option) {
 			$tags = $this->Taxonomy->getTaxonomyTags($k, false, true);
 			if (empty($tags)) unset($options[$k]);
 		}
@@ -323,7 +323,7 @@ class TagsController extends AppController {
 		} else {
 			$taxonomies = $this->Taxonomy->getTaxonomy($taxonomy_id);
 			$options = array();
-			foreach ($taxonomies['entries'] as &$entry) {
+			foreach ($taxonomies['entries'] as $entry) {
 				if (!empty($entry['existing_tag']['Tag'])) {
 					$options[$entry['existing_tag']['Tag']['id']] = $entry['existing_tag']['Tag']['name'];
 					$expanded[$entry['existing_tag']['Tag']['id']] = $entry['expanded'];
@@ -386,11 +386,11 @@ class TagsController extends AppController {
 			arsort($taxonomies);
 		}
 		if ($percentage === 'true') {
-			foreach ($tags as $tag => &$count) {
-				$count = round(100 * $count / $totalCount, 3) . '%';
+			foreach ($tags as $tag => $count) {
+				$tags[$tag] = round(100 * $count / $totalCount, 3) . '%';
 			}
-			foreach ($taxonomies as $taxonomy => &$count) {
-				$count = round(100 * $count / $totalCount, 3) . '%';
+			foreach ($taxonomies as $taxonomy => $count) {
+				$taxonomies[$taxonomy] = round(100 * $count / $totalCount, 3) . '%';
 			}
 		}
 		$results = array('tags' => $tags, 'taxonomies' => $taxonomies);

--- a/app/Controller/TaxonomiesController.php
+++ b/app/Controller/TaxonomiesController.php
@@ -26,14 +26,14 @@ class TaxonomiesController extends AppController {
 		$this->paginate['recursive'] = -1;
 		$taxonomies = $this->paginate();
 		$this->loadModel('Tag');
-		foreach ($taxonomies as &$taxonomy) {
+		foreach ($taxonomies as $key => $taxonomy) {
 			$total = 0;
-			foreach ($taxonomy['TaxonomyPredicate'] as &$predicate) {
+			foreach ($taxonomy['TaxonomyPredicate'] as $predicate) {
 				$total += empty($predicate['TaxonomyEntry']) ? 1 : count($predicate['TaxonomyEntry']);
 			}
-			$taxonomy['total_count'] = $total;
-			$taxonomy['current_count'] = $this->Tag->find('count', array('conditions' => array('lower(Tag.name) LIKE ' => strtolower($taxonomy['Taxonomy']['namespace']) . ':%')));
-			unset($taxonomy['TaxonomyPredicate']);
+			$taxonomies[$key]['total_count'] = $total;
+			$taxonomies[$key]['current_count'] = $this->Tag->find('count', array('conditions' => array('lower(Tag.name) LIKE ' => strtolower($taxonomy['Taxonomy']['namespace']) . ':%')));
+			unset($taxonomies[$key]['TaxonomyPredicate']);
 		}
 		$this->set('taxonomies', $taxonomies);
 	}
@@ -121,7 +121,7 @@ class TaxonomiesController extends AppController {
 		$successes = 0;
 		if (!empty($result)) {
 			if (isset($result['success'])) {
-				foreach ($result['success'] as $id => &$success) {
+				foreach ($result['success'] as $id => $success) {
 					if (isset($success['old'])) $change = $success['namespace'] . ': updated from v' . $success['old'] . ' to v' . $success['new'];
 					else $change = $success['namespace'] . ' v' . $success['new'] . ' installed';
 					$this->Log->create();
@@ -139,7 +139,7 @@ class TaxonomiesController extends AppController {
 				}
 			}
 			if (isset($result['fails'])) {
-				foreach ($result['fails'] as $id => &$fail) {
+				foreach ($result['fails'] as $id => $fail) {
 					$this->Log->create();
 					$this->Log->save(array(
 							'org' => $this->Auth->user('Organisation')['name'],

--- a/app/Controller/TemplateElementsController.php
+++ b/app/Controller/TemplateElementsController.php
@@ -72,10 +72,10 @@ class TemplateElementsController extends AppController {
 				$this->set('attrDescriptions', $this->Attribute->fieldDescriptions);
 				$this->set('typeDefinitions', $this->Attribute->typeDefinitions);
 				$categoryDefinitions = $this->Attribute->categoryDefinitions;
-				foreach ($categoryDefinitions as $k => &$catDef) {
+				foreach ($categoryDefinitions as $k => $catDef) {
 					foreach ($catDef['types'] as $l => $t) {
 						if ($t == 'malware-sample' || $t == 'attachment') {
-							unset($catDef['types'][$l]);
+							unset($categoryDefinitions[$k]['types'][$l]);
 						}
 					}
 				}
@@ -156,10 +156,10 @@ class TemplateElementsController extends AppController {
 				$categories = $this->_arrayToValuesIndexArray($categories);
 				$this->set('categories', compact('categories'));
 				$categoryDefinitions = $this->Attribute->categoryDefinitions;
-				foreach ($categoryDefinitions as $k => &$catDef) {
+				foreach ($categoryDefinitions as $k => $catDef) {
 					foreach ($catDef['types'] as $l => $t) {
 						if ($t == 'malware-sample' || $t == 'attachment') {
-							unset($catDef['types'][$l]);
+							unset($categoryDefinitions[$k]['types'][$l]);
 						}
 					}
 				}

--- a/app/Controller/TemplatesController.php
+++ b/app/Controller/TemplatesController.php
@@ -166,8 +166,8 @@ class TemplatesController extends AppController {
 		$this->autoRender = false;
 		$this->request->onlyAllow('ajax');
 		$orderedElements = $this->request->data;
-		foreach ($orderedElements as &$e) {
-			$e = ltrim($e, 'id_');
+		foreach ($orderedElements as $key => $e) {
+			$orderedElements[$key] = ltrim($e, 'id_');
 		}
 		$extractedIds = array();
 		foreach ($orderedElements as $element) $extractedIds[] = $element;
@@ -187,11 +187,11 @@ class TemplatesController extends AppController {
 		if (count($elements) != count($orderedElements)) return new CakeResponse(array('body'=> json_encode(array('saved' => false, 'errors' => 'Incomplete template element list passed as argument. Expecting ' . count($elements) . ' elements, only received positions for ' . count($orderedElements) . '.')),'status'=>200));
 		$template_id = $elements[0]['TemplateElement']['template_id'];
 
-		foreach ($elements as &$e) {
+		foreach ($elements as $key => $e) {
 			if ($template_id !== $e['TemplateElement']['template_id']) return new CakeResponse(array('body'=> json_encode(array('saved' => false, 'errors' => 'Cannot sort template elements belonging to separate templates. You should never see this message during legitimate use.')),'status'=>200));
 			foreach ($orderedElements as $k => $orderedElement) {
 				if ($orderedElement == $e['TemplateElement']['id']) {
-					$e['TemplateElement']['position'] = $k+1;
+					$elements[$key]['TemplateElement']['position'] = $k+1;
 				}
 			}
 		}
@@ -326,11 +326,11 @@ class TemplatesController extends AppController {
 				$attributes = json_decode($this->request->data['Template']['attributes'], true);
 				$this->loadModel('Attribute');
 				$fails = 0;
-				foreach ($attributes as $k => &$attribute) {
+				foreach ($attributes as $k => $attribute) {
 					if (isset($attribute['data']) && $this->Template->checkFilename($attribute['data'])) {
 						$file = new File(APP . 'tmp/files/' . $attribute['data']);
 						$content = $file->read();
-						$attribute['data'] = base64_encode($content);
+						$attributes[$k]['data'] = base64_encode($content);
 						$file->delete();
 					}
 					$this->Attribute->create();

--- a/app/Controller/ThreadsController.php
+++ b/app/Controller/ThreadsController.php
@@ -65,9 +65,9 @@ class ThreadsController extends AppController {
 		);
 		$posts = $this->paginate('Post');
 		if (!$this->_isSiteAdmin()) {
-			foreach ($posts as &$post) {
+			foreach ($posts as $key => $post) {
 				if ($post['User']['org_id'] != $this->Auth->user('org_id')) {
-					$post['User']['email'] = 'User ' . $post['User']['id'] . ' (' . $post['User']['org_id'] . ')';
+					$posts[$key]['User']['email'] = 'User ' . $post['User']['id'] . ' (' . $post['User']['org_id'] . ')';
 				}
 			}
 		}
@@ -156,9 +156,9 @@ class ThreadsController extends AppController {
 			);
 			$posts = $this->paginate('Post');
 			if (!$this->_isSiteAdmin()) {
-				foreach ($posts as &$post) {
+				foreach ($posts as $key => $post) {
 					if ($post['User']['org_id'] != $this->Auth->user('org_id')) {
-						$post['User']['email'] = 'User ' . $post['User']['id'] . ' (' . $post['User']['org_id'] . ')';
+						$posts[$key]['User']['email'] = 'User ' . $post['User']['id'] . ' (' . $post['User']['org_id'] . ')';
 					}
 				}
 			}
@@ -226,9 +226,9 @@ class ThreadsController extends AppController {
 		);
 		$threadsBeforeEmailRemoval = $this->paginate();
 		if (!$this->_isSiteAdmin()) {
-			foreach ($threadsBeforeEmailRemoval as &$thread) {
-				if (empty($thread['Post'][0]['User']['org_id'])) $thread['Post'][0]['User']['email'] = 'Deactivated user';
-				else if ($thread['Post'][0]['User']['org_id'] != $this->Auth->user('org_id')) $thread['Post'][0]['User']['email'] = 'User ' . $thread['Post'][0]['User']['id'] . " (" . $thread['Post'][0]['User']['Organisation']['name'] . ")";
+			foreach ($threadsBeforeEmailRemoval as $key => $thread) {
+				if (empty($thread['Post'][0]['User']['org_id'])) $threadsBeforeEmailRemoval[$key]['Post'][0]['User']['email'] = 'Deactivated user';
+				else if ($thread['Post'][0]['User']['org_id'] != $this->Auth->user('org_id')) $threadsBeforeEmailRemoval[$key]['Post'][0]['User']['email'] = 'User ' . $thread['Post'][0]['User']['id'] . " (" . $thread['Post'][0]['User']['Organisation']['name'] . ")";
 			}
 		}
 		$this->set('threads', $threadsBeforeEmailRemoval);

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -769,10 +769,11 @@ class UsersController extends AppController {
 			}
 		}
 		$max = 1;
-		foreach ($data as &$d) {
+		foreach ($data as $key => $d) {
 			foreach ($d['data'] as $t) {
 				$d['total'] += $t;
 			}
+			$data[$key]['total'] = $d['total'];
 			if ($d['total'] > $max) $max = $d['total'];
 		}
 		$this->set('data', $data);

--- a/app/Controller/WarninglistsController.php
+++ b/app/Controller/WarninglistsController.php
@@ -44,7 +44,7 @@ class WarninglistsController extends AppController {
 		$successes = 0;
 		if (!empty($result)) {
 			if (isset($result['success'])) {
-				foreach ($result['success'] as $id => &$success) {
+				foreach ($result['success'] as $id => $success) {
 					if (isset($success['old'])) $change = $success['name'] . ': updated from v' . $success['old'] . ' to v' . $success['new'];
 					else $change = $success['name'] . ' v' . $success['new'] . ' installed';
 					$this->Log->create();
@@ -62,7 +62,7 @@ class WarninglistsController extends AppController {
 				}
 			}
 			if (isset($result['fails'])) {
-				foreach ($result['fails'] as $id => &$fail) {
+				foreach ($result['fails'] as $id => $fail) {
 					$this->Log->create();
 					$this->Log->save(array(
 							'org' => $this->Auth->user('Organisation')['name'],

--- a/app/Lib/Tools/ColourPaletteTool.php
+++ b/app/Lib/Tools/ColourPaletteTool.php
@@ -49,7 +49,7 @@ class ColourPaletteTool {
 
 	function convertToHex($channels) {
 		$colour = '#';
-		foreach ($channels as &$channel) {
+		foreach ($channels as $channel) {
 			$channel = strval(dechex(round($channel*255)));
 			if (strlen($channel) == 1) $channel = '0' . $channel;
 			$colour .= $channel;

--- a/app/Lib/Tools/ComplexTypeTool.php
+++ b/app/Lib/Tools/ComplexTypeTool.php
@@ -68,18 +68,20 @@ class ComplexTypeTool {
 		return array('type' => 'other', 'value' => $input);
 	}
 
-	private function __returnOddElements(&$array) {
-		foreach ($array as $k => &$v) if ($k % 2 != 1) unset($array[$k]);
+	private function __returnOddElements($array) {
+		foreach ($array as $k => $v) if ($k % 2 != 1) unset($array[$k]);
 		return array_values($array);
 	}
 
 	public function checkFreeText($input) {
 		$iocArray = preg_split("/\r\n|\n|\r|\s|\s+|,|;/", $input);
 		$quotedText = explode('"', $input);
-		foreach ($quotedText as $k => &$temp) {
+		foreach ($quotedText as $k => $temp) {
 			$temp = trim($temp);
 			if (empty($temp)) {
 				unset($quotedText[$k]);
+			} else {
+				$quotedText[$k] = $temp;
 			}
 		}
 		$iocArray = array_merge($iocArray, $this->__returnOddElements($quotedText));
@@ -116,7 +118,7 @@ class ComplexTypeTool {
 			$compositeParts = explode('|', $input);
 			if (count($compositeParts) == 2) {
 				if ($this->__resolveFilename($compositeParts[0])) {
-					foreach ($this->__hexHashTypes as $k => &$v) {
+					foreach ($this->__hexHashTypes as $k => $v) {
 						if (strlen($compositeParts[1]) == $k && preg_match("#[0-9a-f]{" . $k . "}$#i", $compositeParts[1])) return array('types' => $v['composite'], 'to_ids' => true, 'default_type' => $v['composite'][0]);
 					}
 					if (preg_match('#^[0-9]+:.+:.+$#', $compositeParts[1])) return array('types' => array('ssdeep'), 'to_ids' => true, 'default_type' => 'filename|ssdeep');
@@ -125,7 +127,7 @@ class ComplexTypeTool {
 		}
 
 		// check for hashes
-		foreach ($this->__hexHashTypes as $k => &$v) {
+		foreach ($this->__hexHashTypes as $k => $v) {
 			if (strlen($input) == $k && preg_match("#[0-9a-f]{" . $k . "}$#i", $input)) return array('types' => $v['single'], 'to_ids' => true, 'default_type' => $v['single'][0]);
 		}
 		if (preg_match('#^[0-9]+:.+:.+$#', $input)) return array('types' => array('ssdeep'), 'to_ids' => true, 'default_type' => 'ssdeep');

--- a/app/Lib/Tools/CustomPaginationTool.php
+++ b/app/Lib/Tools/CustomPaginationTool.php
@@ -1,7 +1,7 @@
 <?php
 class CustomPaginationTool {
 
-	function createPaginationRules(&$items, $options, $model, $sort = 'id') {
+	function createPaginationRules($items, $options, $model, $sort = 'id') {
 		$params = array(
 			'model' => $model,
 			'current' => 1,

--- a/app/Lib/Tools/FinancialTool.php
+++ b/app/Lib/Tools/FinancialTool.php
@@ -131,7 +131,7 @@ class FinancialTool {
 			unset($numberArray[count($numberArray) - 1]);
 			$numberArray = array_reverse($numberArray);
 			$sum = 0;
-			foreach ($numberArray as $k => &$number) {
+			foreach ($numberArray as $k => $number) {
 				$number = intval($number);
 				if ($k%2 == 0) $number *= 2;
 				if ($number > 9) $number -=9;

--- a/app/Lib/Tools/JSONConverterTool.php
+++ b/app/Lib/Tools/JSONConverterTool.php
@@ -63,20 +63,20 @@ class JSONConverterTool {
 				if (!is_array($temp)) {
 					$resultArray[] = '[' . $k .']' . $temp;
 				} else {
-					foreach ($temp as &$t) $resultArray[] = '[' . $k . ']' . $t;
+					foreach ($temp as $t) $resultArray[] = '[' . $k . ']' . $t;
 				}
 			}
 		} else $resultArray = ': ' . $array . PHP_EOL;
 		if ($root) {
 			$text = '';
-			foreach ($resultArray as &$r) $text .= $r;
+			foreach ($resultArray as $r) $text .= $r;
 			return $text;
 		} else return $resultArray;
 	}
 
 	public function eventCollection2Format($events, $isSiteAdmin=false) {
 		$results = array();
-		foreach ($events as &$event) $results[] = $this->event2JSON($event, $isSiteAdmin);
+		foreach ($events as $event) $results[] = $this->event2JSON($event, $isSiteAdmin);
 		return implode(',' . PHP_EOL, $results);
 	}
 

--- a/app/Lib/Tools/PubSubTool.php
+++ b/app/Lib/Tools/PubSubTool.php
@@ -10,9 +10,9 @@ class PubSubTool {
 				'redis_namespace' => 'mispq',
 				'port' => '50000',
 		);
-		foreach ($settings as $key => &$setting) {
+		foreach ($settings as $key => $setting) {
 			$temp = Configure::read('Plugin.ZeroMQ_' . $key);
-			if ($temp) $setting = $temp;
+			if ($temp) $settings[$key] = $temp;
 		}
 		$settingsFile = new File(APP . 'files' . DS . 'scripts' . DS . 'mispzmq' . DS . 'settings.json', true, 0644);
 		$settingsFile->write(json_encode($settings, true));

--- a/app/Lib/Tools/RequestRearrangeTool.php
+++ b/app/Lib/Tools/RequestRearrangeTool.php
@@ -1,6 +1,6 @@
 <?php
 class RequestRearrangeTool {
-	public function rearrangeArray(&$data, $rules) {
+	public function rearrangeArray($data, $rules) {
 		foreach ($rules as $from => $to) {
 			if (isset($data[$from])) {
 				if ($to !== false) {

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -79,7 +79,7 @@ class AppModel extends Model {
 		$this->Feed = ClassRegistry::init('Feed');
 		$this->Log = ClassRegistry::init('Log');
 		$feedNames = array();
-		foreach ($feeds as &$feed) $feedNames[] = $feed['name'];
+		foreach ($feeds as $feed) $feedNames[] = $feed['name'];
 		$feedNames = implode(', ', $feedNames);
 		$result = $this->Feed->addDefaultFeeds($feeds);
 		$this->Log->create();

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -1502,7 +1502,7 @@ class Attribute extends AppModel {
 	}
 
 
-	public function checkTemplateAttributes($template, &$data, $event_id) {
+	public function checkTemplateAttributes($template, $data, $event_id) {
 		$result = array();
 		$errors = array();
 		$attributes = array();

--- a/app/Model/Behavior/TrimBehavior.php
+++ b/app/Model/Behavior/TrimBehavior.php
@@ -39,9 +39,9 @@ class TrimBehavior extends ModelBehavior {
  * @param unknown_type $array
  */
 	public function trimStringFields(Model $Model) {
-		foreach ($Model->data[$Model->name] as &$field) {
+		foreach ($Model->data[$Model->name] as $key => $field) {
 			if (is_string($field)) {
-				$field = trim($field);
+				$Model->data[$Model->name][$key] = trim($field);
 			}
 		}
 		return true;

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -56,7 +56,7 @@ class Feed extends AppModel {
 			'recursive' => -1,
 			'fields' => array('Event.id', 'Event.uuid', 'Event.timestamp')
 		));
-		foreach ($events as &$event) {
+		foreach ($events as $event) {
 			if ($event['Event']['timestamp'] < $manifest[$event['Event']['uuid']]['timestamp']) $result['edit'][] = array('uuid' => $event['Event']['uuid'], 'id' => $event['Event']['id']);
 			unset($manifest[$event['Event']['uuid']]);
 		}
@@ -171,7 +171,7 @@ class Feed extends AppModel {
 		if (isset($feed['Feed']['rules']) && !empty($feed['Feed']['rules'])) {
 			$filterRules = json_decode($feed['Feed']['rules'], true);
 		}
-		foreach ($events as $k => &$event) {
+		foreach ($events as $k => $event) {
 			if (isset($filterRules['orgs']['OR']) && !empty($filterRules['orgs']['OR']) && !in_array($event['Orgc']['name'], $filterRules['orgs']['OR'])) {
 				unset($events[$k]);
 				continue;
@@ -183,7 +183,7 @@ class Feed extends AppModel {
 			if (isset($filterRules['tags']['OR']) && !empty($filterRules['tags']['OR'])) {
 				if (!isset($event['Tag']) || empty($event['Tag'])) unset($events[$k]);
 				$found = false;
-				foreach ($event['Tag'] as &$tag) {
+				foreach ($event['Tag'] as $tag) {
 					foreach ($filterRules['tags']['OR'] as $filterTag) {
 						if (strpos(strtolower($tag['name']), strtolower($filterTag))) $found = true;
 					}
@@ -196,7 +196,7 @@ class Feed extends AppModel {
 			if (isset($filterRules['tags']['NOT']) && !empty($filterRules['tags']['NOT'])) {
 				if (isset($event['Tag']) && !empty($event['Tag'])) {
 					$found = false;
-					foreach ($event['Tag'] as &$tag) {
+					foreach ($event['Tag'] as $tag) {
 						foreach ($filterRules['tags']['NOT'] as $filterTag) if (strpos(strtolower($tag['name']), strtolower($filterTag))) $found = true;
 					}
 					if ($found) {
@@ -254,7 +254,7 @@ class Feed extends AppModel {
 		if (!isset($event['Event']['uuid'])) return false;
 		$event['Event']['distribution'] = $feed['Feed']['distribution'];
 		$event['Event']['sharing_group_id'] = $feed['Feed']['sharing_group_id'];
-		foreach ($event['Event']['Attribute'] as &$attribute) $attribute['distribution'] = 5;
+		foreach ($event['Event']['Attribute'] as $key => $attribute) $event['Event']['Attribute'][$key]['distribution'] = 5;
 		if ($feed['Feed']['tag_id']) {
 			if (!isset($event['Event']['Tag'])) $event['Event']['Tag'] = array();
 			$found = false;

--- a/app/Model/Module.php
+++ b/app/Model/Module.php
@@ -82,7 +82,7 @@ class Module extends AppModel {
 	public function getEnabledModules($type = false, $moduleFamily = 'Enrichment') {
 		$modules = $this->getModules($type, $moduleFamily);
 		if (is_array($modules)) {
-			foreach ($modules['modules'] as $k => &$module) {
+			foreach ($modules['modules'] as $k => $module) {
 				if (!Configure::read('Plugin.' . $moduleFamily . '_' . $module['name'] . '_enabled') || ($type && in_array(strtolower($type), $module['meta']['module-type']))) {
 					unset($modules['modules'][$k]);
 				}
@@ -111,7 +111,7 @@ class Module extends AppModel {
 		$module = false;
 		if (!Configure::read('Plugin.' . $moduleFamily . '_' . $name . '_enabled')) return 'The requested module is not enabled.';
 		if (is_array($modules)) {
-			foreach ($modules['modules'] as $k => &$module) {
+			foreach ($modules['modules'] as $module) {
 				if ($module['name'] == $name) {
 					if ($type && in_array(strtolower($type), $module['meta']['module-type'])) {
 						return $module;

--- a/app/Model/Post.php
+++ b/app/Model/Post.php
@@ -116,12 +116,12 @@ class Post extends AppModel {
 		$bodyDetail .= $message . "\n";
 		$tplColorString = !empty(Configure::read('MISP.email_subject_TLP_string')) ? Configure::read('MISP.email_subject_TLP_string') : "TLP Amber";
 		$subject = "[" . Configure::read('MISP.org') . " MISP] New post in discussion " . $post['Post']['thread_id'] . " - ".$tplColorString;
-		foreach ($orgMembers as &$recipient) {
+		foreach ($orgMembers as $recipient) {
 			$this->User->sendEmail($recipient, $bodyDetail, $body, $subject);
 		}
 	}
 
-	public function findPageNr($id, $context = 'thread', &$post_id = false) {
+	public function findPageNr($id, $context = 'thread', $post_id = false) {
 		// find the current post and its position in the thread
 		if ($context == 'event') $conditions = array('Thread.event_id' => $id);
 		else $conditions = array('Thread.id' => $id);

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1257,7 +1257,7 @@ class Server extends AppModel {
 				App::uses('SyncTool', 'Tools');
 				$syncTool = new SyncTool();
 				$HttpSocket = $syncTool->setupHttpSocket($server);
-				foreach ($eventIds as $k => &$eventId) {
+				foreach ($eventIds as $k => $eventId) {
 					$event = $eventModel->downloadEventFromServer(
 							$eventId,
 							$server);
@@ -1291,13 +1291,13 @@ class Server extends AppModel {
 										break;
 								}
 								if (isset($event['Event']['Attribute']) && !empty($event['Event']['Attribute'])) {
-									foreach ($event['Event']['Attribute'] as &$a) {
+									foreach ($event['Event']['Attribute'] as $key => $a) {
 										switch ($a['distribution']) {
 											case '1':
-												$a['distribution'] = '0';
+												$event['Event']['Attribute'][$key]['distribution'] = '0';
 												break;
 											case '2':
-												$a['distribution'] = '1';
+												$event['Event']['Attribute'][$key]['distribution'] = '1';
 												break;
 										}
 									}
@@ -1402,7 +1402,7 @@ class Server extends AppModel {
 			} else {
 				// Fallback for < 2.4.7 instances
 				$k = 0;
-				foreach ($events as $eid => &$event) {
+				foreach ($events as $eid => $event) {
 					$proposals = $eventModel->downloadEventFromServer($event, $server, null, true);
 					if (null != $proposals) {
 						if (isset($proposals['ShadowAttribute']['id'])) {
@@ -1478,8 +1478,8 @@ class Server extends AppModel {
 		foreach ($filter_rules as $field => $rules) {
 			$temp = array();
 			foreach ($rules as $operator => $elements) {
-				foreach ($elements as $k => &$element) {
-					if ($operator === 'NOT') $element = '!' . $element;
+				foreach ($elements as $k => $element) {
+					if ($operator === 'NOT') $elements[$k] = '!' . $element;
 					if (!empty($element)) $temp[] = $element;
 				}
 			}
@@ -1531,7 +1531,7 @@ class Server extends AppModel {
 				} else {
 					// multiple events, iterate over the array
 					$this->Event = ClassRegistry::init('Event');
-					foreach ($eventArray as $k => &$event) {
+					foreach ($eventArray as $k => $event) {
 						if (1 != $event['published']) {
 							unset($eventArray[$k]); // do not keep non-published events
 						}
@@ -1904,8 +1904,8 @@ class Server extends AppModel {
 					$finalSettingsUnsorted[$branchKey] = $branchValue;
 			}
 		}
-		foreach ($finalSettingsUnsorted as &$temp) if (in_array($temp['tab'], array_keys($this->__settingTabMergeRules))) {
-			$temp['tab'] = $this->__settingTabMergeRules[$temp['tab']];
+		foreach ($finalSettingsUnsorted as $key => $temp) if (in_array($temp['tab'], array_keys($this->__settingTabMergeRules))) {
+			$finalSettingsUnsorted[$key]['tab'] = $this->__settingTabMergeRules[$temp['tab']];
 		}
 		if ($unsorted) return $finalSettingsUnsorted;
 		$finalSettings = array();
@@ -2254,7 +2254,7 @@ class Server extends AppModel {
 		$validItems = $this->getFileRules();
 		App::uses('Folder', 'Utility');
 		App::uses('File', 'Utility');
-		foreach ($validItems as $k => &$item) {
+		foreach ($validItems as $k => $item) {
 			$dir = new Folder($item['path']);
 			$files = $dir->find($item['regex'], true);
 			foreach ($files as $file) {
@@ -2642,11 +2642,11 @@ class Server extends AppModel {
 			}
 			$worker_array[$entry]['workers'][] = array('pid' => $pid, 'user' => $worker['user'], 'alive' => $alive, 'correct_user' => $correct_user, 'ok' => $ok);
 		}
-		foreach ($worker_array as $k => &$queue) {
+		foreach ($worker_array as $k => $queue) {
 			if ($k != 'scheduler') $worker_array[$k]['jobCount'] = CakeResque::getQueueSize($k);
 			if (!isset($queue['workers'])) {
 				$workerIssueCount++;
-				$queue['ok'] = false;
+				$worker_array[$k]['ok'] = false;
 			}
 		}
 		$worker_array['proc_accessible'] = $procAccessible;
@@ -2851,8 +2851,8 @@ class Server extends AppModel {
 			$this->Job->saveField('message', 'Starting organisation creation');
 		}
 		$orgMapping = array();
-		foreach ($orgs as $k => &$orgArray) {
-			foreach ($orgArray as &$org) {
+		foreach ($orgs as $k => $orgArray) {
+			foreach ($orgArray as $org) {
 				$orgMapping[$org] = $this->Organisation->createOrgFromName($org, $user_id, $k == 'local' ? true : false);
 			}
 		}
@@ -2971,11 +2971,11 @@ class Server extends AppModel {
 			} catch (Exception $e) {
 				return 1;
 			}
-			if (!empty($events)) foreach ($events as &$event) {
+			if (!empty($events)) foreach ($events as $k => $event) {
 				if (!isset($event['Orgc'])) $event['Orgc']['name'] = $event['orgc'];
 				if (!isset($event['Org'])) $event['Org']['name'] = $event['org'];
 				if (!isset($event['EventTag'])) $event['EventTag'] = array();
-				$event = array('Event' => $event);
+				$events[$k] = array('Event' => $event);
 			} else return 3;
 			return $events;
 		}

--- a/app/Model/ShadowAttribute.php
+++ b/app/Model/ShadowAttribute.php
@@ -162,22 +162,20 @@ class ShadowAttribute extends AppModel {
 		return true;
 	}
 
-	private function __beforeDeleteCorrelation(&$sa) {
-		$temp = $sa;
-		if (isset($temp['ShadowAttribute'])) $temp = $temp['ShadowAttribute'];
+	private function __beforeDeleteCorrelation($sa) {
+		if (isset($sa['ShadowAttribute'])) $sa = $sa['ShadowAttribute'];
 		$this->ShadowAttributeCorrelation = ClassRegistry::init('ShadowAttributeCorrelation');
-		$this->ShadowAttributeCorrelation->deleteAll(array('ShadowAttributeCorrelation.1_shadow_attribute_id' => $temp['id']));
+		$this->ShadowAttributeCorrelation->deleteAll(array('ShadowAttributeCorrelation.1_shadow_attribute_id' => $sa['id']));
 	}
 
-	private function __afterSaveCorrelation(&$sa) {
-		$temp = $sa;
-		if (isset($temp['ShadowAttribute'])) $temp = $temp['ShadowAttribute'];
-		if (in_array($temp['type'], $this->Event->Attribute->nonCorrelatingTypes)) return;
+	private function __afterSaveCorrelation($sa) {
+		if (isset($sa['ShadowAttribute'])) $sa = $sa['ShadowAttribute'];
+		if (in_array($sa['type'], $this->Event->Attribute->nonCorrelatingTypes)) return;
 		$this->ShadowAttributeCorrelation = ClassRegistry::init('ShadowAttributeCorrelation');
 		$shadow_attribute_correlations = array();
 		$fields = array('value1', 'value2');
-		$correlatingValues = array($temp['value1']);
-		if (!empty($temp['value2'])) $correlatingValues[] = $temp['value2'];
+		$correlatingValues = array($sa['value1']);
+		if (!empty($sa['value2'])) $correlatingValues[] = $sa['value2'];
 		foreach ($correlatingValues as $k => $cV) {
 			$correlatingAttributes[$k] = $this->Event->Attribute->find('all', array(
 					'conditions' => array(
@@ -199,8 +197,8 @@ class ShadowAttribute extends AppModel {
 				foreach ($cA as $corr) {
 					$shadow_attribute_correlations[] = array(
 							'value' => $correlatingValues[$key],
-							'1_event_id' => $temp['event_id'],
-							'1_shadow_attribute_id' => $temp['id'],
+							'1_event_id' => $sa['event_id'],
+							'1_shadow_attribute_id' => $sa['id'],
 							'event_id' => $corr['Attribute']['event_id'],
 							'attribute_id' => $corr['Attribute']['id'],
 							'org_id' => $corr['Event']['org_id'],
@@ -434,7 +432,7 @@ class ShadowAttribute extends AppModel {
 		$body .= 'To view the event in question, follow this link: ' . Configure::read('MISP.baseurl') . '/events/view/' . $id . "\n";
 		$subject =  "[" . Configure::read('MISP.org') . " MISP] Proposal to event #" . $id;
 		$result = true;
-		foreach ($orgMembers as &$user) {
+		foreach ($orgMembers as $user) {
 			$result = $this->User->sendEmail($user, $body, $body, $subject) && $result;
 		}
 		return $result;

--- a/app/Model/SharingGroup.php
+++ b/app/Model/SharingGroup.php
@@ -463,7 +463,7 @@ class SharingGroup extends AppModel {
 		$this->Log = ClassRegistry::init('Log');
 		$this->User = ClassRegistry::init('User');
 		$syncUsers = array();
-		foreach ($sgs as &$sg) {
+		foreach ($sgs as $sg) {
 			if (!isset($syncUsers[$sg['SharingGroup']['sync_user_id']])) {
 				$syncUsers[$sg['SharingGroup']['sync_user_id']] = $this->User->getAuthUser($sg['SharingGroup']['sync_user_id']);
 				if (empty($syncUsers[$sg['SharingGroup']['sync_user_id']])) {
@@ -508,7 +508,7 @@ class SharingGroup extends AppModel {
 				'conditions' => array('local' => 1, 'roaming' => 0),
 				'contain' => array('SharingGroupServer')
 		));
-		foreach ($sgs as &$sg) {
+		foreach ($sgs as $sg) {
 			if (empty($sg['SharingGroupServer'])) {
 				$sg['SharingGroup']['roaming'] = 1;
 				$this->save($sg);

--- a/app/Model/SharingGroupServer.php
+++ b/app/Model/SharingGroupServer.php
@@ -105,7 +105,7 @@ class SharingGroupServer extends AppModel {
 		));
 		if (empty($sgs)) return array();
 		$sgids = array();
-		foreach ($sgs as &$temp) {
+		foreach ($sgs as $temp) {
 			$sgids[] = $temp[$this->alias]['id'];
 		}
 		return $sgids;

--- a/app/Model/Sighting.php
+++ b/app/Model/Sighting.php
@@ -68,7 +68,7 @@ class Sighting extends AppModel {
 		if (empty($sightings)) return array();
 		$anonymise = Configure::read('Plugin.Sightings_anonymise');
 
-		foreach ($sightings as $k => &$sighting) {
+		foreach ($sightings as $k => $sighting) {
 			if ($anonymise && !$user['Role']['perm_site_admin']) {
 				if ($sighting['Sighting']['org_id'] != $user['org_id']) {
 					unset($sightings[$k]['Sighting']['org_id']);
@@ -91,7 +91,7 @@ class Sighting extends AppModel {
 			else $conditions = array('Attribute.id' => $id);
 		} else {
 			if (!$values) return 0;
-			foreach ($values as &$value) {
+			foreach ($values as $value) {
 				foreach (array('value1', 'value2') as $field) {
 					$conditions['OR'][] = array(
 						'LOWER(Attribute.' . $field . ') LIKE' => strtolower($value)
@@ -102,7 +102,7 @@ class Sighting extends AppModel {
 		$attributes = $this->Attribute->fetchAttributes($user, array('conditions' => $conditions));
 		if (empty($attributes)) return 0;
 		$sightingsAdded = 0;
-		foreach ($attributes as &$attribute) {
+		foreach ($attributes as $attribute) {
 			$this->create();
 			$sighting = array(
 					'attribute_id' => $attribute['Attribute']['id'],

--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -167,7 +167,7 @@ class Tag extends AppModel {
 				'conditions' => array('UPPER(name) LIKE' => strtoupper($namespace) . '%'),
 		));
 		$tags = array();
-		foreach ($tags_temp as &$temp) $tags[strtoupper($temp['Tag']['name'])] = $temp;
+		foreach ($tags_temp as $temp) $tags[strtoupper($temp['Tag']['name'])] = $temp;
 		return $tags;
 	}
 }

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -228,7 +228,7 @@ class User extends AppModel {
 			$chars = implode('', $groups);
 			$pw .= $chars[mt_rand(0, strlen($chars)-1)];
 		}
-		foreach ($groups as &$group) {
+		foreach ($groups as $group) {
 			$pw .= $group[mt_rand(0, strlen($group)-1)];
 		}
 		return $pw;
@@ -630,10 +630,10 @@ class User extends AppModel {
 			'fields' => array('id', 'email', 'gpgkey', 'certif_public', 'org_id'),
 			'contain' => array('Role' => array('fields' => array('perm_site_admin'))),
 		));
-		foreach ($users as &$user) {
-			$temp = $user['User'];
-			unset($user['User']);
-			$user = array_merge($temp, $user);
+		foreach ($users as $k => $user) {
+			$user = $user['User'];
+			unset($users[$k]['User']);
+			$users[$k] = array_merge($user, $users[$k]);
 		}
 		return $users;
 	}

--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -39,7 +39,7 @@ class Warninglist extends AppModel{
 	public function update() {
 		$directories = glob(APP . 'files' . DS . 'warninglists' . DS . 'lists' . DS . '*', GLOB_ONLYDIR);
 		$updated = array();
-		foreach ($directories as &$dir) {
+		foreach ($directories as $dir) {
 			$file = new File($dir . DS . 'list.json');
 			$list = json_decode($file->read(), true);
 			$file->close();
@@ -133,7 +133,7 @@ class Warninglist extends AppModel{
 		$eventWarnings = array();
 		foreach ($event['objects'] as &$object) {
 			if ($object['to_ids']) {
-				foreach ($warninglists as &$list) {
+				foreach ($warninglists as $list) {
 					if (in_array('ALL', $list['types']) || in_array($object['type'], $list['types'])) {
 						$result = $this->__checkValue($list['values'], $object['value'], $object['type'], $list['Warninglist']['type']);
 						if (!empty($result)) {
@@ -150,7 +150,7 @@ class Warninglist extends AppModel{
 		return $event;
 	}
 
-	private function __checkValue(&$listValues, $value, $type, $listType) {
+	private function __checkValue($listValues, $value, $type, $listType) {
 		if (strpos($type, '|')) $value = explode('|', $value);
 		else $value = array($value);
 		$components = array(0, 1);
@@ -168,7 +168,7 @@ class Warninglist extends AppModel{
 
 	// This requires an IP type attribute in a non CIDR notation format
 	// For the future we can expand this to look for CIDR overlaps?
-	private function __evalCIDRList(&$listValues, $value) {
+	private function __evalCIDRList($listValues, $value) {
 		$ipv4cidrlist = array();
 		$ipv6cidrlist = array();
 		// separate the CIDR list into IPv4 and IPv6
@@ -190,7 +190,7 @@ class Warninglist extends AppModel{
 
 	}
 
-	private function __evalCIDR($value, &$listValues, $function) {
+	private function __evalCIDR($value, $listValues, $function) {
 		$found = false;
 		foreach ($listValues as $lv) {
 			$found = $this->$function($value, $lv);
@@ -232,7 +232,7 @@ class Warninglist extends AppModel{
 		return $binaryip;
 	}
 
-	private function __evalString(&$listValues, $value) {
+	private function __evalString($listValues, $value) {
 		if (in_array($value, $listValues)) return true;
 		return false;
 	}

--- a/app/View/Helper/HighlightHelper.php
+++ b/app/View/Helper/HighlightHelper.php
@@ -17,11 +17,13 @@ App::uses('AppHelper', 'View/Helper');
 			if (!is_array($keywordArray)) {
 				$keywordArray = array($keywordArray);
 			}
-			foreach ($keywordArray as $k => &$keywordArrayElement) {
+			foreach ($keywordArray as $k => $keywordArrayElement) {
 				$keywordArrayElement = trim($keywordArrayElement);
 				if ("" == $keywordArrayElement) {
 					unset($keywordArray[$k]);
 					continue;
+				} else {
+					$keywordArray[$k] = $keywordArrayElement;
 				}
 				$replacementArray[] = '<span style="color:red">'.$keywordArrayElement.'</span>';
 			}


### PR DESCRIPTION
#### What does it do?

this reduces the usage of references by almost 60%
`grep -rIF "&$" app/ | grep -vF "Lib/cake" | grep -F ".php:" | wc -l`

references don't save space in PHP (-> copy-on-write!) and don't speed up anything, sometimes may be slower.
but they may lead to changes that you didn't want, because you may not know that some variable is actually a reference.

see this blogpost from Johannes Schlüter, for example:
http://schlueters.de/blog/archives/125-Do-not-use-PHP-references.html

please wait with merging until you have time for a second look on the changes - although i did look on them at least twice.
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
