### PR TITLE
inThreat OSINT Feed as a default Feed

### DIFF
--- a/INSTALL/MYSQL.sql
+++ b/INSTALL/MYSQL.sql
@@ -1010,7 +1010,8 @@ INSERT INTO `admin_settings` (`id`, `setting`, `value`) VALUES
 
 INSERT INTO `feeds` (`id`, `provider`, `name`, `url`, `distribution`, `default`, `enabled`) VALUES
 (1, 'CIRCL', 'CIRCL OSINT Feed', 'https://www.circl.lu/doc/misp/feed-osint', 3, 1, 0),
-(2, 'Botvrij.eu', 'The Botvrij.eu Data', 'http://www.botvrij.eu/data/feed-osint', 3, 1, 0);
+(2, 'Botvrij.eu', 'The Botvrij.eu Data', 'http://www.botvrij.eu/data/feed-osint', 3, 1, 0),
+(3, 'inThreat', 'inThreat OSINT Feed', 'https://feeds.inthreat.com/osint/misp', 3, 1, 0);
 
  INSERT INTO `regexp` (`id`, `regexp`, `replacement`, `type`) VALUES
  (1, '/.:.ProgramData./i', '%ALLUSERSPROFILE%\\\\', 'ALL'),

--- a/INSTALL/POSTGRESQL-data-initial.sql
+++ b/INSTALL/POSTGRESQL-data-initial.sql
@@ -10,7 +10,8 @@ SELECT SETVAL('admin_settings_id_seq', (SELECT MAX(id) FROM admin_settings));
 
 INSERT INTO feeds (id, provider, name, url, distribution, "default", enabled) VALUES
 (1, 'CIRCL', 'CIRCL OSINT Feed', 'https://www.circl.lu/doc/misp/feed-osint', 3, 1, 0),
-(2, 'Botvrij.eu', 'The Botvrij.eu Data', 'http://www.botvrij.eu/data/feed-osint', 3, 1, 0);
+(2, 'Botvrij.eu', 'The Botvrij.eu Data', 'http://www.botvrij.eu/data/feed-osint', 3, 1, 0),
+(3, 'inThreat', 'inThreat OSINT Feed', 'https://feeds.inthreat.com/osint/misp', 3, 1, 0);
 SELECT SETVAL('feeds_id_seq', (SELECT MAX(id) FROM feeds));
 
 INSERT INTO regexp (id, regexp, replacement, type) VALUES

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -106,6 +106,12 @@ class AppModel extends Model {
 				}
 				$this->updateDatabase($command);
 				break;
+			case '2.4.74':
+				$newFeeds = array(
+					array('provider' => 'inThreat', 'name' => 'inThreat OSINT Feed', 'url' => 'https://feeds.inthreat.com/osint/misp', 'enabled' => 0)
+				);
+				$this->__addNewFeeds($newFeeds);
+				break;				
 			default:
 				$this->updateDatabase($command);
 				break;


### PR DESCRIPTION
See Issue #2188 for more details.

This PR registers the feed in the MySQL (`INSTALL.sql`) and PostgreSQL (`POSTGRESQL-data-initial.sql`) install scripts. The MISP update process is also modified (`AppModel.php`) to insert the feed when upgrading to v. 2.4.74.

**Feed parameters**

- Provider: inThreat
- Name: inThreat OSINT Feed
- URL: https://feeds.inthreat.com/osint/misp



#### Questions

- [X] Does it require a DB change?
- [ ] Are you using it in production? _(not this patch, but the feed yes)_
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
