### PR TITLE
Baseurl miss in events filter

### DIFF
--- a/app/View/Events/index.ctp
+++ b/app/View/Events/index.ctp
@@ -41,7 +41,7 @@
 				<?php echo $this->Html->link('', array('controller' => 'events', 'action' => 'index'), array('class' => 'icon-remove', 'title' => 'Remove filters'));?>
 			</span>
 			<?php endif;?>
-			<span role="button" tabindex="0" aria-label="Quickfilter" title="Quickfilter" id="quickFilterButton" class="tabMenuFilterFieldButton useCursorPointer" onClick='quickFilter(<?php echo h($passedArgs);?>, "/events/index");'>Filter</span>
+			<span role="button" tabindex="0" aria-label="Quickfilter" title="Quickfilter" id="quickFilterButton" class="tabMenuFilterFieldButton useCursorPointer" onClick="quickFilter(<?php echo h($passedArgs); ?>, '<?php echo $baseurl . '/events/index'; ?>');">Filter</span>
 			<input class="tabMenuFilterField" type="text" id="quickFilterField"></input>
 			<?php
 				$tempArgs = json_decode($passedArgs, true);


### PR DESCRIPTION
Minor change, adding baseurl for events search

#### What does it do?

Fix failed searches when a baseurl is configured.

#### Questions

- [NO] Does it require a DB change?
- [Y] Are you using it in production?
- [NO] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
