### PR TITLE
Pass attribute UUID to enrichment modules

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -4416,7 +4416,7 @@ class EventsController extends AppController {
 					}
 				}
 			}
-			$data = array('module' => $module, $attribute[0]['Attribute']['type'] => $attribute[0]['Attribute']['value'], 'event_id' => $attribute[0]['Attribute']['event_id']);
+			$data = array('module' => $module, $attribute[0]['Attribute']['type'] => $attribute[0]['Attribute']['value'], 'event_id' => $attribute[0]['Attribute']['event_id'], 'attribute_uuid' => $attribute[0]['Attribute']['uuid']);
 			if ($this->Event->Attribute->typeIsAttachment($attribute[0]['Attribute']['type'])) {
 				$data['data'] = $this->Event->Attribute->base64EncodeAttachment($attribute[0]['Attribute']);
 			}


### PR DESCRIPTION
#### What does it do?

Attribute UUID is now passed to enrichment modules for unique identification of the attribute.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
