### PR TITLE
remove spurious php5-xml

### DIFF
--- a/INSTALL/INSTALL.debian7.txt
+++ b/INSTALL/INSTALL.debian7.txt
@@ -28,7 +28,7 @@ apt-get install vim
 
 # Note that the php5-redis package in Debian oldstable (wheezy) only exists in the backports repository: http://backports.debian.org/Instructions/
 # Install the dependencies:
-apt-get install gcc zip php-pear git redis-server make python-dev python-pip libxml2-dev libxslt1-dev zlib1g-dev php5-dev libapache2-mod-php5 php5-xml php5-mysql php5-json php5-redis curl
+apt-get install gcc zip php-pear git redis-server make python-dev python-pip libxml2-dev libxslt1-dev zlib1g-dev php5-dev libapache2-mod-php5 php5-mysql php5-json php5-redis curl
 pear install Crypt_GPG    # we need version >1.3.0
 #if you are using a proxy do:
 pear config-set http_proxy http://username:password@yourproxy:80


### PR DESCRIPTION
php5-xml is not a separate package; it's included with libapache2-mod-php5.

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2016-06-03: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

If it fixes an existing issue, please use github syntax: `#<IssueID>`

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
