### PR TITLE
testForPath regex fixed in Server.php

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -2102,7 +2102,7 @@ class Server extends AppModel {
 
 	public function testForPath($value) {
 		if ($value === '') return true;
-		if (preg_match('@^\/?(([a-z0-9_.]+[a-z0-9_.\- ]*[a-z0-9_.\-]|[a-z0-9_.])+\/?)+$@i', $value)) return true;
+		if (preg_match('@^\/?(([a-z0-9_.]+[a-z0-9_.\-.\:]*[a-z0-9_.\-.\:]|[a-z0-9_.])+\/?)+$@i', $value)) return true;
 		return 'Invalid characters in the path.';
 	}
 


### PR DESCRIPTION
#### What does it do?

BugFix in app/Model/Server.php testForPath Function. It was not undestandin concatenated paths such as the one in rh_shell_fix_path config default value.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
