### PR TITLE
auditor user can see user creator email

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1437,6 +1437,11 @@ class Event extends AppModel {
 				}
 				$event['ShadowAttribute'] = array_values($event['ShadowAttribute']);
 			}
+			// for auditor user : 
+			// insert into roles values (7,"Auditor","2017-01-27","2017-01-27",0,0,0,0,0,0, 0,1,0,1, 0,0,0,0,0,0,0);
+			if ($user['Role']['perm_audit']) {
+				$event['Event']['event_creator_id'] = $event['Event']['user_id'];
+			}
 		}
 		return $results;
 	}

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1439,10 +1439,12 @@ class Event extends AppModel {
 			}
 			// for auditor user : 
 			// insert into roles values (7,"Auditor","2017-01-27","2017-01-27",0,0,0,0,0,0, 0,1,0,1, 0,0,0,0,0,0,0);
-			if ($user['Role']['perm_audit']) {
+			if ($event['Event']['org_id'] === $user['org_id'] &&  $user['Role']['perm_audit']) {
 				$this->User = ClassRegistry::init('User');
 				$UserEmail = $this->User->getAuthUser($event['Event']['user_id'])['email'];
 				$event['Event']['event_creator_email'] = $UserEmail;
+			}else{
+				$event['Event']['event_creator_email'] = false;
 			}
 		}
 		return $results;

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1440,7 +1440,9 @@ class Event extends AppModel {
 			// for auditor user : 
 			// insert into roles values (7,"Auditor","2017-01-27","2017-01-27",0,0,0,0,0,0, 0,1,0,1, 0,0,0,0,0,0,0);
 			if ($user['Role']['perm_audit']) {
-				$event['Event']['event_creator_id'] = $event['Event']['user_id'];
+				$this->User = ClassRegistry::init('User');
+				$UserEmail = $this->User->getAuthUser($event['Event']['user_id'])['email'];
+				$event['Event']['event_creator_email'] = $UserEmail;
 			}
 		}
 		return $results;


### PR DESCRIPTION
## Why this pull request ?

Now you can create a user with auditor role.

add auditor roles with SQL or by UI
SQL : 
```SQL
INSERT INTO roles VALUES (7,"Auditor","2017-01-27","2017-01-27",0,0,0,0,0,0, 0,1,0,1, 0,0,0,0,0,0,0);
```
UI : 
- Name : Auditor
- Permissions : Read only
- [x] Perm Audit
- [x] Perm Auth

Create new user and assign Auditor role.
This user can search event and have access to the creator of the event if it is in the right organization.

#### sample with python  : 
```python
misp = PyMISP('http://mymisp.com/', 'AuditorApiKey')
print(misp.search(eventid='42')['response'][0]['Event']['event_creator_email'])
```
Result : 
```
test@test.com
```
#### Restriction : 
I just added the code for JSON. Look later if having this information in XML is necessary ^^

#### What does it do?

This proposal is an alternative solution for this issue : https://github.com/MISP/MISP/issues/1691

#### Questions

- [x] Does it require a DB change? (if you use sql ether not ^^)
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
