### PR TITLE
chg: Default roles all have API access

### DIFF
--- a/INSTALL/POSTGRESQL-data-initial.sql
+++ b/INSTALL/POSTGRESQL-data-initial.sql
@@ -66,19 +66,16 @@ INSERT INTO roles (id, name, created, modified, perm_add, perm_modify, perm_modi
 VALUES ('2', 'Org Admin', NOW(), NOW(), 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1, 0);
 
 INSERT INTO roles (id, name, created, modified, perm_add, perm_modify, perm_modify_org, perm_publish, perm_sync, perm_admin, perm_audit, perm_full, perm_auth, perm_regexp_access, perm_tagger, perm_site_admin, perm_template, perm_sharing_group, perm_tag_editor, perm_delegate, default_role)
-VALUES ('3', 'User', NOW(), NOW(), 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1);
+VALUES ('3', 'User', NOW(), NOW(), 1, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1);
 
 INSERT INTO roles (id, name, created, modified, perm_add, perm_modify, perm_modify_org, perm_publish, perm_sync, perm_admin, perm_audit, perm_full, perm_auth, perm_regexp_access, perm_tagger, perm_site_admin, perm_template, perm_sharing_group, perm_tag_editor, perm_delegate, default_role)
-VALUES ('4', 'Publisher', NOW(), NOW(), 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0);
+VALUES ('4', 'Publisher', NOW(), NOW(), 1, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0);
 
 INSERT INTO roles (id, name, created, modified, perm_add, perm_modify, perm_modify_org, perm_publish, perm_sync, perm_admin, perm_audit, perm_full, perm_auth, perm_regexp_access, perm_tagger, perm_site_admin, perm_template, perm_sharing_group, perm_tag_editor, perm_delegate, default_role)
 VALUES ('5', 'Sync user', NOW(), NOW(), 1, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0);
 
 INSERT INTO roles (id, name, created, modified, perm_add, perm_modify, perm_modify_org, perm_publish, perm_sync, perm_admin, perm_audit, perm_full, perm_auth, perm_regexp_access, perm_tagger, perm_site_admin, perm_template, perm_sharing_group, perm_tag_editor, perm_delegate, default_role)
-VALUES ('6', 'Automation user', NOW(), NOW(), 1, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0);
-
-INSERT INTO roles (id, name, created, modified, perm_add, perm_modify, perm_modify_org, perm_publish, perm_sync, perm_admin, perm_audit, perm_full, perm_auth, perm_regexp_access, perm_tagger, perm_site_admin, perm_template, perm_sharing_group, perm_tag_editor, perm_delegate, default_role)
-VALUES ('7', 'Read Only', NOW(), NOW(), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+VALUES ('6', 'Read Only', NOW(), NOW(), 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0);
 
 SELECT SETVAL('roles_id_seq', (SELECT MAX(id) FROM roles));
 


### PR DESCRIPTION
#### What does it do?

same as aa0383064345d24e1ceb32621457ec156c2cd809
but for postgres
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
- changed the default role set to have api access enabled
- existing installations not affected
- if a community wants to restrict API access for certain users they're free to do it

(same as aa0383064345d24e1ceb32621457ec156c2cd809 but for postgres this time)
