### PR TITLE
don't exlude attributes with non-exportable tag

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -797,6 +797,7 @@ class EventsController extends AppController {
 			$conditions['deleted'] = 1;
 		}
 		$conditions['includeFeedCorrelations'] = true;
+		$conditions['includeAllTags'] = true;
 		$results = $this->Event->fetchEvent($this->Auth->user(), $conditions);
 		if (empty($results)) throw new NotFoundException('Invalid event');
 		$event = $results[0];


### PR DESCRIPTION
exclude filter on attributes when tag is non-exportable

This fixe a probleme when you clic on filters header table.

When attributes have non-exportable table, he is not display when filters apply.


#### What does it do?

I d'ont think there is an issue on this ...

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
