### PR TITLE
Add an optional setting attachments_dir, and adapt existing code to use this setting

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -295,7 +295,7 @@ class AttributesController extends AppController {
 		$attachments_dir = Configure::read('MISP.attachments_dir');
 		if (empty($attachments_dir)) {
 			$this->loadModel('Server');
-			$attachments_dir = $this->Server->serverSettings['MISP']['attachments_dir']['value'];
+			$attachments_dir = $this->Server->getDefaultAttachments_dir();
 		}
 		$path = $attachments_dir . DS . $attribute['event_id'] . DS;
 		$file = $attribute['id'];
@@ -2820,7 +2820,7 @@ class AttributesController extends AppController {
 			$attachments_dir = Configure::read('MISP.attachments_dir');
 			if (empty($attachments_dir)) {
 				$this->loadModel('Server');
-				$attachments_dir = $this->Server->serverSettings['MISP']['attachments_dir']['value'];
+				$attachments_dir = $this->Server->getDefaultAttachments_dir();
 			}
 			foreach ($attributes as $attribute) {
 					$path = $attachments_dir . DS . $attribute['Attribute']['event_id'] . DS;

--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -292,7 +292,12 @@ class AttributesController extends AppController {
 	}
 
 	private function __downloadAttachment($attribute) {
-		$path = "files" . DS . $attribute['event_id'] . DS;
+		$attachments_dir = Configure::read('MISP.attachments_dir');
+		if (empty($attachments_dir)) {
+			$this->loadModel('Server');
+			$attachments_dir = $this->Server->serverSettings['MISP']['attachments_dir']['value'];
+		}
+		$path = $attachments_dir . DS . $attribute['event_id'] . DS;
 		$file = $attribute['id'];
 		if ('attachment' == $attribute['type']) {
 			$filename = $attribute['value'];
@@ -2812,8 +2817,13 @@ class AttributesController extends AppController {
 					'recursive' => -1)
 			);
 			$counter = 0;
+			$attachments_dir = Configure::read('MISP.attachments_dir');
+			if (empty($attachments_dir)) {
+				$this->loadModel('Server');
+				$attachments_dir = $this->Server->serverSettings['MISP']['attachments_dir']['value'];
+			}
 			foreach ($attributes as $attribute) {
-					$path = APP . "files" . DS . $attribute['Attribute']['event_id'] . DS;
+					$path = $attachments_dir . DS . $attribute['Attribute']['event_id'] . DS;
 					$file = $attribute['Attribute']['id'];
 					if (!file_exists($path . $file)) {
 							$counter++;

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -2172,7 +2172,12 @@ class EventsController extends AppController {
 			$zipData = $fileAccessTool->readFromFile($this->data['Event']['submittedgfi']['tmp_name'], $this->data['Event']['submittedgfi']['size']);
 
 			// write
-			$rootDir = APP . "files" . DS . "GFI" . DS . $id . DS;
+			$attachments_dir = Configure::read('MISP.attachments_dir');
+			if (empty($attachments_dir)) {
+				$this->loadModel('Server');
+				$attachments_dir = $this->Server->serverSettings['MISP']['attachments_dir']['value'];
+			}
+			$rootDir = $attachments_dir . DS . "GFI" . DS . $id . DS;
 			App::uses('Folder', 'Utility');
 			$dir = new Folder($rootDir, true);
 			if (!$this->Event->checkFilename($this->data['Event']['submittedgfi']['name'])) {
@@ -2212,7 +2217,12 @@ class EventsController extends AppController {
 			$iocData = $fileAccessTool->readFromFile($this->data['Event']['submittedioc']['tmp_name'], $this->data['Event']['submittedioc']['size']);
 
 			// write
-			$rootDir = APP . "files" . DS . $id . DS;
+			$attachments_dir = Configure::read('MISP.attachments_dir');
+			if (empty($attachments_dir)) {
+				$this->loadModel('Server');
+				$attachments_dir = $this->Server->serverSettings['MISP']['attachments_dir']['value'];
+			}
+			$rootDir = $attachments_dir . DS . $id . DS;
 			App::uses('Folder', 'Utility');
 			$dir = new Folder($rootDir . 'ioc', true);
 			$destPath = $rootDir . 'ioc';
@@ -2377,13 +2387,18 @@ class EventsController extends AppController {
 				if ((string)$key == 'filename') $realFileName = (string)$val;
 			}
 		}
-		$rootDir = APP . "files" . DS . $id . DS;
+		$attachments_dir = Configure::read('MISP.attachments_dir');
+		if (empty($attachments_dir)) {
+			$this->loadModel('Server');
+			$attachments_dir = $this->Server->serverSettings['MISP']['attachments_dir']['value'];
+		}
+		$rootDir = $attachments_dir . DS . $id . DS;
 		$malware = $rootDir . DS . 'sample';
 		$this->Event->Attribute->uploadAttachment($malware,	$realFileName,	true, $id, null, '', $this->Event->data['Event']['uuid'] . '-sample', $dist, true);
 
 		// Network activity -- .pcap
 		$realFileName = 'analysis.pcap';
-		$rootDir = APP . "files" . DS . $id . DS;
+		$rootDir = $attachments_dir . DS . $id . DS;
 		$malware = $rootDir . DS . 'Analysis' . DS . 'analysis.pcap';
 		$this->Event->Attribute->uploadAttachment($malware,	$realFileName,	false, $id, 'Network activity', '', $this->Event->data['Event']['uuid'] . '-analysis.pcap', $dist, true);
 

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -2175,7 +2175,7 @@ class EventsController extends AppController {
 			$attachments_dir = Configure::read('MISP.attachments_dir');
 			if (empty($attachments_dir)) {
 				$this->loadModel('Server');
-				$attachments_dir = $this->Server->serverSettings['MISP']['attachments_dir']['value'];
+				$attachments_dir = $this->Server->getDefaultAttachments_dir();
 			}
 			$rootDir = $attachments_dir . DS . "GFI" . DS . $id . DS;
 			App::uses('Folder', 'Utility');
@@ -2220,7 +2220,7 @@ class EventsController extends AppController {
 			$attachments_dir = Configure::read('MISP.attachments_dir');
 			if (empty($attachments_dir)) {
 				$this->loadModel('Server');
-				$attachments_dir = $this->Server->serverSettings['MISP']['attachments_dir']['value'];
+				$attachments_dir = $this->Server->getDefaultAttachments_dir();
 			}
 			$rootDir = $attachments_dir . DS . $id . DS;
 			App::uses('Folder', 'Utility');
@@ -2390,7 +2390,7 @@ class EventsController extends AppController {
 		$attachments_dir = Configure::read('MISP.attachments_dir');
 		if (empty($attachments_dir)) {
 			$this->loadModel('Server');
-			$attachments_dir = $this->Server->serverSettings['MISP']['attachments_dir']['value'];
+			$attachments_dir = $this->Server->getDefaultAttachments_dir();
 		}
 		$rootDir = $attachments_dir . DS . $id . DS;
 		$malware = $rootDir . DS . 'sample';

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -576,7 +576,7 @@ class Attribute extends AppModel {
 			$attachments_dir = Configure::read('MISP.attachments_dir');
 			if (empty($attachments_dir)) {
 				$my_server = ClassRegistry::init('Server');
-				$attachments_dir = $my_server->serverSettings['MISP']['attachments_dir']['value'];
+				$attachments_dir = $my_server->getDefaultAttachments_dir();
 			}
 			$filepath = $attachments_dir . DS . $this->data['Attribute']['event_id'] . DS . $this->data['Attribute']['id'];
 			$file = new File($filepath);
@@ -1256,7 +1256,7 @@ class Attribute extends AppModel {
 		$attachments_dir = Configure::read('MISP.attachments_dir');
 		if (empty($attachments_dir)) {
 			$my_server = ClassRegistry::init('Server');
-			$attachments_dir = $my_server->serverSettings['MISP']['attachments_dir']['value'];
+			$attachments_dir = $my_server->getDefaultAttachments_dir();
 		}
 		$filepath = $attachments_dir . DS . $attribute['event_id'] . DS . $attribute['id'];
 		$file = new File($filepath);
@@ -1271,7 +1271,7 @@ class Attribute extends AppModel {
 		$attachments_dir = Configure::read('MISP.attachments_dir');
 		if (empty($attachments_dir)) {
 			$my_server = ClassRegistry::init('Server');
-			$attachments_dir = $my_server->serverSettings['MISP']['attachments_dir']['value'];
+			$attachments_dir = $my_server->getDefaultAttachments_dir();
 		}
 		$rootDir = $attachments_dir . DS . $attribute['event_id'];
 		$dir = new Folder($rootDir, true);						// create directory structure
@@ -1321,7 +1321,7 @@ class Attribute extends AppModel {
 		$attachments_dir = Configure::read('MISP.attachments_dir');
 		if (empty($attachments_dir)) {
 			$my_server = ClassRegistry::init('Server');
-			$attachments_dir = $my_server->serverSettings['MISP']['attachments_dir']['value'];
+			$attachments_dir = $my_server->getDefaultAttachments_dir();
 		}
 		$rootDir = $attachments_dir . DS . $eventId;
 		$dir = new Folder($rootDir, true);
@@ -2309,7 +2309,7 @@ class Attribute extends AppModel {
 		$attachments_dir = Configure::read('MISP.attachments_dir');
 		if (empty($attachments_dir)) {
 			$my_server = ClassRegistry::init('Server');
-			$attachments_dir = $my_server->serverSettings['MISP']['attachments_dir']['value'];
+			$attachments_dir = $my_server->getDefaultAttachments_dir();
 		}
 		if ($proposal) {
 			$dir = new Folder($attachments_dir . DS . $event_id . DS . 'shadow', true);

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -337,7 +337,7 @@ class Event extends AppModel {
 		$attachments_dir = Configure::read('MISP.attachments_dir');
 		if (empty($attachments_dir)) {
 			$my_server = ClassRegistry::init('Server');
-			$attachments_dir = $my_server->serverSettings['MISP']['attachments_dir']['value'];
+			$attachments_dir = $my_server->getDefaultAttachments_dir();
 		}
 		$filepath = $attachments_dir . DS . $this->id;
 		App::uses('Folder', 'Utility');

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -334,7 +334,12 @@ class Event extends AppModel {
 		$this->EventTag->deleteAll(array('event_id' => $this->id));
 
 		// only delete the file if it exists
-		$filepath = APP . "files" . DS . $this->id;
+		$attachments_dir = Configure::read('MISP.attachments_dir');
+		if (empty($attachments_dir)) {
+			$my_server = ClassRegistry::init('Server');
+			$attachments_dir = $my_server->serverSettings['MISP']['attachments_dir']['value'];
+		}
+		$filepath = $attachments_dir . DS . $this->id;
 		App::uses('Folder', 'Utility');
 		if (is_dir($filepath)) {
 			if (!$this->destroyDir($filepath)) {

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -348,6 +348,15 @@ class Server extends AppModel {
 							'test' => 'testBool',
 							'type' => 'boolean',
 					),
+					'attachments_dir' => array(
+							'level' => 2,
+							'description' => 'Directory where attachments are stored. MISP will NOT migrate the existing data if you change this setting. The only safe way to change this setting is in config.php, when MISP is not running, and after having moved/copied the existing data to the new location. This directory must already exist and be writable and readable by the MISP application.',
+							'value' => APP . 'files',
+							'errorMessage' => '',
+							'null' => false,
+							'test' => 'testForWritableDir',
+							'type' => 'string',
+					),
 					'cached_attachments' => array(
 							'level' => 1,
 							'description' => 'Allow the XML caches to include the encoded attachments.',
@@ -2201,6 +2210,12 @@ class Server extends AppModel {
 		if ($value === '') return true;
 		if (preg_match('@^\/?(([a-z0-9_.]+[a-z0-9_.\-.\:]*[a-z0-9_.\-.\:]|[a-z0-9_.])+\/?)+$@i', $value)) return true;
 		return 'Invalid characters in the path.';
+	}
+
+	public function testForWritableDir($value) {
+		if (!is_dir($value)) return 'Not a valid directory.';
+		if (!is_writeable($value)) return 'Not a writable directory.';
+		return true;
 	}
 
 	public function testDebug($value) {

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -351,7 +351,7 @@ class Server extends AppModel {
 					'attachments_dir' => array(
 							'level' => 2,
 							'description' => 'Directory where attachments are stored. MISP will NOT migrate the existing data if you change this setting. The only safe way to change this setting is in config.php, when MISP is not running, and after having moved/copied the existing data to the new location. This directory must already exist and be writable and readable by the MISP application.',
-							'value' => APP . 'files',
+							'value' =>  'app/files', # GUI display purpose only. Default value defined in func getDefaultAttachments_dir()
 							'errorMessage' => '',
 							'null' => false,
 							'test' => 'testForWritableDir',
@@ -3537,5 +3537,9 @@ class Server extends AppModel {
 		exec($command2, $output);
 		$final .= implode("\n", $output);
 		return $final;
+	}
+
+	public function getDefaultAttachments_dir() {
+		return APP . 'files';
 	}
 }

--- a/app/Model/ShadowAttribute.php
+++ b/app/Model/ShadowAttribute.php
@@ -232,7 +232,7 @@ class ShadowAttribute extends AppModel {
 				$attachments_dir = Configure::read('MISP.attachments_dir');
 				if (empty($attachments_dir)) {
 					$my_server = ClassRegistry::init('Server');
-					$attachments_dir = $my_server->serverSettings['MISP']['attachments_dir']['value'];
+					$attachments_dir = $my_server->getDefaultAttachments_dir();
 				}
 				$filepath = $attachments_dir . DS . 'shadow' . DS . $sa['ShadowAttribute']['event_id'] . DS . $sa['ShadowAttribute']['id'];
 				$file = new File($filepath);
@@ -264,7 +264,7 @@ class ShadowAttribute extends AppModel {
 			$attachments_dir = Configure::read('MISP.attachments_dir');
 			if (empty($attachments_dir)) {
 				$my_server = ClassRegistry::init('Server');
-				$attachments_dir = $my_server->serverSettings['MISP']['attachments_dir']['value'];
+				$attachments_dir = $my_server->getDefaultAttachments_dir();
 			}
 			$filepath = $attachments_dir . DS . 'shadow' . DS . $this->data['ShadowAttribute']['event_id'] . DS . $this->data['ShadowAttribute']['id'];
 			$file = new File($filepath);
@@ -362,7 +362,7 @@ class ShadowAttribute extends AppModel {
 		$attachments_dir = Configure::read('MISP.attachments_dir');
 		if (empty($attachments_dir)) {
 			$my_server = ClassRegistry::init('Server');
-			$attachments_dir = $my_server->serverSettings['MISP']['attachments_dir']['value'];
+			$attachments_dir = $my_server->getDefaultAttachments_dir();
 		}
 		$filepath = $attachments_dir . DS . 'shadow' . DS . $attribute['event_id'] . DS. $attribute['id'];
 		$file = new File($filepath);
@@ -377,7 +377,7 @@ class ShadowAttribute extends AppModel {
 		$attachments_dir = Configure::read('MISP.attachments_dir');
 		if (empty($attachments_dir)) {
 			$my_server = ClassRegistry::init('Server');
-			$attachments_dir = $my_server->serverSettings['MISP']['attachments_dir']['value'];
+			$attachments_dir = $my_server->getDefaultAttachments_dir();
 		}
 		$rootDir = $attachments_dir . DS . 'shadow' . DS . $attribute['event_id'];
 		$dir = new Folder($rootDir, true);						// create directory structure

--- a/app/Model/ShadowAttribute.php
+++ b/app/Model/ShadowAttribute.php
@@ -229,7 +229,12 @@ class ShadowAttribute extends AppModel {
 			$sa = $this->find('first', array('conditions' => array('ShadowAttribute.id' => $this->data['ShadowAttribute']['id']), 'recursive' => -1, 'fields' => array('ShadowAttribute.id', 'ShadowAttribute.event_id', 'ShadowAttribute.type')));
 			if ($this->typeIsAttachment($sa['ShadowAttribute']['type'])) {
 				// only delete the file if it exists
-				$filepath = APP . "files" . DS . 'shadow' . DS . $sa['ShadowAttribute']['event_id'] . DS . $sa['ShadowAttribute']['id'];
+				$attachments_dir = Configure::read('MISP.attachments_dir');
+				if (empty($attachments_dir)) {
+					$my_server = ClassRegistry::init('Server');
+					$attachments_dir = $my_server->serverSettings['MISP']['attachments_dir']['value'];
+				}
+				$filepath = $attachments_dir . DS . 'shadow' . DS . $sa['ShadowAttribute']['event_id'] . DS . $sa['ShadowAttribute']['id'];
 				$file = new File($filepath);
 				if ($file->exists()) {
 					if (!$file->delete()) {
@@ -256,7 +261,12 @@ class ShadowAttribute extends AppModel {
 		$this->read(); // first read the attribute from the db
 		if ($this->typeIsAttachment($this->data['ShadowAttribute']['type'])) {
 			// only delete the file if it exists
-			$filepath = APP . "files" . DS . 'shadow' . DS . $this->data['ShadowAttribute']['event_id'] . DS . $this->data['ShadowAttribute']['id'];
+			$attachments_dir = Configure::read('MISP.attachments_dir');
+			if (empty($attachments_dir)) {
+				$my_server = ClassRegistry::init('Server');
+				$attachments_dir = $my_server->serverSettings['MISP']['attachments_dir']['value'];
+			}
+			$filepath = $attachments_dir . DS . 'shadow' . DS . $this->data['ShadowAttribute']['event_id'] . DS . $this->data['ShadowAttribute']['id'];
 			$file = new File($filepath);
 			if ($file->exists()) {
 				if (!$file->delete()) {
@@ -349,7 +359,12 @@ class ShadowAttribute extends AppModel {
 	}
 
 	public function base64EncodeAttachment($attribute) {
-		$filepath = APP . "files" . DS . 'shadow' . DS . $attribute['event_id'] . DS. $attribute['id'];
+		$attachments_dir = Configure::read('MISP.attachments_dir');
+		if (empty($attachments_dir)) {
+			$my_server = ClassRegistry::init('Server');
+			$attachments_dir = $my_server->serverSettings['MISP']['attachments_dir']['value'];
+		}
+		$filepath = $attachments_dir . DS . 'shadow' . DS . $attribute['event_id'] . DS. $attribute['id'];
 		$file = new File($filepath);
 		if (!$file->exists()) {
 			return '';
@@ -359,7 +374,12 @@ class ShadowAttribute extends AppModel {
 	}
 
 	public function saveBase64EncodedAttachment($attribute) {
-		$rootDir = APP . DS . "files" . DS . 'shadow' . DS . $attribute['event_id'];
+		$attachments_dir = Configure::read('MISP.attachments_dir');
+		if (empty($attachments_dir)) {
+			$my_server = ClassRegistry::init('Server');
+			$attachments_dir = $my_server->serverSettings['MISP']['attachments_dir']['value'];
+		}
+		$rootDir = $attachments_dir . DS . 'shadow' . DS . $attribute['event_id'];
 		$dir = new Folder($rootDir, true);						// create directory structure
 		$destpath = $rootDir . DS . $attribute['id'];
 		$file = new File($destpath, true);						// create the file


### PR DESCRIPTION
#### What does it do?

Currently, attachments are stored in the hard-coded directory `app/files/`. This PR adds an optional setting `attachments_dir`. (The discussion started in #2193)
If this setting is not set by user, it defaults to `app/file` (in other words: It should not break existing MISP installations). 
If this setting is set in `config.php`, every attachment (including attachment proposals + GFI files) will be read from/written to the location defined in the setting.

This setting will appear in the Server Settings -> MISP settings page, with a comment indicating that: 
1. This setting should only be changed when MISP is not running. 
2. MISP will not migrate the data by itself. User has to do it.
3. MISP will not even create the directory. User has to do it.


#### Testing
The current path (`app/files`) was hard-coded in 15 different functions through the codebase. 
I managed to test this PR on 12 of those modified functions (Thanks @iglocska for the help!).
I have not been able to properly exercise the 3 remaining functions, though I'm reasonably confident the changes should work OK (in those 3 cases, The exact same modification was tested OK elsewhere in the same class).

controller `EventsController` `_addGfiZip` TESTED OK (doesn't actually need a GFI file to test the modified part)
controller `EventsController` `_addIOCFile` TESTED OK
controller `EventsController` `_readGfiXML` **NOT TESTED**

controller `AttributesController` `__downloadAttachment` TESTED OK
controller `AttributesController` `checkAttachments` TESTED OK

model `Attribute` `base64EncodeAttachment` TESTED OK
model `Attribute` `saveBase64EncodeAttachment` TESTED OK
model `Attribute` `handleMaliciousBase64` TESTED OK
model `Attribute` `uploadAttachment`  **NOT TESTED**
model `Attribute` `beforeDelete` TESTED OK

model `Event` `beforeDelete` TESTED OK

model `ShadowAttribute` `afterSave` TESTED OK
model `ShadowAttribute` `beforeDelete` **NOT TESTED**
model `ShadowAttribute` `base64EncodeAttachment` TESTED OK
model `ShadowAttribute` `saveBase64EncodeAttachment` TESTED OK

TESTED OK means that I successfully tested both with the `attachments_dir` setting set in `config.php` AND without.

If someone is willing to provide me with (or tell me where I can find) a GFI sandbox file (whatever that is), that would allow me to test 2 untested cases. 
The last untested case is -- it seems -- code that is never called (but that should be)

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
