### PR TITLE
Fix: misp-backup explanation for meaning of variables

### DIFF
--- a/tools/misp-backup/misp-backup.conf.sample
+++ b/tools/misp-backup/misp-backup.conf.sample
@@ -1,3 +1,10 @@
+# Path to your MISP installation
 MISPPath=/var/www/MISP
+
+# First part of output file name
+# Name of output file for default would be e.g. MISP-Backup-20170601_215628.tar.gz
 OutputFileName="MISP-Backup"
-OutputDirName="./"
+
+# Folder where you want to put the backup. This folder must exist!
+# Path of output file for default would be e.g. /opt/backup/MISP-Backup-20170601_215628.tar.gz
+OutputDirName="/opt/backup"


### PR DESCRIPTION
#### What does it do?

misp-backup's default OutputDirName (current dir) led to error on Ubuntu 16.04, tar 1.28. Provided works and look neater.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [X] Minor
- [X] Patch
