### PR TITLE
Change shebang to /usr/bin/env xxx for better portability

### DIFF
--- a/INSTALL/get-misp-automation.py
+++ b/INSTALL/get-misp-automation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 '''
 Example file on how to get the exported IDS data from MISP

--- a/app/Console/worker/start.sh
+++ b/app/Console/worker/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check if run as root
 if [ "$EUID" -eq 0 ]; then

--- a/app/update_thirdparty.sh
+++ b/app/update_thirdparty.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/tests/curl_tests.sh
+++ b/tests/curl_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -x

--- a/tools/get-misp-automation-client-cert.py
+++ b/tools/get-misp-automation-client-cert.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 '''
 Example file on how to get the exported IDS data from MISP


### PR DESCRIPTION
#### What does it do?

This small patch fixes non-portable shebang:
- #!/bin/bash --> #!/usr/bin/env bash
- #!/usr/bin/python --> #!/usr/bin/env python

Note: 
- This patch does NOT change shebang when it's #!/bin/sh (I consider that portable enough)
- This patch does NOT change shebang in INSTALL/ansible (which is only for Debian/Ubuntu)
- This patch does NOT change shebang in app/Console/cake.php because it uses php -q (and the documented way of using it is through the app/Console/cake shell script anyway)

Tested on : 
- Debian 9
- FreeBSD 11
- The latest ubuntu MISP VM (found at https://www.circl.lu/services/misp-training-materials/#misp-virtual-machine)

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
