### PR TITLE
fix: Change validation rules for Server

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -70,9 +70,9 @@ class Server extends AppModel {
 		'push' => array(
 			'boolean' => array(
 				'rule' => array('boolean'),
-				//'message' => 'Your custom message here',
+				'message' => 'push parameter is mandatory. type(boolean)',
 				'allowEmpty' => true,
-				'required' => false,
+				'required' => true,
 				//'last' => false, // Stop validation after this rule
 				//'on' => 'create', // Limit validation to 'create' or 'update' operations
 			),
@@ -80,11 +80,35 @@ class Server extends AppModel {
 		'pull' => array(
 			'boolean' => array(
 				'rule' => array('boolean'),
-				//'message' => 'Your custom message here',
+				'message' => 'pull parameter is mandatory. type(boolean)',
 				'allowEmpty' => true,
-				//'required' => false,
+				'required' => true,
 				//'last' => false, // Stop validation after this rule
 				//'on' => 'create', // Limit validation to 'create' or 'update' operations
+			),
+		),
+		'self_signed' => array(
+			'boolean' => array(
+				'rule' => array('boolean'),
+				'message' => 'self_signed parameter is mandatory. type(boolean)',
+				'allowEmpty' => true,
+				'required' => true,
+				//'last' => false, // Stop validation after this rule
+				//'on' => 'create', // Limit validation to 'create' or 'update' operations
+			),
+		),
+		'push_rules' => array(
+			'alphaNumeric' => array(
+				'rule' => array('alphaNumeric'),
+				'message' => 'push_rules parameter is mandatory. type(string), could be empty',
+				'allowEmpty' => true,
+			),
+		),
+		'pull_rules' => array(
+			'alphaNumeric' => array(
+				'rule' => array('alphaNumeric'),
+				'message' => 'pull_rules parameter is mandatory. type(string), could be empty',
+				'allowEmpty' => true,
 			),
 		),
 		'lastpushedid' => array(


### PR DESCRIPTION
Database doesn't have default values on the following fields. 
* push 
* pull 
* self_signed
* push_rules
* pull_rules

PyMISP fail when creating a server if these fields have not beeing setted in the request.
This match the pull request https://github.com/MISP/PyMISP/pull/69

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch