### PR TITLE
Add missing tags from pushed events

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -2059,9 +2059,9 @@ class Event extends AppModel {
 					}
 				}
 			}
-			if (isset($data['Event']['Tag']) && $user['Role']['perm_tagger']) {
-				foreach ($data['Event']['Tag'] as $tag) {
-					$tag_id = $this->EventTag->Tag->captureTag($tag, $user);
+			if (isset($data['Event']['EventTag']) && $user['Role']['perm_tagger']) {
+				foreach ($data['Event']['EventTag'] as $tag) {
+					$tag_id = $this->EventTag->Tag->captureTag($tag['Tag'], $user);
 					if ($tag_id) {
 						$this->EventTag->attachTagToEvent($this->id, $tag_id);
 					} else {


### PR DESCRIPTION
#### What does it do?

When the same event exists in two MISP instances additional tags placed on the event are not synced. This patch fixes that.

I'm not sure if both ['Event']['Tag'] and ['Event']['EventTag'] should be supported but I observed that pushed events use ['Event']['EventTag']. 
#### Questions
- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
