### PR TITLE
fix: Event graph stalling when object has unknown-category

### DIFF
--- a/app/webroot/js/event-graph.js
+++ b/app/webroot/js/event-graph.js
@@ -24,7 +24,7 @@ class EventGraph {
 		this.mapping_meta_fa.set('file', {"meta-category": "file","fa_text": "file","fa-hex": "f15b"});
 		this.mapping_meta_fa.set('financial', {"meta-category": "financial","fa_text": "money-bil-alt","fa-hex": "f3d1"});
 		this.mapping_meta_fa.set('network', {"meta-category": "network","fa_text": "server","fa-hex": "f233"});
-		this.mapping_meta_fa.set('misc', {"meta-category": "misc","fa_text": "cube","fa-hex": "f1b2"});
+		this.mapping_meta_fa.set('misc', {"meta-category": "misc","fa_text": "cube","fa-hex": "f1b2"}); // Also considered as default
 		// FIXME
 		this.nodes = nodes;
 		this.edges = edges;
@@ -59,6 +59,11 @@ class EventGraph {
 	get_node_color(uuid) {
 		return this.nodes.get(uuid).icon.color;
 	}
+	get_FA_icon(metaCateg) {
+		var dict = this.mapping_meta_fa.get(metaCateg);
+		dict = dict === undefined ? this.mapping_meta_fa.get('misc') : dict; // if unknown meta-categ, take default
+		return String.fromCharCode(parseInt(dict['fa-hex'], 16))
+	}
 
 	// Graph interaction
 	reset_graphs() {
@@ -89,7 +94,7 @@ class EventGraph {
 					icon: {
 						color: getRandomColor(),
 						face: 'FontAwesome',
-						code: String.fromCharCode(parseInt(this.mapping_meta_fa.get(node['meta-category'])['fa-hex'], 16)),
+						code: this.get_FA_icon(node['meta-category']),
 					}
 				};
 				dataHandler.mapping_value_to_nodeID.set(striped_value, node.id);


### PR DESCRIPTION
Unknown meta-category in object template do not longer raise an exception (use a default value instead)
