### PR TITLE
NidsSuricataExport refactoring for attribute *URL*

### DIFF
--- a/app/Lib/Export/NidsExport.php
+++ b/app/Lib/Export/NidsExport.php
@@ -496,4 +496,32 @@ class NidsExport {
 		}
 		return false;
 	}
+
+    public static function getProtocolPort($protocol, $customPort) {
+        if($customPort == null) {
+            switch ($protocol) {
+                case "http":
+                    return '$HTTP_PORTS';
+                case "https":
+                    return '443';
+                case "ssh":
+                    return '22';
+                case "ftp":
+                    return '[20,21]';
+                default:
+                    return 'any';
+            }
+        } else {
+            return $customPort;
+        }
+    }
+
+    public static function getCustomIP($customIP) {
+        if(filter_var($customIP, FILTER_VALIDATE_IP)) {
+            return $customIP;
+        }
+        else {
+            return '$EXTERNAL_NET';
+        }
+    }
 }

--- a/app/Lib/Export/NidsSuricataExport.php
+++ b/app/Lib/Export/NidsSuricataExport.php
@@ -88,28 +88,124 @@ class NidsSuricataExport extends NidsExport {
 	}
 
 	public function urlRule($ruleFormat, $attribute, &$sid) {
-		// TODO in hindsight, an url should not be excluded given a host or domain name.
-		//$hostpart = parse_url($attribute['value'], PHP_URL_HOST);
-		//$overruled = $this->checkNames($hostpart);
-		// warning: only suricata compatible
+		$createRule = true;
 		$overruled = $this->checkWhitelist($attribute['value']);
-		$attribute['value'] = NidsExport::replaceIllegalChars($attribute['value']);  // substitute chars not allowed in rule
-		$content = 'flow:to_server,established; content:"' . $attribute['value'] . '"; fast_pattern; nocase; http_uri;';
-		$this->rules[] = sprintf($ruleFormat,
-				($overruled) ? '#OVERRULED BY WHITELIST# ' : '',
-				'http',							// proto
-				'$HOME_NET',					// src_ip
-				'any',							// src_port
-				'->',							// direction
-				'$EXTERNAL_NET',				// dst_ip
-				'any',							// dst_port
-				'Outgoing HTTP URL: ' . $attribute['value'],		// msg
-				$content,						// rule_content
-				'tag:session,600,seconds;',		// tag
-				$sid,							// sid
-				1								// rev
-		);
-	}
+	
+		$scheme = parse_url($attribute['value'], PHP_URL_SCHEME);
+		$data = parse_url($attribute['value']);
+		if (!array_key_exists('port', $data)) {
+		    $data['port'] = null;
+		}
+	
+		switch ($scheme) {
+		    case "http":
+				$data['host'] = NidsExport::replaceIllegalChars($data['host']);
+		
+				$suricata_protocol = 'http';
+				$suricata_src_ip = '$HOME_NET';
+				$suricata_src_port = 'any';
+				$suricata_dst_ip = NidsExport::getCustomIP($data['host']);
+				$suricata_dst_port = NidsExport::getProtocolPort($scheme, $data['port']);
+				$tag = 'tag:session,600,seconds;';
+		
+				if (!array_key_exists('path', $data)) {
+				    $data['path'] = NidsExport::replaceIllegalChars($data['host']);
+				    $content = 'flow:to_server,established; content:"' . $data['host'] . '"; nocase; http_header;';
+				} else {
+				    $content = 'flow:to_server,established; content:"' . $data['host'] . '"; fast_pattern; nocase; http_header; content:"' . $data['path'] . '"; nocase; http_uri;';
+				}
+		
+				break;
+	
+		    case "https":
+				$data['host'] = NidsExport::replaceIllegalChars($data['host']);
+				$tag = 'tag:session,600,seconds;';
+		
+				# IP: classic IP rule for HTTPS
+				if (filter_var($data['host'], FILTER_VALIDATE_IP)) {
+				    $suricata_protocol = 'tcp';
+				    $suricata_src_ip = '$HOME_NET';
+				    $suricata_src_port = 'any';
+				    $suricata_dst_ip = $data['host'];
+				    $suricata_dst_port = NidsExport::getProtocolPort($scheme, $data['port']);
+				    $content = 'flow:to_server; app-layer-protocol:tls;';
+				}
+				# Domain: rule on https certificate subject
+				else {
+				    $suricata_protocol = 'tls';
+				    $suricata_src_ip = '$EXTERNAL_NET';
+				    $suricata_src_port = NidsExport::getProtocolPort($scheme, $data['port']);
+				    $suricata_dst_ip = '$HOME_NET';
+				    $suricata_dst_port = 'any';
+				    $content = 'tls_cert_subject; content:"' . $data['host'] . '"; nocase; pcre:"/' . $data['host'] . '$/";';
+				}
+				break;
+	
+		    case "ssh":
+				# IP: classic IP rule for SSH
+				if (filter_var($data['host'], FILTER_VALIDATE_IP)) {
+				    $suricata_protocol = 'tcp';
+				    $suricata_src_ip = '$HOME_NET';
+				    $suricata_src_port = 'any';
+				    $suricata_dst_ip = $data['host'];
+				    $suricata_dst_port = '$SSH_PORTS';
+				    $content = 'flow:to_server; app-layer-protocol:ssh;';
+				    $tag = '';
+				}
+				# Cannot create a satisfaisant rule (user could create a domain attribute if needed)
+				else {
+				    $createRule = false;
+				}
+				break;
+
+		    case "ftp":
+				# IP: classic IP rule for FTP
+				if (filter_var($data['host'], FILTER_VALIDATE_IP)) {
+				    $suricata_protocol = 'tcp';
+				    $suricata_src_ip = '$HOME_NET';
+				    $suricata_src_port = 'any';
+				    $suricata_dst_ip = $data['host'];
+				    $suricata_dst_port = NidsExport::getProtocolPort($scheme, $data['port']);
+				    $content = 'flow:to_server; app-layer-protocol:ftp;';
+				    $tag = '';
+				}
+				# Cannot create a satisfaisant rule (user could create a domain attribute if needed)
+				else {
+				    $createRule = false;
+				}
+				break;
+	
+		    # Unknown/No protocol: keep old behaviour
+		    default:
+				$suricata_protocol = 'http';
+				$suricata_src_ip = '$HOME_NET';
+				$suricata_src_port = 'any';
+				$suricata_dst_ip = '$EXTERNAL_NET';
+				$suricata_dst_port = 'any';
+		
+				$url = NidsExport::replaceIllegalChars($attribute['value']);  // substitute chars not allowed in rule
+				$content = 'flow:to_server,established; content:"' . $url . '"; fast_pattern; nocase; http_uri;';
+				$tag = 'tag:session,600,seconds;';
+		
+				break;
+		}
+	
+		if ($createRule) {
+			$attribute['value'] = NidsExport::replaceIllegalChars($attribute['value']);  // substitute chars not allowed in rule
+			$this->rules[] = sprintf($ruleFormat, ($overruled) ? '#OVERRULED BY WHITELIST# ' : '', $suricata_protocol, // proto
+				$suricata_src_ip,			// src_ip
+				$suricata_src_port,			// src_port
+				'->',						// direction
+				$suricata_dst_ip,			// dst_ip
+				$suricata_dst_port,			// dst_port
+				'Outgoing URL: ' . $attribute['value'],		// msg
+				$content,					// rule_content
+				$tag,						// tag
+				$sid,						// sid
+				1							// rev
+			);
+		}
+    }
 
 	public function userAgentRule($ruleFormat, $attribute, &$sid) {
 		$overruled = $this->checkWhitelist($attribute['value']);


### PR DESCRIPTION
# What does it do ?

## The problem
The current export function for the attribute URL does not work as expected. The problem was already mentioned in issue #1658 and is the following::

1. The function processes the attribute as a whole and looks for the full pattern in the **HTTP-request-URI**. This is a problem since the HTTP-request-URI has multiples forms (see [RFC2616](https://www.ietf.org/rfc/rfc2616.txt)): 

        Request-URI    = "*" | absoluteURI | abs_path | authority
        
    This will only works if the **absoluteURI** is used but not when the **abs_path**. Example:
        
        attribute[URL]: "http://example.com/path1/path2/resource"
        [A] HTTP-request-URI with absoluteURI: "http://example.com/path1/path2/resource" **OK**
        [B] HTTP-request-URI with abs_path: "/path1/path2/resource" **PROBLEM**
        
    In example B, the HTTP-request-URI will never contain the attribute[URL] and we won't get any Suricata alert.
    
2. The function does not process the attribute URL as an URL. As explained in (1), the processing looks for the attribute in the HTTP request and assume that the URL is HTTP which is not always the case. We should process the attribute URL as defined in [RFC1738](https://www.ietf.org/rfc/rfc1738.txt):

        <scheme>//<user>:<password>@<host>:<port>/<url-path>
        
## The refactoring

1. We assume the user wrote an URL (RFC1738) and we look for the scheme.
2. Two cases
    * **there is a scheme**: we process the URL on the basis of this scheme
    * **no scheme**: this is not a valid URL and we can't do anything except processing the URL like before. This means looking for the attribute[URL] in the **HTTP-Request-URI** which was the default behavior. Note that this prevents changing how are processed old attributes.
3. Depending of the scheme
    1. **HTTP**: parsing the URL and create a rule which combines the information from the **url-path* and the **host**
    2. **HTTPS**: parsing the URL and looking for the host
        * host is a Domain Name: create a rule which looks for a match between the certificate subject coming from the server and the Domain Name
        * host is an IP address: create a new TCP rule on port 443 (default) with layer-protocol-detection=TLS since the certificate cannot be used. Note that with layer protocol specified the alert will only trigger when a packet containing TLS protocol is sent
    
    3. **FTP**: parsing the URL and looking for the host
    
        * host is a Domain Name: we cannot create a rule for FTP. The only option is to create a DNS rule on port 53 for this Domain Name but we leave this to the user who could create a domain attribute
        * host is an IP address: create a new TCP rule on port 20,21 (default) with layer-protocol-detection=FTP. Note that with layer protocol specified the alert will only trigger when a packet containing FTP data is sent (e.g. username data) but not at the initial TCP connection on port 20,21
    
    4. **SSH**: similar to FTP

## Examples

Here is a list of examples with different kind of URL and what is checked by Suricata for the generated rules:

#### HTTP rules
![http](https://cloud.githubusercontent.com/assets/14250017/22194814/e985cf94-e144-11e6-831f-74220d09c574.png)

![http_ip](https://cloud.githubusercontent.com/assets/14250017/22194817/ed3abe38-e144-11e6-8482-a50e43063d53.png)

![http_port](https://cloud.githubusercontent.com/assets/14250017/22194824/f0add5b4-e144-11e6-987c-f0c28ce79614.png)

#### HTTPS rules
![https](https://cloud.githubusercontent.com/assets/14250017/22194826/f3292988-e144-11e6-8d20-12698e45813c.png)

![https_ip](https://cloud.githubusercontent.com/assets/14250017/22194830/f8aa4e78-e144-11e6-8314-c19d7102c478.png)

![https_port](https://cloud.githubusercontent.com/assets/14250017/22194831/fb121cb8-e144-11e6-839d-18d4ca71c1e6.png)

#### SSH rules
![ssh](https://cloud.githubusercontent.com/assets/14250017/22194835/feb26058-e144-11e6-8f3e-6c97dccd0f17.png)

#### FTP rules
![ftp](https://cloud.githubusercontent.com/assets/14250017/22194848/014ab70c-e145-11e6-90d9-6ce280a5dd00.png)

# Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [X] Minor
- [ ] Patch
