### PR TITLE
Fixed typo in xINSTALL.centos7.txt

### DIFF
--- a/INSTALL/xINSTALL.centos7.txt
+++ b/INSTALL/xINSTALL.centos7.txt
@@ -206,7 +206,7 @@ cp -a config.default.php config.php
 
 # Configure the fields in the newly created files:
 # config.php   : baseurl (example: 'baseurl' => 'http://misp',) - don't use "localhost" it causes issues when browsing externally
-# config.php   : Uncomment and set the timezone: `// date_default_timezone_set('UTC');`
+# core.php   : Uncomment and set the timezone: `// date_default_timezone_set('UTC');`
 # database.php : login, port, password, database
 
 # Important! Change the salt key in /var/www/MISP/app/Config/config.php


### PR DESCRIPTION
xINTALL.centos7.txt refers to config.php when setting the timezone. This should be core.php.