### PR TITLE
remove view function that was broken for months

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -797,22 +797,6 @@ class AttributesController extends AppController {
 		}
 	}
 
-	public function view($id) {
-		$this->Attribute->id = $id;
-		if (!$this->Attribute->exists()) {
-			throw new NotFoundException('Invalid attribute');
-		}
-		if ($this->_isRest()) {
-			$attribute = $this->Attribute->fetchAttributes($this->Auth->user(), array('conditions' => array('Attribute.id' => $id), 'withAttachments' => true));
-			if (empty($attribute)) throw new MethodNotAllowedException('Invalid attribute');
-			$attribute = $attribute[0];
-			$this->set('Attribute', $attribute['Attribute']);
-			$this->set('_serialize', array('Attribute'));
-		} else {
-			$this->redirect('/events/view/' . $this->Attribute->data['Attribute']['event_id']);
-		}
-	}
-
 	public function delete($id = null, $hard = false) {
 		$this->set('id', $id);
 		$conditions = array('id' => $id);


### PR DESCRIPTION
#### What does it do?

this PR removes the view() method from AttributesController.php
the method was broken since 2016-02-19, commit 52ddfb17ea9d029ca908cf8cbdf928907093bb8f
this commit removed View/Elements/eventattributerow.ctp which was used by View/Attributes/view.ctp
this view.ctp was removed two weeks ago because of its missing dependency in 3c7117b122bd6d2c539787d4487c37d304603f8c (#1511)
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
