### PR TITLE
Accessibility improvement: ARIA properties for the "Add new cluster" button - events/view

### DIFF
--- a/app/View/Elements/galaxyQuickView.ctp
+++ b/app/View/Elements/galaxyQuickView.ctp
@@ -97,7 +97,7 @@
 <?php
 	if ($isSiteAdmin || ($mayModify && $isAclTagger)):
 ?>
-		<span class="useCursorPointer btn btn-inverse" id="addGalaxy" data-event-id="<?php echo h($event['Event']['id']); ?>" style="margin-top:20px;padding: 1px 5px !important;font-size: 12px !important;">Add new cluster</span>
+		<span class="useCursorPointer btn btn-inverse" id="addGalaxy" data-event-id="<?php echo h($event['Event']['id']); ?>" role="button" tabindex="0" aria-label="Add new cluster" style="margin-top:20px;padding: 1px 5px !important;font-size: 12px !important;">Add new cluster</span>
 <?php
 	endif;
 ?>


### PR DESCRIPTION
Given the "button" role and appropriate aria-label to the "Add new cluster" button in the "galaxy quick preview" on an events/view page.