### PR TITLE
misp.search_index returns now a same format than misp.search

### DIFF
--- a/app/View/Events/json/index.ctp
+++ b/app/View/Events/json/index.ctp
@@ -1,15 +1,15 @@
 <?php
 foreach ($events as $key => $event) {
     // rearrange things to be compatible with the Xml::fromArray()
-    $events[$key] = $events[$key]['Event'];
-    unset($events[$key]['Event']);
-    $events[$key]['Org'] = $event['Org'];
-    $events[$key]['Orgc'] = $event['Orgc'];
-    if (isset($event['GalaxyCluster'])) {
-    	$events[$key]['GalaxyCluster'] = $event['GalaxyCluster'];
+    // $events[$key] = $events[$key]['Event'];
+    // unset($events[$key]['Event']);
+    $events[$key]['Event']['Org'] = $event['Org'];
+    $events[$key]['Event']['Orgc'] = $event['Orgc'];
+    if (isset($event['Event']['GalaxyCluster'])) {
+    	$events[$key]['Event']['GalaxyCluster'] = $event['GalaxyCluster'];
     }
-    if (isset($event['EventTag'])) $events[$key]['EventTag'] = $event['EventTag'];
-    $events[$key]['SharingGroup'] = $event['SharingGroup'];
+    if (isset($event['EventTag'])) $events[$key]['Event']['EventTag'] = $event['EventTag'];
+    $events[$key]['Event']['SharingGroup'] = $event['SharingGroup'];
 
     // cleanup the array from things we do not want to expose
     unset($events[$key]['user_id']);


### PR DESCRIPTION
#### What does it do?

This fixes the opened bug on [PyMISP](https://github.com/CIRCL/PyMISP/issues/78) about: "misp.search_index returns a different format than misp.search"

```php
unset($events[$key]['Event']);
```
Has been commented in order to keep the "Event" structure.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [x] Does it require a change in the API (PyMISP for example)?

Yes, it's now generic, whether you use misp.search and/or mis.search_index. 

#### Release Type:
- [X] Major
- [ ] Minor
- [ ] Patch

This might break code that people already developed so I put it as "Major". 
