### PR TITLE
Add an imput for search on all attributes in an event.

### DIFF
--- a/app/Config/config.default.php
+++ b/app/Config/config.default.php
@@ -36,6 +36,7 @@ $config = array(
 			'take_ownership_xml_import'      => false,
 			'unpublishedprivate'             => false,
 			'disable_emailing'               => false,
+			'Attributes_Values_Filter_In_Event' => 'id, uuid, value, comment, type, category, Tag.name',
 		),
 	'GnuPG'            =>
 		array(

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -792,6 +792,14 @@ class Server extends AppModel {
 						'test' => null,
 						'type' => 'string',
 						'redacted' => true
+					),
+					'Attributes_Values_Filter_In_Event' => array(
+						'level' => 1,
+						'description' => 'Specify wich field to filter on when you serch in an event. "value" will search in "Attribute.value and Object.Attribute.value". Default value are : "id, uuid, value, comment, type, category, Tag.name"',
+						'value' => 'id, uuid, value, comment, type, category, Tag.name',
+						'errorMessage' => '',
+						'test' => null,
+						'type' => 'string',
 					)
 			),
 			'GnuPG' => array(

--- a/app/View/Elements/eventattribute.ctp
+++ b/app/View/Elements/eventattribute.ctp
@@ -33,6 +33,12 @@
 			}
 		}
 	}
+	$filtered = false;
+	if(isset($passedArgsArray)){
+		if (count($passedArgsArray) > 0) {
+			$filtered = true;
+		}
+	}
 ?>
 	<div class="pagination">
 		<ul>
@@ -109,6 +115,15 @@
 		<?php if (Configure::read('Plugin.Sightings_enable')): ?>
 			<span id="multi-sighting-button" title="Sightings display for selected attributes" role="button" tabindex="0" aria-label="Sightings display for selected attributes" class="hidden icon-wrench mass-select useCursorPointer sightings_advanced_add" data-object-id="selected" data-object-context="attribute"></span>
 		<?php endif; ?>
+		<?php if ($filtered):?>
+			<div class='attribute_filter_text attribute_filter_text_active'>
+			<?php foreach ($passedArgsArray as $k => $v):?>
+				<span><?php echo h(ucfirst($k)) . " : " . h($v); ?></span>
+			<?php endforeach; ?>
+			<span tabindex="0" aria-label="Show all attributes" title="Remove filters" role="button" onClick="filterAttributes('all', '<?php echo h($event['Event']['id']); ?>');" class='icon-remove'>
+			</span>
+			</div>
+		<?php endif;?>
 	</div>
 	<div class="tabMenu tabMenuToolsBlock noPrint">
 		<?php if ($mayModify): ?>
@@ -132,6 +147,11 @@
 			<div id="filter_deleted" title="Include deleted attributes" role="button" tabindex="0" aria-label="Include deleted attributes" class="attribute_filter_text<?php if ($deleted) echo '_active'; ?>" onClick="toggleDeletedAttributes('<?php echo Router::url( $this->here, true );?>');">Include deleted attributes</div>
 		<?php endif; ?>
 		<div id="show_context" title="Show attribute context fields" role="button" tabindex="0" aria-label="Show attribute context fields" class="attribute_filter_text" onClick="toggleContextFields();">Show context fields</div>
+		<div title="input filter" tabindex="0" aria-label="input filter" class="attribute_filter_text">
+			<span id="attributesFilterButton" role="button" tabindex="0" aria-label="Filter on attributes value" 
+				onClick="filterAttributes('value', '<?php echo h($event['Event']['id']); ?>');"></span>
+			<input type="text" id="attributesFilterField" style="height:20px;padding:0px;margin:0px;" class="form-control"></input>
+		</div>
 	</div>
 
 	<table class="table table-striped table-condensed">

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -2558,6 +2558,10 @@ function syncUserSelected() {
 
 function filterAttributes(filter, id) {
 	url = "/events/viewEventAttributes/" + id + "/attributeFilter:" + filter;
+	if(filter === 'value'){
+		filter = $('#attributesFilterField').val().trim();
+		url += "/searchFor:" + filter;
+	}
 	if (deleted) url += '/deleted:true';
 	$.ajax({
 		type:"get",


### PR DESCRIPTION
## What does it do?
this PR add possibility to filter on attributes in an event.

![animation](https://user-images.githubusercontent.com/17462115/31190535-a7ef6e40-a93b-11e7-9859-2ba38071a06c.gif)

## Generic requirements in order to contribute to MISP:

check you conf file ti add requierement field and add this in the MISP array : 
```php
'Attributes_Values_Filter_In_Event' => 'id, uuid, value, comment, type, category, Tag.name',
```
the option can be change in the administration page.


#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:


- [ ] Major
- [ ] Minor
- [X] Patch
