### PR TITLE
adds the option to add required fields and a validation pattern to the import

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -3085,8 +3085,13 @@ class Event extends AppModel {
 							'default_type' => $r['types'][0],
 							'comment' => isset($r['comment']) ? $r['comment'] : false,
 							'to_ids' => isset($r['to_ids']) ? $r['to_ids'] : false,
-							'value' => $value
+							'value' => $value,
 					);
+					if (isset($r['required'])) {
+						$temp['required'] = $r['required'];
+						if (isset($r['pattern']) && !empty($r['pattern']))
+							$temp['pattern'] = $r['pattern'];
+					}
 					if (isset($r['categories'])) {
 						$temp['categories'] = $r['categories'];
 						$temp['default_category'] = $r['categories'][0];

--- a/app/View/Events/resolved_attributes.ctp
+++ b/app/View/Events/resolved_attributes.ctp
@@ -61,10 +61,12 @@
 							'label' => false,
 							'value' => $item['value'],
 							'style' => 'padding:0px;height:20px;margin-bottom:0px;width:90%;',
-							'div' => false
+							'div' => false,
+							'required' => (isset($item['required']) && $item['required'] === true) ? $item['required'] : false,
+							'pattern' => isset($item['pattern']) ? $item['pattern'] : '.+',
 					));
 				?>
-				<input type="hidden" id="<?php echo 'Attribute' . $k . 'Save'; ?>" value=1 >
+				<input type="hidden" id="<?php echo 'Attribute' . $k . 'Save'; ?>" value="1" />
 			</td>
 			<td class="shortish">
 				<?php

--- a/app/webroot/js/misp2.4.62.js
+++ b/app/webroot/js/misp2.4.62.js
@@ -1799,6 +1799,20 @@ function freetextImportResultsSubmit(id, count) {
 	var temp;
 	for (i = 0; i < count; i++) {
 		if ($('#Attribute' + i + 'Save').val() == 1) {
+			var crtAttrValFld = $('#Attribute' + i + 'Value');
+			if (crtAttrValFld.prop('required')) {
+				if (crtAttrValFld.val().length == 0) {
+					crtAttrValFld.attr('placeholder', 'Please fill in this field').focus();
+					return false;
+				} else {
+					if (crtAttrValFld.prop('pattern') != '') {
+						if (new RegExp(crtAttrValFld.prop('pattern'), '').test(crtAttrValFld.val()) !== true) {
+							crtAttrValFld.focus();
+							return false;
+						}
+					}
+				}
+			}
 			temp = {
 				value:$('#Attribute' + i + 'Value').val(),
 				category:$('#Attribute' + i + 'Category').val(),


### PR DESCRIPTION
adds the possibility to mark required fields and a validation pattern to the import. 

in the import module the following need to be set -  'required': True, 'pattern': '[a-z][0-9]{4,8}'}

#### What does it do?

If it fixes an existing issue, please use github syntax: `#<IssueID>`

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
