### PR TITLE
Added URLhaus (http://urlhaus.abuse.ch) malware urls as feed.

### DIFF
--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -1455,5 +1455,38 @@
       "lookup_visible": true,
       "headers": ""
     }
+  },
+  {
+    "Feed": {
+        "id": "69",
+        "name": "URLHaus Malware URLs",
+        "provider": "Abuse.ch",
+        "url": "https:\/\/urlhaus.abuse.ch\/downloads\/csv\/",
+        "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]}}",
+        "enabled": true,
+        "distribution": "3",
+        "sharing_group_id": "0",
+        "tag_id": "615",
+        "default": false,
+        "source_format": "csv",
+        "fixed_event": false,
+        "delta_merge": false,
+        "event_id": "0",
+        "publish": false,
+        "override_ids": false,
+        "settings": "{\"csv\":{\"value\":\"3\",\"delimiter\":\",\"},\"common\":{\"excluderegex\":\"\"}}",
+        "input_source": "network",
+        "delete_local_file": false,
+        "lookup_visible": true,
+        "headers": ""
+    },
+    "Tag": {
+      "id": "615",
+      "name": "osint:source-type=\"block-or-filter-list\"",
+      "colour": "#004f89",
+      "exportable": true,
+      "org_id": "0",
+      "hide_tag": false
+    }
   }
 ]


### PR DESCRIPTION
#### What does it do?
Added the urlhaus malware url list as feed.

#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
