### PR TITLE
Two small fixes

### DIFF
--- a/app/Controller/EventDelegationsController.php
+++ b/app/Controller/EventDelegationsController.php
@@ -41,7 +41,7 @@ class EventDelegationsController extends AppController {
 			$this->EventDelegation->create();
 			$this->EventDelegation->save($this->request->data['EventDelegation']);
 			$org = $this->EventDelegation->Event->Org->find('first', array(
-					'conditions' => array('id' => $this->request->data['EventDelegation']['requester_org_id']),
+					'conditions' => array('id' => $this->request->data['EventDelegation']['org_id']),
 					'recursive' => -1,
 					'fields' => array('name')
 			));

--- a/app/View/Elements/side_menu.ctp
+++ b/app/View/Elements/side_menu.ctp
@@ -45,7 +45,7 @@
 					<?php
 						$publishButtons = ' style="display:none;"';
 						$exportButtons = ' style="display:none;"';
-						if (isset($event['Event']['published']) && 0 == $event['Event']['published'] && ($isAdmin || (isset($mayPublish) && $mayPublish))) $publishButtons = "";
+						if (isset($event['Event']['published']) && 0 == $event['Event']['published'] && ($isSiteAdmin || (isset($mayPublish) && $mayPublish))) $publishButtons = "";
 						if (isset($event['Event']['published']) && $event['Event']['published']) $exportButtons = "";
 					?>
 					<li<?php echo $publishButtons; ?> class="publishButtons"><a href="#" onClick="publishPopup('<?php echo h($event['Event']['id']); ?>', 'alert')">Publish Event</a></li>


### PR DESCRIPTION
#### What does it do?

2 small fixes for bugs found while testing the delegation feature:
- Log target org instead of requesting org for the delegation
- Only show publish links for site admins (instead of org admins)
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
