### PR TITLE
Set job_input explicitly to an empty string for cache feed jobs

### DIFF
--- a/app/Console/Command/ServerShell.php
+++ b/app/Console/Command/ServerShell.php
@@ -243,6 +243,7 @@ class ServerShell extends AppShell
         $data = array(
             'worker' => 'default',
             'job_type' => 'feed_cache',
+            'job_input' => '',
             'retries' => 0,
             'org' => $user['Organisation']['name'],
             'org_id' => $user['org_id'],


### PR DESCRIPTION
#### What does it do?

Older MISP deployments may interpret a missing field as a null value instead
of an empty string, which causes the NOT NULL restriction on the jobs.job_input
field to raise an error.  Fixes issue #2804.

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch