### PR TITLE
Add rh-php56-bcmath as a requirement for CentOS

### DIFF
--- a/INSTALL/INSTALL.centos6.txt
+++ b/INSTALL/INSTALL.centos6.txt
@@ -33,7 +33,7 @@ yum install vim
 yum install gcc git httpd zip redis mysql-server python-devel python-pip libxslt-devel zlib-devel
 
 # Install PHP 5.6 from SCL, see https://www.softwarecollections.org/en/scls/rhscl/rh-php56/
-yum install rh-php56 rh-php56-php-fpm rh-php56-php-devel rh-php56-php-mysqlnd rh-php56-php-mbstring
+yum install rh-php56 rh-php56-php-fpm rh-php56-php-devel rh-php56-php-mysqlnd rh-php56-php-mbstring rh-php56-bcmath
 
 # rh-php56-php only provided mod_php for httpd24-httpd from SCL
 # if we want to use httpd from CentOS base we can use rh-php56-php-fpm instead

--- a/INSTALL/INSTALL.centos7.txt
+++ b/INSTALL/INSTALL.centos7.txt
@@ -31,7 +31,7 @@ yum install centos-release-scl
 yum install gcc git httpd zip redis mariadb mariadb-server python-devel python-pip libxslt-devel zlib-devel
 
 # Install PHP 5.6 from SCL, see https://www.softwarecollections.org/en/scls/rhscl/rh-php56/
-yum install rh-php56 rh-php56-php-fpm rh-php56-php-devel rh-php56-php-mysqlnd rh-php56-php-mbstring
+yum install rh-php56 rh-php56-php-fpm rh-php56-php-devel rh-php56-php-mysqlnd rh-php56-php-mbstring rh-php56-bcmath
 
 # rh-php56-php only provided mod_php for httpd24-httpd from SCL
 # if we want to use httpd from CentOS base we can use rh-php56-php-fpm instead


### PR DESCRIPTION
#### What does it do?

CentOS does not install the bcmath php module by default. MISP uses the bcmod() function when validating IBAN numbers. So rh-php56-bcmath needs to be installed to avoid this error message:

```
2016-10-12 15:33:43 Error: Fatal Error (1): Call to undefined function bcmod() in [/var/www/MISP/app/Lib/Tools/FinancialTool.php, line 112]
2016-10-12 15:33:43 Error: [InternalErrorException] Internal Server Error
```
#### Questions
- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
