### PR TITLE
Check bad links on attachments

### DIFF
--- a/app/Controller/Component/ACLComponent.php
+++ b/app/Controller/Component/ACLComponent.php
@@ -368,6 +368,7 @@ class ACLComponent extends Component {
 					'attributehistogram' => array('*'),
 					'change_pw' => array('*'),
 					'checkAndCorrectPgps' => array(),
+					'checkAttachments' => array(),
 					'dashboard' => array('*'),
 					'delete' => array('perm_admin'),
 					'downloadTerms' => array('*'),

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -1451,4 +1451,21 @@ class UsersController extends AppController {
 		$this->set('notifications', $notifications);
 		$this->set('events', $events);
 	}
+
+    public function checkAttachments() {
+        $this->loadModel('Attribute');
+        $attributes = $this->Attribute->find('all', array(
+            'conditions' => array('Attribute.type' => array('attachment', 'malware-sample')),
+            'recursive' => -1)
+        );
+        $counter = 0;
+        foreach ($attributes as $attribute) {
+            $path = APP . "files" . DS . $attribute['Attribute']['event_id'] . DS;
+            $file = $attribute['Attribute']['id'];
+            if (!file_exists($path . $file)) {
+                $counter++;
+            }
+        }
+        return new CakeResponse(array('body'=>$counter, 'status'=>200));
+    }
 }

--- a/app/View/Elements/healthElements/diagnostics.ctp
+++ b/app/View/Elements/healthElements/diagnostics.ctp
@@ -333,4 +333,14 @@
 	</h3>
 	<p>Click the following button to go to the legacy administrative tools page. There should in general be no need to do this unless you are upgrading a very old MISP instance (<2.4), all updates are done automatically with more current versions.</p>
 	<span class="btn btn-inverse" style="padding-top:1px;padding-bottom:1px;" onClick="location.href = '<?php echo $baseurl; ?>/pages/display/administration';">Legacy Administrative Tools</span>
+    <h3>
+		Saved Files and Database Coherence
+	</h3>
+	<p>Verify each attachment referenced in database is accessible on filesystem.</p>
+	<div style="background-color:#f7f7f9;width:400px;">
+        Non existing attachments referenced in Database....<span id="orphanedFileCount"><span style="color:orange;">Run the test below</span></span>
+    </div><br />
+	<span class="btn btn-inverse" role="button" tabindex="0" aria-label="Check non-existing attachments" title="Check non-existing attachments" style="padding-top:1px;padding-bottom:1px;" onClick="checkAttachments();">Check non-existing attachments</span>
+
+
 </div>

--- a/app/View/Elements/healthElements/diagnostics.ctp
+++ b/app/View/Elements/healthElements/diagnostics.ctp
@@ -334,13 +334,12 @@
 	<p>Click the following button to go to the legacy administrative tools page. There should in general be no need to do this unless you are upgrading a very old MISP instance (<2.4), all updates are done automatically with more current versions.</p>
 	<span class="btn btn-inverse" style="padding-top:1px;padding-bottom:1px;" onClick="location.href = '<?php echo $baseurl; ?>/pages/display/administration';">Legacy Administrative Tools</span>
     <h3>
-		Saved Files and Database Coherence
+		Verify bad link on attachments
 	</h3>
 	<p>Verify each attachment referenced in database is accessible on filesystem.</p>
 	<div style="background-color:#f7f7f9;width:400px;">
         Non existing attachments referenced in Database....<span id="orphanedFileCount"><span style="color:orange;">Run the test below</span></span>
-    </div><br />
-	<span class="btn btn-inverse" role="button" tabindex="0" aria-label="Check non-existing attachments" title="Check non-existing attachments" style="padding-top:1px;padding-bottom:1px;" onClick="checkAttachments();">Check non-existing attachments</span>
-
+    </div><br>
+	<span class="btn btn-inverse" role="button" tabindex="0" aria-label="Check bad link on attachments" title="Check bad link on attachments" style="padding-top:1px;padding-bottom:1px;" onClick="checkAttachments();">Check bad link on attachments</span>
 
 </div>

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -2774,7 +2774,7 @@ function checkAttachments() {
 		},
 		success:function (data, textStatus) {
 			var color = 'red';
-			var text = ' (KO)';
+			var text = ' (Bad links detected)';
 			if (data !== undefined && data.trim() == '0') {
 				color = 'green';
 				text = ' (OK)';

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -2767,6 +2767,29 @@ function checkOrphanedAttributes() {
 	});
 }
 
+function checkAttachments() {
+	$.ajax({
+		beforeSend: function (XMLHttpRequest) {
+			$(".loading").show();
+		},
+		success:function (data, textStatus) {
+			var color = 'red';
+			var text = ' (KO)';
+			if (data !== undefined && data.trim() == '0') {
+				color = 'green';
+				text = ' (OK)';
+			}
+			$("#orphanedFileCount").html('<span class="' + color + '">' + data + text + '</span>');
+		},
+		complete:function() {
+			$(".loading").hide();
+		},
+		type:"get",
+		cache: false,
+		url: "/users/checkAttachments/",
+	});
+}
+
 function loadTagTreemap() {
 	$.ajax({
 		async:true,


### PR DESCRIPTION
#### What does it do?

Adding small diagnostic on Server Settings > Diagnostics Page to check if some attachments referenced in Database doesn't exist on filesystem.

- Initial state :
![verifybadlinkinit](https://cloud.githubusercontent.com/assets/28621435/25951479/2c23673a-365e-11e7-8e37-61d54e60fea6.png)

- Let's rename/delete one file on storage directory (app/files/<id_event>/<id_attribute>):
#/var/www/MISP/app/files/1# ls
2  ioc
#/var/www/MISP/app/files/1# mv 2 3
#/var/www/MISP/app/files/1# ls
3  ioc

- Now run the test :
![verifybadlinkerror](https://cloud.githubusercontent.com/assets/28621435/25951652/99bc71c4-365e-11e7-9e47-baa294b40d69.png)

- Let's rename the file and test again :
#/var/www/MISP/app/files/1# ls
3  ioc
#/var/www/MISP/app/files/1# mv 3 2
#/var/www/MISP/app/files/1# ls
2  ioc
![verifybadlinkok](https://cloud.githubusercontent.com/assets/28621435/25951650/9725bad8-365e-11e7-9a77-1b64a15936db.png)

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch

#### Improvements
Could be easily improved to list files and database entries in order to help correct anomalies.