### PR TITLE
Show the welcome_text in tab title

### DIFF
--- a/app/View/Layouts/default.ctp
+++ b/app/View/Layouts/default.ctp
@@ -4,7 +4,7 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<?php echo $this->Html->charset(); ?>
 	<title>
-		<?php echo $title_for_layout, ' - MISP'; ?>
+		<?php echo $title_for_layout, ' - MISP '. h(Configure::read('MISP.welcome_text_top')); ?>
 	</title>
 	<?php
 		if (!isset($debugMode)) {


### PR DESCRIPTION
#### What does it do?

Show MISP.welcome_text_top value also in the tab title.
Useful when managing many MISP instances.

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
