### PR TITLE
Feature/apache auth allow update

### DIFF
--- a/app/Controller/Component/Auth/ApacheAuthenticate.php
+++ b/app/Controller/Component/Auth/ApacheAuthenticate.php
@@ -25,19 +25,15 @@ class ApacheAuthenticate extends BaseAuthenticate {
 	 */
 	private function isUserMemberOf($group, $ldapUserData) {
 	// return true of false depeding on if user is a member of group.
-		CakeLog::write("debug", print_r($ldapUserData, true) );
 		$returnCode = false;
 		unset($ldapUserData[0]['memberof']["count"]);
 		foreach ($ldapUserData[0]['memberof'] as $result) {
 			$r = explode(",", $result, 2);
 			$ldapgroup = explode("=", $r[0]);
-			CakeLog::write("debug", $ldapgroup[1]. " == ".$group);
 			if ($ldapgroup[1] == $group) {
-				CakeLog::write("debug", "!!!TRUE!!!!");
 				$returnCode = true;
 			}
 		}
-		CakeLog::write("debug", "isUserMemberOf: ".$returnCode);
 		return $returnCode;
 	}
 
@@ -95,21 +91,11 @@ class ApacheAuthenticate extends BaseAuthenticate {
 		// Find user with real username (mail)
 		$user = $this->_findUser($mispUsername);
 
-		CakeLog::write("debug","_findUser: ".print_r($user,true));
-
-        	if (Configure::read('ApacheSecureAuth.updateUser')) {
-            		CakeLog::write("debug", "UpdateUser!");
-        	} else {
-            		CakeLog::write("debug", "DO NOT UpdateUser!");
-        	}
-
 		if ($user) {
 	           if (!Configure::read('ApacheSecureAuth.updateUser')) {
-			        return $user;
+		        return $user;
                    }
 		}
-
-		CakeLog::write("debug",print_r($ldapUserData,true));
 
 		// insert user in database if not existent
 		$userModel = ClassRegistry::init($this->settings['userModel']);
@@ -128,7 +114,6 @@ class ApacheAuthenticate extends BaseAuthenticate {
 
 		 // Set roleid depending on group membership
 		$roleIds = Configure::read('ApacheSecureAuth.ldapDefaultRoleId');
-		CakeLog::write("debug","RoleIDs: ". print_r($roleIds, true));
 		if (is_array($roleIds)) {
 			foreach ($roleIds as $key => $id) {
 				if ($this->isUserMemberOf($key, $ldapUserData)) {

--- a/app/Controller/Component/Auth/ApacheAuthenticate.php
+++ b/app/Controller/Component/Auth/ApacheAuthenticate.php
@@ -128,6 +128,7 @@ class ApacheAuthenticate extends BaseAuthenticate {
 
 		 // Set roleid depending on group membership
 		$roleIds = Configure::read('ApacheSecureAuth.ldapDefaultRoleId');
+		CakeLog::write("debug","RoleIDs: ". print_r($roleIds, true));
 		if (is_array($roleIds)) {
 			foreach ($roleIds as $key => $id) {
 				if ($this->isUserMemberOf($key, $ldapUserData)) {
@@ -154,10 +155,18 @@ class ApacheAuthenticate extends BaseAuthenticate {
 			// save user
 			$userModel->save($userData, false);
 		} else {
-			// Update existing user
-			$user['email'] = $mispUsername;
-			$user['org_id'] = $org_id;
-			$user['role_id'] = $roleId;
+			if (!isset($roleId)) {
+			   // User has no role anymore, disable user
+			   $user['disabled'] = 1;
+			   return false;
+			} else {
+			   // Update existing user
+			   $user['email'] = $mispUsername;
+			   $user['org_id'] = $org_id;
+			   $user['role_id'] = $roleId;
+			   # Reenable user in case it has been disabled
+			   $user['disabled'] = 0;
+			}
 
 			$userModel->save($user, false);
 		}


### PR DESCRIPTION
#### What does it do?

* Correct ldap group membership checking when using group-to-role mapping
* Allow Updating of User data with ldap data (group membership, email)
* Disable users when no longer member of any required ldap group
* Reenable user when added to a required ldap group

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
