### PR TITLE
feature: Add support for user creation with authkey

### DIFF
--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -346,6 +346,7 @@ class UsersController extends AppController {
 						'disabled' => 0,
 						'newsread' => 0,
 						'change_pw' => 1,
+						'authkey' => $this->User->generateAuthKey(),
 						'termsaccepted' => 0
 				);
 				foreach ($defaults as $key => $value) {


### PR DESCRIPTION
## Allow to set authkey with PyMISP at user creation level

#### What does it do?

This allow PyMISP to create a user with a specified authkey. If "authkey" isn't specified, a value is autogenerated by conventional way.

A similar pull requested has been pushed to PyMISP repo.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [X] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [X] Minor
- [ ] Patch
