### PR TITLE
Move keyboard shortcuts from misp.js to its own file (to regain compatibility with IE11)

### DIFF
--- a/app/View/Layouts/default.ctp
+++ b/app/View/Layouts/default.ctp
@@ -89,6 +89,7 @@
 	echo $this->Html->script('bootstrap-colorpicker');
 	if ($me) {
 		echo $this->Html->script('misp.js?' . $queryVersion);
+		echo $this->Html->script('keyboard-shortcuts.js?' . $queryVersion);
 	}
 	?>
 	<div id = "ajax_success_container" class="ajax_container">

--- a/app/View/Layouts/graph.ctp
+++ b/app/View/Layouts/graph.ctp
@@ -71,6 +71,7 @@
 	echo $this->Html->script('bootstrap-datepicker');
 	echo $this->Html->script('bootstrap-colorpicker');
 	echo $this->Html->script('misp.js?' . $queryVersion);
+	echo $this->Html->script('keyboard-shortcuts.js?' . $queryVersion);
 	?>
 	<div id = "ajax_success_container" class="ajax_container">
 		<div id="ajax_success" class="ajax_result ajax_success"></div>

--- a/app/View/Layouts/iframe.ctp
+++ b/app/View/Layouts/iframe.ctp
@@ -30,4 +30,5 @@ echo $this->Html->script('bootstrap-timepicker');
 echo $this->Html->script('bootstrap-datepicker');
 echo $this->Html->script('bootstrap-colorpicker');
 echo $this->Html->script('misp.js?' . $queryVersion);
+echo $this->Html->script('keyboard-shortcuts.js?' . $queryVersion);
 echo $content_for_layout; ?>

--- a/app/webroot/js/keyboard-shortcuts.js
+++ b/app/webroot/js/keyboard-shortcuts.js
@@ -1,0 +1,104 @@
+/**
+ * This classes deals with the front-end keyboard shortcuts and is included in every page.
+ */
+let keyboardShortcutsManager = {
+
+	shortcutKeys: new Map(),
+	shortcutListToggled: false,
+	escapedTagNames: ["INPUT", "TEXTAREA", "SELECT"],
+
+	/**
+	 * Fetches the keyboard shortcut config files and populates this.shortcutJSON.
+	 */
+	init() {
+		let shortcutURIs = [];
+		for(let keyboardShortcutElement of $('.keyboardShortcutsConfig')) {
+			shortcutURIs.push(keyboardShortcutElement.value);
+			this.ajaxGet(window.location.protocol + "//" + window.location.host + keyboardShortcutElement.value).then(response => {
+				this.mapKeyboardShortcuts(JSON.parse(response));
+			});
+		}
+		this.setKeyboardListener();
+	},
+
+	/**
+	 * Toggles the view on the list of shortcuts at the bottom of the screen.
+	 */
+	onTriangleClick() {
+		let activated = this.shortcutListToggled;
+		let shortcutListElement = $('#shortcutsListContainer');
+		let triangleElement = $('#triangle');
+		let shortcutListElementHeight = shortcutListElement.height();
+		shortcutListElement.css('top', activated ? '' : '-' + shortcutListElementHeight + 'px');
+		triangleElement.css('bottom', activated ? '' : shortcutListElementHeight + 30 + 'px');
+		this.shortcutListToggled = !activated;
+	},
+
+	/**
+	 * Creates the HTML list of shortcuts for the user to read and sets it in the DOM.
+	 */
+	addShortcutListToHTML() {
+		let html = "<ul>";
+		for(let shortcut of this.shortcutKeys.values()) {
+			html += `<li><strong>${shortcut.key.toUpperCase()}</strong>: ${shortcut.description}</li>`
+		}
+		html += "</ul>"
+		$('#shortcuts').html(html);
+	},
+
+	/**
+	 * Sets the shortcut object list.
+	 * @param {} config The shortcut JSON list: [{key: string, description: string, action: string(eval-able JS code)}]
+	 */
+	mapKeyboardShortcuts(config) {
+		for(let shortcut of config.shortcuts) {
+			this.shortcutKeys.set(shortcut.key, shortcut);
+		}
+		this.addShortcutListToHTML();
+	},
+
+	/**
+	 * Sets the event to listen to and the routine to call on keypress.
+	 */
+	setKeyboardListener() {
+		window.onkeyup = (keyboardEvent) => {
+			if(this.shortcutKeys.has(keyboardEvent.key)) {
+				let activeElement = document.activeElement.tagName;
+				if( !this.escapedTagNames.includes(activeElement)) {
+					eval(this.shortcutKeys.get(keyboardEvent.key).action);
+				}
+			}
+		}
+	},
+
+	/**
+	 * Queries the given URL with a GET request and returns a Promise
+	 * that resolves when the response arrives.
+	 * @param string url The URL to fetch.
+	 */
+	ajaxGet(url) {
+		return new Promise(function(resolve, reject) {
+			let req = new XMLHttpRequest();
+			req.open("GET", url);
+			req.onload = function() {
+				if (req.status === 200) {
+					resolve(req.response);
+				} else {
+					reject(new Error(req.statusText));
+				}
+			};
+
+			req.onerror = function() {
+				reject(new Error("Network error"));
+			};
+
+			req.send();
+		});
+	}
+}
+
+// Inits the keyboard shortcut manager's main routine.
+$(document).ready(() => keyboardShortcutsManager.init());
+
+// Inits the click event on the keyboard shortcut triangle at the bottom of the screen.
+$('#triangle').click(keyboardShortcutsManager.onTriangleClick);


### PR DESCRIPTION
#### What does it do?

Moves the keyboard shortcuts code from `misp.js` to its own file.

**Q: Why?**
**A:** So using ECMAScript6 for keyboard shortcuts broke the whole `misp.js` script which was not parsable by IE11 (it doesnt support ECMAScript6). Since a whole team at my office couldn't use MISP at all (since the front-end relies a lot on `misp.js`), I moved the code to its own file.

**Q: What does that change when using MISP?**
**A:** If using anything else than IE, nothing. If using IE, the app is going to work again, beside the keyboard shortcuts part.

Sorry for that, completely forgot IE (fuck IE).

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
