### PR TITLE
Fixed install instructions

### DIFF
--- a/INSTALL/INSTALL.ubuntu1604.txt
+++ b/INSTALL/INSTALL.ubuntu1604.txt
@@ -43,7 +43,7 @@ sudo a2dissite 000-default
 sudo a2ensite default-ssl
 
 # Install PHP and dependencies
-sudo apt-get install libapache2-mod-php php php-cli php-crypt-gpg php-dev php-json php-mysql php-opcache php-readline php-redis
+sudo apt-get install libapache2-mod-php php php-cli php-crypt-gpg php-dev php-json php-mysql php-opcache php-readline php-redis php-xml
 
 # Apply all changes
 sudo systemctl restart apache2


### PR DESCRIPTION
Added php-xml, without it this issue can rise:
Class 'DOMDocument' not found in [/var/www/MISP/app/Lib/cakephp/lib/Cake/Utility/Xml.php


#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
