### PR TITLE
Script to wipe (reset) a MISP installation

### DIFF
--- a/tools/misp-wipe/misp-wipe.conf.sample
+++ b/tools/misp-wipe/misp-wipe.conf.sample
@@ -1,0 +1,1 @@
+MISPPath=/var/www/MISP

--- a/tools/misp-wipe/misp-wipe.sh
+++ b/tools/misp-wipe/misp-wipe.sh
@@ -62,15 +62,6 @@ MySQLUPass=$(grep -o -P "(?<='password' => ').*(?=')" $MISPPath/app/Config/datab
 MISPDB=$(grep -o -P "(?<='database' => ').*(?=')" $MISPPath/app/Config/database.php)
 DB_Port=$(grep -o -P "(?<='port' => ).*(?=,)" $MISPPath/app/Config/database.php)
 MISPDBHost=$(grep -o -P "(?<='host' => ').*(?=')" $MISPPath/app/Config/database.php)
-# config.php
-Salt=$(grep -o -P "(?<='salt' => ').*(?=')" $MISPPath/app/Config/config.php)
-BaseURL=$(grep -o -P "(?<='baseurl' => ').*(?=')" $MISPPath/app/Config/config.php)
-OrgName=$(grep -o -P "(?<='org' => ').*(?=')" $MISPPath/app/Config/config.php)
-LogEmail=$(grep -o -P "(?<='email' => ').*(?=')" $MISPPath/app/Config/config.php|head -1)
-AdminEmail=$(grep -o -P "(?<='contact' => ').*(?=')" $MISPPath/app/Config/config.php)
-GnuPGEmail=$(sed -n -e '/GnuPG/,$p' $MISPPath/app/Config/config.php|grep -o -P "(?<='email' => ').*(?=')")
-GnuPGHomeDir=$(grep -o -P "(?<='homedir' => ').*(?=')" $MISPPath/app/Config/config.php)
-GnuPGPass=$(grep -o -P "(?<='password' => ').*(?=')" $MISPPath/app/Config/config.php)
 
 echo "Wiping MySQL tables"
 MySQLRUser=${MySQLRUser:-$MySQLUUser}

--- a/tools/misp-wipe/misp-wipe.sql
+++ b/tools/misp-wipe/misp-wipe.sql
@@ -1,0 +1,35 @@
+-- Clear tables that should be empty
+TRUNCATE `attributes`;
+TRUNCATE `correlations`;
+TRUNCATE `events`;
+TRUNCATE `event_delegations`;
+TRUNCATE `event_tags`;
+TRUNCATE `favourite_tags`;
+TRUNCATE `jobs`;
+TRUNCATE `logs`;
+TRUNCATE `posts`;
+TRUNCATE `servers`;
+TRUNCATE `shadow_attributes`;
+TRUNCATE `shadow_attribute_correlations`;
+TRUNCATE `sharing_groups`;
+TRUNCATE `sharing_group_orgs`;
+TRUNCATE `sharing_group_servers`;
+TRUNCATE `sightings`;
+TRUNCATE `threads`;
+
+-- Clear tables that have defaults
+TRUNCATE `feeds`;
+TRUNCATE `regexp`;
+TRUNCATE `roles`;
+TRUNCATE `threat_levels`;
+TRUNCATE `templates`;
+TRUNCATE `template_elements`;
+TRUNCATE `template_element_attributes`;
+TRUNCATE `template_element_files`;
+TRUNCATE `template_element_texts`;
+
+-- Remove entries from tables and reset index
+DELETE FROM `users` WHERE id > 2;
+ALTER TABLE `users` AUTO_INCREMENT = 3;
+DELETE FROM `organisations` WHERE id > 2;
+ALTER TABLE `organisations` AUTO_INCREMENT = 3;

--- a/tools/misp-wipe/misp-wipe.sql
+++ b/tools/misp-wipe/misp-wipe.sql
@@ -16,6 +16,10 @@ TRUNCATE `sharing_group_orgs`;
 TRUNCATE `sharing_group_servers`;
 TRUNCATE `sightings`;
 TRUNCATE `threads`;
+TRUNCATE `bruteforces`;
+TRUNCATE `news`;
+TRUNCATE `template_tags`;
+TRUNCATE `whitelist`;
 
 -- Clear tables that have defaults
 TRUNCATE `feeds`;

--- a/tools/misp-wipe/misp-wipe.sql
+++ b/tools/misp-wipe/misp-wipe.sql
@@ -29,7 +29,7 @@ TRUNCATE `template_element_files`;
 TRUNCATE `template_element_texts`;
 
 -- Remove entries from tables and reset index
-DELETE FROM `users` WHERE id > 2;
-ALTER TABLE `users` AUTO_INCREMENT = 3;
+DELETE FROM `users` WHERE id > 3;
+ALTER TABLE `users` AUTO_INCREMENT = 4;
 DELETE FROM `organisations` WHERE id > 2;
 ALTER TABLE `organisations` AUTO_INCREMENT = 3;

--- a/tools/misp-wipe/misp-wipe.sql
+++ b/tools/misp-wipe/misp-wipe.sql
@@ -21,6 +21,18 @@ TRUNCATE `news`;
 TRUNCATE `template_tags`;
 TRUNCATE `whitelist`;
 
+-- Clear tables that can be re-populated
+TRUNCATE `taxonomies`;
+TRUNCATE `taxonomy_entries`;
+TRUNCATE `taxonomy_predicates`;
+TRUNCATE `warninglists`;
+TRUNCATE `warninglist_entries`;
+TRUNCATE `warninglist_types`;
+TRUNCATE `galaxies`;
+TRUNCATE `galaxy_clusters`;
+TRUNCATE `galaxy_elements`;
+TRUNCATE `galaxy_reference`;
+
 -- Clear tables that have defaults
 TRUNCATE `feeds`;
 TRUNCATE `regexp`;


### PR DESCRIPTION
As requested in #1677 

For now, the script will reset a MISP installation to same state as a fresh install. It leaves the first 3 users though, as this is useful for the MISP training instance.

It would be nice if the taxonomies/warninglists/galaxies could be automatically be repopulated by the script in the future.

