### PR TITLE
Custom csv export

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -2251,9 +2251,9 @@ class EventsController extends AppController {
 				}
 			}
 		}
-		$requested_attributes = ['uuid', 'event_id', 'category', 'type',
-								'value', 'comment', 'to_ids', 'timestamp'];
-		$requested_obj_attributes = ['uuid', 'name', 'meta-category'];
+		$requested_attributes = array('uuid', 'event_id', 'category', 'type',
+								'value', 'comment', 'to_ids', 'timestamp');
+		$requested_obj_attributes = array('uuid', 'name', 'meta-category');
 		if($this->params['url']['attributes']) {
 		    $requested_attributes = explode(',', $this->params['url']['attributes']);
 			 $requested_obj_attributes = array();

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -2277,6 +2277,7 @@ class EventsController extends AppController {
 					}
 					$line2 = rtrim($line2, ",");
 					$line = $line1 . ',' . $line2;
+					$line = rtrim($line, ",");
 					if ($includeContext) {
 						foreach ($this->Event->csv_event_context_fields_to_fetch as $header => $field) {
 							if ($field['object']) $line .= ',' . $attribute['Event'][$field['object']][$field['var']];


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:


#### What does it do?

Enables the user to select the attributes to be included in the CSV export. It is possible to specify attributes of events and attributes of objects.

##### Get all attributes (legacy)

```bash
GET https://<misp-instance>/events/csv/download/<event-id>
```

##### Select some event attributes

```bash
GET https://<misp-instance>/events/csv/download/<event-id>?attributes=timestamp,type,uuid,value
```
(the order of the attributes wil be honored, by default attributes of the object won't be returned)


##### Select some event attributes with object attributes

```bash
GET https://<misp-instance>/events/csv/download/<event-id>?attributes=timestamp,type,uuid,value&obj_attributes=uuid,name
```

Columns of the CSV file that will be returned:
`timestamp,type,uuid,value,object-uuid,object-name`

The string _object-_ is prepended to the object attributes names.


#### Questions

- [NO] Does it require a DB change?
- [NO] Are you using it in production?
- [NO] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
