### PR TITLE
Fixed typo in dependency installs

### DIFF
--- a/INSTALL/xINSTALL.centos7.txt
+++ b/INSTALL/xINSTALL.centos7.txt
@@ -31,7 +31,7 @@ yum install centos-release-scl
 yum install gcc git httpd zip redis mariadb mariadb-server python-devel python-pip libxslt-devel zlib-devel
 
 # Install PHP 5.6 from SCL, see https://www.softwarecollections.org/en/scls/rhscl/rh-php56/
-yum install rh-php56 rh-php56-php-fpm rh-php56-php-devel rh-php56-php-mysqlnd rh-php56-php-mbstring rh-php56-bcmath
+yum install rh-php56 rh-php56-php-fpm rh-php56-php-devel rh-php56-php-mysqlnd rh-php56-php-mbstring rh-php56-php-bcmath
 
 # rh-php56-php only provided mod_php for httpd24-httpd from SCL
 # if we want to use httpd from CentOS base we can use rh-php56-php-fpm instead


### PR DESCRIPTION
rh-php56-bcmath should be rh-php56-php-bcmath

#### What does it do?

Just a minor edit correcting a typo when running through the install document in the dependency section.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
