### PR TITLE
Fixing crash on Event Tag delete+refresh on recent MySQL version

### DIFF
--- a/app/Controller/TagsController.php
+++ b/app/Controller/TagsController.php
@@ -374,7 +374,7 @@ class TagsController extends AppController {
 			throw new MethodNotAllowedException('Invalid event.');
 		}
 		$this->loadModel('GalaxyCluster');
-		$cluster_names = $this->GalaxyCluster->find('list', array('fields' => array('GalaxyCluster.tag_name'), 'group' => array('GalaxyCluster.tag_name')));
+		$cluster_names = $this->GalaxyCluster->find('list', array('fields' => array('GalaxyCluster.tag_name'), 'group' => array('GalaxyCluster.id', 'GalaxyCluster.tag_name')));
 		$this->helpers[] = 'TextColour';
 		$tags = $this->EventTag->find('all', array(
 				'conditions' => array(


### PR DESCRIPTION
The bug can be reproduced on MISP VM v2.4.76
After deleting a tag from _/events/view/[id]_ , the AJAX query from loadEventTags to _/tags/showEventTag/[id]_ produced an error 500