### PR TITLE
Use sanitized orgname in STIX header

### DIFF
--- a/app/files/scripts/misp2stix_framing.py
+++ b/app/files/scripts/misp2stix_framing.py
@@ -103,18 +103,18 @@ def main(args):
     NS_DICT[namespace[0]]=namespace[1]
 
     try:
-        idgen.set_id_namespace({baseURL: orgname})
+        idgen.set_id_namespace({baseURL: namespace[1]})
     except ValueError:
         # Some weird stix error that sometimes occurs if the stars
         # align and Mixbox is being mean to us
         # Glory to STIX, peace and good xmlns be upon it
         try:
-            idgen.set_id_namespace(Namespace(baseURL, orgname))
+            idgen.set_id_namespace(Namespace(baseURL, namespace[1]))
         except TypeError:
             # Ok this only occurs if the script is being run under py3
             # and if we're running a REALLY weird version of stix
             # May as well catch it
-            idgen.set_id_namespace(Namespace(baseURL, orgname, "MISP"))
+            idgen.set_id_namespace(Namespace(baseURL, namespace[1], "MISP"))
 
 
     stix_package = STIXPackage()


### PR DESCRIPTION
The STIX header used the plain orgname where the STIX elements used the sanitized version. This makes the STIX document not validate (undefined namespace used).