### PR TITLE
Feature/allow proxy config

### DIFF
--- a/app/Controller/FeedsController.php
+++ b/app/Controller/FeedsController.php
@@ -209,7 +209,7 @@ class FeedsController extends AppController {
 				$this->request->data['Feed']['settings']['delimiter'] = ',';
 			}
 			$this->request->data['Feed']['settings'] = json_encode($this->request->data['Feed']['settings']);
-			$fields = array('id', 'name', 'provider', 'enabled', 'rules', 'url', 'distribution', 'sharing_group_id', 'tag_id', 'fixed_event', 'event_id', 'publish', 'delta_merge', 'source_format', 'override_ids', 'settings', 'input_source', 'delete_local_file', 'lookup_visible');
+			$fields = array('id', 'name', 'provider', 'enabled', 'rules', 'url', 'distribution', 'sharing_group_id', 'tag_id', 'fixed_event', 'event_id', 'publish', 'delta_merge', 'source_format', 'override_ids', 'settings', 'input_source', 'delete_local_file', 'lookup_visible', 'disable_proxy');
 			$feed = array();
 			foreach ($fields as $field) {
 				if (isset($this->request->data['Feed'][$field])) {

--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -344,7 +344,7 @@ class ServersController extends AppController {
 			}
 			if (!$fail) {
 				// say what fields are to be updated
-				$fieldList = array('id', 'url', 'push', 'pull', 'unpublish_event', 'publish_without_email', 'remote_org_id', 'name' ,'self_signed', 'cert_file', 'client_cert_file', 'push_rules', 'pull_rules', 'internal');
+				$fieldList = array('id', 'url', 'push', 'pull', 'unpublish_event', 'publish_without_email', 'remote_org_id', 'name' ,'self_signed', 'cert_file', 'client_cert_file', 'push_rules', 'pull_rules', 'internal', 'disable_proxy');
 				$this->request->data['Server']['id'] = $id;
 				if (isset($this->request->data['Server']['authkey']) && "" != $this->request->data['Server']['authkey']) $fieldList[] = 'authkey';
 				if(isset($this->request->data['Server']['organisation_type']) && isset($json)) {

--- a/app/Lib/Tools/SyncTool.php
+++ b/app/Lib/Tools/SyncTool.php
@@ -13,7 +13,7 @@ class SyncTool {
 		$HttpSocket = new HttpSocket($params);
 
 		$proxy = Configure::read('Proxy');
-		if (isset($proxy['host']) && !empty($proxy['host'])) $HttpSocket->configProxy($proxy['host'], $proxy['port'], $proxy['method'], $proxy['user'], $proxy['password']);
+		if (isset($proxy['host']) && !empty($proxy['host']) && !$server['Server']['disable_proxy']) $HttpSocket->configProxy($proxy['host'], $proxy['port'], $proxy['method'], $proxy['user'], $proxy['password']);
 		return $HttpSocket;
 	}
 
@@ -21,7 +21,7 @@ class SyncTool {
 		App::uses('HttpSocket', 'Network/Http');
 		$HttpSocket = new HttpSocket();
 		$proxy = Configure::read('Proxy');
-		if (isset($proxy['host']) && !empty($proxy['host'])) $HttpSocket->configProxy($proxy['host'], $proxy['port'], $proxy['method'], $proxy['user'], $proxy['password']);
+		if (isset($proxy['host']) && !empty($proxy['host']) && !$feed['Feed']['disable_proxy']) $HttpSocket->configProxy($proxy['host'], $proxy['port'], $proxy['method'], $proxy['user'], $proxy['password']);
 		return $HttpSocket;
 	}
 }

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -42,7 +42,8 @@ class AppModel extends Model {
 				51 => false, 52 => false, 55 => true, 56 => true, 57 => true,
 				58 => false, 59 => false, 60 => false, 61 => false, 62 => false,
 				63 => false, 64 => false, 65 => false, 66 => false, 67 => true,
-				68 => false, 69 => false, 71 => false, 72 => false, 73 => false
+				68 => false, 69 => false, 71 => false, 72 => false, 73 => false,
+				74 => false
 			)
 		)
 	);
@@ -687,6 +688,10 @@ class AppModel extends Model {
 			case '2.4.73':
 				$sqlArray[] = 'ALTER TABLE `servers` ADD `unpublish_event` tinyint(1) NOT NULL DEFAULT 0;';
 				$sqlArray[] = 'ALTER TABLE `servers` ADD `publish_without_email` tinyint(1) NOT NULL DEFAULT 0;';
+				break;
+			case '2.4.74':
+				$sqlArray[] = 'ALTER TABLE feeds ADD disable_proxy tinyint(1) NOT NULL DEFAULT 0;';
+				$sqlArray[] = 'ALTER TABLE `servers` ADD disable_proxy tinyint(1) NOT NULL DEFAULT 0;';
 				break;
 			case 'fixNonEmptySharingGroupID':
 				$sqlArray[] = 'UPDATE `events` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -222,7 +222,7 @@ class Feed extends AppModel {
 			$feeds = $this->find('all', array(
 				'recursive' => -1,
 				'conditions' => array('Feed.id !=' => $feedId),
-				'fields' => array('id', 'name', 'url', 'provider', 'source_format')
+				'fields' => array('id', 'name', 'url', 'provider', 'source_format', 'disable_proxy')
 			));
 			foreach ($feeds as $k => $v) {
 				if (!$redis->exists('misp:feed_cache:' . $v['Feed']['id'])) {
@@ -753,7 +753,7 @@ class Feed extends AppModel {
 		$params = array(
 			'conditions' => array('enabled' => 1),
 			'recursive' => -1,
-			'fields' => array('source_format', 'input_source', 'url', 'id', 'settings')
+			'fields' => array('source_format', 'input_source', 'url', 'id', 'settings', 'disable_proxy')
 		);
 		if ($scope !== 'all') {
 			if (is_numeric($scope)) {

--- a/app/View/Feeds/add.ctp
+++ b/app/View/Feeds/add.ctp
@@ -9,6 +9,10 @@
 		<div class="input clear"></div>
 	<?php
 		echo $this->Form->input('lookup_visible', array());
+	?>
+		<div class="input clear"></div>
+	<?php
+		echo $this->Form->input('disable_proxy', array());
 		echo $this->Form->input('name', array(
 				'div' => 'input clear',
 				'placeholder' => 'Feed name',

--- a/app/View/Feeds/edit.ctp
+++ b/app/View/Feeds/edit.ctp
@@ -9,6 +9,10 @@
 		<div class="input clear"></div>
 	<?php
 			echo $this->Form->input('lookup_visible', array());
+	?>
+		<div class="input clear"></div>
+	<?php
+			echo $this->Form->input('disable_proxy', array());
 			echo $this->Form->input('name', array(
 					'div' => 'input clear',
 					'placeholder' => 'Feed name',

--- a/app/View/Feeds/index.ctp
+++ b/app/View/Feeds/index.ctp
@@ -44,6 +44,7 @@
 			<th><?php echo $this->Paginator->sort('tag');?></th>
 			<th><?php echo $this->Paginator->sort('enabled');?></th>
 			<th><?php echo $this->Paginator->sort('lookup_visible');?></th>
+            <th><?php echo $this->Paginator->sort('disable_proxy');?></th>
 			<th class="actions"><?php echo __('Caching');?></th>
 			<th class="actions"><?php echo __('Actions');?></th>
 	</tr><?php
@@ -136,7 +137,8 @@ foreach ($feeds as $item):
 		<?php endif;?>
 		</td>
 		<td class="short"><span class="<?php echo ($item['Feed']['enabled'] ? 'icon-ok' : 'icon-remove'); ?>"></span><span class="short <?php if (!$item['Feed']['enabled'] || empty($ruleDescription)) echo "hidden"; ?>" data-toggle="popover" title="Filter rules" data-content="<?php echo $ruleDescription; ?>"> (Rules)</span>
-			<td class="short"><span class="<?php echo ($item['Feed']['lookup_visible'] ? 'icon-ok' : 'icon-remove'); ?>"></span>
+        <td class="short"><span class="<?php echo ($item['Feed']['lookup_visible'] ? 'icon-ok' : 'icon-remove'); ?>"></span>
+        <td class="short"><span class="<?php echo ($item['Feed']['disable_proxy'] ? 'icon-ok' : 'icon-remove'); ?>"></span>
 		<td class="short action-links <?php echo !empty($item['Feed']['cache_timestamp']) ? 'bold' : 'bold red';?>">
 			<?php
 				if (!empty($item['Feed']['cache_timestamp'])):

--- a/app/View/Servers/add.ctp
+++ b/app/View/Servers/add.ctp
@@ -88,6 +88,12 @@
 		echo $this->Form->input('self_signed', array(
 			'type' => 'checkbox',
 		));
+	?>
+		<div class = "input clear"></div>
+	<?php
+		echo $this->Form->input('disable_proxy', array(
+			'type' => 'checkbox',
+		));
 
 		echo $this->Form->input('Server.submitted_cert', array(
 			'label' => '<b>Server certificate file</b>',

--- a/app/View/Servers/edit.ctp
+++ b/app/View/Servers/edit.ctp
@@ -95,6 +95,13 @@
 			'type' => 'checkbox',
 		));
 	?>
+
+		<div class = "input clear"></div>
+	<?php
+		echo $this->Form->input('disable_proxy', array(
+			'type' => 'checkbox',
+		));
+	?>
 	<div class="clear">
 		<p>
 			<span class="bold">Server certificate file (*.pem): </span>

--- a/app/View/Servers/index.ctp
+++ b/app/View/Servers/index.ctp
@@ -31,6 +31,7 @@
 			<th><?php echo $this->Paginator->sort('cert_file');?></th>
 			<th><?php echo $this->Paginator->sort('client_cert_file');?></th>
 			<th><?php echo $this->Paginator->sort('self_signed');?></th>
+            <th><?php echo $this->Paginator->sort('disable_proxy');?></th>
 			<th><?php echo $this->Paginator->sort('org');?></th>
 			<th class="actions">Actions</th>
 	</tr>
@@ -78,6 +79,7 @@ foreach ($servers as $server):
 		<td class="short"><?php echo h($server['Server']['cert_file']); ?>&nbsp;</td>
 		<td class="short"><?php echo h($server['Server']['client_cert_file']); ?>&nbsp;</td>
 		<td class="short"><span class="<?php echo ($server['Server']['self_signed'] ? 'icon-ok' : 'icon-remove'); ?>"></span></td>
+        <td class="short"><span class="<?php echo ($server['Server']['disable_proxy'] ? 'icon-ok' : 'icon-remove'); ?>"></span></td>
 		<td class="short"><a href="/organisations/view/<?php echo h($server['Organisation']['id']); ?>"><?php echo h($server['Organisation']['name']); ?></a></td>
 		<td class="short action-links">
 			<?php


### PR DESCRIPTION
#### What does it do?

This PR allows disabling the proxy for a specific feed or server. Therefore a new field is introduced in Sync Actions->Feeds and Sync Actions->Servers. This field is used in app/Lib/Tools/SyncTool.php to disable the proxy for a specific feed or server. 

This fixes #1134.


#### Questions

- [X] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
