### PR TITLE
Truncate bro cached export files

### DIFF
--- a/app/Console/Command/EventShell.php
+++ b/app/Console/Command/EventShell.php
@@ -347,6 +347,7 @@ class EventShell extends AppShell
 			$file = new File($dir->pwd() . DS . 'misp.bro.' . $user['Organisation']['name'] . '.intel');
 		}
 
+		$file->write('');
 		foreach ($types as $k => $type) {
 			$final = $this->Attribute->bro($user, $type);
 			foreach ($final as $attribute) {


### PR DESCRIPTION
MISP only appends to bro cached export files, making them grow larger and larger until they fill up the entire partition, crashing MISP and making MISP admin very unhappy. This patch fixes all of that. In a single line.