### PR TITLE
fix: The server settings page (servers/serverSettings) was crashing w…

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -3040,7 +3040,18 @@ class Server extends AppModel {
 	}
 
 	public function workerDiagnostics(&$workerIssueCount) {
-		$this->ResqueStatus = new ResqueStatus\ResqueStatus(Resque::redis());
+		try {
+			$this->ResqueStatus = new ResqueStatus\ResqueStatus(Resque::redis());
+		} catch (Exception $e) {
+			// redis connection failed
+			return array(
+					'cache' => array('ok' => false),
+					'default' => array('ok' => false),
+					'email' => array('ok' => false),
+					'prio' => array('ok' => false),
+					'scheduler' => array('ok' => false)
+			);
+		}
 		$workers = $this->ResqueStatus->getWorkers();
 		if (function_exists('posix_getpwuid')) {
 			$currentUser = posix_getpwuid(posix_geteuid());


### PR DESCRIPTION
…hen the redis connection wasn't properly working.

#### What does it do?

It fixes an issue. The server settings page (servers/serverSettings) was crashing when the redis connection wasn't properly working.

Below the stack trace of the solved bug wheb the user go to the page _servers/serverSettings_:

```
2017-07-06 09:11:54 Warning: Warning (2): Redis::pconnect(): connect() failed: Connection refused in [/var/www/MISP/app/Vendor/kamisama/php-resque-ex/lib/Resque/Redis.php, line 23]
Trace:
ErrorHandler::handleError() - APP/Lib/cakephp/lib/Cake/Error/ErrorHandler.php, line 230
Redis::pconnect() - [internal], line ??
RedisApi::establishConnection() - APP/Vendor/kamisama/php-resque-ex/lib/Resque/Redis.php, line 23
RedisApi::__construct() - APP/Vendor/kamisama/php-resque-ex/lib/Resque/Redis.php, line 18
Resque_Redis::__construct() - APP/Vendor/kamisama/php-resque-ex/lib/Resque/Redis.php, line 168
Resque::redis() - APP/Vendor/kamisama/php-resque-ex/lib/Resque.php, line 102
Server::workerDiagnostics() - APP/Model/Server.php, line 3033
ServersController::serverSettings() - APP/Controller/ServersController.php, line 844
ReflectionMethod::invokeArgs() - [internal], line ??
Controller::invokeAction() - APP/Lib/cakephp/lib/Cake/Controller/Controller.php, line 491
Dispatcher::_invoke() - APP/Lib/cakephp/lib/Cake/Routing/Dispatcher.php, line 193
Dispatcher::dispatch() - APP/Lib/cakephp/lib/Cake/Routing/Dispatcher.php, line 167
[main] - APP/webroot/index.php, line 92

2017-07-06 09:11:54 Error: [RedisException] Redis server went away
Request URL: /servers/serverSettings
Stack Trace:
#0 /var/www/MISP/app/Vendor/kamisama/php-resque-ex/lib/Resque/Redis.php(28): Redis->setOption(2, 'resque:')
#1 /var/www/MISP/app/Vendor/kamisama/php-resque-ex/lib/Resque/Redis.php(18): RedisApi->establishConnection()
#2 /var/www/MISP/app/Vendor/kamisama/php-resque-ex/lib/Resque/Redis.php(168): RedisApi->__construct('localhost', '6379', 5, NULL)
#3 /var/www/MISP/app/Vendor/kamisama/php-resque-ex/lib/Resque.php(102): Resque_Redis->__construct('localhost', '6379', NULL)
#4 /var/www/MISP/app/Model/Server.php(3033): Resque::redis()
#5 /var/www/MISP/app/Controller/ServersController.php(844): Server->workerDiagnostics(0)
#6 [internal function]: ServersController->serverSettings()
#7 /var/www/MISP/app/Lib/cakephp/lib/Cake/Controller/Controller.php(491): ReflectionMethod->invokeArgs(Object(ServersController), Array)
#8 /var/www/MISP/app/Lib/cakephp/lib/Cake/Routing/Dispatcher.php(193): Controller->invokeAction(Object(CakeRequest))
#9 /var/www/MISP/app/Lib/cakephp/lib/Cake/Routing/Dispatcher.php(167): Dispatcher->_invoke(Object(ServersController), Object(CakeRequest))
#10 /var/www/MISP/app/webroot/index.php(92): Dispatcher->dispatch(Object(CakeRequest), Object(CakeResponse))
#11 {main}
```

I solved the problem here:
```
Server::workerDiagnostics() - APP/Model/Server.php, line 3033
```
when an exception is caught, the following array is simply returned
```php
array(
    'cache' => array('ok' => false),
    default' => array('ok' => false),
    'email' => array('ok' => false),
    'prio' => array('ok' => false),
    'scheduler' => array('ok' => false)
);
```
With False values...

#### Questions

- [No] Does it require a DB change?
- [No] Are you using it in production?
- [No] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
