### PR TITLE
Origin/fix free text import for new tld

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -2796,8 +2796,8 @@ class EventsController extends AppController {
 			App::uses('ComplexTypeTool', 'Tools');
 			$complexTypeTool = new ComplexTypeTool();
 			$this->loadModel('Warninglist');
-			$IANATLDentries = $this->Warninglist->getAllIANAEntries();
-			$resultArray = $complexTypeTool->checkComplexRouter($this->request->data['Attribute']['value'], 'FreeText', $IANATLDentries);
+			$IANATLDEntries = $this->Warninglist->getAllIANAEntries();
+			$resultArray = $complexTypeTool->checkComplexRouter($this->request->data['Attribute']['value'], 'FreeText', $IANATLDEntries);
 			foreach ($resultArray as $key => $r) {
 				$temp = array();
 				foreach ($r['types'] as $type) {

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -2795,7 +2795,9 @@ class EventsController extends AppController {
 		if ($this->request->is('post')) {
 			App::uses('ComplexTypeTool', 'Tools');
 			$complexTypeTool = new ComplexTypeTool();
-			$resultArray = $complexTypeTool->checkComplexRouter($this->request->data['Attribute']['value'], 'FreeText');
+			$this->loadModel('Warninglist');
+			$IANATLDentries = $this->Warninglist->getAllIANAEntries();
+			$resultArray = $complexTypeTool->checkComplexRouter($this->request->data['Attribute']['value'], 'FreeText', $IANATLDentries);
 			foreach ($resultArray as $key => $r) {
 				$temp = array();
 				foreach ($r['types'] as $type) {

--- a/app/Lib/Tools/ComplexTypeTool.php
+++ b/app/Lib/Tools/ComplexTypeTool.php
@@ -10,7 +10,7 @@ class ComplexTypeTool {
 		'/\.+/' => '.'
 	);
 
-	public function checkComplexRouter($input, $type) {
+	public function checkComplexRouter($input, $type, $IANATLDentries) {
 		switch ($type) {
 			case 'File':
 				return $this->checkComplexFile($input);
@@ -19,7 +19,7 @@ class ComplexTypeTool {
 				return $this->checkComplexCnC($input);
 				break;
 			case 'FreeText':
-				return $this->checkFreeText($input);
+				return $this->checkFreeText($input, $IANATLDentries);
 				break;
 			default:
 				return false;
@@ -73,7 +73,7 @@ class ComplexTypeTool {
 		return array_values($array);
 	}
 
-	public function checkFreeText($input) {
+	public function checkFreeText($input, $IANATLDentries) {
 		$iocArray = preg_split("/\r\n|\n|\r|\s|\s+|,|;/", $input);
 		$quotedText = explode('"', $input);
 		foreach ($quotedText as $k => $temp) {
@@ -93,7 +93,7 @@ class ComplexTypeTool {
 				$ioc = trim($ioc, ',');
 				$ioc = preg_replace('/\p{C}+/u', '', $ioc);
 				if (empty($ioc)) continue;
-				$typeArray = $this->__resolveType($ioc);
+				$typeArray = $this->__resolveType($ioc, $IANATLDentries);
 				if ($typeArray === false) continue;
 				$temp = $typeArray;
 				if (!isset($temp['value'])) $temp['value'] = $ioc;
@@ -112,8 +112,9 @@ class ComplexTypeTool {
 		128 => array('single' => array('sha512'), 'composite' => array('filename|sha512'))
 	);
 
-	private function __resolveType($input) {
+	private function __resolveType($input, $IANATLDentries) {
 		$input = trim($input);
+		// check for composite (|) attributes
 		if (strpos($input, '|')) {
 			$compositeParts = explode('|', $input);
 			if (count($compositeParts) == 2) {
@@ -156,6 +157,13 @@ class ComplexTypeTool {
 		// check for domain name, hostname, filename
 		if (strpos($inputRefanged, '.') !== false) {
 			$temp = explode('.', $inputRefanged);
+			// check for the new TLDs as known by IANA (IF the Warninglists are not empty)
+			if (!empty($IANATLDentries)) {
+				$stringEnd = $temp[count($temp)-1];
+				if (in_array($stringEnd, $IANATLDentries)) {
+					return array('types' => array('filename', 'domain'), 'to_ids' => true, 'default_type' => 'filename');
+				}
+			}
 			// TODO: use a more flexible matching approach, like the one below (that still doesn't support non-ASCII domains)
 			//if (filter_var($input, FILTER_VALIDATE_URL)) {
 			if (preg_match('/^([-\pL\pN]+\.)+([a-z][a-z]|biz|cat|com|edu|gov|int|mil|net|org|pro|tel|aero|arpa|asia|coop|info|jobs|mobi|name|museum|travel)(:[0-9]{2,5})?$/iu', $inputRefanged)) {

--- a/app/Lib/Tools/ComplexTypeTool.php
+++ b/app/Lib/Tools/ComplexTypeTool.php
@@ -157,11 +157,14 @@ class ComplexTypeTool {
 		// check for domain name, hostname, filename
 		if (strpos($inputRefanged, '.') !== false) {
 			$temp = explode('.', $inputRefanged);
-			// check for the new TLDs as known by IANA (IF the Warninglists are not empty)
+			// check for the new TLDs as known by IANA (if the Warninglists are not empty)
 			if (!empty($IANATLDentries)) {
 				$stringEnd = $temp[count($temp)-1];
 				if (in_array($stringEnd, $IANATLDentries)) {
-					return array('types' => array('filename', 'domain'), 'to_ids' => true, 'default_type' => 'filename');
+					$types = array('filename', 'domain');
+					if (count($temp) > 2)
+						$types[] = 'url';
+					return array('types' => $types, 'to_ids' => true, 'default_type' => 'filename', 'merge_categories' => true);
 				}
 			}
 			// TODO: use a more flexible matching approach, like the one below (that still doesn't support non-ASCII domains)

--- a/app/Lib/Tools/ComplexTypeTool.php
+++ b/app/Lib/Tools/ComplexTypeTool.php
@@ -164,7 +164,7 @@ class ComplexTypeTool {
 					$types = array('filename', 'domain');
 					if (count($temp) > 2)
 						$types[] = 'url';
-					return array('types' => $types, 'to_ids' => true, 'default_type' => 'filename', 'merge_categories' => true);
+					return array('types' => $types, 'to_ids' => true, 'default_type' => 'domain', 'merge_categories' => true);
 				}
 			}
 			// TODO: use a more flexible matching approach, like the one below (that still doesn't support non-ASCII domains)

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -1726,7 +1726,9 @@ class Attribute extends AppModel {
 		if ($element['complex']) {
 			App::uses('ComplexTypeTool', 'Tools');
 			$complexTypeTool = new ComplexTypeTool();
-			$result = $complexTypeTool->checkComplexRouter($value, ucfirst($element['type']));
+			$this->loadModel('Warninglist');
+			$IANATLDEntries = $this->Warninglist->getAllIANAEntries();
+			$result = $complexTypeTool->checkComplexRouter($value, ucfirst($element['type'], $IANATLDEntries));
 			if (isset($result['multi'])) {
 				$temp = $attribute;
 				$attribute = array();

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -2759,6 +2759,8 @@ class Event extends AppModel {
 		$freetextResults = array();
 		App::uses('ComplexTypeTool', 'Tools');
 		$complexTypeTool = new ComplexTypeTool();
+		$this->loadModel('Warninglist');
+		$IANATLDEntries = $this->Warninglist->getAllIANAEntries();
 		if (isset($result['results']) && !empty($result['results'])) {
 			foreach ($result['results'] as $k => &$r) {
 				if (!is_array($r['values'])) {
@@ -2778,7 +2780,7 @@ class Event extends AppModel {
 				foreach ($r['values'] as &$value) {
 					if (in_array('freetext', $r['types'])) {
 						if (is_array($value)) $value = json_encode($value);
-						$freetextResults = array_merge($freetextResults, $complexTypeTool->checkComplexRouter($value, 'FreeText'));
+						$freetextResults = array_merge($freetextResults, $complexTypeTool->checkComplexRouter($value, 'FreeText', $IANATLDEntries));
 						if (!empty($freetextResults)) {
 							foreach ($freetextResults as &$ft) {
 								$temp = array();

--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -236,4 +236,26 @@ class Warninglist extends AppModel{
 		if (in_array($value, $listValues)) return true;
 		return false;
 	}
+
+	public function getAllIANAEntries() {
+		$result = $this->find('first', array(
+			'conditions' => array('Warninglist.name' => 'TLDs as known by IANA', 'enabled' => 1),
+			'recursive' => -1,
+			'contain' => array(
+				'WarninglistEntry' => array(
+					'fields' => array('WarninglistEntry.value')
+				)
+			)
+		));
+		if ((count($result))>0) {
+			return array_map(
+				function ($element) {
+					return strtolower($element['value']);
+				},
+				$result['WarninglistEntry']
+			);
+		} else {
+			return [];
+		}
+	}
 }

--- a/app/View/Events/resolved_attributes.ctp
+++ b/app/View/Events/resolved_attributes.ctp
@@ -244,3 +244,4 @@
 	echo $this->element('side_menu', array('menuList' => 'event', 'menuItem' => 'freetextResults'));
 ?>
 <?php echo $this->Js->writeBuffer(); // Write cached scripts ?>
+

--- a/app/View/Events/resolved_attributes.ctp
+++ b/app/View/Events/resolved_attributes.ctp
@@ -35,6 +35,7 @@
 		</tr>
 		<?php
 			$options = array();
+			$allTypes = array();
 			foreach ($resultArray as $k => $item):
 		?>
 		<tr id="row_<?php echo $k; ?>" class="freetext_row">
@@ -100,14 +101,7 @@
 				?>
 				<select id="<?php echo 'Attribute' . $k . 'Category'; ?>" style="padding:0;height:20px;margin-bottom:0;">
 				<?php
-					$categoriesArray = $typeCategoryMapping[$item['default_type']];
-					if (isset($item['merge_categories']) && $item['merge_categories'] === true) {
-						$categoriesArray = [];
-						foreach ($item['types'] as $type) {
-							$categoriesArray = array_merge($categoriesArray, $typeCategoryMapping[$type]);
-						}
-					}
-					foreach ($categoriesArray as $category) {
+					foreach ($typeCategoryMapping[$item['default_type']] as $category) {
 						if (isset($item['categories']) && !in_array($category, $item['categories'])) {
 							continue;
 						}
@@ -130,9 +124,10 @@
 					}
 				?>
 				<div id = "<?php echo 'Attribute' . $k . 'TypeStatic'; ?>" <?php echo $divVisibility; ?> ><?php echo h($item['default_type']); ?></div>
-				<select id = "<?php echo 'Attribute' . $k . 'Type'; ?>" class='typeToggle' style='padding:0px;height:20px;margin-bottom:0px;<?php echo $selectVisibility; ?>'>
+				<select id = "<?php echo 'Attribute' . $k . 'Type'; ?>" class="typeToggle" style="padding:0px;height:20px;margin-bottom:0px;<?php echo $selectVisibility; ?>">
 					<?php
 						foreach ($item['types'] as $type) {
+							if (!in_array($type, $allTypes))	$allTypes[$type] = $type;
 							echo '<option value="' . $type . '" ';
 							echo ($type == $item['default_type'] ? 'selected="selected"' : '') . '>' . $type . '</option>';
 						}
@@ -196,9 +191,40 @@
 	</span>
 </div>
 	<script>
+		var type_category_mapping = [];
+	<?php
+		// Categories per Type
+		foreach ($allTypes as $type => $def) {
+			echo "type_category_mapping['" . addslashes($type) . "'] = {";
+			$first = true;
+			$pos = strpos($type, '/');
+			if ($pos !== false) {//this should be extended to include the categories of the both types (rec)
+				$type = explode('/', $type);
+				$type = $type[0];
+			}
+			if (isset($typeCategoryMapping[$type]))
+				foreach ($typeCategoryMapping[$type] as $category => $def) {
+					if ($first) $first = false;
+					else echo ', ';
+					echo "'" . addslashes($category) . "' : '" . addslashes($category) . "'";
+				}
+			echo "}; \n";
+		}
+	?>
 		var options = <?php echo json_encode($optionsRearranged);?>;
 		$(document).ready(function(){
 			popoverStartup();
+			$('.typeToggle').change(function () {
+				var categorySelect = $('#'+$(this).attr('id').replace("Type", "Category"));
+				categorySelect.empty();
+				var options = categorySelect.prop('options');
+				$.each(type_category_mapping[$(this).val()], function(val, text) {
+					options[options.length] = new Option(text, val);
+					if (typeof alreadySelected != 'undefined' && val == alreadySelected) {
+						options[options.length-1].selected = true;
+					}
+				});
+			});
 	<?php
 		if (!empty($optionsRearranged)):
 	?>
@@ -217,3 +243,4 @@
 <?php
 	echo $this->element('side_menu', array('menuList' => 'event', 'menuItem' => 'freetextResults'));
 ?>
+<?php echo $this->Js->writeBuffer(); // Write cached scripts ?>

--- a/app/View/Events/resolved_attributes.ctp
+++ b/app/View/Events/resolved_attributes.ctp
@@ -99,16 +99,23 @@
 					}
 				?>
 				<select id="<?php echo 'Attribute' . $k . 'Category'; ?>" style="padding:0;height:20px;margin-bottom:0;">
-					<?php
-						foreach ($typeCategoryMapping[$item['default_type']] as $category) {
-							if (isset($item['categories']) && !in_array($category, $item['categories'])) {
-								continue;
-							}
-							echo '<option value="' . $category . '" ';
-							if ($category == $default) echo 'selected="selected"';
-							echo '>' . $category . '</option>';
+				<?php
+					$categoriesArray = $typeCategoryMapping[$item['default_type']];
+					if (isset($item['merge_categories']) && $item['merge_categories'] === true) {
+						$categoriesArray = [];
+						foreach ($item['types'] as $type) {
+							$categoriesArray = array_merge($categoriesArray, $typeCategoryMapping[$type]);
 						}
-					?>
+					}
+					foreach ($categoriesArray as $category) {
+						if (isset($item['categories']) && !in_array($category, $item['categories'])) {
+							continue;
+						}
+						echo '<option value="' . $category . '" ';
+						if ($category == $default) echo 'selected="selected"';
+						echo '>' . $category . '</option>';
+					}
+				?>
 				</select>
 			</td>
 			<td class="short">

--- a/app/View/Events/resolved_attributes.ctp
+++ b/app/View/Events/resolved_attributes.ctp
@@ -29,7 +29,7 @@
 				<th>Similar Attributes</th>
 				<th>Category</th>
 				<th>Type</th>
-				<th>IDS<input type="checkbox" id="checkAll" style="margin:0px;margin-left:3px;"/></th>
+				<th>IDS<input type="checkbox" id="checkAll" style="margin:0;margin-left:3px;"/></th>
 				<th>Comment</th>
 				<th>Actions</th>
 		</tr>
@@ -55,7 +55,7 @@
 					echo $this->Form->input('Attribute' . $k . 'Value', array(
 							'label' => false,
 							'value' => h($item['value']),
-							'style' => 'padding:0px;height:20px;margin-bottom:0px;width:90%;',
+							'style' => 'padding:0;height:20px;margin-bottom:0;width:90%;',
 							'div' => false
 					));
 				?>
@@ -98,7 +98,7 @@
 
 					}
 				?>
-				<select id="<?php echo 'Attribute' . $k . 'Category'; ?>" style='padding:0px;height:20px;margin-bottom:0px;'>
+				<select id="<?php echo 'Attribute' . $k . 'Category'; ?>" style="padding:0;height:20px;margin-bottom:0;">
 					<?php
 						foreach ($typeCategoryMapping[$item['default_type']] as $category) {
 							if (isset($item['categories']) && !in_array($category, $item['categories'])) {


### PR DESCRIPTION
#### What does it do?

new TLDs from IANA in the free text import, closes `#<1149>`
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
