### PR TITLE
Fix gpgv2+ key generation

### DIFF
--- a/INSTALL/INSTALL.debian9.txt
+++ b/INSTALL/INSTALL.debian9.txt
@@ -245,9 +245,8 @@ sudo chown -R www-data:www-data /var/www/MISP/app/Config
 sudo chmod -R 750 /var/www/MISP/app/Config
 
 # Generate a GPG encryption key.
-sudo -u www-data mkdir /var/www/MISP/.gnupg
-sudo chmod 700 /var/www/MISP/.gnupg
-sudo -u www-data gpg --homedir /var/www/MISP/.gnupg --gen-key
+sudo gpg --homedir /var/www/MISP/.gnupg --gen-key
+sudo chown -R www-data:www-data /var/www/MISP/.gnupg
 # The email address should match the one set in the config.php / set in the configuration menu in the administration menu configuration file
 
 # And export the public key to the webroot


### PR DESCRIPTION
#### What does it do?
This resolves failing of gpgv2 key generation with the following error message:
```
gpg: agent_genkey failed: Permission denied
Key generation failed: Permission denied
```

##### Explanation
gpgv2's `pinentry-curses` requires access to a current `tty`. If you `su` or `sudo` between users, your tty's permission will stay the same as the initial login user (see illustrating below). You could, in general, work around issues like this by:
 - `old_perms=$(stat -c "%U:%G" $(tty)); chown "www-data:tty" "$(tty)" && { sudo -u www-data gpg --gen-key; chown "${old_perms}" "$(tty)"; }` (uncertain security implications and looks rather obscure)
 - starting screen/tmux within the newuser and then running `gpg --gen-key`
 - starting a script session

But first point can't really be recommended, latter two will fail because www-data login shell is `/usr/sbin/nologin`. 

Just for illustrating the problem better for you:
```
ssh alice@somehost
stat -c "%U:%G $(tty)" $(tty)
alice:tty /dev/pts/1
su - root
stat -c "%U:%G $(tty)" $(tty)
alice:tty /dev/pts/1
```

#### Questions

- Does it require a DB change?
No

- Are you using it in production?
I've managed to follow the guide

- Does it require a change in the API (PyMISP for example)?
No.

#### Release Type:
- [X] Patch
