### PR TITLE
Fix: Attribute type list when editing should be the category's one if…

### DIFF
--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -2741,6 +2741,7 @@ function initPopoverContent(context) {
 			});
 		}
 	}
+	formCategoryChanged('Attribute');
 }
 
 function getFormInfoContent(property, field) {


### PR DESCRIPTION
#### What does it do?

[No issue has been open for this]
When editing an attribute even if the category was already set the type list will be the full list. It should only display the corresponding list to the category.

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
