### PR TITLE
Make STIX validate

### DIFF
--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -280,8 +280,7 @@ def main(args):
     if len(sys.argv) > 4:
         namespace[1] = sys.argv[4].replace(" ", "_")
         namespace[1] = re.sub('[\W]+', '', namespace[1])
-    cybox.utils.idgen.set_id_namespace(Namespace(namespace[1], namespace[0]))
-    stix.utils.idgen.set_id_namespace({namespace[1]: namespace[0]})
+    stix.utils.idgen.set_id_namespace({namespace[0]: namespace[1]})
     event = loadEvent(args, pathname)
     stix_package = generateEventPackage(event)
     saveFile(args, pathname, stix_package)

--- a/app/files/scripts/misp2stix_framing.py
+++ b/app/files/scripts/misp2stix_framing.py
@@ -89,7 +89,6 @@ def main(args):
         sys.exit("Invalid parameters")
     namespace = [sys.argv[1], sys.argv[2]]
     NS_DICT[namespace[0]]=namespace[1]
-    cybox.utils.idgen.set_id_namespace(Namespace(namespace[0], namespace[1]))
     stix.utils.idgen.set_id_namespace({namespace[0]: namespace[1]})
     stix_package = STIXPackage()
     stix_header = STIXHeader()


### PR DESCRIPTION
After this patch the STIX XML export passes the stix_validator

```
- correct namespace order
- stix set_id_namespace calls cybox set_id_namespace
```
