### PR TITLE
Updated comment for enrichment modules to reference value used for enri…

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -3936,7 +3936,7 @@ class EventsController extends AppController {
 				$importComment = $result['comment'];
 			}
 			else {
-				$importComment = 'Enriched via the ' . $module . ' module';
+				$importComment = $attribute[0]['Attribute']['value'] . ': Enriched via the ' . $module . ' module';
 			}
 			$typeCategoryMapping = array();
 			foreach ($this->Event->Attribute->categoryDefinitions as $k => $cat) {


### PR DESCRIPTION
…chment for added context

#### What does it do?
It solves an issue I was coming across with identifying what attribute the enrichment came from. Passive Total whois details is a prime example, dns/reverse dns resolution is another. Ideally it would be nice if we could associate attributes to each other, but this is a quick fix for eye-balling what a piece of enrichment is related to within the event. 
![capture](https://cloud.githubusercontent.com/assets/3334810/23342446/6b0ff1c2-fc28-11e6-909c-e530f2e97794.JPG)


#### Questions

- No DB change?
- Not yet being used in production, but tested
- No change in the API.

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
