### PR TITLE
fix: settings editor not working on touch devices

### DIFF
--- a/app/View/Layouts/default.ctp
+++ b/app/View/Layouts/default.ctp
@@ -36,6 +36,7 @@
 		echo $this->fetch('script');
 
 		echo $this->Html->script('jquery'); // Include jQuery library
+		echo $this->Html->script('misp-touch'); // touch interface support
 	?>
 
 </head>

--- a/app/webroot/js/misp-touch.js
+++ b/app/webroot/js/misp-touch.js
@@ -1,0 +1,39 @@
+/**
+ * support for touch devices without the need
+ */
+
+$(document).ready(function() {
+	var touchStartTime = 0;
+	var touchTarget = null;
+
+	document.body.addEventListener('touchstart', function(ev) {
+		if (touchStartTime == 0) {
+			touchStartTime = (new Date()).getTime();
+			touchTarget = ev.target;	
+		}
+	}, false);
+	document.body.addEventListener('touchcancel', function(ev) {
+		// iphone only
+		touchStartTime = 0;
+		touchTarget = null;
+	}, false);
+	document.body.addEventListener('touchend', function(ev) {
+		var touchEndTime = (new Date()).getTime();
+		var canTrigger = (touchStartTime > 0 && (touchEndTime - touchStartTime) > 500 && touchTarget == ev.target);
+
+		// reset the variables BEFORE calling the event handler
+		// so that our code works even if the handler dies
+		touchStartTime = 0;
+		touchTarget = null;
+
+		if (canTrigger) {
+			var newEvent = new MouseEvent('dblclick', ev);
+			try {
+				ev.target.dispatchEvent(newEvent);
+			} catch (e) {
+				// don't care, this was complimentary event anyway
+			}
+		}
+	}, false);
+
+});


### PR DESCRIPTION
#### What does it do?

Fix: double click in settings editor was not working on touch devices.  This patch sends synthetic double-click event on long touch. 

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch