### PR TITLE
default org changed to id instead of name

### DIFF
--- a/app/Plugin/ShibbAuth/Controller/Component/Auth/ApacheShibbAuthenticate.php
+++ b/app/Plugin/ShibbAuth/Controller/Component/Auth/ApacheShibbAuthenticate.php
@@ -91,9 +91,9 @@ class ApacheShibbAuthenticate extends BaseAuthenticate {
 		//Obtain default org. If not, org keeps the default value
 		if (isset($_SERVER[$OrgTag])) {
 			$org = $_SERVER[$OrgTag];
+			//Check if the organization exits and create it if not
+			$org = $this->checkOrganization($org, $user);
 		}
-		//Check if the organization exits and create it if not
-		$org = $this->checkOrganization($org, $user);
 
 		//Get user role from its list of groups
 		list($roleChanged, $roleId) = $this->getUserRoleFromGroup($groupTag, $groupRoleMatching, $roleId);


### PR DESCRIPTION
#### What does it do?

Default organisation changed to id (numeric) instead of name, just in case an organisation changes the name, to be able to preserve the consistency with the numeric id.
#### Questions
- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
