### PR TITLE
search input for "select tag" is fixed and does not scroll up anymore

### DIFF
--- a/app/View/Tags/ajax/select_tag.ctp
+++ b/app/View/Tags/ajax/select_tag.ctp
@@ -1,4 +1,4 @@
-<div class="popover_choice">
+<div class="popover_choice select_tag">
 	<legend>Select Tag</legend>
 	<div style="display:none;">
 		<?php
@@ -7,13 +7,11 @@
 			echo $this->Form->end();
 		?>
 	</div>
+	<div style="text-align:right;width:100%;" class="select_tag_search">
+		<input id="filterField" style="width:100%;border:0px;padding:0px;" placeholder="search tags..."/>
+	</div>
 	<div class="popover_choice_main" id ="popover_choice_main">
 		<table style="width:100%;">
-		<tr>
-			<td style="text-align:right;width:100%;">
-				<input id="filterField" style="width:100%;border:0px;padding:0px;"></input>
-			</td>
-		</tr>
 		<?php foreach ($options as $k => &$option): ?>
 			<tr id="field_<?php echo h($k); ?>" style="border-bottom:1px solid black;" class="templateChoiceButton">
 				<td style="padding-left:10px;padding-right:10px; text-align:center;width:100%;" onClick="quickSubmitTagForm('<?php echo h($event_id);?>', '<?php echo h($k); ?>');" title="<?php echo h($expanded[$k]);?>"><?php echo h($option); ?></td>

--- a/app/View/Tags/ajax/taxonomy_choice.ctp
+++ b/app/View/Tags/ajax/taxonomy_choice.ctp
@@ -1,4 +1,4 @@
-<div class="popover_choice">
+<div class="popover_choice  select_tag_source">
 	<legend>Select Tag Source</legend>
 	<div class="popover_choice_main" id ="popover_choice_main">
 		<table style="width:100%;">


### PR DESCRIPTION
#### What does it do?

few minimal changes: 
- search input for "select tag" is fixed and does not scroll up anymore
- removed input end tag
- added css classes to select tag and select tag source popups - so they can be easily changed via the local extra css.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch