### PR TITLE
fix: self signed cert verification

### DIFF
--- a/app/Lib/Tools/SyncTool.php
+++ b/app/Lib/Tools/SyncTool.php
@@ -8,7 +8,12 @@ class SyncTool {
 		if (!empty($server)) {
 			if ($server['Server']['cert_file']) $params['ssl_cafile'] = APP . "files" . DS . "certs" . DS . $server['Server']['id'] . '.pem';
 			if ($server['Server']['client_cert_file']) $params['ssl_local_cert'] = APP . "files" . DS . "certs" . DS . $server['Server']['id'] . '_client.pem';
-			if ($server['Server']['self_signed']) $params['ssl_allow_self_signed'] = $server['Server']['self_signed'];
+			if ($server['Server']['self_signed']) {
+				$params['ssl_allow_self_signed'] = true;
+				$params['ssl_verify_peer_name'] = false;
+				if (!isset($server['Server']['cert_file']))
+					$params['ssl_verify_peer'] = false;
+			}
 		}
 		$HttpSocket = new HttpSocket($params);
 


### PR DESCRIPTION
#### What does it do?

This changes the behavior of certificate verification for remote server connections, if (and only if) "Self Signed" check box is checked:
 * server name will not be verified (because very often DNS records are missing and IP addresses, or different server names are used in URLs)
* if sever certificate is not uploaded to MISP, verification would normally fail, so it is disabled.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch