### PR TITLE
FIX #2205 attachTagToObject permissions so that tagger role are able …

### DIFF
--- a/app/Controller/TagsController.php
+++ b/app/Controller/TagsController.php
@@ -580,7 +580,7 @@ class TagsController extends AppController {
 		));
 		$type = 'Event';
 		if (!empty($object)) {
-			if (!$this->_isSiteAdmin() && $object['Event']['orgc_id'] != $this->Auth->user('org_id')) {
+			if (!$this->_isSiteAdmin() && !$this->userRole['perm_tagger'] && $object['Event']['orgc_id'] != $this->Auth->user('org_id')) {
 					throw new MethodNotAllowedException('Invalid Target.');
 			}
 		} else {
@@ -594,7 +594,7 @@ class TagsController extends AppController {
 				'contain' => array('Event.orgc_id')
 			));
 			if (!empty($object)) {
-				if (!$this->_isSiteAdmin() && $object['Event']['orgc_id'] != $this->Auth->user('org_id')) {
+				if (!$this->_isSiteAdmin() && !$this->userRole['perm_tagger'] && $object['Event']['orgc_id'] != $this->Auth->user('org_id')) {
 						throw new MethodNotAllowedException('Invalid Target.');
 				}
 			} else {


### PR DESCRIPTION
…to tag objects where obj.orgc_id != user.org_id


#### What does it do?

`#2205`

using "tags/attachTagToObject" users with permission tagger cannot tag objects where obj.orgc_id != user.org_id

however using "events/addTag" allows it

therefore PyMISP tag() call will not work, however the deprecated addTag() and the MISP interface will work

this fixs add a condition to check first if a user has the tagger permission before sending back "invalid target" error

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
