### PR TITLE
fix: missing new TLDs in free text import, resolves #1149

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -2899,7 +2899,9 @@ class EventsController extends AppController {
 		if ($this->request->is('post')) {
 			App::uses('ComplexTypeTool', 'Tools');
 			$complexTypeTool = new ComplexTypeTool();
-			$resultArray = $complexTypeTool->checkComplexRouter($this->request->data['Attribute']['value'], 'freetext');
+			$this->loadModel('Warninglist');
+			$IANATLDEntries = $this->Warninglist->getAllIANAEntries();
+			$resultArray = $complexTypeTool->checkComplexRouter($this->request->data['Attribute']['value'], 'freetext', [], $IANATLDEntries);
 			foreach ($resultArray as $key => $r) {
 				$temp = array();
 				foreach ($r['types'] as $type) {

--- a/app/Lib/Tools/ComplexTypeTool.php
+++ b/app/Lib/Tools/ComplexTypeTool.php
@@ -208,9 +208,17 @@ class ComplexTypeTool {
 			if (!empty($IANATLDEntries) && preg_match('/^([-\pL\pN]+\.)+([a-z]{2,25})(\:[0-9]{2,5})?$/iu', $inputRefanged) > 0) {
 				$stringEnd = $temp[count($temp)-1];
 				$types = array('filename');
-				if (strpos($IANATLDEntries, $stringEnd) !== false) $types[] = 'domain';
-				if (count($temp) > 2) $types[] = 'url';
-				return array('types' => $types, 'to_ids' => true, 'default_type' => 'domain', 'merge_categories' => true);
+				$defaultType = 'filename';
+				if (strpos($IANATLDEntries, $stringEnd) !== false) {
+					$types[] = 'domain';
+					$defaultType = 'domain';
+				}
+				if (count($temp) > 2) {
+					$types[] = 'hostname';
+					$types[] = 'url';
+					$defaultType = 'hostname';
+				}
+				return array('types' => $types, 'to_ids' => true, 'default_type' => $defaultType, 'merge_categories' => true);
 			}
 
 			if (preg_match('/^([-\pL\pN]+\.)+([a-z][a-z]|biz|cat|com|edu|gov|int|mil|net|org|pro|tel|aero|arpa|asia|coop|info|jobs|mobi|name|museum|travel)(:[0-9]{2,5})?$/iu', $inputRefanged)) {

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -1726,7 +1726,9 @@ class Attribute extends AppModel {
 		if ($element['complex']) {
 			App::uses('ComplexTypeTool', 'Tools');
 			$complexTypeTool = new ComplexTypeTool();
-			$result = $complexTypeTool->checkComplexRouter($value, ucfirst($element['type']));
+			$this->loadModel('Warninglist');
+			$IANATLDEntries = $this->Warninglist->getAllIANAEntries();
+			$result = $complexTypeTool->checkComplexRouter($value, ucfirst($element['type']), [], $IANATLDEntries);
 			if (isset($result['multi'])) {
 				$temp = $attribute;
 				$attribute = array();

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -2813,6 +2813,8 @@ class Event extends AppModel {
 		$freetextResults = array();
 		App::uses('ComplexTypeTool', 'Tools');
 		$complexTypeTool = new ComplexTypeTool();
+		$this->loadModel('Warninglist');
+		$IANATLDEntries = $this->Warninglist->getAllIANAEntries();
 		if (isset($result['results']) && !empty($result['results'])) {
 			foreach ($result['results'] as $k => &$r) {
 				if (!is_array($r['values'])) {
@@ -2832,7 +2834,7 @@ class Event extends AppModel {
 				foreach ($r['values'] as &$value) {
 					if (in_array('freetext', $r['types'])) {
 						if (is_array($value)) $value = json_encode($value);
-						$freetextResults = array_merge($freetextResults, $complexTypeTool->checkComplexRouter($value, 'FreeText'));
+						$freetextResults = array_merge($freetextResults, $complexTypeTool->checkComplexRouter($value, 'FreeText', [], $IANATLDEntries));
 						if (!empty($freetextResults)) {
 							foreach ($freetextResults as &$ft) {
 								$temp = array();

--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -236,4 +236,27 @@ class Warninglist extends AppModel{
 		if (in_array($value, $listValues)) return true;
 		return false;
 	}
+
+	public function getAllIANAEntries() {
+		$result = $this->find('first', array(
+			'conditions' => array('Warninglist.name' => 'TLDs as known by IANA', 'enabled' => 1),
+			'recursive' => -1,
+			'contain' => array(
+				'WarninglistEntry' => array(
+					'fields' => array('WarninglistEntry.value')
+				)
+			)
+		));
+		if ((count($result))>0) {
+			return array_map(
+				function ($element) {
+					return strtolower($element['value']);
+				},
+				$result['WarninglistEntry']
+			);
+		} else {
+			return [];
+		}
+	}
+
 }

--- a/app/View/Events/resolved_attributes.ctp
+++ b/app/View/Events/resolved_attributes.ctp
@@ -199,12 +199,12 @@
 	<script>
 		var type_category_mapping = [];
 		<?php
-		// Categories per Type
+		//Adding categories per Type based for all visible types (based on $allTypes array)
 		foreach ($allTypes as $type => $def) {
 			echo "type_category_mapping['" . addslashes($type) . "'] = {";
 			$first = true;
 			$pos = strpos($type, '/');
-			if ($pos !== false) {//this should be extended to include the categories of the both types (rec)
+			if ($pos !== false) {//added for hardcoded types, like ip-src/ip-des. This should maybe extended to include the categories of the both types (rec)
 				$type = explode('/', $type);
 				$type = $type[0];
 			}
@@ -250,4 +250,3 @@
 <?php
 	echo $this->element('side_menu', array('menuList' => 'event', 'menuItem' => 'freetextResults'));
 ?>
-<?php echo $this->Js->writeBuffer(); // Write cached scripts ?>

--- a/app/View/Events/resolved_attributes.ctp
+++ b/app/View/Events/resolved_attributes.ctp
@@ -35,6 +35,7 @@
 		</tr>
 		<?php
 			$options = array();
+			$allTypes = array();
 			foreach ($resultArray as $k => $item):
 		?>
 		<tr id="row_<?php echo $k; ?>" class="freetext_row">
@@ -131,6 +132,8 @@
 				<select id = "<?php echo 'Attribute' . $k . 'Type'; ?>" class='typeToggle' style='padding:0px;height:20px;margin-bottom:0px;<?php echo $selectVisibility; ?>'>
 					<?php
 						foreach ($item['types'] as $type) {
+							if (!in_array($type, $allTypes))
+								$allTypes[$type] = $type;
 							echo '<option value="' . $type . '" ';
 							echo ($type == $item['default_type'] ? 'selected="selected"' : '') . '>' . $type . '</option>';
 						}
@@ -194,9 +197,41 @@
 	</span>
 </div>
 	<script>
+		var type_category_mapping = [];
+		<?php
+		// Categories per Type
+		foreach ($allTypes as $type => $def) {
+			echo "type_category_mapping['" . addslashes($type) . "'] = {";
+			$first = true;
+			$pos = strpos($type, '/');
+			if ($pos !== false) {//this should be extended to include the categories of the both types (rec)
+				$type = explode('/', $type);
+				$type = $type[0];
+			}
+			if (isset($typeCategoryMapping[$type]))
+				foreach ($typeCategoryMapping[$type] as $category => $def) {
+					if ($first) $first = false;
+					else echo ', ';
+					echo "'" . addslashes($category) . "' : '" . addslashes($category) . "'";
+				}
+			echo "}; \n";
+		}
+		?>
 		var options = <?php echo json_encode($optionsRearranged);?>;
 		$(document).ready(function(){
 			popoverStartup();
+			$('.typeToggle').change(function () {
+				var categorySelect = $('#'+$(this).attr('id').replace("Type", "Category"));
+				var alreadySelected = categorySelect.val();
+				categorySelect.empty();
+				var options = categorySelect.prop('options');
+				$.each(type_category_mapping[$(this).val()], function(val, text) {
+					options[options.length] = new Option(text, val);
+					if (typeof alreadySelected != 'undefined' && val == alreadySelected) {
+						options[options.length-1].selected = true;
+					}
+				});
+			});
 	<?php
 		if (!empty($optionsRearranged)):
 	?>
@@ -215,3 +250,4 @@
 <?php
 	echo $this->element('side_menu', array('menuList' => 'event', 'menuItem' => 'freetextResults'));
 ?>
+<?php echo $this->Js->writeBuffer(); // Write cached scripts ?>


### PR DESCRIPTION
#### What does it do?

fixes `#1149`: 
- adds the dynamic category -> changes type functionality in Freetext Import Attributes list;
- IANAknown TLDs are only checked if the warninglists are present and enabled.
  
  NOTEs:
- the warninglist "TLDs as known by IANA" must be not empty and enabled for this functionality to work;
- a limitation of the current behaviour is using the IANA list which has around 500 domains less than the ICANN list;
- for the moment special characters - like 在线 or .الجزائر‎ - are not translated to their equivalent IANA code (xn--3ds443g and xn--lgbbat1ad8j).
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
