### PR TITLE
Misp-wipe: Ensure root, don't echo password

### DIFF
--- a/tools/misp-wipe/misp-wipe.sh
+++ b/tools/misp-wipe/misp-wipe.sh
@@ -38,8 +38,8 @@ else
         ## MySQL stuff
         echo 'Please enter your MySQL root account username'
         read MySQLRUser
-        echo 'Please enter your MySQL root account password'
-        read MySQLRPass
+        echo 'Please enter your MySQL root account password (will not be echoed)'
+        read -s MySQLRPass
 fi
 
 

--- a/tools/misp-wipe/misp-wipe.sh
+++ b/tools/misp-wipe/misp-wipe.sh
@@ -24,6 +24,12 @@
 ## Time to set some variables
 ##
 
+if (( $EUID > 0 ))
+  then 
+  echo "Please run this as a privileged user"
+  echo "(usually 'sudo !!' will cover you)"
+  exit
+fi
 
 FILE=./misp-wipe.conf
 SQL=./misp-wipe.sql


### PR DESCRIPTION
#### What does it do?

When running misp-wipe, ensure we're running as root.
Also, don't echo MySQL password to STDOUT.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
