### PR TITLE
Fix: validation for port attribute

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -806,7 +806,7 @@ class Attribute extends AppModel {
 				}
 				break;
 			case 'port':
-				if (!is_numeric($value) || $value > 1 || $value < 65536) {
+				if (!is_numeric($value) || $value < 1 || $value > 65536) {
 					$returnValue = 'Port numbers have to be positive integers under 65536.';
 				} else {
 					$returnValue = true;


### PR DESCRIPTION
The logical check for a valid port attribute was backwards.  It looked for an integer outside the range of 1-65535 rather than inside.

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2016-06-03: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

Adding a port attribute to an event resulted in the error "Port numbers have to be positive integers under 65536."  The logic to check for a valid port was backwards.  This update fixes it.

#### Questions

- [No ] Does it require a DB change?
- [Yes ] Are you using it in production?
- [No ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
