### PR TITLE
new: Add search shortcut for events and attributes + small bugfix

### DIFF
--- a/app/View/Events/index.ctp
+++ b/app/View/Events/index.ctp
@@ -93,5 +93,6 @@
 		</ul>
 	</div>
 </div>
+<input type="hidden" class="keyboardShortcutsConfig" value="/shortcuts/event_index.json" />
 <?php
 	if (!$ajax) echo $this->element('side_menu', array('menuList' => 'event-collection', 'menuItem' => 'index'));

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -3269,6 +3269,7 @@ let keyboardShortcutsManager = {
 	
 	shortcutKeys: new Map(),
 	shortcutListToggled: false,
+	escapedTagNames: ["INPUT", "TEXTAREA", "SELECT"],
 	
 	/**
 	 * Fetches the keyboard shortcut config files and populates this.shortcutJSON.
@@ -3303,7 +3304,7 @@ let keyboardShortcutsManager = {
 	addShortcutListToHTML() {
 		let html = "<ul>";
 		for(let shortcut of this.shortcutKeys.values()) {
-			html += `<li><strong>${shortcut.key}</strong>: ${shortcut.description}</li>`
+			html += `<li><strong>${shortcut.key.toUpperCase()}</strong>: ${shortcut.description}</li>`
 		}
 		html += "</ul>"
 		$('#shortcuts').html(html);
@@ -3327,7 +3328,7 @@ let keyboardShortcutsManager = {
 		window.onkeyup = (keyboardEvent) => {
 			if(this.shortcutKeys.has(keyboardEvent.key)) {
 				let activeElement = document.activeElement.tagName;
-				if( activeElement !== "TEXTAREA" && activeElement !== "INPUT") {
+				if( !this.escapedTagNames.includes(activeElement)) {
 					eval(this.shortcutKeys.get(keyboardEvent.key).action);
 				}
 			}

--- a/app/webroot/shortcuts/event_index.json
+++ b/app/webroot/shortcuts/event_index.json
@@ -1,0 +1,9 @@
+{
+	"shortcuts": [
+		{
+			"key": "s",
+			"description": "Focus the filter events bar",
+			"action": "$('#quickFilterField').focus()"
+		}
+	]
+}

--- a/app/webroot/shortcuts/event_view.json
+++ b/app/webroot/shortcuts/event_view.json
@@ -13,7 +13,12 @@
 		{
 			"key": "a",
 			"description": "Add an attribute",
-			"action": "console.log($('#liaddAttribute').children()[0].click())"
+			"action": "$('#liaddAttribute').children()[0].click()"
+		},
+		{
+			"key": "s",
+			"description": "Focus the filter attribute bar",
+			"action": "$('#attributesFilterField').focus()"
 		}
 	]
 }


### PR DESCRIPTION
#### What does it do?

- Add search shortcut for events and attributes
- Fix a bug that triggered shortcuts even when a dropdown menu was selected (forgot that).
- Removed a `console.log()` that I forgot
- Keys in shortcut list are now in uppercase (idk why I removed it it's in the original gif lol)

See https://github.com/MISP/MISP/pull/2906

Sorry for that, didn't see it yesterday!

#### Questions

- [ No ] Does it require a DB change?
- [ No ] Are you using it in production?
- [ No ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
