### PR TITLE
Cleanup

### DIFF
--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -60,8 +60,6 @@ class ServersController extends AppController {
 	}
 
 	public function previewIndex($id) {
-		if (isset($this->passedArgs['pages'])) $currentPage = $this->passedArgs['pages'];
-		else $currentPage = 1;
 		$urlparams = '';
 		$passedArgs = array();
 		if (!$this->_isSiteAdmin()) {
@@ -86,7 +84,6 @@ class ServersController extends AppController {
 		$this->loadModel('Event');
 		$threat_levels = $this->Event->ThreatLevel->find('all');
 		$this->set('threatLevels', Set::combine($threat_levels, '{n}.ThreatLevel.id', '{n}.ThreatLevel.name'));
-		$pageCount = count($events);
 		App::uses('CustomPaginationTool', 'Tools');
 		$customPagination = new CustomPaginationTool();
 		$params = $customPagination->createPaginationRules($events, $this->passedArgs, $this->alias);

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1818,22 +1818,6 @@ class Server extends AppModel {
 		return true;
 	}
 
-	private function __getEnrichmentSettings() {
-		$modules = $this->getEnrichmentModules();
-		$result = array();
-		if (!empty($modules['modules'])) {
-			foreach ($modules['modules'] as $module) {
-				$result[$module['name']][0] = array('name' => 'enabled', 'type' => 'boolean');
-				if (isset($module['meta']['config'])) {
-					foreach ($module['meta']['config'] as $conf) {
-						$result[$module['name']][] = array('name' => $conf, 'type' => 'string');
-					}
-				}
-			}
-		}
-		return $result;
-	}
-
 	public function getCurrentServerSettings() {
 		$this->Module = ClassRegistry::init('Module');
 		$serverSettings = $this->serverSettings;

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -2741,33 +2741,6 @@ class Server extends AppModel {
 		}
 	}
 
-	// currently unused, but let's keep it in the code-base in case we need it in the future.
-	private function __dropIndex($table, $field) {
-		$this->Log = ClassRegistry::init('Log');
-		$indexCheck = "SELECT INDEX_NAME FROM INFORMATION_SCHEMA.STATISTICS WHERE table_schema=DATABASE() AND table_name='" . $table . "' AND index_name LIKE '" . $field . "%'";
-		$indexCheckResult = $this->query($indexCheck);
-		foreach ($indexCheckResult as $icr) {
-			$dropIndex = 'ALTER TABLE ' . $table . ' DROP INDEX ' . $icr['STATISTICS']['INDEX_NAME'];
-			$result = true;
-			try {
-				$this->query($dropIndex);
-			} catch (Exception $e) {
-				$result = false;
-			}
-			$this->Log->create();
-			$this->Log->save(array(
-					'org' => 'SYSTEM',
-					'model' => 'Server',
-					'model_id' => 0,
-					'email' => 'SYSTEM',
-					'action' => 'update_database',
-					'user_id' => 0,
-					'title' => ($result ? 'Removed index ' : 'Failed to remove index ') . $icr['STATISTICS']['INDEX_NAME'] . ' from ' . $table,
-					'change' => ($result ? 'Removed index ' : 'Failed to remove index ') . $icr['STATISTICS']['INDEX_NAME'] . ' from ' . $table,
-			));
-		}
-	}
-
 	public function upgrade2324($user_id, $jobId = false) {
 		$this->cleanCacheFiles();
 		if (Configure::read('MISP.background_jobs') && $jobId) {


### PR DESCRIPTION
#### What does it do?

```
chg: remove obsolete dropIndex() - not needed only for reference, as there's a duplicate in AppModel.php (& in git)

chg: remove obsolete variables (i could not find any usage of those two)

chg: remove obsolete getEnrichmentSettings() - seems to have been replaced by Module.php getModuleSettings, please check!
```
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
