### PR TITLE
Added support for attribute tags in the restSearch API

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -1649,7 +1649,7 @@ class AttributesController extends AppController {
 	// the last 4 fields accept the following operators:
 	// && - you can use && between two search values to put a logical OR between them. for value, 1.1.1.1&&2.2.2.2 would find attributes with the value being either of the two.
 	// ! - you can negate a search term. For example: google.com&&!mail would search for all attributes with value google.com but not ones that include mail. www.google.com would get returned, mail.google.com wouldn't.
-	public function restSearch($key = 'download', $value = false, $type = false, $category = false, $org = false, $tags = false, $from = false, $to = false, $last = false, $eventid = false, $withAttachments = false, $uuid = false, $publish_timestamp = false, $published = false, $timestamp = false, $enforceWarninglist = false, $to_ids = false, $deleted = false) {
+	public function restSearch($key = 'download', $value = false, $type = false, $category = false, $org = false, $tags = false, $attribute_tags = false, $from = false, $to = false, $last = false, $eventid = false, $withAttachments = false, $uuid = false, $publish_timestamp = false, $published = false, $timestamp = false, $enforceWarninglist = false, $to_ids = false, $deleted = false) {
 		if ($tags) $tags = str_replace(';', ':', $tags);
 		$simpleFalse = array('value' , 'type', 'category', 'org', 'tags', 'from', 'to', 'last', 'eventid', 'withAttachments', 'uuid', 'publish_timestamp', 'timestamp', 'enforceWarninglist', 'to_ids', 'deleted');
 		foreach ($simpleFalse as $sF) {
@@ -1686,13 +1686,13 @@ class AttributesController extends AppController {
 			if (!isset($data['request'])) {
 				$data['request'] = $data;
 			}
-			$paramArray = array('value', 'type', 'category', 'org', 'tags', 'from', 'to', 'last', 'eventid', 'uuid', 'published', 'publish_timestamp', 'timestamp', 'enforceWarninglist', 'to_ids', 'deleted');
+			$paramArray = array('value', 'type', 'category', 'org', 'tags', 'attribute_tags', 'from', 'to', 'last', 'eventid', 'uuid', 'published', 'publish_timestamp', 'timestamp', 'enforceWarninglist', 'to_ids', 'deleted');
 			foreach ($paramArray as $p) {
 				if (isset($data['request'][$p])) ${$p} = $data['request'][$p];
 				else ${$p} = null;
 			}
 		}
-		$simpleFalse = array('value' , 'type', 'category', 'org', 'tags', 'from', 'to', 'last', 'eventid', 'withAttachments', 'uuid', 'publish_timestamp', 'timestamp', 'enforceWarninglist', 'to_ids', 'deleted');
+		$simpleFalse = array('value' , 'type', 'category', 'org', 'tags', 'attribute_tags', 'from', 'to', 'last', 'eventid', 'withAttachments', 'uuid', 'publish_timestamp', 'timestamp', 'enforceWarninglist', 'to_ids', 'deleted');
 		foreach ($simpleFalse as $sF) {
 			if (!is_array(${$sF}) && (${$sF} === 'null' || ${$sF} == '0' || ${$sF} === false || strtolower(${$sF}) === 'false')) ${$sF} = false;
 		}
@@ -1713,6 +1713,7 @@ class AttributesController extends AppController {
 
 		// If we sent any tags along, load the associated tag names for each attribute
 		if ($tags) $conditions = $this->Attribute->setTagConditions($tags, $conditions);
+		if ($attribute_tags) $conditions['AND'][] = $this->Attribute->setAttributeTagConditions($attribute_tags, $conditions);
 		if ($from) $conditions['AND'][] = array('Event.date >=' => $from);
 		if ($to) $conditions['AND'][] = array('Event.date <=' => $to);
 		if ($publish_timestamp) $conditions = $this->Attribute->setPublishTimestampConditions($publish_timestamp, $conditions);

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -2366,6 +2366,22 @@ class Attribute extends AppModel {
 		return $conditions;
 	}
 
+	public function setAttributeTagConditions($tags, $conditions) {
+		$args = $this->dissectArgs($tags);
+		$tagArray = $this->AttributeTag->Tag->fetchAttributeTagIds($args[0], $args[1]);
+		$temp = array();
+		foreach ($tagArray[0] as $accepted) {
+			$temp['OR'][] = array('Attribute.id' => $accepted);
+		}
+		$conditions['AND'][] = $temp;
+		$temp = array();
+		foreach ($tagArray[1] as $rejected) {
+			$temp['AND'][] = array('Attribute.id !=' => $rejected);
+		}
+		$conditions['AND'][] = $temp;
+		return $conditions;
+	}
+
 	public function setPublishTimestampConditions($publish_timestamp, $conditions) {
 		if (is_array($publish_timestamp)) {
 			$conditions['AND'][] = array('Event.publish_timestamp >=' => $publish_timestamp[0]);

--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -110,6 +110,19 @@ class Tag extends AppModel {
 		return $ids;
 	}
 
+	public function fetchAttributeTagIds($accept=array(), $reject=array()) {
+		$acceptIds = array();
+		$rejectIds = array();
+		if (!empty($accept)) {
+			$acceptIds = $this->findAttributeIdsByAttributeTagNames($accept);
+			if (empty($acceptIds)) $acceptIds[] = -1;
+		}
+		if (!empty($reject)) {
+			$rejectIds = $this->findAttributeIdsByAttributeTagNames($reject);
+		}
+		return array($acceptIds, $rejectIds);
+	}
+
 	public function findAttributeIdsByAttributeTagNames($array) {
 		$ids = array();
 		foreach ($array as $a) {


### PR DESCRIPTION
#### What does it do?

Allows you to search attributes using attribute tags, using the restSearch API.

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [X] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
