### PR TITLE
Put tag info from event in E-mail subject

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1521,8 +1521,21 @@ class Event extends AppModel {
 		} else {
 			$subject = '';
 		}
-		$tplColorString = !empty(Configure::read('MISP.email_subject_TLP_string')) ? Configure::read('MISP.email_subject_TLP_string') : "TLP Amber";
-		$subject = "[" . Configure::read('MISP.org') . " MISP] Event " . $id . " - " . $subject . $event[0]['ThreatLevel']['name'] . " - ".$tplColorString;
+		$subjMarkingString = !empty(Configure::read('MISP.email_subject_TLP_string')) ? Configure::read('MISP.email_subject_TLP_string') : "TLP Amber";
+		$subjTag = !empty(Configure::read('MISP.email_subject_tag')) ? Configure::read('MISP.email_subject_tag') : "tlp";
+		$tagLen = strlen($subjTag);
+		foreach ($event[0]['EventTag'] as $k => $tag) {
+			$tagName=$tag['Tag']['name'];
+			if(strncasecmp($subjTag, $tagName, $tagLen) == 0 && strlen($tagName) > $tagLen && ($tagName[$tagLen] == ':' || $tagName[$tagLen] == '=')) {
+				if(Configure::read('MISP.email_subject_include_tag_name') === false) {
+					$subjMarkingString = trim(substr($tagName, $tagLen+1), '"');
+				} else {
+					$subjMarkingString = $tagName;
+				}
+				break;
+			}
+		}
+		$subject = "[" . Configure::read('MISP.org') . " MISP] Event " . $id . " - " . $subject . $event[0]['ThreatLevel']['name'] . " - ".$subjMarkingString;
 
 		// Initialise the Job class if we have a background process ID
 		// This will keep updating the process's progress bar

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -267,11 +267,27 @@ class Server extends AppModel {
 					),
 					'email_subject_TLP_string' => array(
 							'level' => 2,
-							'description' => 'This is the TLP string in alert e-mail sent when an event is published.',
+							'description' => 'This is the TLP string for e-mails when email_subject_tag is not found.',
 							'value' => 'TLP Amber',
 							'errorMessage' => '',
 							'test' => 'testForEmpty',
 							'type' => 'string',
+						),
+					'email_subject_tag' => array(
+							'level' => 2,
+							'description' => "If this tag is set on an event it's value will be sent in the E-mail subject. If the tag is not set the email_subject_TLP_string will be used.",
+							'value' => 'tlp',
+							'errorMessage' => '',
+							'test' => 'testForEmpty',
+							'type' => 'string',
+						),
+					'email_subject_include_tag_name' => array(
+							'level' => 2,
+							'description' => 'Include in name of the email_subject_tag in the subject. When false only the tag value is used.',
+							'value' => true,
+							'errorMessage' => '',
+							'test' => 'testBool',
+							'type' => 'boolean',
 						),
 					'taxii_sync' => array(
 							'level' => 3,


### PR DESCRIPTION
#### What does it do?

This patch introduces 2 new settings:
- _email_subject_tag_ to hold the name of the tag you want in the E-mail subject line
- _email_subject_include_tag_name_ to indicate if you want the name of the tag or only the value of the tag in the E-mail subject

The default is "tlp" and "true" so it fixes #1107 
#### Questions
- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
