### PR TITLE
sudo is needed to create new ssl key.

### DIFF
--- a/INSTALL/INSTALL.ubuntu1604.txt
+++ b/INSTALL/INSTALL.ubuntu1604.txt
@@ -137,7 +137,7 @@ sudo cp /var/www/MISP/INSTALL/apache.misp.ssl /etc/apache2/sites-available/misp-
 # For more information, visit http://httpd.apache.org/docs/2.4/upgrading.html
 
 # If a valid SSL certificate is not already created for the server, create a self-signed certificate:
-openssl req -newkey rsa:4096 -days 365 -nodes -x509 \
+sudo openssl req -newkey rsa:4096 -days 365 -nodes -x509 \
 -subj "/C=<Country>/ST=<State>/L=<Locality>/O=<Organization>/OU=<Organizational Unit Name>/CN=<QDN.here>/emailAddress=admin@<your.FQDN.here>" \
 -keyout /etc/ssl/private/misp.local.key -out /etc/ssl/private/misp.local.crt
 


### PR DESCRIPTION
#### What does it do?

I just added sudo to one command in the Ubuntu readme file.
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch

A normal user does not have permissions to the used folder /etc/ssl/private in Ubuntu 16.04/Mint 18 by default.
