### PR TITLE
Add ip-src|port and ip-dst|port attributes to STIX export

### DIFF
--- a/app/files/scripts/misp2stix_framing.py
+++ b/app/files/scripts/misp2stix_framing.py
@@ -31,6 +31,7 @@ NS_DICT = {
         "http://cybox.mitre.org/default_vocabularies-2" : 'cyboxVocabs',
         "http://cybox.mitre.org/objects#ASObject-1" : 'ASObj',
         "http://cybox.mitre.org/objects#AddressObject-2" : 'AddressObj',
+        "http://cybox.mitre.org/objects#PortObject-2" : 'PortObj',
         "http://cybox.mitre.org/objects#DomainNameObject-1" : 'DomainNameObj',
         "http://cybox.mitre.org/objects#EmailMessageObject-2" : 'EmailMessageObj',
         "http://cybox.mitre.org/objects#FileObject-2" : 'FileObj',


### PR DESCRIPTION
The _ip-src|port_ and _ip-dst|port_ attributes were missing in STIX exports. 
This patch also correctly sets the _is_source_ and _is_destination_ STIX attributes and leaves those out when unknown (like for _domain|ip_).