### PR TITLE
pecl and phpenmod need root privileges

### DIFF
--- a/INSTALL/INSTALL.ubuntu1604.txt
+++ b/INSTALL/INSTALL.ubuntu1604.txt
@@ -326,11 +326,11 @@ sudo make install
 ssdeep -h # test
 
 #installing ssdeep_php
-pecl install ssdeep
+sudo pecl install ssdeep
 
 # 7.0 if your PHP 7.0 and you know what to do if you have a different version
 sudo echo "extension=ssdeep.so" > /etc/php/7.0/mods-available/ssdeep.ini
-phpenmod ssdeep
+sudo phpenmod ssdeep
 service apache2 restart
 
 Optional features: misp-modules


### PR DESCRIPTION
[line 329] According to stat -c "%U %G" /usr/share/php/.channels/pecl.php.net, the owner is root, so you can't edit this file as normal user,
[line 333] As above, both directories (/etc/php/7.0/cli/conf.d/ and /var/lib/php/modules/7.0/cli/enabled_by_admin/) are "root root": "Permission denied" while creating symbolic link or touching file.
Tested on Ubuntu server x64 16.04 LTS

#### Release Type:
- [ ] Major
- [ ] Minor
- [x] Patch
