### PR TITLE
newsread attribute fixed for user registration via sso

### DIFF
--- a/app/Plugin/ShibbAuth/Controller/Component/Auth/ApacheShibbAuthenticate.php
+++ b/app/Plugin/ShibbAuth/Controller/Component/Auth/ApacheShibbAuthenticate.php
@@ -133,7 +133,7 @@ class ApacheShibbAuthenticate extends BaseAuthenticate {
 			'confirm_password' => $password,
 			'authkey' => $authKey,
 			'nids_sid' => ((int)$nidsMax[0][0]['nidsMax'])+1,
-			'newsread' => date('Y-m-d'),
+			'newsread' => time(),
 			'role_id' => $roleId,
 			'change_pw' => 0
 		));


### PR DESCRIPTION
#### What does it do?

Fixes SSO regitration
#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
