### PR TITLE
Keep misp2stix Python 2.6 compatible

### DIFF
--- a/app/files/scripts/misp2stix_framing.py
+++ b/app/files/scripts/misp2stix_framing.py
@@ -120,7 +120,7 @@ def main(args):
     stix_package = STIXPackage()
     stix_header = STIXHeader()
 
-    stix_header.title="Export from {} MISP".format(orgname)
+    stix_header.title="Export from " + orgname + " MISP"
     stix_header.package_intents="Threat Report"
     stix_package.stix_header = stix_header
 


### PR DESCRIPTION
Even though we all want to live in a perfect world, some of us are still running RHEL 6 which ships with 2.6.6. So please, when possible and not too much of a nuisance, keep MISP compatible with this ancient technology a little while longer. 