### PR TITLE
Add Condition attribute to HTTP_Method STIX export

### DIFF
--- a/app/files/scripts/misp2cybox.py
+++ b/app/files/scripts/misp2cybox.py
@@ -280,6 +280,7 @@ def resolveHTTPObservable(indicator, attribute):
     else:
         line = HTTPRequestLine()
         line.http_method = attribute["value"]
+        line.http_method.condition = "Equals"
         client_request.http_request_line = line
     request_response.http_client_request = client_request
     new_object = HTTPSession()


### PR DESCRIPTION
To avoid these warning from stix-validator.py:
```
[!] Best Practices: False
    [!] Indicator Pattern Properties Missing Condition Attributes
        [-] line : 251
        [-] message : None
        [-] id : None
        [-] idref : None
        [-] tag : {http://cybox.mitre.org/objects#HTTPSessionObject-2}HTTP_Method
        [-] parent indicator id : MISP:MispObject-59d5209c-6768-4fc9-92c9-784795d2dbc0
        [-] parent indicator line : 231
```