### PR TITLE
Snort attribute generation rule now contains the initial msg field

### DIFF
--- a/app/Lib/Export/NidsExport.php
+++ b/app/Lib/Export/NidsExport.php
@@ -403,8 +403,7 @@ class NidsExport {
 		if (null == $tmpRule) return false;	// don't output the rule on error with the regex
 		$tmpRule = preg_replace('/classtype:[a-zA-Z_-]+;/', 'classtype:' . $this->classtype . ';', $tmpRule, -1, $replaceCount['classtype']);
 		if (null == $tmpRule) return false;	// don't output the rule on error with the regex
-		$tmpMessage = sprintf($ruleFormatMsg, 'snort-rule');
-		$tmpRule = preg_replace('/msg\s*:\s*".*?"\s*;/', $tmpMessage . ';', $tmpRule, -1, $replaceCount['msg']);
+		$tmpRule = preg_replace('/msg\s*:\s*"(.*?)"\s*;/', sprintf($ruleFormatMsg, 'snort-rule | $1') . ';', $tmpRule, -1, $replaceCount['msg']);
 		if (null == $tmpRule) return false;	// don't output the rule on error with the regex
 		$tmpRule = preg_replace('/reference\s*:\s*.+?;/', $ruleFormatReference . ';', $tmpRule, -1, $replaceCount['reference']);
 		if (null == $tmpRule) return false;	// don't output the rule on error with the regex


### PR DESCRIPTION
#### What does it do?

When generating IDS rules for attribute "snort" the generated msg field is the following:
`msg: "MISP eXXX [tag] snort-rule"`

This value overwrites the initial msg value of the snort attribute.

The current PR will keep the snort attribube msg value. We will now get:
`msg: "MISP eXXX [tag] snort-rule | the initial snort msg"`


#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [X] Minor
- [ ] Patch
