### PR TITLE
Attribute tags: fixing automatic refresh after deleting/adding a tag

### DIFF
--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -776,7 +776,7 @@ function loadAttributeTags(id) {
 		dataType:"html",
 		cache: false,
 		success:function (data, textStatus) {
-			$("#Attribute_"+id+"_tr .attributeTagContainer").html(data);
+			$("#ShadowAttribute_"+id+"_tr .attributeTagContainer").html(data);
 		},
 		url:"/tags/showAttributeTag/" + id
 	});


### PR DESCRIPTION
Error could be reproduced on MISP VM v2.4.76.
Adding/deleting a tag to an Attribute previously required manual refreshing