### PR TITLE
Use posix_getpgid to check whether a pid is running

### DIFF
--- a/app/Lib/Tools/PubSubTool.php
+++ b/app/Lib/Tools/PubSubTool.php
@@ -46,8 +46,7 @@ class PubSubTool {
 		$pid = $pidFile->read(true, 'r');
 		if ($pid === false || $pid === '') return false;
 		if (!is_numeric($pid)) throw new Exception('Internal error (invalid PID file for the MISP zmq script)');
-		$result = trim(shell_exec('ps aux | awk \'{print $2}\' | grep "^' . $pid . '$"'));
-		if (empty($result)) return false;
+		if (!posix_getpgid($pid)) return false;
 		return $pid;
 	}
 

--- a/app/View/Elements/healthElements/workers.ctp
+++ b/app/View/Elements/healthElements/workers.ctp
@@ -1,22 +1,11 @@
 <div style="border:1px solid #dddddd; margin-top:1px; width:100%; padding:10px">
 	<?php
-		if (!$worker_array['proc_accessible']):
-	?>
-		<div style="background-color:red !important;color:white;"><b>Warning</b>: MISP cannot access your /proc directory to check the status of the worker processes, which means that dead workers will not be detected by the diagnostic tool. If you would like to regain this functionality, make sure that the open_basedir directive is not set, or that /proc is included in it.</div>
-	<?php
-		endif;
 		foreach ($worker_array as $type => $data):
-		if ($type == 'proc_accessible') continue;
 		$queueStatusMessage = "Issues prevent jobs from being processed. Please resolve them below.";
 		$queueStatus = false;
 		if ($data['ok']) {
-			if (!$worker_array['proc_accessible']) {
-				$queueStatus = 'N/A';
-				$queueStatusMessage = "Worker started with the correct user, but the current status is unknown.";
-			} else {
-				$queueStatus = true;
-				$queueStatusMessage = "OK";
-			}
+			$queueStatus = true;
+			$queueStatusMessage = "OK";
 		} else if (!empty($data['workers'])) {
 			foreach ($data['workers'] as $worker) {
 				if ($worker['alive']) {


### PR DESCRIPTION
#### What does it do?

To check whether or not a process is running, the current code base uses: 
- `(substr_count(trim(shell_exec('ps -p ' . $pid)), PHP_EOL) > 0 ? true : false)`
- or a `file_exists('/proc/' . $pid)` without testing that `/proc` is mounted

This patch replaces all those with a call to [`posix_getpgid($pid)`](http://php.net/manual/en/function.posix-getpgid.php). 
It fixes the workers status page on systems where `/proc` does not exist or where `/proc` is not mounted. 
Since this patch removes the dependence on `/proc`, it also removes the error message "MISP cannot access your /proc directory[...]"


Tested OK on Debian 9, Ubuntu Training VM and FreeBSD 11.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
