### PR TITLE
fix: php warning on buildAlertEmailBody in Event.php

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1592,10 +1592,12 @@ class Event extends AppModel {
 				if ($attribute['distribution'] == 4 && !$sgModel->checkIfAuthorised($user, $attribute['sharing_group_id'])) continue;
 				$ids = '';
 				if ($attribute['to_ids']) $ids = ' (IDS)';
+				$strRepeatCount = $appendlen - 2 - strlen($attribute['type']);
+				$strRepeat = ($strRepeatCount > 0) ? str_repeat(' ', $strRepeatCount) : '';
 				if (isset($event['Event']['publish_timestamp']) && isset($attribute['timestamp']) && $attribute['timestamp'] > $event['Event']['publish_timestamp']) {
-					$line = '* ' . $attribute['type'] . str_repeat(' ', $appendlen - 2 - strlen($attribute['type'])) . ': ' . $attribute['value'] . $ids . " *\n";
+					$line = '* ' . $attribute['type'] . $strRepeat . ': ' . $attribute['value'] . $ids . " *\n";
 				} else {
-					$line = $attribute['type'] . str_repeat(' ', $appendlen - 2 - strlen($attribute['type'])) . ': ' . $attribute['value'] . $ids .  "\n";
+					$line = $attribute['type'] . $strRepeat . ': ' . $attribute['value'] . $ids .  "\n";
 				}
 				// Defanging URLs (Not "links") emails domains/ips in notification emails
 				if ('url' == $attribute['type']) {


### PR DESCRIPTION
#### What does it do?

if an attributes type was longer than $appendlen-2 a php warning was logged.
str_repeat()'s 2nd parameter, an integer, must not be smaller than 0.
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
