### PR TITLE
Changes to allowed CVE format and hover output being displayed on top of the attribute

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -1024,10 +1024,10 @@ class Attribute extends AppModel {
 				break;
 			case 'vulnerability':
 				$value = str_replace('–', '-', $value);
-				if (preg_match("#^(CVE-)[0-9]{4}(-)[0-9]{4,6}$#", $value)) {
+				if (preg_match("#^(CVE-)[0-9]{4}(-)[0-9]{4,}$#", $value)) {
 					$returnValue = true;
 				} else {
-					$returnValue = 'Invalid format. Expected: CVE-xxxx-xxxx.';
+					$returnValue = 'Invalid format. Expected: CVE-xxxx-xxxx...';
 				}
 				break;
 			case 'named pipe':

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -2730,7 +2730,7 @@ function runHoverLookup(type, id) {
 			$('#' + type + '_' + id + '_container').popover({
 				title: 'Lookup results:',
 				content: html,
-				placement: 'left',
+				placement: 'top',
 				html: true,
 				trigger: 'hover',
 				container: 'body'
@@ -2749,7 +2749,7 @@ $(".eventViewAttributeHover").mouseenter(function() {
 		$('#' + type + '_' + id + '_container').popover({
 			title: 'Lookup results:',
 			content: ajaxResults[type + "_" + id],
-			placement: 'left',
+			placement: 'top',
 			html: true,
 			trigger: 'hover',
 			container: 'body'


### PR DESCRIPTION

#### What does it do?

It fixes #2757 and allows for more CVE digits

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
