### PR TITLE
Fix STIX exports for malware-sample attributes

### DIFF
--- a/app/files/scripts/misp2cybox.py
+++ b/app/files/scripts/misp2cybox.py
@@ -92,7 +92,7 @@ def resolveFileObservable(indicator, attribute):
         hashValue = values[1]
         indicator.add_indicator_type("File Hash Watchlist")
         composite = attribute["type"].split('|')
-        if (composite[1] == "ssdeep"):
+        if (len(composite) > 1 and composite[1] == "ssdeep"):
           fuzzy = True
     else:
         if (attribute["type"] in ("filename", "attachment")):


### PR DESCRIPTION
Fix a bug introduced by #1779 that causes STIX exports of events with a malware-sample attribute to fail.