### PR TITLE
Added python-setuptools for ubuntu install howto

### DIFF
--- a/INSTALL/INSTALL.ubuntu1604.txt
+++ b/INSTALL/INSTALL.ubuntu1604.txt
@@ -66,7 +66,7 @@ sudo -u www-data git checkout tags/$(git describe --tags `git rev-list --tags --
 sudo -u www-data git config core.filemode false
 
 # install Mitre's STIX and its dependencies by running the following commands:
-sudo apt-get install python-dev python-pip libxml2-dev libxslt1-dev zlib1g-dev
+sudo apt-get install python-dev python-pip libxml2-dev libxslt1-dev zlib1g-dev python-setuptools
 cd /var/www/MISP/app/files/scripts
 sudo -u www-data git clone https://github.com/CybOXProject/python-cybox.git
 sudo -u www-data git clone https://github.com/STIXProject/python-stix.git


### PR DESCRIPTION
#### What does it do?

The installation Ubuntu installation readme file did not contain the package python-setuptools. I added it.
#### Questions
- [  ] Does it require a DB change?
- [  ] Are you using it in production?
- [  ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [  ] Major
- [  ] Minor
- [X] Patch

You need to install the package python-setuptools on Ubuntu 16.04/Mint 18 to use the setup.py for the STIX installation.
