### PR TITLE
sorts the "Attributes per organization" array by the total number of …

### DIFF
--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -855,6 +855,9 @@ class UsersController extends AppController {
 			$data[$key]['total'] = $d['total'];
 			if ($d['total'] > $max) $max = $d['total'];
 		}
+		uasort($data, function($a, $b) {
+			return $b['total'] - $a['total'];
+		});
 		$this->set('data', $data);
 		$this->set('max', $max);
 		$this->set('selectedTypes', $selectedTypes);


### PR DESCRIPTION
#### What does it do?


sorts the "Attributes per organization" array (and histogram) by the total number of attr, highest on top.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [X] Minor
- [ ] Patch
