### PR TITLE
Fix IE11 final: remove arrow function (ecmascript6 stuff)

### DIFF
--- a/app/View/Tags/ajax/taxonomy_choice.ctp
+++ b/app/View/Tags/ajax/taxonomy_choice.ctp
@@ -29,7 +29,7 @@
 	$(document).ready(function() {
 		resizePopoverBody();
 		try {
-			new Promise(resolve => setTimeout(function() {$("#filterField").focus()}, 100));
+			new Promise(function(resolve) { setTimeout(function() {$("#filterField").focus()}, 100)});
 		} catch(error) {
 			setTimeout(function() {$("#filterField").focus()}, 100);
 		}


### PR DESCRIPTION
Really sorry for all of this. I handled this like shit but now I set up an environment to properly test. Everything is tested and working.

Removed the arrow function for the promise when opening the add tag modal.