### PR TITLE
basic support for misp-modules via API

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -3345,7 +3345,12 @@ class EventsController extends AppController {
 			$result['type'] = $result['default_type'];
 			unset($result['default_type']);
 			unset($result['types']);
-			$result['category'] = $this->Event->Attribute->defaultCategories[$result['type']];
+			if (isset($result['default_category'])) {
+				$result['category'] = $result['default_category'];
+				unset($result['default_category']);
+			} else {
+				$result['category'] = $this->Event->Attribute->defaultCategories[$result['type']];
+			}
 			if ($distribution === false) {
 				if (Configure::read('MISP.default_attribute_distribution') != null) {
 					if (Configure::read('MISP.default_attribute_distribution') == 'event') {
@@ -3405,8 +3410,6 @@ class EventsController extends AppController {
 						$types = array('ip-src|port', 'ip-dst|port');
 					} else if ($attribute['type'] == 'malware-sample') {
 						if (!isset($attribute['data_is_handled']) || !$attribute['data_is_handled']) {
-							App::uses('FileAccessTool', 'Tools');
-							$tmpdir = Configure::read('MISP.tmpdir') ? Configure::read('MISP.tmpdir') : '/tmp';
 							$result = $this->Event->Attribute->handleMaliciousBase64($id, $attribute['value'], $attribute['data'], array('md5', 'sha1', 'sha256'), $objectType == 'ShadowAttribute' ? true : false);
 							if (!$result['success']) {
 								$failed++;
@@ -4257,7 +4260,10 @@ class EventsController extends AppController {
 						else $this->request->data['Event']['source'] = '1';
 					}
 					if ($this->request->data['Event']['source'] == '1') {
-						if (!isset($this->request->data['Event']['fileupload']) || empty($this->request->data['Event']['fileupload'])) {
+						if (isset($this->request->data['Event']['data'])) {
+							$modulePayload['data'] = base64_decode($this->request->data['Event']['data']);
+						}
+						else if (!isset($this->request->data['Event']['fileupload']) || empty($this->request->data['Event']['fileupload'])) {
 							$fail = 'Invalid file upload.';
 						} else {
 							$fileupload = $this->request->data['Event']['fileupload'];
@@ -4286,6 +4292,15 @@ class EventsController extends AppController {
 					if (isset($result['error'])) $this->Session->setFlash($result['error']);
 					if (!is_array($result)) throw new Exception($result);
 					$resultArray = $this->Event->handleModuleResult($result, $eventId);
+					if ($this->_isRest()) {
+						return $this->__pushFreetext(
+							$resultArray,
+							$eventId,
+							false,
+							false,
+							false
+						);
+					}
 					if (isset($result['comment'])) {
 						$importComment = $result['comment'];
 					}


### PR DESCRIPTION
Please review the code and if possible complete the missing elements before full merge.

#### What does it do?

- mini cleanup of FileAccessTool that's not needed
- basic support for file uploads with misp-modules via API (malware-samples not supported yet)

The file upload should happen with the following http post json
```
{"Event": {"data": data_base64_encoded}}
```

Malware samples generated by the misp-module are not yet supported and result in an error "Composite type, but value not explodable". This is because the ```__pushFreetext()``` function does not have support for this. There are some challenges with the ```saveFreeText()``` function in relation to redundant code if malware-sample support is added in the ```__pushFreetext()``` function.


#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [x] Does it require a change in the API (PyMISP for example)?  Yes, adding a new function to provide access to the misp-modules API.

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
