### PR TITLE
Allow Redis to be password-protected

### DIFF
--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -1013,7 +1013,11 @@ class ServersController extends AppController {
 			if ($found['type'] == 'numeric') {
 				$this->request->data['Server']['value'] = intval($this->request->data['Server']['value']);
 			}
-			$testResult = $this->Server->{$found['test']}($this->request->data['Server']['value']);
+			if  (!empty($leafValue['test'])) {
+				$testResult = $this->Server->{$found['test']}($this->request->data['Server']['value']);
+			} else  {
+				$testResult = true;  # No test defined for this setting: cannot fail
+			}
 			if (!$forceSave && $testResult !== true) {
 				if ($testResult === false) $errorMessage = $found['errorMessage'];
 				else $errorMessage = $testResult;

--- a/app/Lib/Tools/PubSubTool.php
+++ b/app/Lib/Tools/PubSubTool.php
@@ -29,6 +29,8 @@ class PubSubTool {
 			$settings = $this->__setupPubServer();
 			$redis = new Redis();
 			$redis->connect($settings['redis_host'], $settings['redis_port']);
+			$redis_pwd = $settings['redis_password'];
+			if (!empty($redis_pwd)) $redis->auth($redis_pwd);
 			$redis->select($settings['redis_database']);
 			$this->__redis = $redis;
 			$this->__settings = $settings;
@@ -55,6 +57,8 @@ class PubSubTool {
 		$redis = new Redis();
 		$settings = $this->__getSetSettings();
 		$redis->connect($settings['redis_host'], $settings['redis_port']);
+		$redis_pwd = $settings['redis_password'];
+		if (!empty($redis_pwd)) $redis->auth($redis_pwd);
 		$redis->select($settings['redis_database']);
 		$redis->rPush($settings['redis_namespace'] . ':command', 'status');
 		sleep(1);
@@ -112,6 +116,8 @@ class PubSubTool {
 		if ($this->checkIfRunning()) {
 			if ($settings == false) $settings = $this->__getSetSettings();
 			$redis->connect($settings['redis_host'], $settings['redis_port']);
+			$redis_pwd = $settings['redis_password'];
+			if (!empty($redis_pwd)) $redis->auth($redis_pwd);
 			$redis->select($settings['redis_database']);
 			$redis->rPush($settings['redis_namespace'] . ':command', 'kill');
 			sleep(1);
@@ -128,6 +134,8 @@ class PubSubTool {
 			$settings = $this->__getSetSettings();
 			$redis = new Redis();
 			$redis->connect($settings['redis_host'], $settings['redis_port']);
+			$redis_pwd = $settings['redis_password'];
+			if (!empty($redis_pwd)) $redis->auth($redis_pwd);
 			$redis->select($settings['redis_database']);
 			$redis->rPush($settings['redis_namespace'] . ':command', 'reload');
 		}

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -1027,9 +1027,11 @@ class AppModel extends Model {
 		$host = Configure::read('MISP.redis_host') ? Configure::read('MISP.redis_host') : '127.0.0.1';
 		$port = Configure::read('MISP.redis_port') ? Configure::read('MISP.redis_port') : 6379;
 		$database = Configure::read('MISP.redis_database') ? Configure::read('MISP.redis_database') : 13;
+		$pass = Configure::read('MISP.redis_password');
 		if (!$redis->connect($host, $port)) {
 			return false;
 		}
+		if (!empty($pass)) $redis->auth($pass);
 		$redis->select($database);
 		$this->__redisConnection = $redis;
 		return $redis;

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -765,6 +765,14 @@ class Server extends AppModel {
 						'errorMessage' => '',
 						'test' => 'testForNumeric',
 						'type' => 'numeric'
+					),
+					'redis_password' => array(
+						'level' => 0,
+						'description' => 'The password on the redis server (if any) to be used for generic MISP tasks.',
+						'value' => '',
+						'errorMessage' => '',
+						'test' => 'testForEmpty',
+						'type' => 'string'
 					)
 			),
 			'GnuPG' => array(

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -771,7 +771,7 @@ class Server extends AppModel {
 						'description' => 'The password on the redis server (if any) to be used for generic MISP tasks.',
 						'value' => '',
 						'errorMessage' => '',
-						'test' => 'testForEmpty',
+						'test' => null,
 						'type' => 'string'
 					)
 			),
@@ -2142,10 +2142,12 @@ class Server extends AppModel {
 
 	private function __evaluateLeaf($leafValue, $leafKey, $setting) {
 		if (isset($setting)) {
-			$result = $this->{$leafValue['test']}($setting);
-			if ($result !== true) {
-				$leafValue['error'] = 1;
-				if ($result !== false) $leafValue['errorMessage'] = $result;
+			if (!empty($leafValue['test'])) {
+				$result = $this->{$leafValue['test']}($setting);
+				if ($result !== true) {
+					$leafValue['error'] = 1;
+					if ($result !== false) $leafValue['errorMessage'] = $result;
+				}
 			}
 			if ($setting !== '') $leafValue['value'] = $setting;
 		} else {


### PR DESCRIPTION
#### What does it do?

This patch allows MISP to work with a password-protected Redis server. 
Every time a redis connection is made, it checks whether `MISP.redis_password` is set in `config.php` and if so, issues a `$redis->auth($redis_pwd)`. 
This fixes the last components of MISP that don't already support a password-protected Redis. 

If `MISP.redis_password` is not set in `config.php`, this patch should have no impact.

I'm unsure about how to handle this setting though: Should an "official" `redis_password` option be added to `app/Model/Server.php` ? 
I think changing/setting the redis password from the gui is a terrible idea. If you use only one redis server like I expect 99% of people do, the password should also be set in many other places (php.ini, CakeResque config, Plugin.ZeroMQ_redis_password, app/config/bootstrap.php)
Any thought on that ?

A word of caution: Given how poorly some libraries are handling the redis password (CakeResque, I'm looking at you!), several "special" characters will break things if used in the redis password. In particular, ' (single quote), " (double quote) and $ will create problems. (The list is probably much longer.) 
CakeResque-ex will pass the Redis password to workers through env variables on the command line (!), without proper escaping (!!) and in such a way that bash will evaluate the content (!!!). 
One other side effect of that: the redis password is visible with `ps`

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
