### PR TITLE
Allow empty STIX files to be returned, closes #2478

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -3235,7 +3235,7 @@ class Event extends AppModel {
 		}
 		$i = 0;
 		$eventCount = count($event_ids);
-		foreach ($event_ids as $event_id) {
+		if ($event_ids) foreach ($event_ids as $event_id) {
 			$tempFile = new File($tmpDir . DS . $randomFileName, true, 0644);
 			$event = $this->fetchEvent($user, array('eventid' => $event_id));
 			if (empty($event)) continue;

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -3290,9 +3290,6 @@ class Event extends AppModel {
 			}
 			$tempFile->close();
 		}
-		if (empty($i)) {
-			return array('success' => 0, 'message' => 'Invalid event.');
-		}
 		if ($returnType == 'xml') {
 			$stixFile->append("    </stix:Related_Packages>\n</stix:STIX_Package>\n\n");
 		} else {


### PR DESCRIPTION
Returning empty STIX files is the only right thing to do when nothing matches a search. Automated tools break when HTTP 500 is returned.