### PR TITLE
Validate suricata rules

### DIFF
--- a/app/Lib/Tools/SuricataRuleFormat.php
+++ b/app/Lib/Tools/SuricataRuleFormat.php
@@ -1,6 +1,11 @@
 <?php
 
-$rule = "drop tcp $HOME_NET any -> $EXTERNAL_NET any (msg:”ET TROJAN Likely Bot Nick in IRC (USA +..)”; flow:established,to_server; flowbits:isset,is_proto_irc; content:”NICK “; reference:url,doc.emergingthreats.net/2008124; classtype:trojan-activity; sid:2008124; rev:2;)";
+# based on @jasonish idstools regexp
+# https://github.com/jasonish/py-idstools/blob/master/idstools/rule.py
+
+#$rule = "drop tcp $HOME_NET any -> $EXTERNAL_NET any (msg:”ET TROJAN Likely Bot Nick in IRC (USA +..)”; flow:established,to_server; flowbits:isset,is_proto_irc; content:”NICK “; reference:url,doc.emergingthreats.net/2008124; classtype:trojan-activity; sid:2008124; rev:2;)";
+#$rule = "drop  ->  (msg:”ET TROJAN Likely Bot Nick in IRC (USA +..)”; flow:established,to_server; flowbits:isset,is_proto_irc; content:”NICK “; reference:url,doc.emergingthreats.net/2008124; classtype:trojan-activity; sid:2008124; rev:2;)";
+#$rule = 'empty';
 
 class SuricataRuleFormat {
     private $actions = array("alert", "log", "pass", "activate", "dynamic", "drop", "reject", "sdrop");
@@ -14,9 +19,52 @@ class SuricataRuleFormat {
                             . '\((?P<options>.*)\)\s*'
                             . '/';
 
+    private function findOptionEnd($option) {
+        $offset = 0;
+        while (true) {
+            $i = strpos($option, ';');
+            if ($i === false) {
+                return -1;
+            }
+            if ($option[$offset + $i - 1] == '\\') {
+                $offset += 2;
+            }
+            else {
+                return $offset + 1;
+            }
+        }
+    }
+
     function parseRule($rule) {
         $regexp = sprintf($this->rule_pattern, join('|', $this->actions));
         preg_match($regexp, $rule, $matches);
         return $matches;
+    }
+
+    # function to validate the global syntax of a suricata rule
+    function validateRuleSyntax($rule) {
+        $matches = $this->parseRule($rule);
+        if (($matches == false) or ($matches['src_ip'] == false) or ($matches['dst_ip'] == false)) {
+            return false;
+        }
+        return true;
+    }
+
+    #function to validate http rule mandatory arguments
+    function validateRuleHTTP($rule) {
+        // FIXME
+        return true;
+    }
+
+    # function to validate dns rule mandatory arguments
+    function validateRuleDNS($rule) {
+        // FIXME
+        return true;
+    }
+
+    # function to validate the complete syntax of a suricata rule
+    # idea is to 
+    function validateRule($rule) {
+        return validateRuleSyntax($rule) and validateRuleHTTP($rule) and validateRuleDNS($rule);
     }
 }

--- a/app/Lib/Tools/SuricataRuleFormat.php
+++ b/app/Lib/Tools/SuricataRuleFormat.php
@@ -1,0 +1,22 @@
+<?php
+
+$rule = "drop tcp $HOME_NET any -> $EXTERNAL_NET any (msg:”ET TROJAN Likely Bot Nick in IRC (USA +..)”; flow:established,to_server; flowbits:isset,is_proto_irc; content:”NICK “; reference:url,doc.emergingthreats.net/2008124; classtype:trojan-activity; sid:2008124; rev:2;)";
+
+class SuricataRuleFormat {
+    private $actions = array("alert", "log", "pass", "activate", "dynamic", "drop", "reject", "sdrop");
+    private $rule_pattern = '/(?P<action>%s)\s*'
+                            . '(?P<protocol>[^\s]*)\s*'
+                            . '(?P<src_ip>[^\s]*)\s*'
+                            . '(?P<src_port>[^\s]*)\s*'
+                            . '(?P<direction>->|<>)\s*'
+                            . '(?P<dst_ip>[^\s]*)\s*'
+                            . '(?P<dst_port>[^\s]*)\s*'
+                            . '\((?P<options>.*)\)\s*'
+                            . '/';
+
+    function parseRule($rule) {
+        $regexp = sprintf($this->rule_pattern, join('|', $this->actions));
+        preg_match($regexp, $rule, $matches);
+        return $matches;
+    }
+}

--- a/app/Lib/Tools/SuricataRuleFormat.php
+++ b/app/Lib/Tools/SuricataRuleFormat.php
@@ -3,13 +3,6 @@
 # based on @jasonish idstools regexp
 # https://github.com/jasonish/py-idstools/blob/master/idstools/rule.py
 
-#$rule = 'drop tcp $HOME_NET any -> $EXTERNAL_NET any (msg:"ET TROJAN Likely Bot Nick in IRC (USA +..)"; flow:established,to_server; flowbits:isset,is_proto_irc; content:"NICK "; reference:url,doc.emergingthreats.net/2008124; classtype:trojan-activity; sid:2008124; rev:2;)';
-#$rule = 'drop  ->  (msg:"ET TROJAN Likely Bot Nick in IRC (USA +..)"; flow:established,to_server; flowbits:isset,is_proto_irc; content:"NICK "; reference:url,doc.emergingthreats.net/2008124; classtype:trojan-activity; sid:2008124; rev:2;)';
-#$rule = 'empty';
-#$rule = 'alert dns any any -> any any (msg:"Test dns_query option"; dns_query; content:"google"; nocase; sid:1;)';
-$rule = 'alert http any any -> any any (content:"403 Forbidden"; http_response_line; sid:1;)';
-#$rule = 'alert http any any -> any any (content:"index.php"; http_uri; sid:1;)';
-
 class SuricataRuleFormat {
     private $actions = array("alert", "log", "pass", "activate", "dynamic", "drop", "reject", "sdrop");
     private $rule_pattern = '/(?P<action>%s)\s*'


### PR DESCRIPTION
#### What does it do?

This class allows to validate Suricata rules format. HTTP and DNS rules are also checked for keywords order (sticky vs modifiers).

Not called in the code anywhere. We only discussed the idea during MISP Hackathon in Zurich.

Known limitations:
- rules using list of src/dst (ex: [a.b.c.d, w.x.y.z]) shouldn't contain whitespaces
- this could be corrected using custom decoder instead of regexp. This is something from the devel branch of jasonish project.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [X] Minor
- [] Patch
