### PR TITLE
Use 24 hour clock

### DIFF
--- a/app/Model/Thread.php
+++ b/app/Model/Thread.php
@@ -30,7 +30,7 @@ class Thread extends AppModel {
 		} else {
 			$thread['Thread']['post_count'] = $count;
 			if ($add) {
-				$thread['Thread']['date_modified'] = date('Y/m/d h:i:s');
+				$thread['Thread']['date_modified'] = date('Y/m/d H:i:s');
 			}
 			$this->save($thread);
 			return true;

--- a/app/View/Elements/eventattribute.ctp
+++ b/app/View/Elements/eventattribute.ctp
@@ -55,7 +55,7 @@
 				foreach ($attributeSightingsPopover as $aid =>  &$attribute) {
 					$attributeSightingsPopoverText[$aid] = '';
 					foreach ($attribute as $org => $data) {
-						$attributeSightingsPopoverText[$aid] .= '<span class=\'bold\'>' . h($org) . '</span>: <span class=\'green bold\'>' . h($data['count']) . ' (' . date('Y-m-d h:i:s', $data['date']) . ')</span><br />';
+						$attributeSightingsPopoverText[$aid] .= '<span class=\'bold\'>' . h($org) . '</span>: <span class=\'green bold\'>' . h($data['count']) . ' (' . date('Y-m-d H:i:s', $data['date']) . ')</span><br />';
 					}
 				}
 			}

--- a/app/View/Events/view.ctp
+++ b/app/View/Events/view.ctp
@@ -31,7 +31,7 @@
 				}
 			}
 			foreach ($orgSightings as $org => $data) {
-				$sightingPopover .= '<span class=\'bold\'>' . h($org) . '</span>: <span class=\'green bold\'>' . h($data['count']) . ' (' . date('Y-m-d h:i:s', $data['date']) . ')' . '</span><br />';
+				$sightingPopover .= '<span class=\'bold\'>' . h($org) . '</span>: <span class=\'green bold\'>' . h($data['count']) . ' (' . date('Y-m-d H:i:s', $data['date']) . ')' . '</span><br />';
 			}
 		}
 	}

--- a/app/View/ShadowAttributes/index.ctp
+++ b/app/View/ShadowAttributes/index.ctp
@@ -93,7 +93,7 @@
 				<?php echo h($event['ShadowAttribute']['type']);?>
 			</td>
 			<td class="short" onclick="document.location.href ='<?php echo $baseurl."/events/view/".$event['Event']['id'];?>'">
-				<?php echo date('Y-m-d h:i:s', $event['ShadowAttribute']['timestamp']);?>
+				<?php echo date('Y-m-d H:i:s', $event['ShadowAttribute']['timestamp']);?>
 			</td>
 		</tr>
 		<?php endforeach; ?>


### PR DESCRIPTION
#### What does it do?

Several places in MISP used a 12-hour notation without AM/PM indicators. This leads to odd (off-by-12) results.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch

