### PR TITLE
Under some DBs, org creation would fail due to NOT NULL constraint

### DIFF
--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -729,7 +729,7 @@ class UsersController extends AppController {
 						'local' => 1,
 						'sector' => '',
 						'nationality' => '',
-                        'date_created' => Date("Y-m-d H:i:s")
+                        			'date_created' => Date("Y-m-d H:i:s")
 				));
 				$this->User->Organisation->save($org);
 				// PostgreSQL: update value of auto incremented serial primary key after setting the column by force

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -728,7 +728,8 @@ class UsersController extends AppController {
 						'uuid' => CakeText::uuid(),
 						'local' => 1,
 						'sector' => '',
-						'nationality' => ''
+						'nationality' => '',
+                        'date_created' => Date("Y-m-d H:i:s")
 				));
 				$this->User->Organisation->save($org);
 				// PostgreSQL: update value of auto incremented serial primary key after setting the column by force


### PR DESCRIPTION
#### What does it do?

Under mysql (not maria I think), admin org creation would fail due to date_created not being set. This would conflict with the `NOT NULL` constraint and cause login to be rendered impossible. 

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
