### PR TITLE
Rebuild _authenticateObjects cache in mixed authentication setups

### DIFF
--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -764,6 +764,7 @@ class UsersController extends AppController {
 					$passwordToSave = $this->request->data['User']['password'];
 				}
 				unset($this->Auth->authenticate['Form']['passwordHasher']);
+				$this->Auth->constructAuthenticate();
 			}
 		}
 		if ($this->Auth->login()) {


### PR DESCRIPTION
When CertAuth is mixed with normal FormAuthentication the upgrade from Simple to Blowfish did not happen because of the internal _authenticateObjects cache. Calling constructAuthenticate() rebuilds this cache.