### PR TITLE
fix: refresh rows in settings editor

### DIFF
--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -676,6 +676,13 @@ class ServersController extends AppController {
 		$this->set('priorities', $priorities);
 		$this->set('k', $id);
 		$this->layout = false;
+
+		$subGroup = 'general';
+		if ($pathToSetting[0] === 'Plugin') {
+			$subGroup = explode('_', $pathToSetting[1])[0];
+		}
+		$this->set('subGroup', $subGroup);
+
 		$this->render('/Elements/healthElements/settings_row');
 	}
 
@@ -939,6 +946,9 @@ class ServersController extends AppController {
 	}
 
 	public function serverSettingsEdit($setting, $id = false, $forceSave = false) {
+		// invalidate config.php from php opcode cache
+		opcache_reset();
+
 		if (!$this->_isSiteAdmin()) throw new MethodNotAllowedException();
 		if (!isset($setting) || !isset($id)) throw new MethodNotAllowedException();
 		$this->set('id', $id);

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -2204,6 +2204,9 @@ class Server extends AppModel {
 	}
 
 	public function serverSettingReadSingle($settingObject, $settingName, $leafKey) {
+		// invalidate config.php from php opcode cache
+		opcache_reset();
+
 		$setting = Configure::read($settingName);
 		$result = $this->__evaluateLeaf($settingObject, $leafKey, $setting);
 		$result['setting'] = $settingName;

--- a/app/View/Elements/healthElements/settings_row.ctp
+++ b/app/View/Elements/healthElements/settings_row.ctp
@@ -8,7 +8,7 @@
 	if ($setting['type'] == 'boolean') $setting['value'] = ($setting['value'] === true ? 'true' : 'false');
 	if (isset($setting['options'])) $setting['value'] = $setting['options'][$setting['value']];
 ?>
-<tr id ="<?php echo h($k); ?>_row">
+<tr id ="<?php echo h("${subGroup}_$k"); ?>_row" class="subGroup_<?php echo h($subGroup);?>">
 	<?php
 		if (!empty($setting['redacted'])) {
 			$setting['value'] = '*****';
@@ -17,10 +17,10 @@
 	<td class="short" style="<?php echo $bgColour; ?>"><?php echo h($priorities[$setting['level']]);?></td>
 	<td class="short" style="<?php echo $bgColour; ?>"><?php echo h($setting['setting']);?></td>
 	<?php if ((isset($setting['editable']) && !$setting['editable']) || $setting['level'] == 3): ?>
-		<td id="setting_<?php echo $k; ?>_passive" class="inline-field-solid" style="<?php echo $bgColour; ?>width:500px;"><?php echo nl2br(h($setting['value']));?></td>
+		<td id="setting_<?php echo h("${subGroup}_$k"); ?>_passive" class="inline-field-solid" style="<?php echo $bgColour; ?>width:500px;"><?php echo nl2br(h($setting['value']));?></td>
 	<?php else: ?>
-		<td id="setting_<?php echo $k; ?>_solid" class="inline-field-solid" ondblclick="serverSettingsActivateField('<?php echo $setting['setting'];?>', '<?php echo $k;?>')" style="<?php echo $bgColour; ?>width:500px;"><?php echo h($setting['value']);?></td>
-		<td id="setting_<?php echo $k; ?>_placeholder" class="short hidden inline-field-placeholder" style="<?php echo $bgColour; ?>width:500px;"></td>
+		<td id="setting_<?php echo h("${subGroup}_$k"); ?>_solid" class="inline-field-solid" ondblclick="serverSettingsActivateField('<?php echo $setting['setting'];?>', '<?php echo $k;?>')" style="<?php echo $bgColour; ?>width:500px;"><?php echo h($setting['value']);?></td>
+		<td id="setting_<?php echo h("${subGroup}_$k"); ?>_placeholder" class="short hidden inline-field-placeholder" style="<?php echo $bgColour; ?>width:500px;"></td>
 	<?php endif; ?>
 	<td style="<?php echo $bgColour; ?>"><?php echo h($setting['description']);?></td>
 	<td  class="short" style="<?php echo $bgColour; ?>"><?php if (isset($setting['error']) && $setting['level'] != 3) echo h($setting['errorMessage']); ?></td>


### PR DESCRIPTION
Fixed following problems connected to settings editor:
 - unable to open row editor after changing item,
 - old value is displayed after item is changed,
 - fast modifications to configuration might get lost. (if user changed more items within 3 seconds)
