### PR TITLE
fix - allows upload of files using the misp-modules API

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -337,6 +337,7 @@ class Attribute extends AppModel {
 					)
 	);
 
+	// FIXME we need a better way to list the defaultCategories knowing that new attribute types will continue to appear in the future. We should generate this dynamically or use a function using the default_category of the $typeDefinitions
 	public $defaultCategories = array(
 			'md5' => 'Payload delivery',
 			'sha1' => 'Payload delivery',
@@ -357,6 +358,7 @@ class Attribute extends AppModel {
 			'filename' => 'Payload delivery',
 			'ip-src' => 'Network activity',
 			'ip-dst' => 'Network activity',
+			'ip-dst|port' => 'Network activity',
 			'mac-address' => 'Network activity',
 			'mac-eui-64' => 'Network activity',
 			'hostname' => 'Network activity',


### PR DESCRIPTION
#### What does it do?

This PR fixes an incomplete implementation of the REST api when talking to MISP modules.
While the original implementation ( #2719 ) allowed files to be uploaded, the misp-module could not create attachment/malware-sample attributes. 

It will allow a tool to populate an existing event with data from a misp-module. Warninglists will be applied in the 'soft' mode: attributes are added, but the `to_ids` flag is set to `0`

Please see #2719 for more details on how to talk to the REST API.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [x] Does it require a change in the API (PyMISP for example)? ==> optionally yes, to allow PyMISP to use this functionality

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
