### PR TITLE
Account for broken apache_request_headers()

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -2119,13 +2119,16 @@ class Server extends AppModel {
 
 
 	public function getHost() {
-		if (function_exists('apache_request_headers')){
+		$headers = [];
+		if (function_exists('apache_request_headers')) {
 				 $headers = apache_request_headers();
-		} else {
+		}
+
+		if (!array_key_exists('HTTP_HOST', $headers)) {
 				 $headers = $_SERVER;
 		}
 
-		if ( array_key_exists( 'X-Forwarded-Host', $headers ) ) {
+		if (array_key_exists( 'X-Forwarded-Host', $headers)) {
 				 $host = $headers['X-Forwarded-Host'];
 		} else {
 				 $host = $headers['HTTP_HOST'];
@@ -2134,13 +2137,16 @@ class Server extends AppModel {
 	}
 
 	public function getProto() {
-		if (function_exists('apache_request_headers')){
+		$headers = [];
+		if (function_exists('apache_request_headers')) {
 				 $headers = apache_request_headers();
-		} else {
+		}
+
+		if (!array_key_exists('SERVER_PORT', $headers)) {
 				 $headers = $_SERVER;
 		}
 
-		if (array_key_exists('X-Forwarded-Proto',$headers)){
+		if (array_key_exists('X-Forwarded-Proto', $headers)) {
 				 $proto = $headers['X-Forwarded-Proto'];
 		} else {
 				 $proto = ((!empty($headers['HTTPS']) && $headers['HTTPS'] !== 'off') || $headers['SERVER_PORT'] == 443) === true ? 'HTTPS' : 'HTTP';


### PR DESCRIPTION
On Ubuntu Xenial appreantly I have apache_request_headers() but it does not return the required headers. This patch makes testBaseURL() work regardless.