### PR TITLE
Update xINSTALL.centos6.txt

### DIFF
--- a/INSTALL/xINSTALL.centos6.txt
+++ b/INSTALL/xINSTALL.centos6.txt
@@ -33,7 +33,7 @@ yum install vim
 yum install gcc git httpd zip redis mysql-server python-devel python-pip libxslt-devel zlib-devel
 
 # Install PHP 5.6 from SCL, see https://www.softwarecollections.org/en/scls/rhscl/rh-php56/
-yum install rh-php56 rh-php56-php-fpm rh-php56-php-devel rh-php56-php-mysqlnd rh-php56-php-mbstring rh-php56-php-xml rh-php56-bcmath
+yum install rh-php56 rh-php56-php-fpm rh-php56-php-devel rh-php56-php-mysqlnd rh-php56-php-mbstring rh-php56-php-xml rh-php56-php-bcmath
 
 # rh-php56-php only provided mod_php for httpd24-httpd from SCL
 # if we want to use httpd from CentOS base we can use rh-php56-php-fpm instead


### PR DESCRIPTION
#### What does it do?

Addresses PHP package install error: "No package rh-php56-bcmath available."
Change package name on line 36: 
From: "rh-php56-bcmath" 
To: "rh-php56-php-bcmath"

#### Questions

- [N] Does it require a DB change?
- [Y] Are you using it in production?
- [N] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
