### PR TITLE
Deal with the stupid errors STIX thinks it's ok to just throw

### DIFF
--- a/app/files/scripts/misp2stix_framing.py
+++ b/app/files/scripts/misp2stix_framing.py
@@ -18,6 +18,7 @@ from stix.common.confidence import Confidence
 from stix.common.vocabs import IncidentStatus
 from cybox.utils import Namespace
 from mixbox import idgen
+from stix import __version__ as STIXVER
 
 NS_DICT = {
         "http://cybox.mitre.org/common-2" : 'cyboxCommon',
@@ -88,21 +89,43 @@ SCHEMALOC_DICT = {
 def main(args):
     if len(sys.argv) < 4:
         sys.exit("Invalid parameters")
-    namespace = [sys.argv[1], sys.argv[2].replace(" ", "_")]
+
+    baseURL = sys.argv[1]
+    orgname = sys.argv[2]
+    
+    namespace = [baseURL, orgname.replace(" ", "_")]
     namespace[1] = re.sub('[\W]+', '', namespace[1])
     NS_DICT[namespace[0]]=namespace[1]
-    idgen.set_id_namespace({namespace[0]: namespace[1]})
+
+    try:
+        stix.utils.idgen.set_id_namespace({baseURL: orgname})
+    except ValueError:
+        # Some weird stix error that sometimes occurs if the stars
+        # align and Mixbox is being mean to us
+        # Glory to STIX, peace and good xmlns be upon it
+        try:
+            idgen.set_id_namespace(Namespace(baseURL, orgname))
+        except TypeError:
+            # Ok this only occurs if the script is being run under py3
+            # and if we're running a REALLY weird version of stix
+            # May as well catch it
+            idgen.set_id_namespace(Namespace(baseURL, orgname, "MISP"))
+            
+
     stix_package = STIXPackage()
     stix_header = STIXHeader()
-    stix_header.title="Export from " + sys.argv[2] + " MISP"
+
+    stix_header.title="Export from {} MISP".format(orgname)
     stix_header.package_intents="Threat Report"
     stix_package.stix_header = stix_header
+
     if sys.argv[3] == 'json':
         stix_string = stix_package.to_json()[:-1]
         stix_string += ', "related_packages": ['
     else:
         stix_string = stix_package.to_xml(auto_namespace=False, ns_dict=NS_DICT, schemaloc_dict=SCHEMALOC_DICT)
         stix_string = stix_string.replace("</stix:STIX_Package>\n", "");
+
     print(stix_string)
 
 if __name__ == "__main__":


### PR DESCRIPTION
#2181 
**SHOULD** fix all instances of exporting under different STIX versions. 

Uses stix.utils if possible, if not, tries to use mixbox. If mixbox works, which it sometimes doesn't.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
