### PR TITLE
fixes issue #2698 - malware-sample fails with import modules

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -3407,12 +3407,6 @@ class EventsController extends AppController {
 						if (!isset($attribute['data_is_handled']) || !$attribute['data_is_handled']) {
 							App::uses('FileAccessTool', 'Tools');
 							$tmpdir = Configure::read('MISP.tmpdir') ? Configure::read('MISP.tmpdir') : '/tmp';
-							$tempFile = explode('|', $attribute['data']);
-							if (!$this->Event->checkFilename($tempFile[0])) {
-								throw new Exception('Invalid filename.');
-							}
-							$attribute['data'] = (new FileAccessTool())->readFromFile($tmpdir . '/' . $tempFile[0], $tempFile[1]);
-							unlink($tmpdir . '/' . $tempFile[0]);
 							$result = $this->Event->Attribute->handleMaliciousBase64($id, $attribute['value'], $attribute['data'], array('md5', 'sha1', 'sha256'), $objectType == 'ShadowAttribute' ? true : false);
 							if (!$result['success']) {
 								$failed++;


### PR DESCRIPTION
#### What does it do?

it fixes the malware-sample submission problems with the import modules.
An import module (like the existing email import) should use the following code to submit a malware-sample:
```
{
'values': sample_filename,
'data': base64.b64encode(file_data).decode(),
'type': 'malware-sample',
'categories': ['Artifacts dropped', 'Payload delivery'],
'to_ids': True,
'comment': ''
}
```

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
