### PR TITLE
Fixes display of <select> (dropdown) in import module, closes #3005

### DIFF
--- a/app/Model/Module.php
+++ b/app/Model/Module.php
@@ -71,6 +71,10 @@ class Module extends AppModel {
 		return 'Value has to be a boolean.';
 	}
 
+	public function validateSelectField($value) {
+		return true;
+	}
+
 
 	public function getModules($type = false, $moduleFamily = 'Enrichment', &$exception = false) {
 		$modules = $this->queryModuleServer('/modules', false, false, $moduleFamily, $exception);

--- a/app/View/Events/import_module.ctp
+++ b/app/View/Events/import_module.ctp
@@ -15,6 +15,11 @@
 					if (isset($configTypes[$config['type']]['field'])) {
 						$settings['type'] = $configTypes[$config['type']]['field'];
 					}
+					if ($settings['type'] == 'select') {
+						if (isset($config['options'])) {
+							$settings['options'] = $config['options'];
+						}
+					}
 					?>
 					<span class="bold">
 						<?php


### PR DESCRIPTION
#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch

To use, define your module like so:

    def introspection():
      modulesetup = {}
      modulesetup["inputSource"] = []
      modulesetup["userConfig"] = {
        "What day is it today": {
          "type": "Select",
          "message": "Select day of the week",
          "options": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
        }
      }

The value returned in `handler` is the index of the selected option.