### PR TITLE
Push Conversation items to a ZMQ topic

### DIFF
--- a/app/Lib/Tools/PubSubTool.php
+++ b/app/Lib/Tools/PubSubTool.php
@@ -69,6 +69,11 @@ class PubSubTool {
 		return $this->__pushToRedis(':data:misp_json', $json);
 	}
 
+    public function publishConversation($message) {
+        return $this->__pushToRedis(':data:misp_json_conversation', json_encode($message, JSON_PRETTY_PRINT));
+    }
+
+
 	private function __pushToRedis($ns, $data) {
 		$settings = $this->__setupPubServer();
 		$redis = new Redis();

--- a/app/files/scripts/mispzmq/mispzmq.py
+++ b/app/files/scripts/mispzmq/mispzmq.py
@@ -74,7 +74,8 @@ def main(args):
         command = r.lpop(namespace + ":command")
         if command is not None:
             handleCommand(command)
-        topics = ["misp_json", "misp_json_attribute", "misp_json_sighting", "misp_json_organisation", "misp_json_user"]
+        topics = ["misp_json", "misp_json_attribute", "misp_json_sighting", 
+                  "misp_json_organisation", "misp_json_user", "misp_json_conversation"]
         message_received = False
         for topic in topics:
             data = r.lpop(namespace + ":data:" + topic)


### PR DESCRIPTION
#### What does it do?

Whenever a new thread or post is added to a conversation, it's sent to ZMQ like so

```
{'Thread': 
  {'distribution': 1, 'title': 'yay', 'date_created': '2017/06/15 15:21:19', 'event_id': 0, 'user_id': '1', 
   'sharing_group_id': 0, 'post_count': 1, 'date_modified': '2017/06/15 15:21:19', 'org_id': '1'}}

{'Post': 
  {'date_created': '2017/06/15 15:21:19', 'thread_id': '10', 'contents': 'no', 'post_id': 0, 'user_id': '1', 
   'date_modified': '2017/06/15 15:21:19'}}
```

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [x] Patch
