### PR TITLE
Make all tag with disable taxonomy to hidden

### DIFF
--- a/app/Controller/TagsController.php
+++ b/app/Controller/TagsController.php
@@ -735,4 +735,23 @@ class TagsController extends AppController {
 			return $this->RestResponse->saveFailResponse('Tags', 'removeTagFromObject', false, 'Failed to remove tag from object.', $this->response->type());
 		}
 	}
+
+	public function hideThemAll(){
+		$this->loadModel('Taxonomy');
+		$taxonomyEnabled = $this->Taxonomy->listTaxonomies(array('full' => false, 'enabled' => true));
+
+		$allTags = $this->Tag->find('all');
+		$modifiedTags = array();
+		foreach($allTags as $k => $v){
+			if($v['Tag']['hide_tag'] == false){
+
+				if (!in_array(explode(':', $v['Tag']['name'])[0], array_keys($taxonomyEnabled))){
+					$v['Tag']['hide_tag'] = true;
+					$this->Tag->save($v['Tag']);
+					$modifiedTags[] = $v['Tag']['name'];
+				}
+			}
+		}
+		return new CakeResponse(array('body'=>json_encode($modifiedTags), 'status'=>200));
+	}
 }

--- a/app/View/Elements/healthElements/diagnostics.ctp
+++ b/app/View/Elements/healthElements/diagnostics.ctp
@@ -352,11 +352,11 @@
 	<div style="background-color:#f7f7f9;width:400px;">
         <span id="hideThemAllResult"><span style="color:orange;">Run the test below</span></span>
     </div><br>
-	<span class="btn btn-inverse" 
-		role="button" tabindex="0" 
-		aria-label="Hide them all" 
-		title="Check bad link on attachments" 
-		style="padding-top:1px;padding-bottom:1px;" 
+	<span class="btn btn-inverse"
+		role="button" tabindex="0"
+		aria-label="Hide them all"
+		title="Check bad link on attachments"
+		style="padding-top:1px;padding-bottom:1px;"
 		onClick="hideThemAll();">Hide them all</span>
 	<div class = 'input clear'></div>
 </div>

--- a/app/View/Elements/healthElements/diagnostics.ctp
+++ b/app/View/Elements/healthElements/diagnostics.ctp
@@ -342,5 +342,21 @@
         Non existing attachments referenced in Database....<span id="orphanedFileCount"><span style="color:orange;">Run the test below</span></span>
     </div><br>
 	<span class="btn btn-inverse" role="button" tabindex="0" aria-label="Check bad link on attachments" title="Check bad link on attachments" style="padding-top:1px;padding-bottom:1px;" onClick="checkAttachments();">Check bad link on attachments</span>
-
+	<hr>
+	<h3>
+		Make all tag with disable taxonomy to hidden
+	</h3>
+	<p>You can restrict the use of taxonomy to your instance from the list of taxonomies.</p>
+	<p>To be sure that other tag imported are not selectable too, you must change MISP.incoming_tags_disabled_by_default to true.</p>
+	<p>but for old tags, you need to make all tag as disable. For those who are not in an enable taxonomy</p>
+	<div style="background-color:#f7f7f9;width:400px;">
+        <span id="hideThemAllResult"><span style="color:orange;">Run the test below</span></span>
+    </div><br>
+	<span class="btn btn-inverse" 
+		role="button" tabindex="0" 
+		aria-label="Hide them all" 
+		title="Check bad link on attachments" 
+		style="padding-top:1px;padding-bottom:1px;" 
+		onClick="hideThemAll();">Hide them all</span>
+	<div class = 'input clear'></div>
 </div>

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -2849,6 +2849,32 @@ function checkAttachments() {
 	});
 }
 
+function hideThemAll(){
+	$.getJSON("/tags/hideThemAll/", function(data){
+		var color = 'grey';
+		var text = ' tag(s) and not in an enable taxonomy will become hidden ';
+		if (data !== undefined && data.length == '0') {
+			color = 'green';
+			text = ' No tag (not in an enable taxonomy) have the field "hidden" to false';
+			$("#hideThemAllResult").html('<span class="' + color + '">' + text + '</span>');
+		}else{
+			$("#hideThemAllResult").html('<span class="' + color + '">' + data.length + text + '</span>');
+		
+			$('<ul>', {
+				id:"hideThemAllResultList",
+				class:"list-group"})
+				.appendTo("#hideThemAllResult");
+			$.each( data, function( key, val ) {
+				$('<li class="list-group-item">').text(val).appendTo("#hideThemAllResultList");
+			});
+		}
+	})
+	.done(function(){$(".loading").show()})
+	.complete(function(){$(".loading").hide()})
+	.fail(function(data){console.log(data)});
+}
+
+
 function loadTagTreemap() {
 	$.ajax({
 		async:true,


### PR DESCRIPTION
You can restrict the use of taxonomy to your instance from the list of taxonomies.

but this is not applicable with old tag. This old tag can be selectable by user ether if they are not in an enable taxonomy.

this function make all tags who are not in an enable taxonomy selectable.
It passes them in hidden.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch