### PR TITLE
Removed trustedsec.com and openbl.org

### DIFF
--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -181,40 +181,7 @@
       "hide_tag": false
     }
   },
-  {
-    "Feed": {
-      "id": "6",
-      "name": "Binary Defense Systems Artillery Threat Intelligence Feed and Banlist Feed",
-      "provider": "Binary Defense Systems",
-      "url": "https://www.trustedsec.com/banlist.txt",
-      "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]}}",
-      "enabled": true,
-      "distribution": "0",
-      "sharing_group_id": "0",
-      "tag_id": "615",
-      "default": false,
-      "source_format": "csv",
-      "fixed_event": true,
-      "delta_merge": true,
-      "event_id": "5153",
-      "publish": false,
-      "override_ids": true,
-      "settings": "{\"csv\":{\"value\":\"1\"}}",
-      "input_source": "network",
-      "delete_local_file": false,
-      "lookup_visible": false,
-      "cache_timestamp": "1495871960"
-    },
-    "Tag": {
-      "id": "615",
-      "name": "osint:source-type=\"block-or-filter-list\"",
-      "colour": "#004f89",
-      "exportable": true,
-      "org_id": "0",
-      "hide_tag": false
-    }
-  },
-  {
+   {
     "Feed": {
       "id": "7",
       "name": "malwaredomainlist",
@@ -559,39 +526,6 @@
       "delete_local_file": false,
       "lookup_visible": false,
       "cache_timestamp": "1495871995"
-    },
-    "Tag": {
-      "id": "615",
-      "name": "osint:source-type=\"block-or-filter-list\"",
-      "colour": "#004f89",
-      "exportable": true,
-      "org_id": "0",
-      "hide_tag": false
-    }
-  },
-  {
-    "Feed": {
-      "id": "25",
-      "name": "openbl.org base",
-      "provider": "openbl.org",
-      "url": "http://www.openbl.org/lists/base.txt",
-      "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]}}",
-      "enabled": true,
-      "distribution": "0",
-      "sharing_group_id": "0",
-      "tag_id": "615",
-      "default": false,
-      "source_format": "freetext",
-      "fixed_event": true,
-      "delta_merge": true,
-      "event_id": "6293",
-      "publish": true,
-      "override_ids": false,
-      "settings": "{\"csv\":{\"value\":\"\",\"delimiter\":\",\"},\"common\":{\"excluderegex\":\"\"}}",
-      "input_source": "network",
-      "delete_local_file": false,
-      "lookup_visible": true,
-      "cache_timestamp": "1495871996"
     },
     "Tag": {
       "id": "615",


### PR DESCRIPTION
Removed https://www.trustedsec.com/banlist.txt and http://www.openbl.org 

#### What does it do?

fixes #2541

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
