### PR TITLE
fix: remove trailing slash from MISP.baseurl

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -145,7 +145,7 @@ class AppController extends Controller {
 		if (substr($baseurl, -1) == '/') {
 			// if the baseurl has a trailing slash, remove it. It can lead to issues with the CSRF protection
 			$baseurl = rtrim($baseurl, '/');
-			Configure::write('MISP.baseurl', $baseurl);
+			$this->Server->serverSettingsSaveValue('MISP.baseurl', $baseurl);
 		}
 		$this->set('baseurl', h($baseurl));
 

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -2592,6 +2592,7 @@ class Server extends AppModel {
 		}
 		$settingsString = var_export($settingsArray, true);
 		$settingsString = '<?php' . "\n" . '$config = ' . $settingsString . ';';
+		opcache_reset();
 		file_put_contents(APP . 'Config' . DS . 'config.php', $settingsString);
 	}
 


### PR DESCRIPTION
#### What does it do?

Automatic removal of trailing slash from MISP.baseurl setting is stored in configuration as well.

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
