### PR TITLE
new: Add keyboard shortcuts application-wide, managed using JSON files

### DIFF
--- a/app/View/Elements/footer.ctp
+++ b/app/View/Elements/footer.ctp
@@ -1,5 +1,12 @@
 <div class="footer <?php echo $debugMode;?>">
-	<div class="navbar navbar-inverse">
+	<div id="shortcutsListContainer">
+		<div id="triangle"></div>
+		<div id="shortcutsList">
+			<span> <?php echo __('Keyboard shortcuts for this page'); ?>:</span><br />
+			<div id="shortcuts"><?php echo __('none'); ?></div>
+		</div>
+	</div>
+	<div id="footerContainer" class="navbar navbar-inverse">
 		<div class="navbar-inner">
 			<div class="pull-left footerText" style="float:left;position:absolute;padding-top:12px;z-index:2;">
 				<?php

--- a/app/View/Elements/global_menu.ctp
+++ b/app/View/Elements/global_menu.ctp
@@ -212,3 +212,4 @@
 		</div>
 	</div>
 </div>
+<input type="hidden" class="keyboardShortcutsConfig" value="/shortcuts/global_menu.json" />

--- a/app/View/Events/view.ctp
+++ b/app/View/Events/view.ctp
@@ -371,3 +371,4 @@ $(document).ready(function () {
 	});
 });
 </script>
+<input type="hidden" value="/shortcuts/event_view.json" class="keyboardShortcutsConfig" />

--- a/app/webroot/css/main.css
+++ b/app/webroot/css/main.css
@@ -464,6 +464,38 @@ dd {
 	}
 }
 
+#footerContainer {
+	z-index: 20;
+	position:relative;
+}
+
+/* footer shortcut list */
+#shortcutsListContainer {
+	z-index: 10;
+	position: absolute;
+	background-color: #1b1b1b;
+	top: 0;
+	width:100%;
+}
+
+#triangle {
+	position:fixed;
+	background-color: #1b1b1b;
+	width: 20px;
+	height: 20px;
+	bottom:30px;
+	right: 30px;
+	transform: rotate(45deg);
+}
+
+#shortcutsList {
+	top: 0;
+	width: 100%;
+	position:relative;
+	color: #999999;
+	margin: 5px 5px 0px 5px;
+}
+
 /* header */
 .header {
 	width:100%;

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -3263,3 +3263,106 @@ $(document).ready(function() {
         format: 'yyyy-mm-dd',
     });
 }());
+
+/* ============== KEYBOARD SHORTCUTS ==============*/
+let keyboardShortcutsManager = {
+	
+	shortcutKeys: new Map(),
+	shortcutListToggled: false,
+	
+	/**
+	 * Fetches the keyboard shortcut config files and populates this.shortcutJSON.
+	 */
+	init() {
+		let shortcutURIs = [];
+		for(let keyboardShortcutElement of $('.keyboardShortcutsConfig')) {
+			shortcutURIs.push(keyboardShortcutElement.value);
+			this.ajaxGet(window.location.protocol + "//" + window.location.host + keyboardShortcutElement.value).then(response => {
+				this.mapKeyboardShortcuts(JSON.parse(response));
+			});
+		}
+		this.setKeyboardListener();
+	},
+
+	/**
+	 * Toggles the view on the list of shortcuts at the bottom of the screen.
+	 */
+	onTriangleClick() {
+		let activated = this.shortcutListToggled;
+		let shortcutListElement = $('#shortcutsListContainer');
+		let triangleElement = $('#triangle');
+		let shortcutListElementHeight = shortcutListElement.height();
+		shortcutListElement.css('top', activated ? '' : '-' + shortcutListElementHeight + 'px');
+		triangleElement.css('bottom', activated ? '' : shortcutListElementHeight + 30 + 'px');
+		this.shortcutListToggled = !activated;
+	},
+
+	/**
+	 * Creates the HTML list of shortcuts for the user to read and sets it in the DOM.
+	 */
+	addShortcutListToHTML() {
+		let html = "<ul>";
+		for(let shortcut of this.shortcutKeys.values()) {
+			html += `<li><strong>${shortcut.key.toUpperCase()}</strong>: ${shortcut.description}</li>`
+		}
+		html += "</ul>"
+		$('#shortcuts').html(html);
+	},
+
+	/**
+	 * Sets the shortcut object list.
+	 * @param {} config The shortcut JSON list: [{key: string, description: string, action: string(eval-able JS code)}]
+	 */
+	mapKeyboardShortcuts(config) {
+		for(let shortcut of config.shortcuts) {
+			this.shortcutKeys.set(shortcut.key, shortcut);
+		}
+		this.addShortcutListToHTML();
+	},
+
+	/**
+	 * Sets the event to listen to and the routine to call on keypress.
+	 */
+	setKeyboardListener() {
+		window.onkeyup = (keyboardEvent) => {
+			if(this.shortcutKeys.has(keyboardEvent.key)) {
+				let activeElement = document.activeElement.tagName;
+				if( activeElement !== "TEXTAREA" && activeElement !== "INPUT") {
+					eval(this.shortcutKeys.get(keyboardEvent.key).action);
+				}
+			}
+		}
+	},
+
+	/**
+	 * Queries the given URL with a GET request and returns a Promise
+	 * that resolves when the response arrives.
+	 * @param string url The URL to fetch.
+	 */
+	ajaxGet(url) {
+		return new Promise(function(resolve, reject) {
+			let req = new XMLHttpRequest();
+			req.open("GET", url);
+			req.onload = function() {
+				if (req.status === 200) {
+					resolve(req.response);
+				} else {
+					reject(new Error(req.statusText));
+				}
+			};
+	
+			req.onerror = function() {
+				reject(new Error("Network error"));
+			};
+	
+			req.send();
+		});
+	}
+}
+
+// Inits the keyboard shortcut manager's main routine.
+$(document).ready(() => keyboardShortcutsManager.init());
+
+// Inits the click event on the keyboard shortcut triangle at the bottom of the screen.
+$('#triangle').click(keyboardShortcutsManager.onTriangleClick);
+/* ============ END KEYBOARD SHORTCUTS ============*/

--- a/app/webroot/shortcuts/event_view.json
+++ b/app/webroot/shortcuts/event_view.json
@@ -1,0 +1,19 @@
+{
+	"shortcuts": [
+		{
+			"key": "t",
+			"description": "Open the tag selection modal",
+			"action": "$('#addTagButton').click()"
+		},
+		{
+			"key": "f",
+			"description": "Open the freetext import modal",
+			"action": "$('#freetext-button').click()"
+		},
+		{
+			"key": "a",
+			"description": "Add an attribute",
+			"action": "console.log($('#liaddAttribute').children()[0].click())"
+		}
+	]
+}

--- a/app/webroot/shortcuts/global_menu.json
+++ b/app/webroot/shortcuts/global_menu.json
@@ -1,0 +1,14 @@
+{
+	"shortcuts": [
+		{
+			"key": "l",
+			"description": "Go to event list",
+			"action": "document.location.href = '/events/index'"
+		},
+		{
+			"key": "e",
+			"description": "Go to add event page",
+			"action": "document.location.href = '/events/add'"
+		}
+	]
+}


### PR DESCRIPTION
#### What does it do?

![peek 2018-02-09 15-00](https://user-images.githubusercontent.com/14599855/36047440-1b62a658-0daa-11e8-82d3-c1b9136ed856.gif)


Adds the basic support for keyboard shortcuts in MISP.

See issue #2905

I'm open to suggestions for implementation changes! 

I put shortcuts for functions I use the most in MISP.

#### Questions

**Q: How do I add keyboard shortcuts?**
A: 1. Add a JSON file in `app/webroots/shortcuts` named after the page from which it will be included (for exemple `event_view.json`).
2. Set your shortcuts using this format: 
![image](https://user-images.githubusercontent.com/14599855/35830021-c80426f4-0a92-11e8-986f-49ded4414010.png)
(`action` field is JS code) 

2. Include the keyboard shortcut config in the `.ctp` file you wish it to be used in using an `input type="hidden"` tag like this: 
![image](https://user-images.githubusercontent.com/14599855/35830084-02f880ac-0a93-11e8-86fa-9cb4f0f95480.png)

3. Test your shortcuts.

**Q: Is it possible to customize the shortcuts once they are there?**
A: Not at the moment.

- [ No ] Does it require a DB change?
- [ No, tested locally ] Are you using it in production?
- [ No ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
