### PR TITLE
fix: forgot to catch for weird STIX version

### DIFF
--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -285,7 +285,14 @@ def main(args):
     if len(sys.argv) > 4:
         namespace[1] = sys.argv[4].replace(" ", "_")
         namespace[1] = re.sub('[\W]+', '', namespace[1])
-    idgen.set_id_namespace({namespace[0]: namespace[1]})
+    try:
+        idgen.set_id_namespace({namespace[0]: namespace[1]})
+    except ValueError:
+        try:
+            idgen.set_id_namespace(Namespace(namespace[0], namespace[1]))
+        except TypeError:
+            idgen.set_id_namespace(Namespace(namespace[0], namespace[1], "MISP"))
+
     event = loadEvent(args, pathname)
     stix_package = generateEventPackage(event)
     saveFile(args, pathname, stix_package)


### PR DESCRIPTION
I forgot that some versions of STIX are so strange as to not work

May as well patch it

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
