### PR TITLE
chg: creator e-mail in the event details, fixes #1252

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -858,8 +858,8 @@ class EventsController extends AppController {
 		$results = $this->Event->fetchEvent($this->Auth->user(), $conditions);
 		if (empty($results)) throw new NotFoundException('Invalid event');
 		//if the current user is an org admin AND event belongs to his/her org, fetch also the event creator info
-		if ($this->userRole['perm_admin'] && !$this->_isSiteAdmin() && $this->Event->isOwnedByOrg($id, $this->Auth->user('org_id'))) {
-			$results[0]['User'] = $this->User->getUserMinimalInfo($results[0]['Event']['user_id']);
+		if ($this->userRole['perm_admin'] && !$this->_isSiteAdmin() && ($results[0]['Org']['id'] == $this->Auth->user('org_id'))) {
+			$results[0]['User']['email'] = $this->User->field('email', array('id' , $results[0]['Event']['user_id']));
 		}
 		$event = &$results[0];
 		if ($this->_isRest()) {

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -857,6 +857,10 @@ class EventsController extends AppController {
 		}
 		$results = $this->Event->fetchEvent($this->Auth->user(), $conditions);
 		if (empty($results)) throw new NotFoundException('Invalid event');
+		//if the current user is an org admin AND event belongs to his/her org, fetch also the event creator info
+		if ($this->userRole['perm_admin'] && !$this->_isSiteAdmin() && $this->Event->isOwnedByOrg($id, $this->Auth->user('org_id'))) {
+			$results[0]['User'] = $this->User->getUserMinimalInfo($results[0]['Event']['user_id']);
+		}
 		$event = &$results[0];
 		if ($this->_isRest()) {
 			$this->set('event', $event);

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -928,4 +928,15 @@ class User extends AppModel {
 
 		return $admin['User'];
 	}
+
+	public function getUserMinimalInfo($id) {
+		$info = $this->find('first', array(
+			'conditions' => array(
+				'User.id' => $id,
+			),
+			'fields' => array('User.email', 'User.id')
+		));
+		return $info['User'];
+	}
+
 }

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -928,15 +928,4 @@ class User extends AppModel {
 
 		return $admin['User'];
 	}
-
-	public function getUserMinimalInfo($id) {
-		$info = $this->find('first', array(
-			'conditions' => array(
-				'User.id' => $id,
-			),
-			'fields' => array('User.email', 'User.id')
-		));
-		return $info['User'];
-	}
-
 }


### PR DESCRIPTION
#### What does it do?

displays the creator e-mail in the event details for org admins, fixes #1252
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [x] Minor
- [ ] Patch
