### PR TITLE
new: Add reverse proxy support for test of baseurl

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -2126,10 +2126,40 @@ class Server extends AppModel {
 		return true;
 	}
 
+
+	public function getHost() {
+		if (function_exists('apache_request_headers')){
+				 $headers = apache_request_headers();
+		} else {
+				 $headers = $_SERVER;
+		}
+
+		if ( array_key_exists( 'X-Forwarded-Host', $headers ) ) {
+				 $host = $headers['X-Forwarded-Host'];
+		} else {
+				 $host = $headers['HTTP_HOST'];
+		}
+		return $host;
+	}
+
+	public function getProto() {
+		if (function_exists('apache_request_headers')){
+				 $headers = apache_request_headers();
+		} else {
+				 $headers = $_SERVER;
+		}
+
+		if (array_key_exists('X-Forwarded-Proto',$headers)){
+				 $proto = $headers['X-Forwarded-Proto'];
+		} else {
+				 $proto = ((!empty($headers['HTTPS']) && $headers['HTTPS'] !== 'off') || $headers['SERVER_PORT'] == 443) === true ? 'HTTPS' : 'HTTP';
+		}       
+		return $proto;
+	}       
+
 	public function testBaseURL($value) {
 		if ($this->testForEmpty($value) !== true) return $this->testForEmpty($value);
-		$protocol = ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || $_SERVER['SERVER_PORT'] == 443) === true ? 'HTTPS' : 'HTTP';
-		if ($value != strtolower($protocol) . '://' . $_SERVER['HTTP_HOST']) return false;
+		if ($value != strtolower($this->getProto()) . '://' . $this->getHost()) return false;
 		return true;
 	}
 


### PR DESCRIPTION
#### What does it do?

This patch update testBaseUrl to check if MISP is behind a reverse proxy and conventional headers have been setted.


2 functions are added in order to return originally requested protocol or hostname.

Old parsing of $_SERVER values are kept in case the headers variable are not setted.


#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
