### PR TITLE
Fix: Galaxy Cluster JSON encoding broke schema

### DIFF
--- a/app/Model/GalaxyCluster.php
+++ b/app/Model/GalaxyCluster.php
@@ -144,6 +144,13 @@ class GalaxyCluster extends AppModel{
 					$elements[$element['key']][] = $element['value'];
 				}
 			}
+
+            // if $elements is still empty, it will json_encode as [], when
+            // the schema requires it to be {}
+            if (count($elements) === 0) {
+                $elements = json_decode("{}");
+            }
+
 			unset($cluster['GalaxyElement']);
 			$this->Tag = ClassRegistry::init('Tag');
 			$tag_id = $this->Tag->find('first', array(

--- a/app/Model/GalaxyCluster.php
+++ b/app/Model/GalaxyCluster.php
@@ -145,11 +145,11 @@ class GalaxyCluster extends AppModel{
 				}
 			}
 
-            // if $elements is still empty, it will json_encode as [], when
-            // the schema requires it to be {}
-            if (count($elements) === 0) {
-                $elements = json_decode("{}");
-            }
+            		// if $elements is still empty, it will json_encode as [], when
+            		// the schema requires it to be {}
+            		if (count($elements) === 0) {
+                		$elements = json_decode("{}");
+            		}
 
 			unset($cluster['GalaxyElement']);
 			$this->Tag = ClassRegistry::init('Tag');


### PR DESCRIPTION
#### What does it do?

In the `getCluster` method, 

```php
$elements = array();
foreach ($cluster['GalaxyElement'] as $element) {
    if (!isset($elements[$element['key']])) {
        $elements[$element['key']] = array($element['value']);
    } else {
        $elements[$element['key']][] = $element['value'];
   }
}
```

In the case that no items were specified in `$cluster['GalaxyElement']`, this would json_encode as an empty array `[ ]`, the schema specifies that this element should be an object. Also if we *had* elements, it'd json_encode as `{"key":value}`. 
 
#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
