### PR TITLE
open tags search on attribute with api

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -1687,9 +1687,9 @@ class AttributesController extends AppController {
 	// the last 4 fields accept the following operators:
 	// && - you can use && between two search values to put a logical OR between them. for value, 1.1.1.1&&2.2.2.2 would find attributes with the value being either of the two.
 	// ! - you can negate a search term. For example: google.com&&!mail would search for all attributes with value google.com but not ones that include mail. www.google.com would get returned, mail.google.com wouldn't.
-	public function restSearch($key = 'download', $value = false, $type = false, $category = false, $org = false, $tags = false, $from = false, $to = false, $last = false, $eventid = false, $withAttachments = false, $uuid = false, $publish_timestamp = false, $published = false, $timestamp = false, $enforceWarninglist = false, $to_ids = false, $deleted = false) {
+	public function restSearch($key = 'download', $value = false, $type = false, $category = false, $org = false, $tags = false, $from = false, $to = false, $last = false, $eventid = false, $withAttachments = false, $uuid = false, $publish_timestamp = false, $published = false, $timestamp = false, $enforceWarninglist = false, $to_ids = false, $deleted = false, $attributeTags=false) {
 		if ($tags) $tags = str_replace(';', ':', $tags);
-		$simpleFalse = array('value' , 'type', 'category', 'org', 'tags', 'from', 'to', 'last', 'eventid', 'withAttachments', 'uuid', 'publish_timestamp', 'timestamp', 'enforceWarninglist', 'to_ids', 'deleted');
+		$simpleFalse = array('value' , 'type', 'category', 'org', 'tags', 'from', 'to', 'last', 'eventid', 'withAttachments', 'uuid', 'publish_timestamp', 'timestamp', 'enforceWarninglist', 'to_ids', 'deleted', 'attributeTags');
 		foreach ($simpleFalse as $sF) {
 			if (${$sF} === 'null' || ${$sF} == '0' || ${$sF} === false || strtolower(${$sF}) === 'false') ${$sF} = false;
 		}
@@ -1724,13 +1724,13 @@ class AttributesController extends AppController {
 			if (!isset($data['request'])) {
 				$data['request'] = $data;
 			}
-			$paramArray = array('value', 'type', 'category', 'org', 'tags', 'from', 'to', 'last', 'eventid', 'uuid', 'published', 'publish_timestamp', 'timestamp', 'enforceWarninglist', 'to_ids', 'deleted');
+			$paramArray = array('value', 'type', 'category', 'org', 'tags', 'from', 'to', 'last', 'eventid', 'uuid', 'published', 'publish_timestamp', 'timestamp', 'enforceWarninglist', 'to_ids', 'deleted', 'attributeTags');
 			foreach ($paramArray as $p) {
 				if (isset($data['request'][$p])) ${$p} = $data['request'][$p];
 				else ${$p} = null;
 			}
 		}
-		$simpleFalse = array('value' , 'type', 'category', 'org', 'tags', 'from', 'to', 'last', 'eventid', 'withAttachments', 'uuid', 'publish_timestamp', 'timestamp', 'enforceWarninglist', 'to_ids', 'deleted');
+		$simpleFalse = array('value' , 'type', 'category', 'org', 'tags', 'from', 'to', 'last', 'eventid', 'withAttachments', 'uuid', 'publish_timestamp', 'timestamp', 'enforceWarninglist', 'to_ids', 'deleted', 'attributeTags');
 		foreach ($simpleFalse as $sF) {
 			if (!is_array(${$sF}) && (${$sF} === 'null' || ${$sF} == '0' || ${$sF} === false || strtolower(${$sF}) === 'false')) ${$sF} = false;
 		}
@@ -1751,6 +1751,7 @@ class AttributesController extends AppController {
 
 		// If we sent any tags along, load the associated tag names for each attribute
 		if ($tags) $conditions = $this->Attribute->setTagConditions($tags, $conditions);
+		if ($attributeTags) $conditions = $this->Attribute->setTagConditions($attributeTags, $conditions, 'attributeTags');
 		if ($from) $conditions['AND'][] = array('Event.date >=' => $from);
 		if ($to) $conditions['AND'][] = array('Event.date <=' => $to);
 		if ($publish_timestamp) $conditions = $this->Attribute->setPublishTimestampConditions($publish_timestamp, $conditions);

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -2448,17 +2448,25 @@ class Attribute extends AppModel {
 		return $this->IOCExport->buildAll($this->Auth->user(), $event);
 	}
 
-	public function setTagConditions($tags, $conditions) {
+	public function setTagConditions($tags, $conditions, $controller='Events') {
 		$args = $this->dissectArgs($tags);
-		$tagArray = $this->AttributeTag->Tag->fetchEventTagIds($args[0], $args[1]);
+		$tagArray = $this->AttributeTag->Tag->fetchEventTagIds($args[0], $args[1], $controller);
 		$temp = array();
 		foreach ($tagArray[0] as $accepted) {
-			$temp['OR'][] = array('Event.id' => $accepted);
+			if ($controller === 'attributeTags') {
+				$temp['OR'][] = array('Attribute.id' => $accepted);
+			}else{
+				$temp['OR'][] = array('Event.id' => $accepted);
+			}
 		}
 		$conditions['AND'][] = $temp;
 		$temp = array();
 		foreach ($tagArray[1] as $rejected) {
-			$temp['AND'][] = array('Event.id !=' => $rejected);
+			if ($controller === 'attributeTags') {
+				$temp['AND'][] = array('Attribute.id !=' => $rejected);
+			}else{
+				$temp['AND'][] = array('Event.id !=' => $rejected);
+			}
 		}
 		$conditions['AND'][] = $temp;
 		return $conditions;

--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -78,15 +78,24 @@ class Tag extends AppModel {
 	}
 
 	// find all of the event Ids that belong to the accepted tags and the rejected tags
-	public function fetchEventTagIds($accept=array(), $reject=array()) {
+	public function fetchEventTagIds($accept=array(), $reject=array(), $controller='events') {
 		$acceptIds = array();
 		$rejectIds = array();
 		if (!empty($accept)) {
-			$acceptIds = $this->findEventIdsByTagNames($accept);
-			if (empty($acceptIds)) $acceptIds[] = -1;
+			if ($controller === 'attributeTags') {
+				$acceptIds = $this->findAttributeIdsByAttributeTagNames($accept);
+				if (empty($acceptIds)) $acceptIds[] = -1;
+			}else{
+				$acceptIds = $this->findEventIdsByTagNames($accept);
+				if (empty($acceptIds)) $acceptIds[] = -1;
+			}
 		}
 		if (!empty($reject)) {
-			$rejectIds = $this->findEventIdsByTagNames($reject);
+			if ($controller === 'attributeTags') {
+				$rejectIds = $this->findAttributeIdsByAttributeTagNames($reject);
+			}else{
+				$rejectIds = $this->findEventIdsByTagNames($reject);
+			}
 		}
 		return array($acceptIds, $rejectIds);
 	}


### PR DESCRIPTION
https://github.com/MISP/MISP/issues/1870

how to use : 
```python
import requests
session = requests.Session()
session.headers.update(
                {'Authorization': 'HHHhhh22GGGGGGggggggg2222222222',
                 'Accept': 'application/json',
                 'content-type': 'application/json'})
postData = {'attributeTags':
        ['question:univers="loading"', 'answer:univers="42"']
        }
url = 'http://misp.local/attributes/restSearch/json'
r = session.post(url, data=json.dumps(postData))
print(r.text)
```

sample result : 
```json
{
    "response": {
        "Attribute": [
            {
                "type": "ip-dst",
                "category": "Network activity",
                "uuid": "57723088-74c8-4a50-91db-4010950d0000",
                "to_ids": true,
                "deleted": false,
                "value": "42.42.42.42",
                "event_id": "2",
                "comment": "So long, and thanks for all the fish",
                "sharing_group_id": "0",
                "distribution": "0",
                "id": "42",
                "timestamp": "-883620000",
                "disable_correlation": false
            }
        ]
    }
}
```



#### What does it do?

If it fixes an existing issue, please use github syntax: `#1870`

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch