### PR TITLE
add possibility to define tags for import module.

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -3160,6 +3160,9 @@ class Event extends AppModel {
 				if (isset($r['categories']) && !is_array($r['categories'])) {
 					$r['categories'] = array($r['categories']);
 				}
+				if (isset($r['tags']) && !is_array($r['tags'])) {
+					$r['tags'] = array($r['tags']);
+				}
 				foreach ($r['values'] as &$value) {
 					if (!is_array($r['values']) || !isset($r['values'][0])) {
 						$r['values'] = array($r['values']);
@@ -3198,7 +3201,8 @@ class Event extends AppModel {
 							'default_type' => $r['types'][0],
 							'comment' => isset($r['comment']) ? $r['comment'] : false,
 							'to_ids' => isset($r['to_ids']) ? $r['to_ids'] : false,
-							'value' => $value
+							'value' => $value,
+							'tags' => isset($r['tags']) ? $r['tags'] : false
 					);
 					if (isset($r['categories'])) {
 						$temp['categories'] = $r['categories'];

--- a/app/View/Events/resolved_attributes.ctp
+++ b/app/View/Events/resolved_attributes.ctp
@@ -40,6 +40,7 @@
 				<th>IDS<input type="checkbox" id="checkAll" style="margin:0px;margin-left:3px;"/></th>
 				<th>Distribution</th>
 				<th>Comment</th>
+				<th>Tags</th>
 				<th>Actions</th>
 		</tr>
 		<?php
@@ -171,6 +172,9 @@
 			</td>
 			<td class="short">
 				<input type="text" class="freetextCommentField" id="<?php echo 'Attribute' . $k . 'Comment'; ?>" style="padding:0px;height:20px;margin-bottom:0px;" placeholder="<?php echo h($importComment); ?>" <?php if (isset($item['comment']) && $item['comment'] !== false) echo 'value="' . $item['comment'] . '"'?>/>
+			</td>
+			<td class="short">
+				<input type="text" class="freetextTagField" id="<?php echo 'Attribute' . $k . 'Tags'; ?>" style="padding:0px;height:20px;margin-bottom:0px;"<?php if (isset($item['tags']) && $item['tags'] !== false) echo 'value="' . htmlspecialchars(implode(",",$item['tags'])) . '"'?>/>
 			</td>
 			<td class="action short">
 				<span class="icon-remove pointer" title="Remove resolved attribute" role="button" tabindex="0" aria-label="Remove resolved attribute" onClick="freetextRemoveRow('<?php echo $k; ?>', '<?php echo $event['Event']['id']; ?>');"></span>

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -1850,7 +1850,8 @@ function freetextImportResultsSubmit(id, count) {
 				distribution:$('#Attribute' + i + 'Distribution').val(),
 				sharing_group_id:$('#Attribute' + i + 'SharingGroupId').val(),
 				data:$('#Attribute' + i + 'Data').val(),
-				data_is_handled:$('#Attribute' + i + 'DataIsHandled').val()
+				data_is_handled:$('#Attribute' + i + 'DataIsHandled').val(),
+				tags:$('#Attribute' + i + 'Tags').val()
 			}
 			attributeArray[attributeArray.length] = temp;
 		}


### PR DESCRIPTION
Add possibility to define tags for import module.
in you use it like this : 
create input in your 
```python
userConfig = {	'default tag': {
				'type': 'String',
				'message': 'Add tags spaced by a comma (tlp:white,misp:threat-level="no-risk")',
				'validation' : '0'
			}
		}
```
When "validation" is 0 you can leave this field empty.

Add tag in your result : 
```python
    if q['config'].get('default tag') is not None:
        r["results"]["tags"] = q['config']['default tag'].split(",")
return r
```

The result page display tag field.
If the tags exist, it will be automatically added to your attribute.
Otherwise, if you have the right to create it, it will be created and added.


#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
