### PR TITLE
Make search bar available in the "Select Tag Source" modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /vendors
 /app/Vendor
+/app/vendor
 /app/composer*
 !/app/composer.phar
 !/app/composer.license
@@ -73,6 +74,7 @@
 /app/tmp/cached_exports/stix/*
 /app/tmp/cached_exports/sha256/*
 /app/tmp/cached_exports/bro/*
+/app/Plugin/CakeResque
 .gnupg
 .smime
 *.swp

--- a/app/Controller/TagsController.php
+++ b/app/Controller/TagsController.php
@@ -474,7 +474,7 @@ class TagsController extends AppController {
 		$this->render('ajax/taxonomy_choice');
 	}
 
-	public function selectTag($id, $taxonomy_id, $attributeTag = false) {
+	public function selectTag($id, $taxonomy_id, $attributeTag = false, $filterData = '') {
 		if (!$this->_isSiteAdmin() && !$this->userRole['perm_tagger']) throw new NotFoundException('You don\'t have permission to do that.');
 		$this->loadModel('Taxonomy');
 		$expanded = array();
@@ -538,7 +538,7 @@ class TagsController extends AppController {
 			unset($options[$hidden_tag]);
 			unset($expanded[$hidden_tag]);
 		}
-		if ($attributeTag !== false) {
+		if ($attributeTag !== false && $attributeTag !== "false") {
 			$this->set('attributeTag', true);
 		}
 		$this->set('object_id', $id);
@@ -550,6 +550,7 @@ class TagsController extends AppController {
 		$this->set('options', $options);
 		$this->set('expanded', $expanded);
 		$this->set('custom', $taxonomy_id == 0 ? true : false);
+		$this->set('filterData', $filterData);
 		$this->render('ajax/select_tag');
 	}
 

--- a/app/View/Tags/ajax/select_tag.ctp
+++ b/app/View/Tags/ajax/select_tag.ctp
@@ -13,7 +13,7 @@
 		?>
 	</div>
 	<div style="text-align:right;width:100%;" class="select_tag_search">
-		<input id="filterField" style="width:100%;border:0px;padding:0px;" placeholder="<?php echo __('search tags…');?>"/>
+		<input id="filterField" style="width:100%;border:0px;padding:0px;" value="<?php echo $filterData; ?>" placeholder="<?php echo __('search tags…');?>"/>
 	</div>
 	<div class="popover_choice_main" id ="popover_choice_main">
 		<table style="width:100%;">
@@ -35,10 +35,16 @@
 	var tags = <?php echo json_encode($options); ?>;
 	$(document).ready(function() {
 		resizePopoverBody();
-		 $("#filterField").focus();
+		// Places the cursor at the end of the input before focusing
+		var filterField = $("#filterField");
+		var tempValue = filterField.val();
+		filterField.val('');
+		filterField.val(tempValue);
+		filter();
+		filterField.focus();
 	});
 
-	$('#filterField').keyup(function() {
+	function filter() {
 		var filterString =  $("#filterField").val().toLowerCase();
 		$.each(tags, function(index, value) {
 			if (value.toLowerCase().indexOf(filterString) == -1) {
@@ -47,7 +53,9 @@
 				$('#field_' + index).show();
 			}
 		});
-	});
+	}
+
+	$('#filterField').keyup(filter);
 	$(window).resize(function() {
 		resizePopoverBody();
 	});

--- a/app/View/Tags/ajax/select_tag.ctp
+++ b/app/View/Tags/ajax/select_tag.ctp
@@ -13,7 +13,7 @@
 		?>
 	</div>
 	<div style="text-align:right;width:100%;" class="select_tag_search">
-		<input id="filterField" style="width:100%;border:0px;padding:0px;" value="<?php echo $filterData; ?>" placeholder="<?php echo __('search tags…');?>"/>
+		<input id="filterField" style="width:100%;border:0px;padding:0px;" value="<?php echo h($filterData); ?>" placeholder="<?php echo __('search tags…');?>"/>
 	</div>
 	<div class="popover_choice_main" id ="popover_choice_main">
 		<table style="width:100%;">

--- a/app/View/Tags/ajax/taxonomy_choice.ctp
+++ b/app/View/Tags/ajax/taxonomy_choice.ctp
@@ -1,5 +1,8 @@
 <div class="popover_choice  select_tag_source">
 	<legend><?php echo __('Select Tag Source');?></legend>
+	<div style="text-align:right;width:100%;" class="select_tag_search">
+		<input id="filterField" style="width:100%;border:0px;padding:0px;" placeholder="<?php echo __('search tags…');?>"/>
+	</div>
 	<div class="popover_choice_main" id ="popover_choice_main">
 		<table style="width:100%;">
 		<?php if ($favourites): ?>
@@ -11,7 +14,7 @@
 				<td style="padding-left:10px;padding-right:10px; text-align:center;width:100%;" onClick="getPopup('<?php echo h($object_id); ?>/0<?php if (isset($attributeTag)) echo '/true'; ?>', 'tags', 'selectTag');"><?php echo __('Custom Tags');?></td>
 			</tr>
 			<tr style="border-bottom:1px solid black;" class="templateChoiceButton">
-				<td style="padding-left:10px;padding-right:10px; text-align:center;width:100%;" onClick="getPopup('<?php echo h($object_id); ?>/all<?php if (isset($attributeTag)) echo '/true'; ?>', 'tags', 'selectTag');"><?php echo __('All Tags');?></td>
+				<td id="allTags" style="padding-left:10px;padding-right:10px; text-align:center;width:100%;" data-url="<?php echo h($object_id); ?>/all<?php if (isset($attributeTag)) echo '/true/'; else echo '/false/'; ?>" onClick="getPopup(this.getAttribute('data-url') + $('#filterField').val(), 'tags', 'selectTag');"><?php echo __('All Tags');?></td>
 			</tr>
 		<?php foreach ($options as $k => &$option): ?>
 			<tr style="border-bottom:1px solid black;" class="templateChoiceButton">
@@ -25,9 +28,16 @@
 <script type="text/javascript">
 	$(document).ready(function() {
 		resizePopoverBody();
+		new Promise(resolve => setTimeout(function() {$("#filterField").focus()}, 100));
 	});
 
 	$(window).resize(function() {
 		resizePopoverBody();
+	});
+	$('#filterField').keyup(function() {
+		var filterString =  $("#filterField").val().toLowerCase();
+		if(filterString.length > 0) {
+			$('#allTags').click();
+		}
 	});
 </script>


### PR DESCRIPTION
#### What does it do?

![peek 2018-02-09 14-50](https://user-images.githubusercontent.com/14599855/36047331-c871d0cc-0da9-11e8-85f5-6078410a479d.gif)

See issue: #2880

#### Questions

- [No. ] Does it require a DB change?
- [No, tested only locally] Are you using it in production?
- [No.] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch

Note: I failed to gain focus on the input field using `$(document).ready()`, hence the `new Promise` in `taxonomy_choice.ctp`. Any better solution is welcome!