### PR TITLE
Some adjustments to misp-backup.sh:

### DIFF
--- a/tools/misp-backup/misp-backup.conf.sample
+++ b/tools/misp-backup/misp-backup.conf.sample
@@ -1,4 +1,3 @@
-MySQLRUser="misp"
-MySQLRPass="FILLME"
+MISPPath=/var/www/MISP
 OutputFileName="MISP-Backup"
 OutputDirName="./"

--- a/tools/misp-backup/misp-backup.sh
+++ b/tools/misp-backup/misp-backup.sh
@@ -54,7 +54,10 @@ fi
 # Fill in any missing values with defaults
 
 # MISP path
-MISPPath=$(locate MISP/app/webroot/index.php|sed 's/\/app\/webroot\/index\.php//')
+MISPPath=${MISPPath:-$(locate MISP/app/webroot/index.php|sed 's/\/app\/webroot\/index\.php//')}
+# Output
+OutputFileName=${OutputFileName:-MISP-Backup}
+OutputDirName=${OutputDirName:-/tmp}
 # database.php
 MySQLUUser=$(grep -o -P "(?<='login' => ').*(?=')" $MISPPath/app/Config/database.php)
 MySQLUPass=$(grep -o -P "(?<='password' => ').*(?=')" $MISPPath/app/Config/database.php)
@@ -79,8 +82,12 @@ cp -r $MISPPath/app/webroot/img/custom $TmpDir/
 cp -r $MISPPath/app/files $TmpDir
 
 echo "MySQL Dump"
+MySQLRUser=${MySQLRUser:-$MySQLUUser}
+MySQLRPass=${MySQLRPass:-$MySQLUPass}
 mysqldump --opt -u $MySQLRUser -p$MySQLRPass $MISPDB > $TmpDir/MISPbackupfile.sql
 # Create compressed archive
-tar -zcvf $OutputDirName/$OutputFileName-$(date "+%b_%d_%Y_%H_%M_%S").tar.gz $TmpDir
+cd $TmpDir
+tar -zcf $OutputDirName/$OutputFileName-$(date "+%Y%m%d_%H%M%S").tar.gz *
+cd -
 rm -rf $TmpDir
 echo 'MISP Backup Complete!!!'


### PR DESCRIPTION
#### What does it do?

- allow setting MISPPath in misp-backup.conf
- use MySQL username/password from database.php by default
- use machine sortable date for output file
 - do not store TmdDir name in tar
- use tar non-verbosely

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch