### PR TITLE
Added -H flag to the sudo that running as www-data

### DIFF
--- a/INSTALL/UPDATE.txt
+++ b/INSTALL/UPDATE.txt
@@ -38,13 +38,13 @@ git submodule update --init --force
 cd /var/www/MISP/app/files/scripts/
 rm -rf python-cybox
 rm -rf python-stix
-sudo -u www-data git clone https://github.com/CybOXProject/python-cybox.git
-sudo -u www-data git clone https://github.com/STIXProject/python-stix.git
+sudo -u www-data -H git clone https://github.com/CybOXProject/python-cybox.git
+sudo -u www-data -H git clone https://github.com/STIXProject/python-stix.git
 cd /var/www/MISP/app/files/scripts/python-cybox 
-sudo -u www-data git checkout v2.1.0.12
+sudo -u www-data -H git checkout v2.1.0.12
 python setup.py install 
 cd /var/www/MISP/app/files/scripts/python-stix 
-sudo -u www-data git checkout v1.1.1.4
+sudo -u www-data -H git checkout v1.1.1.4
 python setup.py install
 
 


### PR DESCRIPTION
Added -H flag to the sudo that running as www-data,
It eliminates this error: "warning: unable to access '/root/.config/git/attributes': Permission denied".
It can fix the problem when the home variable is not set and the script is trying to write to the root folder instead.
It possible that this issue will only manifest in container environment.

- [ ] Major
- [ ] Minor
- [X] Patch
