### PR TITLE
Configuration for attachments automatically downloaded when loaded in a browser

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -409,7 +409,7 @@ class AttributesController extends AppController {
 		}
 		$this->autoRender = false;
 		$this->response->type($fileExt);
-		$this->response->file($path . $file, array('download' => true, 'name' => $filename . '.' . $fileExt));
+		$this->response->file($path . $file, array('download' => Configure::read('MISP.download_attachments_on_load'), 'name' => $filename . '.' . $fileExt));
 	}
 
 	public function add_attachment($eventId = null) {

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -382,6 +382,14 @@ class Server extends AppModel {
 							'test' => 'testBool',
 							'type' => 'boolean',
 					),
+					'download_attachments_on_load' => array(
+						'level' => 2,
+						'description' => 'Always download attachments when loaded by a user in a browser',
+						'value' => true,
+						'errorMessage' => '',
+						'test' => 'testBool',
+						'type' => 'boolean',
+					),
 					'email' => array(
 							'level' => 0,
 							'description' => 'The e-mail address that MISP should use for all notifications',


### PR DESCRIPTION
#### What does it do?

Adds the configuration option "MISP.download_attachments_on_load" to set whether attachments are always downloaded when loaded or to let the browser try and display the file (eg .pdf) then download it if it cannot be displayed (eg .zip)

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
