### PR TITLE
attribute tag search

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -1749,7 +1749,7 @@ class AttributesController extends AppController {
 		}
 
 		// If we sent any tags along, load the associated tag names for each attribute
-		if ($tags) $conditions = $this->Attribute->setTagConditions($tags, $conditions);
+		if ($tags) $conditions = $this->Attribute->setTagConditions($tags, $conditions, 'attributes');
 		if ($from) $conditions['AND'][] = array('Event.date >=' => $from);
 		if ($to) $conditions['AND'][] = array('Event.date <=' => $to);
 		if ($publish_timestamp) $conditions = $this->Attribute->setPublishTimestampConditions($publish_timestamp, $conditions);

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -2455,17 +2455,25 @@ class Attribute extends AppModel {
 		return $this->IOCExport->buildAll($this->Auth->user(), $event);
 	}
 
-	public function setTagConditions($tags, $conditions) {
+	public function setTagConditions($tags, $conditions, $controller='Events') {
 		$args = $this->dissectArgs($tags);
-		$tagArray = $this->AttributeTag->Tag->fetchEventTagIds($args[0], $args[1]);
+		$tagArray = $this->AttributeTag->Tag->fetchEventTagIds($args[0], $args[1], $controller);
 		$temp = array();
 		foreach ($tagArray[0] as $accepted) {
-			$temp['OR'][] = array('Event.id' => $accepted);
+			if ($controller === 'attributes') {
+				$temp['OR'][] = array('Attribute.id' => $accepted);
+			}else{
+				$temp['OR'][] = array('Event.id' => $accepted);
+			}
 		}
 		$conditions['AND'][] = $temp;
 		$temp = array();
 		foreach ($tagArray[1] as $rejected) {
-			$temp['AND'][] = array('Event.id !=' => $rejected);
+			if ($controller === 'attributes') {
+				$temp['AND'][] = array('Attribute.id !=' => $rejected);
+			}else{
+				$temp['AND'][] = array('Event.id !=' => $rejected);
+			}
 		}
 		$conditions['AND'][] = $temp;
 		return $conditions;

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -244,7 +244,9 @@ class Attribute extends AppModel {
 			'place-port-of-onward-foreign-destination' => array('desc' => 'A Port where the passenger is transiting to', 'default_category' => 'Person', 'to_ids' => 0),
 			'passenger-name-record-locator-number' => array('desc' => 'The Passenger Name Record Locator is a key under which the reservation for a trip is stored in the system. The PNR contains, among other data, the name, flight segments and address of the passenger. It is defined by a combination of five or six letters and numbers.', 'default_category' => 'Person', 'to_ids' => 0),
 			'mobile-application-id' => array('desc' => 'The application id of a mobile application', 'default_category' => 'Payload delivery', 'to_ids' => 1),
-			'cortex' => array('desc' => 'Cortex analysis result', 'default_category' => 'External analysis', 'to_ids' => 0)
+			'cortex' => array('desc' => 'Cortex analysis result', 'default_category' => 'External analysis', 'to_ids' => 0),
+			'logical-operator-and' => array('desc' => 'Create logical and between two attributs', 'default_category' => 'Logical', 'to_ids' => 0),
+			'logical-operator-or' => array('desc' => 'Create logical or between two attributs', 'default_category' => 'Logical', 'to_ids' => 0),
 			// Not convinced about this.
 			//'url-regex' => array('desc' => '', 'default_category' => 'Person', 'to_ids' => 0),
 	);
@@ -323,7 +325,12 @@ class Attribute extends AppModel {
 			'Other' => array(
 					'desc' => 'Attributes that are not part of any other category or are meant to be used as a component in MISP objects in the future',
 					'types' => array('comment', 'text', 'other', 'size-in-bytes', 'counter', 'datetime', 'cpe', 'port', 'float', 'hex')
-					)
+					),
+			'Logical' => array(
+					'desc' => 'Create logic between two attributes',
+					'formdesc' => 'One Category to rule them all, One Category to find them, One categorie to bring them all and in this sharing systeme bind them.',
+					'types' => array('logical-operator-and', 'logical-operator-or')
+			)
 	);
 
 	public $defaultCategories = array(
@@ -356,7 +363,9 @@ class Attribute extends AppModel {
 			'hex' => 'Other',
 			'attachment' => 'External analysis',
 			'malware-sample' => 'Payload delivery',
-			'cortex' => 'External analysis'
+			'cortex' => 'External analysis',
+			'logical-operator-and' => 'Logical',
+			'logical-operator-or' => 'Logical',
 	);
 
 	// typeGroupings are a mapping to high level groups for attributes
@@ -1161,6 +1170,16 @@ class Attribute extends AppModel {
 				break;
 			case 'hex':
 				$value = strtoupper($value);
+				break;
+			case 'logical-operator-and':
+				if (count(explode(':',$value)) >= 1) {
+					$returnValue = true;
+				}
+				break;
+			case 'logical-operator-or':
+				if (count(explode(':',$value)) >= 1) {
+					$returnValue = true;
+				}
 				break;
 		}
 		return $value;

--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -78,15 +78,24 @@ class Tag extends AppModel {
 	}
 
 	// find all of the event Ids that belong to the accepted tags and the rejected tags
-	public function fetchEventTagIds($accept=array(), $reject=array()) {
+	public function fetchEventTagIds($accept=array(), $reject=array(), $controller='events') {
 		$acceptIds = array();
 		$rejectIds = array();
 		if (!empty($accept)) {
-			$acceptIds = $this->findEventIdsByTagNames($accept);
-			if (empty($acceptIds)) $acceptIds[] = -1;
+			if ($controller === 'attributes') {
+				$acceptIds = $this->findAttributeIdsByAttributeTagNames($accept);
+				if (empty($acceptIds)) $acceptIds[] = -1;
+			}else{
+				$acceptIds = $this->findEventIdsByTagNames($accept);
+				if (empty($acceptIds)) $acceptIds[] = -1;
+			}
 		}
 		if (!empty($reject)) {
-			$rejectIds = $this->findEventIdsByTagNames($reject);
+			if ($controller === 'attributes') {
+				$rejectIds = $this->findAttributeIdsByAttributeTagNames($reject);
+			}else{
+				$rejectIds = $this->findEventIdsByTagNames($reject);
+			}
 		}
 		return array($acceptIds, $rejectIds);
 	}

--- a/app/View/Elements/eventattribute.ctp
+++ b/app/View/Elements/eventattribute.ctp
@@ -32,6 +32,32 @@
 			}
 		}
 	}
+	// create logical event
+	// cakeLog::write('debug',print_r($event['objects'], true));
+	$havelogical = false;
+	$listOfLogical = array();
+	foreach ($event['objects'] as $k => $object) {
+		if ($object['category'] === 'Logical') {
+			$listOfLogical[] = $object;
+			$havelogical = true;
+		}
+	}
+	// create minimal logical (all or)
+	if ($havelogical == false) {
+		// cakeLog::write('debug','no logical attrs');
+		foreach ($event['objects'] as $k => $object) {
+			$listOfLogical[] = array(
+				'category' => 'Logical',
+				'type' => 'logical-operator-or',
+				'id_start' => "_",
+				'id_stop' => $object['id'],
+				'value' => "_:".$object['id'],
+				'disable_correlation' => true,
+			);
+		}
+	}
+	// cakeLog::write('debug', print_r($listOfLogical, true));
+
 ?>
 	<div class="pagination">
 		<ul>
@@ -129,9 +155,12 @@
 			<div id="filter_deleted" title="Include deleted attributes" role="button" tabindex="0" aria-label="Include deleted attributes" class="attribute_filter_text<?php if ($deleted) echo '_active'; ?>" onClick="toggleDeletedAttributes('<?php echo Router::url( $this->here, true );?>');">Include deleted attributes</div>
 		<?php endif; ?>
 		<div id="show_context" title="Show attribute context fields" role="button" tabindex="0" aria-label="Show attribute context fields" class="attribute_filter_text" onClick="toggleContextFields();">Show context fields</div>
+		<div id="show_as_logical" title="Show the logic between attributes" role="button" tabindex="0" aria-label="Show the logic between attributes" class="attribute_filter_text" onClick="toggleLogicalFields();">Show logical</div>
 	</div>
 
 	<table class="table table-striped table-condensed">
+	<!-- Add thead and tbody for draggeble element -->
+		<thead>
 		<tr>
 			<?php
 				if ($mayModify && !empty($event['objects'])):
@@ -173,8 +202,24 @@
 			?>
 			<th class="actions">Actions</th>
 		</tr>
+		</thead>
+		<tbody id="sortable">
 		<?php
 			foreach ($event['objects'] as $k => $object):
+
+				// Récupérer les informations sur les logical
+				// cakeLog::write('debug', print_r($object, true));
+				// $listOfLogical
+				// if ( in_array( $object['id'], $listOfLogical['value'] )) {
+				foreach ($listOfLogical as $logical) {
+					if ( array_search($object['id'] , $logical)) {
+						$logicalObject = $logical;
+						break;
+					}
+				}
+				// }
+
+
 				$extra = '';
 				$extra2 = '';
 				$extra3 = '';
@@ -239,6 +284,26 @@
 									?>
 								</div>
 							</td>
+
+
+							<!-- logocal object -->
+
+
+
+							<?php if ($logicalObject['type'] === 'logical-operator-or'): ?>
+								<td class=" short ">OR</td>
+							<?php elseif ($logicalObject['type'] === 'logical-operator-and'): ?>
+								<td class=" short ">AND</td>
+							<?php endif; ?>
+
+
+							
+							<!-- /logocal object -->
+
+
+
+
+
 							<td class="short <?php echo $extra; ?>">
 						<?php
 							if ($object['objectType'] != 0) {
@@ -588,6 +653,7 @@
 		<?php
 			endforeach;
 		?>
+		</tbody>
 	</table>
 </div>
 	<?php if ($emptyEvent): ?>

--- a/app/View/Events/view.ctp
+++ b/app/View/Events/view.ctp
@@ -303,6 +303,7 @@
 </div>
 <script type="text/javascript">
 var showContext = false;
+var showLogical = false;
 $(document).ready(function () {
 	popoverStartup();
 

--- a/app/View/Layouts/default.ctp
+++ b/app/View/Layouts/default.ctp
@@ -34,6 +34,7 @@
 		echo $this->fetch('script');
 
 		echo $this->Html->script('jquery'); // Include jQuery library
+		echo $this->Html->script('jquery-ui');
 	?>
 
 </head>

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -2802,6 +2802,31 @@ function toggleContextFields() {
 	setContextFields();
 }
 
+
+
+function setLogicalFields() {
+	// make logical field alone
+	if (showLogical) {
+		$('.context').hide();
+		$('#show_context').removeClass("attribute_filter_text_active");
+		$('#show_context').addClass("attribute_filter_text");
+		
+		$('#show_as_logical').addClass("attribute_filter_text");
+		$('#show_as_logical').removeClass("attribute_filter_text_active");
+		
+	}
+}
+
+function toggleLogicalFields() {
+	if (!showLogical) {
+		showLogical = true;
+		showContext = false;
+} else {
+		showLogical = false;
+	}
+	setLogicalFields();
+}
+
 function checkOrphanedAttributes() {
 	$.ajax({
 		beforeSend: function (XMLHttpRequest) {


### PR DESCRIPTION
https://github.com/MISP/MISP/issues/1870

```python
r = misp.search(controller='attributes', tags=['test:toto', 'tmp:tt'])
print(json.dumps(r, indent=4))
```
```bash
URL:  http://misp.local/attributes/restSearch/download
Query:  {'tags': 'test:toto&&tmp:tt'}
```
sample result : 
```json
{
    "response": {
        "Attribute": [
            {
                "type": "ip-dst",
                "category": "Network activity",
                "uuid": "57723088-74c8-4a50-91db-4010950d0000",
                "to_ids": true,
                "deleted": false,
                "value": "69.30.210.254",
                "event_id": "2",
                "comment": "",
                "sharing_group_id": "0",
                "distribution": "0",
                "id": "10",
                "timestamp": "1497358924",
                "disable_correlation": false
            }
        ]
    }
}
```

#### What does it do?

If it fixes an existing issue, please use github syntax: `#1870`

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch