### PR TITLE
fixes bug where Server model might not yet be loaded

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -145,6 +145,7 @@ class AppController extends Controller {
 		if (substr($baseurl, -1) == '/') {
 			// if the baseurl has a trailing slash, remove it. It can lead to issues with the CSRF protection
 			$baseurl = rtrim($baseurl, '/');
+			$this->loadModel('Server');
 			$this->Server->serverSettingsSaveValue('MISP.baseurl', $baseurl);
 		}
 		$this->set('baseurl', h($baseurl));


### PR DESCRIPTION
in some specific cases of configuration (like with the MISP VM) the Server model might not be loaded and causing the following error. 
This PR fixes this
```
2017-12-20 10:07:49 Error: [Error] Call to a member function serverSettingsSaveValue() on null
Request URL: /
Stack Trace:
#0 /var/www/MISP/app/Controller/EventsController.php(33): AppController->beforeFilter()
#1 /var/www/MISP/app/Lib/cakephp/lib/Cake/Event/CakeEventManager.php(243): EventsController->beforeFilter(Object(CakeEvent))
#2 /var/www/MISP/app/Lib/cakephp/lib/Cake/Controller/Controller.php(677): CakeEventManager->dispatch(Object(CakeEvent))
#3 /var/www/MISP/app/Lib/cakephp/lib/Cake/Routing/Dispatcher.php(189): Controller->startupProcess()
#4 /var/www/MISP/app/Lib/cakephp/lib/Cake/Routing/Dispatcher.php(167): Dispatcher->_invoke(Object(EventsController), Object(CakeRequest))
#5 /var/www/MISP/app/webroot/index.php(92): Dispatcher->dispatch(Object(CakeRequest), Object(CakeResponse))
#6 {main}
2017-12-20 10:07:49 Error: Fatal Error (1): Uncaught Error: Call to a member function serverSettingsSaveValue() on null in /var/www/MISP/app/Controller/AppController.php:148
Stack trace:
#0 /var/www/MISP/app/Lib/cakephp/lib/Cake/Event/CakeEventManager.php(243): AppController->beforeFilter(Object(CakeEvent))
#1 /var/www/MISP/app/Lib/cakephp/lib/Cake/Controller/Controller.php(677): CakeEventManager->dispatch(Object(CakeEvent))
#2 /var/www/MISP/app/Lib/cakephp/lib/Cake/Error/ExceptionRenderer.php(158): Controller->startupProcess()
#3 /var/www/MISP/app/Lib/cakephp/lib/Cake/Error/ExceptionRenderer.php(95): ExceptionRenderer->_getController(Object(Error))
#4 /var/www/MISP/app/Lib/cakephp/lib/Cake/Error/ErrorHandler.php(126): ExceptionRenderer->__construct(Object(Error))
#5 [internal function]: ErrorHandler::handleException(Object(Error))
#6 {main}
  thrown in [/var/www/MISP/app/Controller/AppController.php, line 148]
2017-12-20 10:07:49 Error: [FatalErrorException] Uncaught Error: Call to a member function serverSettingsSaveValue() on null in /var/www/MISP/app/Controller/AppController.php:148
Stack trace:
#0 /var/www/MISP/app/Lib/cakephp/lib/Cake/Event/CakeEventManager.php(243): AppController->beforeFilter(Object(CakeEvent))
#1 /var/www/MISP/app/Lib/cakephp/lib/Cake/Controller/Controller.php(677): CakeEventManager->dispatch(Object(CakeEvent))
#2 /var/www/MISP/app/Lib/cakephp/lib/Cake/Error/ExceptionRenderer.php(158): Controller->startupProcess()
#3 /var/www/MISP/app/Lib/cakephp/lib/Cake/Error/ExceptionRenderer.php(95): ExceptionRenderer->_getController(Object(Error))
#4 /var/www/MISP/app/Lib/cakephp/lib/Cake/Error/ErrorHandler.php(126): ExceptionRenderer->__construct(Object(Error))
#5 [internal function]: ErrorHandler::handleException(Object(Error))
#6 {main}
  thrown
Request URL: /
Stack Trace:
#0 /var/www/MISP/app/Lib/cakephp/lib/Cake/Error/ErrorHandler.php(212): ErrorHandler::handleFatalError(1, 'Uncaught Error:...', '/var/www/MISP/a...', 148)
#1 /var/www/MISP/app/Lib/cakephp/lib/Cake/Core/App.php(970): ErrorHandler::handleError(1, 'Uncaught Error:...', '/var/www/MISP/a...', 148, Array)
#2 /var/www/MISP/app/Lib/cakephp/lib/Cake/Core/App.php(943): App::_checkFatalError()
#3 [internal function]: App::shutdown()
#4 {main}
```