### PR TITLE
remove redundant className attributes

### DIFF
--- a/app/Controller/NewsController.php
+++ b/app/Controller/NewsController.php
@@ -17,7 +17,6 @@ class NewsController extends AppController {
 	);
 
 	public function index() {
-		$this->News->bindModel(array('belongsTo' => array('User' => array('className' => 'User'))));
 		$this->paginate['contain'] = array('User' => array('fields' => array('User.email')));
 		$newsItems = $this->paginate();
 		$this->loadModel('User');

--- a/app/Model/EventDelegation.php
+++ b/app/Model/EventDelegation.php
@@ -19,18 +19,14 @@ class EventDelegation extends AppModel {
 	);
 
 	public $belongsTo = array(
-		'Event' => array(
-			'className' => 'Event',
-		),
+		'Event',
 		'Org' => array(
 			'className' => 'Organisation',
 		),
 		'RequesterOrg' => array(
 			'className' => 'Organisation'
 		),
-		'SharingGroup' => array(
-			'className' => 'SharingGroup'
-		)
+		'SharingGroup'
 	);
 
 	public function attachTagToEvent($event_id, $tag_id) {

--- a/app/Model/EventTag.php
+++ b/app/Model/EventTag.php
@@ -19,12 +19,8 @@ class EventTag extends AppModel {
 	);
 
 	public $belongsTo = array(
-		'Event' => array(
-			'className' => 'Event',
-		),
-		'Tag' => array(
-			'className' => 'Tag',
-		),
+		'Event',
+		'Tag'
 	);
 
 	// take an array of tag names to be included and an array with tagnames to be excluded and find all event IDs that fit the criteria

--- a/app/Model/News.php
+++ b/app/Model/News.php
@@ -18,9 +18,5 @@ class News extends AppModel {
 		)
 	);
 
-	public $belongsTo = array(
-		'User' => array(
-			'className' => 'User',
-		)
-	);
+	public $belongsTo = 'User';
 }

--- a/app/Model/ServerTag.php
+++ b/app/Model/ServerTag.php
@@ -19,12 +19,8 @@ class ServerTag extends AppModel {
 	);
 
 	public $belongsTo = array(
-		'Server' => array(
-			'className' => 'Server',
-		),
-		'Tag' => array(
-			'className' => 'Tag',
-		),
+		'Server',
+		'Tag'
 	);
 
 	public function attachTagToServer($server_id, $tag_id) {

--- a/app/Model/Sighting.php
+++ b/app/Model/Sighting.php
@@ -19,12 +19,8 @@ class Sighting extends AppModel {
 	);
 
 	public $belongsTo = array(
-			'Attribute' => array(
-					'className' => 'Attribute',
-			),
-			'Event' => array(
-					'className' => 'Event',
-			),
+			'Attribute',
+			'Event',
 			'Organisation' => array(
 					'className' => 'Organisation',
 					'foreignKey' => 'org_id'


### PR DESCRIPTION
#### What does it do?

removes the "className" attribute from class relations where it is redundant because it's the same as the array key.
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
