### PR TITLE
Part 3: Fix IE11 by surrounding a new Promise call with try/catch

### DIFF
--- a/app/View/Tags/ajax/taxonomy_choice.ctp
+++ b/app/View/Tags/ajax/taxonomy_choice.ctp
@@ -28,7 +28,11 @@
 <script type="text/javascript">
 	$(document).ready(function() {
 		resizePopoverBody();
-		new Promise(resolve => setTimeout(function() {$("#filterField").focus()}, 100));
+		try {
+			new Promise(resolve => setTimeout(function() {$("#filterField").focus()}, 100));
+		} catch(error) {
+			setTimeout(function() {$("#filterField").focus()}, 100);
+		}
 	});
 
 	$(window).resize(function() {


### PR DESCRIPTION
This should be the last one. Sorry again for that.

Fuck IE. Before, I hated it because of the meme. Now I hate it with a passion.

@iglocska poking you because people at the office are getting impatient and I need that merged fast :'(

#### What does it do?

Fixes the add tag modal for IE11, because IE11 doesnt know the `Promise` class.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
