### PR TITLE
Tag.php: use dependency instead of explicit deleteAll

### DIFF
--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -40,6 +40,7 @@ class Tag extends AppModel {
 	public $hasMany = array(
 		'EventTag' => array(
 			'className' => 'EventTag',
+			'dependent' => true
 		),
 		'TemplateTag',
 		'FavouriteTag' => array(
@@ -53,11 +54,6 @@ class Tag extends AppModel {
 			'foreignKey' => 'org_id',
 		)
 	);
-
-
-	public function beforeDelete($cascade = true) {
-		$this->EventTag->deleteAll(array('EventTag.tag_id' => $this->id));
-	}
 
 	public function validateColour($fields) {
 		if (!preg_match('/^#[0-9a-f]{6}$/i', $fields['colour'])) return false;


### PR DESCRIPTION
#### What does it do?

as far as i understand the cakephp model relations, setting the hasMany array entry of EventTag to dependent results in the same as the current explicit call of deleteAll.

perhaps i might have forgot something, like the order of the deletion might be different (deleting EventTags before or after Tag deletion)

http://book.cakephp.org/2.0/en/models/associations-linking-models-together.html
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
