### PR TITLE
Fixed error: 'Value is not a boolean, make sure that you convert 'tru…

### DIFF
--- a/app/Console/Command/LiveShell.php
+++ b/app/Console/Command/LiveShell.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Reset a password
+ * Enable/disable misp
  *
- * arg0 = baseurl
+ * arg0 = [0|1]
  */
 class LiveShell extends AppShell {
 
@@ -13,7 +13,7 @@ class LiveShell extends AppShell {
 		if ($live != 0 && $live != 1) {
 			echo 'Invalid parameters. Usage: /var/www/MISP/app/Console/cake Live [0|1]';
 		} else {
-			$this->Server->serverSettingsSaveValue('MISP.live', $live);
+			$this->Server->serverSettingsSaveValue('MISP.live', $live==1);
 		}
 		$status = $live ? 'MISP is now live. Users can now log in.' : 'MISP is now disabled. Only site admins can log in.';
 		echo $status;


### PR DESCRIPTION
…e' to true for example.' when enabling/disabling MISP with the command line tool.


#### What does it do?

It fixes an issue.

When enabling/disabling MISP with the command line tool, the _Error Message_ column of the _server settings_ table was displaying "Value is not a boolean, make sure that you convert 'true' to true for example.".
The strange thing is that the command line tool seemed to really change the state of MISP (enabled/disabled). So I do not exactly know why there was this error message.

#### Questions

- [ No] Does it require a DB change?
- [ No] Are you using it in production?
- [ No] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
