### PR TITLE
Allow merging of event attributes

### DIFF
--- a/app/Controller/Component/ACLComponent.php
+++ b/app/Controller/Component/ACLComponent.php
@@ -116,6 +116,7 @@ class ACLComponent extends Component {
 					'viewEventAttributes' => array('*'),
 					'viewGraph' => array('*'),
 					'xml' => array('*'),
+					'merge' => array('perm_modify'),
 					'importChoice' => array('*'),
 					'importModule' => array('*'),
 					'exportModule' => array('*')

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -1179,48 +1179,46 @@ class EventsController extends AppController {
 				return;
 			}
 			$this->Event->read(null, $source_id);
-			if (!$this->_isSiteAdmin()) {
-				if (!in_array($source_id, $eIds)) {
-					$this->Session->setFlash(__('You are not authorised to read the selected event.'));
-					return;
-				}
-				$r = array('results' => []);
-				foreach ($this->Event->data['Attribute'] as $a) {
-					if ($to_ids && !$a['to_ids']) {
-						continue;
-					}
-					$tmp = array();
-					$tmp['values']     = $a['value'];
-					$tmp['categories'] = $a['category'];
-					$tmp['types']      = $a['type'];
-					$tmp['to_ids']     = $a['to_ids'];
-					$tmp['comment']    = $a['comment'];
-					$r['results'][] = $tmp;
-				}
-				$resultArray = $this->Event->handleModuleResult($r, $target_id);
-				$typeCategoryMapping = array();
-				foreach ($this->Event->Attribute->categoryDefinitions as $k => $cat) {
-					foreach ($cat['types'] as $type) {
-						$typeCategoryMapping[$type][$k] = $k;
-					}
-				}
-				foreach ($resultArray as $key => $result) {
-					$options = array(
-							'conditions' => array('OR' => array('Attribute.value1' => $result['value'], 'Attribute.value2' => $result['value'])),
-							'fields' => array('Attribute.type', 'Attribute.category', 'Attribute.value', 'Attribute.comment'),
-							'order' => false
-					);
-					$resultArray[$key]['related'] = $this->Event->Attribute->fetchAttributes($this->Auth->user(), $options);
-				}
-				$this->set('event', array('Event' => array('id' => $target_id)));
-				$this->set('resultArray', $resultArray);
-				$this->set('typeList', array_keys($this->Event->Attribute->typeDefinitions));
-				$this->set('defaultCategories', $this->Event->Attribute->defaultCategories);
-				$this->set('typeCategoryMapping', $typeCategoryMapping);
-				$this->set('title', 'Merge Results');
-				$this->set('importComment', 'Merged from event ' . $source_id);
-				$this->render('resolved_attributes');
+			if (!$this->_isSiteAdmin() && !in_array($source_id, $eIds)) {
+				$this->Session->setFlash(__('You are not authorised to read the selected event.'));
+				return;
 			}
+			$r = array('results' => []);
+			foreach ($this->Event->data['Attribute'] as $a) {
+				if ($to_ids && !$a['to_ids']) {
+					continue;
+				}
+				$tmp = array();
+				$tmp['values']     = $a['value'];
+				$tmp['categories'] = $a['category'];
+				$tmp['types']      = $a['type'];
+				$tmp['to_ids']     = $a['to_ids'];
+				$tmp['comment']    = $a['comment'];
+				$r['results'][] = $tmp;
+			}
+			$resultArray = $this->Event->handleModuleResult($r, $target_id);
+			$typeCategoryMapping = array();
+			foreach ($this->Event->Attribute->categoryDefinitions as $k => $cat) {
+				foreach ($cat['types'] as $type) {
+					$typeCategoryMapping[$type][$k] = $k;
+				}
+			}
+			foreach ($resultArray as $key => $result) {
+				$options = array(
+						'conditions' => array('OR' => array('Attribute.value1' => $result['value'], 'Attribute.value2' => $result['value'])),
+						'fields' => array('Attribute.type', 'Attribute.category', 'Attribute.value', 'Attribute.comment'),
+						'order' => false
+				);
+				$resultArray[$key]['related'] = $this->Event->Attribute->fetchAttributes($this->Auth->user(), $options);
+			}
+			$this->set('event', array('Event' => array('id' => $target_id)));
+			$this->set('resultArray', $resultArray);
+			$this->set('typeList', array_keys($this->Event->Attribute->typeDefinitions));
+			$this->set('defaultCategories', $this->Event->Attribute->defaultCategories);
+			$this->set('typeCategoryMapping', $typeCategoryMapping);
+			$this->set('title', 'Merge Results');
+			$this->set('importComment', 'Merged from event ' . $source_id);
+			$this->render('resolved_attributes');
 		} else {
 			// set the target event id in the form
 			$this->request->data['Event']['target_id'] = $target_id;

--- a/app/View/Elements/side_menu.ctp
+++ b/app/View/Elements/side_menu.ctp
@@ -36,6 +36,7 @@
 					<?php if ($menuItem === 'populateFromtemplate'): ?>
 							<li class="active"><a href="<?php echo $baseurl;?>/templates/populateEventFromTemplate/<?php echo $template_id . '/' . h($event['Event']['id']); ?>">Populate From Template</a></li>
 						<?php endif; ?>
+					<li id='merge'><a href="<?php echo $baseurl;?>/events/merge/<?php echo h($event['Event']['id']);?>">Merge attributes from...</a></li>
 					<?php endif; ?>
 					<?php if (($isSiteAdmin && (!isset($mayModify) || !$mayModify)) || (!isset($mayModify) || !$mayModify)): ?>
 					<li id='liproposeAttribute'><a href="<?php echo $baseurl;?>/shadow_attributes/add/<?php echo h($event['Event']['id']);?>">Propose Attribute</a></li>

--- a/app/View/Events/merge.ctp
+++ b/app/View/Events/merge.ctp
@@ -1,0 +1,34 @@
+<div class="eventmerge form">
+<?php echo $this->Form->create('Event', array('enctype' => 'multipart/form-data'));?>
+	<fieldset>
+		<legend><?php echo __('Merge events'); ?></legend>
+		<?php
+		echo $this->Form->hidden('target_id');
+		echo $this->Form->input('source_id', array(
+				'type' => 'text',
+				'label' => 'Event id to copy the attributes from',
+				'error' => array('escape' => false),
+				'div' => 'input clear',
+				'class' => 'input'
+		));
+		?>
+		<div class="input clear"></div>
+		<?php
+		echo $this->Form->input('to_ids', array(
+				'type' => 'checkbox',
+				'checked' => false,
+				'label' => 'copy only IDS attributes',
+		));
+		?>
+
+	</fieldset>
+<?php
+echo $this->Form->button('Merge', array('class' => 'btn btn-primary'));
+echo $this->Form->end();
+?>
+	<div id="confirmation_box" class="confirmation_box"></div>
+</div>
+<?php
+	$event['Event']['id'] = $this->request->data['Event']['target_id'];
+	echo $this->element('side_menu', array('menuList' => 'event', 'menuItem' => 'merge', 'event' => $event));
+?>


### PR DESCRIPTION
#### What does it do?

It created a new item in de side menu "Merge attributes from..." which allows for attributes from an existing events to be copied to the current event. The use case is to keep all attributes from a certain threat in a single event. This reduces clutter in highly structured MISP instances.
#### Questions
- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
