### PR TITLE
Add filename key for import modules

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -3980,7 +3980,9 @@ class EventsController extends AppController {
 				}
 				if (!$fail) {
 					$modulePayload['data'] = base64_encode($modulePayload['data']);
-					$modulePayload['filename'] = $filename;
+					if (!empty($filename)) {
+						$modulePayload['filename'] = $filename;
+					}
 					$result = $this->Module->queryModuleServer('/query', json_encode($modulePayload, true), false, $moduleFamily = 'Import');
 					if (!$result) throw new Exception('Import service not reachable.');
 					if (isset($result['error'])) $this->Session->setFlash($result['error']);

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -3980,6 +3980,7 @@ class EventsController extends AppController {
 				}
 				if (!$fail) {
 					$modulePayload['data'] = base64_encode($modulePayload['data']);
+					$modulePayload['filename'] = $filename;
 					$result = $this->Module->queryModuleServer('/query', json_encode($modulePayload, true), false, $moduleFamily = 'Import');
 					if (!$result) throw new Exception('Import service not reachable.');
 					if (isset($result['error'])) $this->Session->setFlash($result['error']);


### PR DESCRIPTION
This pull/request add filename to all misp import module.

With this module, you can use the name file you try to import to misp like this : 
```python
q = json.loads(q)
print(q.get('filename'))
```

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
