### PR TITLE
Set proposal_to_delete default to 0

### DIFF
--- a/INSTALL/MYSQL.sql
+++ b/INSTALL/MYSQL.sql
@@ -475,7 +475,7 @@ CREATE TABLE IF NOT EXISTS `shadow_attributes` (
   `event_uuid` varchar(40) COLLATE utf8_bin NOT NULL,
   `deleted` tinyint(1) NOT NULL DEFAULT 0,
   `timestamp` int(11) NOT NULL DEFAULT 0,
-  `proposal_to_delete` BOOLEAN NOT NULL,
+  `proposal_to_delete` BOOLEAN NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   INDEX `event_id` (`event_id`),
   INDEX `event_uuid` (`event_uuid`),


### PR DESCRIPTION
#### What does it do?

 proposal_to_delete should default to 0, otherwise MISP will throw errors when a proposal is submitted:
```
2016-12-09 09:46:52 Error: [PDOException] SQLSTATE[HY000]: General error: 1364 Field 'proposal_to_delete' doesn't have a default value
Request URL: /shadow_attributes/edit/77722
Stack Trace:
#0 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Datasource/DboSource.php(468): PDOStatement->execute(Array)
#1 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Datasource/DboSource.php(434): DboSource->_execute('INSERT INTO `mi...', Array)
#2 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Datasource/DboSource.php(1026): DboSource->execute('INSERT INTO `mi...')
#3 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Model.php(1940): DboSource->create(Object(ShadowAttribute), Array, Array)
#4 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Model.php(1758): Model->_doSave(Array, Array)
#5 /var/www/MISP/app/Controller/ShadowAttributesController.php(667): Model->save(Array)
#6 [internal function]: ShadowAttributesController->edit('77722')
#7 /var/www/MISP/app/Lib/cakephp/lib/Cake/Controller/Controller.php(491): ReflectionMethod->invokeArgs(Object(ShadowAttributesController), Array)
#8 /var/www/MISP/app/Lib/cakephp/lib/Cake/Routing/Dispatcher.php(193): Controller->invokeAction(Object(CakeRequest))
#9 /var/www/MISP/app/Lib/cakephp/lib/Cake/Routing/Dispatcher.php(167): Dispatcher->_invoke(Object(ShadowAttributesController), Object(CakeRequest))
#10 /var/www/MISP/app/webroot/index.php(92): Dispatcher->dispatch(Object(CakeRequest), Object(CakeResponse))
#11 {main}
```

https://github.com/MISP/MISP/blob/2.4/app/Model/AppModel.php#L165 does this correctly, but on new installs this is broken.

#### Questions

- [x] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
