### PR TITLE
Separate attachments into their own directory

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -292,7 +292,7 @@ class AttributesController extends AppController {
 	}
 
 	private function __downloadAttachment($attribute) {
-		$path = "files" . DS . $attribute['event_id'] . DS;
+		$path = "files" . DS . "attachments" . DS . $attribute['event_id'] . DS;
 		$file = $attribute['id'];
 		if ('attachment' == $attribute['type']) {
 			$filename = $attribute['value'];

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -2152,7 +2152,7 @@ class EventsController extends AppController {
 			$iocData = $fileAccessTool->readFromFile($this->data['Event']['submittedioc']['tmp_name'], $this->data['Event']['submittedioc']['size']);
 
 			// write
-			$rootDir = APP . "files" . DS . $id . DS;
+			$rootDir = APP . "files" . DS . "attachments" . DS . $id . DS;
 			App::uses('Folder', 'Utility');
 			$dir = new Folder($rootDir . 'ioc', true);
 			$destPath = $rootDir . 'ioc';
@@ -2317,13 +2317,13 @@ class EventsController extends AppController {
 				if ((string)$key == 'filename') $realFileName = (string)$val;
 			}
 		}
-		$rootDir = APP . "files" . DS . $id . DS;
+		$rootDir = APP . "files" . DS . "attachments" . DS . $id . DS;
 		$malware = $rootDir . DS . 'sample';
 		$this->Event->Attribute->uploadAttachment($malware,	$realFileName,	true, $id, null, '', $this->Event->data['Event']['uuid'] . '-sample', $dist, true);
 
 		// Network activity -- .pcap
 		$realFileName = 'analysis.pcap';
-		$rootDir = APP . "files" . DS . $id . DS;
+		$rootDir = APP . "files" . DS . "attachments" . DS . $id . DS;
 		$malware = $rootDir . DS . 'Analysis' . DS . 'analysis.pcap';
 		$this->Event->Attribute->uploadAttachment($malware,	$realFileName,	false, $id, 'Network activity', '', $this->Event->data['Event']['uuid'] . '-analysis.pcap', $dist, true);
 

--- a/app/Controller/ShadowAttributesController.php
+++ b/app/Controller/ShadowAttributesController.php
@@ -198,7 +198,7 @@ class ShadowAttributesController extends AppController {
 	// If we accept a proposed attachment, then the attachment itself needs to be moved from files/eventId/shadow/shadowId to files/eventId/attributeId
 	private function _moveFile($shadowId, $newId, $eventId) {
 		$pathOld = APP . "files" . DS . $eventId . DS . "shadow" . DS . $shadowId;
-		$pathNew = APP . "files" . DS . $eventId . DS . $newId;
+		$pathNew = APP . "files" . DS . "attachments" . DS . $eventId . DS . $newId;
 		if (rename($pathOld, $pathNew)) {
 			return true;
 		} else {

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -2228,9 +2228,9 @@ class Attribute extends AppModel {
 	public function handleMaliciousBase64($event_id, $original_filename, $base64, $hash_types, $proposal = false) {
 		if (!is_numeric($event_id)) throw new Exception('Something went wrong. Received a non-numeric event ID while trying to create a zip archive of an uploaded malware sample.');
 		if ($proposal) {
-			$dir = new Folder(APP . "files" . DS . "shadow" . DS . $event_id, true);
+			$dir = new Folder(APP . "tmp" . DS . "files" . DS . "shadow" . DS . $event_id, true);
 		} else {
-			$dir = new Folder(APP . "files" . DS . "attachments" . DS . $event_id, true);
+			$dir = new Folder(APP . "tmp" . DS . "files" . DS . "attachments" . DS . $event_id, true);
 		}
 		$tmpFile = new File($dir->path . DS . $this->generateRandomFileName(), true, 0600);
 		$tmpFile->write(base64_decode($base64));

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -564,7 +564,7 @@ class Attribute extends AppModel {
 		$this->read(); // first read the attribute from the db
 		if ($this->typeIsAttachment($this->data['Attribute']['type'])) {
 			// only delete the file if it exists
-			$filepath = APP . "files" . DS . $this->data['Attribute']['event_id'] . DS . $this->data['Attribute']['id'];
+			$filepath = APP . "files" . DS . "attachments" . DS . $this->data['Attribute']['event_id'] . DS . $this->data['Attribute']['id'];
 			$file = new File($filepath);
 			if ($file->exists()) {
 				if (!$file->delete()) {
@@ -1218,7 +1218,7 @@ class Attribute extends AppModel {
 	}
 
 	public function base64EncodeAttachment($attribute) {
-		$filepath = APP . "files" . DS . $attribute['event_id'] . DS . $attribute['id'];
+		$filepath = APP . "files" . DS . "attachments" . DS . $attribute['event_id'] . DS . $attribute['id'];
 		$file = new File($filepath);
 		if (!$file->readable()) {
 			return '';
@@ -1228,7 +1228,7 @@ class Attribute extends AppModel {
 	}
 
 	public function saveBase64EncodedAttachment($attribute) {
-		$rootDir = APP . DS . "files" . DS . $attribute['event_id'];
+		$rootDir = APP . "files" . DS . "attachments" . DS . $attribute['event_id'];
 		$dir = new Folder($rootDir, true);						// create directory structure
 		$destpath = $rootDir . DS . $attribute['id'];
 		$file = new File($destpath, true);						// create the file
@@ -1273,7 +1273,7 @@ class Attribute extends AppModel {
 		// no errors in file upload, entry already in db, now move the file where needed and zip it if required.
 		// no sanitization is required on the filename, path or type as we save
 		// create directory structure
-		$rootDir = APP . "files" . DS . $eventId;
+		$rootDir = APP . "files" . DS . "attachments" . DS . $eventId;
 		$dir = new Folder($rootDir, true);
 		// move the file to the correct location
 		$destpath = $rootDir . DS . $this->getID(); // id of the new attribute in the database
@@ -2228,9 +2228,9 @@ class Attribute extends AppModel {
 	public function handleMaliciousBase64($event_id, $original_filename, $base64, $hash_types, $proposal = false) {
 		if (!is_numeric($event_id)) throw new Exception('Something went wrong. Received a non-numeric event ID while trying to create a zip archive of an uploaded malware sample.');
 		if ($proposal) {
-			$dir = new Folder(APP . "files" . DS . $event_id . DS . 'shadow', true);
+			$dir = new Folder(APP . "files" . DS . "shadow" . DS . $event_id, true);
 		} else {
-			$dir = new Folder(APP . "files" . DS . $event_id, true);
+			$dir = new Folder(APP . "files" . DS . "attachments" . DS . $event_id, true);
 		}
 		$tmpFile = new File($dir->path . DS . $this->generateRandomFileName(), true, 0600);
 		$tmpFile->write(base64_decode($base64));

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -338,7 +338,7 @@ class Event extends AppModel {
 		$this->EventTag->deleteAll(array('event_id' => $this->id));
 
 		// only delete the file if it exists
-		$filepath = APP . "files" . DS . $this->id;
+		$filepath = APP . "files" . DS . "attachments" . DS . $this->id;
 		App::uses('Folder', 'Utility');
 		if (is_dir($filepath)) {
 			if (!$this->destroyDir($filepath)) {

--- a/app/Model/ShadowAttribute.php
+++ b/app/Model/ShadowAttribute.php
@@ -358,7 +358,7 @@ class ShadowAttribute extends AppModel {
 	}
 
 	public function saveBase64EncodedAttachment($attribute) {
-		$rootDir = APP . DS . "files" . DS . 'shadow' . DS . $attribute['event_id'];
+		$rootDir = APP . "files" . DS . 'shadow' . DS . $attribute['event_id'];
 		$dir = new Folder($rootDir, true);						// create directory structure
 		$destpath = $rootDir . DS . $attribute['id'];
 		$file = new File($destpath, true);						// create the file


### PR DESCRIPTION
#### What does it do?

Separate attachments into their own directory. This allows you to use a different mount point for this directory (in my case s3fuse).

Users will need to move their existing attachments from `/files/<eventid>` to `/files/attachments/<eventid>`. Proposed shadow attachments are still stored locally (this could be changed). Zipping and hashing occurs from the `tmp` directory.

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
