### PR TITLE
Block alert e-mails based on tag

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1490,6 +1490,17 @@ class Event extends AppModel {
 			if (empty($event)) return false;
 			if (strtotime($event['Event']['date']) < $oldest) return true;
 		}
+		if (Configure::read('MISP.block_event_alert') && Configure::read('MISP.block_event_alert_tag') && !empty(Configure::read('MISP.block_event_alert_tag'))) {
+			$noAlertTag = Configure::read('MISP.block_event_alert_tag');
+			$tagLen = strlen($noAlertTag);
+			$event = $this->fetchEvent($user, array('eventid' => $id, 'includeAllTags' => true));
+			if (empty($event)) return false;
+			foreach ($event[0]['EventTag'] as $k => $tag) {
+				if(strcasecmp($noAlertTag, $tag['Tag']['name']) == 0) {
+					return true;
+				}
+			}
+		}
 		if (Configure::read('MISP.disable_emailing')) {
 			$this->Log = ClassRegistry::init('Log');
 			$this->Log->create();

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -600,6 +600,24 @@ class Server extends AppModel {
 							'null' => false,
 
 					),
+					'block_event_alert' => array(
+							'level' => 1,
+							'description' => 'Enable this setting to start blocking alert e-mails for events with a certain tag. Define the tag in MISP.block_event_alert_tag.',
+							'value' => false,
+							'errorMessage' => '',
+							'test' => 'testBool',
+							'type' => 'boolean',
+							'null' => false,
+					),
+					'block_event_alert_tag' => array(
+							'level' => 1,
+							'description' => 'If the MISP.block_event_alert setting is set, alert e-mails for events tagged with the tag defined by this setting will be blocked.',
+							'value' => 'no-alerts="true"',
+							'errorMessage' => '',
+							'test' => 'testForEmpty',
+							'type' => 'string',
+							'null' => false,
+					),
 					'block_old_event_alert' => array(
 							'level' => 1,
 							'description' => 'Enable this setting to start blocking alert e-mails for old events. The exact timing of what constitutes an old event is defined by MISP.block_old_event_alert_age.',


### PR DESCRIPTION
#### What does it do?

It adds the option to block e-mail alerts for events tags with a certain tag. This can be used to explicitly  block sending out alert e-mail for certain class of events.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch

