### PR TITLE
Fix for a small bug: MISP can report mispzmq.py is running when it's not running

### DIFF
--- a/app/Lib/Tools/PubSubTool.php
+++ b/app/Lib/Tools/PubSubTool.php
@@ -46,7 +46,7 @@ class PubSubTool {
 		$pid = $pidFile->read(true, 'r');
 		if ($pid === false || $pid === '') return false;
 		if (!is_numeric($pid)) throw new Exception('Internal error (invalid PID file for the MISP zmq script)');
-		$result = trim(shell_exec('ps aux | awk \'{print $2}\' | grep ' . $pid));
+		$result = trim(shell_exec('ps aux | awk \'{print $2}\' | grep "^' . $pid . '$"'));
 		if (empty($result)) return false;
 		return $pid;
 	}


### PR DESCRIPTION
#### What does it do?

This one-line patch fixes how MISP checks whether mispzmq.py is running. 
The grep pattern was a bit optimistic, so the serverSettings/diagnostics page would sometime report that mispzmq.py is running even if misqpzmq.py is not runnung

Example of the issue:
```bash
$ cat app/files/scripts/mispzmq/mispzmq.pid ; echo
658
$ ps aux | awk '{print $2}' | grep 658
1658  # not what we want
$ ps aux | awk '{print $2}' | grep "^658$" # correct way of grepping a pid
[nothing: this is what we want]
```
This patch was tested OK on Debian 9, the Ubuntu training VM, and on FreeBSD 11

BTW, there are in the MISP code base several ways used to check whether a pid is running, some of which are rather esoteric (like the improper use of /proc in app/Model/Server.php).
Would you be interested in a pull request that would: 
1. Use [posix_getpgid](http://php.net/manual/en/function.posix-getpgid.php);
2. Assume posix_* functions are available;
3. Use posix_getpgid everywhere (i.e. also fix things that are not broken).

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
