### PR TITLE
Remove default value for column comment

### DIFF
--- a/INSTALL/MYSQL.sql
+++ b/INSTALL/MYSQL.sql
@@ -29,7 +29,7 @@ CREATE TABLE IF NOT EXISTS `attributes` (
   `timestamp` int(11) NOT NULL DEFAULT 0,
   `distribution` tinyint(4) NOT NULL DEFAULT 0,
   `sharing_group_id` int(11) NOT NULL,
-  `comment` text COLLATE utf8_bin DEFAULT "",
+  `comment` text COLLATE utf8_bin,
   `deleted` tinyint(1) NOT NULL DEFAULT 0,
   `disable_correlation` tinyint(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),


### PR DESCRIPTION

#### What does it do?

```
ERROR 1101 (42000) at line 20: BLOB, TEXT, GEOMETRY or JSON column 'comment' can't have a default value
```
https://travis-ci.org/juju4/ansible-MISP/jobs/222624828#L7561
(ubuntu xenial, mysql 5.7)
https://dev.mysql.com/doc/refman/5.7/en/blob.html

Strangely, this does not affect centos7 and mariadb 5.5 even if corresponding documentation states the same.
https://travis-ci.org/juju4/ansible-MISP/jobs/222624827#L4862

Coming from recent https://github.com/MISP/MISP/blame/2.4/INSTALL/MYSQL.sql#L32

#### Questions

- [ ] Does it require a DB change? default Mysql template
- [ ] Are you using it in production? no. from travis CI cron test
- [ ] Does it require a change in the API (PyMISP for example)? No

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
