### PR TITLE
Fix indication of new attributes in E-mail alerts

### DIFF
--- a/app/Console/Command/EventShell.php
+++ b/app/Console/Command/EventShell.php
@@ -357,8 +357,9 @@ class EventShell extends AppShell
 		$processId = $this->args[1];
 		$job = $this->Job->read(null, $processId);
 		$eventId = $this->args[2];
+		$oldpublish = $this->args[3];
 		$user = $this->User->getAuthUser($userId);
-		$result = $this->Event->sendAlertEmail($eventId, $user, $processId);
+		$result = $this->Event->sendAlertEmail($eventId, $user, $oldpublish, $processId);
 		$job['Job']['progress'] = 100;
 		$job['Job']['message'] = 'Emails sent.';
 		//$job['Job']['date_modified'] = date("y-m-d H:i:s");

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -1404,7 +1404,7 @@ class EventsController extends AppController {
 		// only allow form submit CSRF protection
 		if ($this->request->is('post') || $this->request->is('put')) {
 			// send out the email
-			$emailResult = $this->Event->sendAlertEmailRouter($id, $this->Auth->user());
+			$emailResult = $this->Event->sendAlertEmailRouter($id, $this->Auth->user(), $this->Event->data['Event']['publish_timestamp']);
 			if (is_bool($emailResult) && $emailResult == true) {
 				// Performs all the actions required to publish an event
 				$result = $this->Event->publishRouter($id, null, $this->Auth->user());


### PR DESCRIPTION
#### What does it do?

This patch fixes a race condition with the E-mail alerts by keeping the old publish_timestamp as a parameter so new attributes can accurately be identified by the E-mail alerting process. Fixes #1521
#### Questions
- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
