### PR TITLE
eventview - cluster id fields

### DIFF
--- a/app/View/Elements/galaxyQuickView.ctp
+++ b/app/View/Elements/galaxyQuickView.ctp
@@ -48,7 +48,7 @@
 							}
 							foreach ($cluster_fields as $cluster_field):
 						?>
-								<tr>
+								<tr id="cluster_<?php echo h($cluster_field['key']); ?>">
 									<td style="width:25%;vertical-align: text-top; padding-bottom:10px;"><?php echo h(ucfirst($cluster_field['key'])); ?></td>
 									<td style="width:75%; padding-bottom:10px;">
 										<?php

--- a/app/View/Elements/galaxyQuickView.ctp
+++ b/app/View/Elements/galaxyQuickView.ctp
@@ -48,7 +48,7 @@
 							}
 							foreach ($cluster_fields as $cluster_field):
 						?>
-								<tr id="cluster_<?php echo h($cluster_field['key']); ?>">
+								<tr class="cluster_<?php echo h($cluster_field['key']); ?>">
 									<td style="width:25%;vertical-align: text-top; padding-bottom:10px;"><?php echo h(ucfirst($cluster_field['key'])); ?></td>
 									<td style="width:75%; padding-bottom:10px;">
 										<?php


### PR DESCRIPTION
#### What does it do?

Allows custom CSS to manage the cluster info fields. (example: #cluster_country { display: none; } )

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [X] Minor
- [ ] Patch
