### PR TITLE
Manage attributes IP-SRC|PORT and IP-DST|PORT when exporting nids rules

### DIFF
--- a/app/Lib/Export/NidsExport.php
+++ b/app/Lib/Export/NidsExport.php
@@ -61,6 +61,12 @@ class NidsExport {
 				case 'ip-src':
 					$this->ipSrcRule($ruleFormat, $item['Attribute'], $sid);
 					break;
+				case 'ip-dst|port':
+					$this->ipDstRule($ruleFormat, $item['Attribute'], $sid);
+					break;
+				case 'ip-src|port':
+					$this->ipSrcRule($ruleFormat, $item['Attribute'], $sid);
+					break;
 				case 'email-src':
 					$this->emailSrcRule($ruleFormat, $item['Attribute'], $sid);
 					break;
@@ -112,15 +118,15 @@ class NidsExport {
 
 	public function ipDstRule($ruleFormat, $attribute, &$sid) {
 		$overruled = $this->checkWhitelist($attribute['value']);
-		$attribute['value'] = NidsExport::replaceIllegalChars($attribute['value']);  // substitute chars not allowed in rule
+		$ipport = NidsExport::getIpPort($attribute);
 		$this->rules[] = sprintf($ruleFormat,
 				($overruled) ? '#OVERRULED BY WHITELIST# ' : '',
 				'ip',							// proto
 				'$HOME_NET',					// src_ip
 				'any',							// src_port
 				'->',							// direction
-				$attribute['value'],			// dst_ip
-				'any',							// dst_port
+				$ipport[0],			// dst_ip
+				$ipport[1],							// dst_port
 				'Outgoing To IP: ' . $attribute['value'],		// msg
 				'',								// rule_content
 				'',								// tag
@@ -131,12 +137,12 @@ class NidsExport {
 
 	public function ipSrcRule($ruleFormat, $attribute, &$sid) {
 		$overruled = $this->checkWhitelist($attribute['value']);
-		$attribute['value'] = NidsExport::replaceIllegalChars($attribute['value']);  // substitute chars not allowed in rule
+		$ipport = NidsExport::getIpPort($attribute);
 		$this->rules[] = sprintf($ruleFormat,
 				($overruled) ? '#OVERRULED BY WHITELIST# ' : '',
 				'ip',							// proto
-				$attribute['value'],			// src_ip
-				'any',							// src_port
+				$ipport[0],			// src_ip
+				$ipport[1],							// src_port
 				'->',							// direction
 				'$HOME_NET',					// dst_ip
 				'any',							// dst_port
@@ -505,31 +511,42 @@ class NidsExport {
 		return false;
 	}
 
-    public static function getProtocolPort($protocol, $customPort) {
-        if($customPort == null) {
-            switch ($protocol) {
-                case "http":
-                    return '$HTTP_PORTS';
-                case "https":
-                    return '443';
-                case "ssh":
-                    return '22';
-                case "ftp":
-                    return '[20,21]';
-                default:
-                    return 'any';
-            }
-        } else {
-            return $customPort;
-        }
-    }
-
-    public static function getCustomIP($customIP) {
-        if(filter_var($customIP, FILTER_VALIDATE_IP)) {
-            return $customIP;
-        }
-        else {
-            return '$EXTERNAL_NET';
-        }
-    }
+	public static function getProtocolPort($protocol, $customPort) {
+		if($customPort == null) {
+		    switch ($protocol) {
+			case "http":
+			    return '$HTTP_PORTS';
+			case "https":
+			    return '443';
+			case "ssh":
+			    return '22';
+			case "ftp":
+			    return '[20,21]';
+			default:
+			    return 'any';
+		    }
+		} else {
+		    return $customPort;
+		}
+	}
+    
+	public static function getCustomIP($customIP) {
+		if(filter_var($customIP, FILTER_VALIDATE_IP)) {
+		    return $customIP;
+		}
+		else {
+		    return '$EXTERNAL_NET';
+		}
+	}
+    
+	public static function getIpPort($attribute) {
+    	$ipport = array();
+		if (strpos($attribute['type'],'port') !== false) {
+			$ipport = explode('|', $attribute['value']);
+		} else {
+		    $ipport[0] = $attribute['value'];
+		    $ipport[1] = 'any';
+		}		
+		return $ipport;
+	}
 }

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -1577,7 +1577,7 @@ class Attribute extends AppModel {
 		$rules = array();
 		foreach ($eventIds as $event) {
 			$conditions['AND'] = array('Attribute.to_ids' => 1, "Event.published" => 1, 'Attribute.event_id' => $event['Event']['id']);
-			$valid_types = array('ip-dst', 'ip-src', 'email-src', 'email-dst', 'email-subject', 'email-attachment', 'domain', 'domain|ip', 'hostname', 'url', 'user-agent', 'snort');
+			$valid_types = array('ip-dst', 'ip-src', 'ip-dst|port', 'ip-src|port', 'email-src', 'email-dst', 'email-subject', 'email-attachment', 'domain', 'domain|ip', 'hostname', 'url', 'user-agent', 'snort');
 			$conditions['AND']['Attribute.type'] = $valid_types;
 			if (!empty($type)) {
 				$conditions['AND'][] = array('Attribute.type' => $type);


### PR DESCRIPTION
# Manage attributes IP-SRC|PORT and IP-DST|PORT when exporting nids rules

#### What does it do?

It fixes issue #2070

#### How ?
Value1:IP and Value2:PORT are exploded and the Suricate function for IP rule generation is called with value1. A port parameter has been added.

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [X] Minor
- [ ] Patch
