### PR TITLE
bro to_IDS and published flags fix on query. Now supporting block_eve…

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -1706,7 +1706,7 @@ class Attribute extends AppModel {
 		$intel = array();
 		foreach ($types as $type) {
 			//restricting to non-private or same org if the user is not a site-admin.
-			$conditions['AND'] = array('Attribute.to_ids =' => 1, 'Event.published =' => 1);
+			$conditions['AND'] = array('Attribute.to_ids' => 1, 'Event.published' => 1);
 			if ($from) $conditions['AND']['Event.date >='] = $from;
 			if ($to) $conditions['AND']['Event.date <='] = $to;
 			if ($last) $conditions['AND']['Event.publish_timestamp >='] = $last;


### PR DESCRIPTION
#### What does it do?

Bug fix on BRO export. It was not taking into account unplublished or to_ids conditions in th equery. Therefore the export was not inline with "block_proposal_attirbutes"

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
