### PR TITLE
Two small STIX fixes (again)

### DIFF
--- a/app/files/scripts/misp2cybox.py
+++ b/app/files/scripts/misp2cybox.py
@@ -142,16 +142,22 @@ def resolveIPType(attribute_value, attribute_type):
 
 def generateDomainIPObservable(indicator, attribute):
     indicator.add_indicator_type("Domain Watchlist")
-    compositeObject = ObservableComposition()
-    compositeObject.operator = "AND"
     domain = attribute["value"].split('|')[0]
     ip = attribute["value"].split('|')[1]
     address_object = resolveIPType(ip, attribute["type"])
+    address_object.parent.id_ = cybox.utils.idgen.__generator.namespace.prefix + ":Address-" + attribute["uuid"]
+    address_observable=Observable(address_object)
+    address_observable.id_ = cybox.utils.idgen.__generator.namespace.prefix + ":Address-" + attribute["uuid"]
     domain_object = DomainName()
     domain_object.value = domain
-    compositeObject.add(address_object)
-    compositeObject.add(domain_object)
-    return compositeObject
+    domain_object.parent.id_ = cybox.utils.idgen.__generator.namespace.prefix + ":DomainName-" + attribute["uuid"]
+    domain_observable = Observable(domain_object)
+    domain_observable.id_ = cybox.utils.idgen.__generator.namespace.prefix + ":DomainName-" + attribute["uuid"]
+    compositeObject = ObservableComposition(observables = [address_observable, domain_observable])
+    compositeObject.operator = "AND"
+    observable = Observable(id_ = cybox.utils.idgen.__generator.namespace.prefix + ":ObservableComposition-" + attribute["uuid"])
+    observable.observable_composition = compositeObject
+    return observable
 
 def generateIPObservable(indicator, attribute):
     indicator.add_indicator_type("IP Watchlist")

--- a/app/files/scripts/misp2stix_framing.py
+++ b/app/files/scripts/misp2stix_framing.py
@@ -42,7 +42,7 @@ NS_DICT = {
         "http://stix.mitre.org/ThreatActor-1" : 'ta',
         "http://stix.mitre.org/common-1" : 'stixCommon',
         "http://stix.mitre.org/default_vocabularies-1" : 'stixVocabs',
-        "http://stix.mitre.org/extensions/Identity#CIQIdentity3.0-1" : 'stix-ciqidentity',
+        "http://stix.mitre.org/extensions/Identity#CIQIdentity3.0-1" : 'ciqIdentity',
         "http://stix.mitre.org/extensions/TestMechanism#Snort-1" : 'snortTM',
         "http://stix.mitre.org/stix-1" : 'stix',
         "http://www.w3.org/2001/XMLSchema-instance" : 'xsi',


### PR DESCRIPTION
- Use the correct CIQ namespace to avoid these errors:

```
    [!] stix-one-new.xml:13093:0:ERROR:SCHEMASV:SCHEMAV_CVC_DATATYPE_VALID_1_2_1: Element '{http://stix.mitre.org/Incident-1}Victim', attribute '{http://www.w3.org/2001/XMLSchema-instance}type': The QName value 'ciqIdentity:CIQIdentity3.0InstanceType' has no corresponding namespace declaration in scope.
    [!] stix-one-new.xml:13095:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{http://stix.mitre.org/extensions/Identity#CIQIdentity3.0-1}Specification': This element is not expected. Expected is ( {http://stix.mitre.org/common-1}Related_Identities ).
```
- Use consistent STIX/CyBOX IDs for domain|ip entries
