### PR TITLE
Extended event support and tag filtergin in the event graph

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -4348,6 +4348,7 @@ class EventsController extends AppController {
 	public function getEventGraphReferences($id, $type = 'event') {
 		$validTools = array('event');
 		if (!in_array($type, $validTools)) throw new MethodNotAllowedException('Invalid type.');
+		$this->loadModel('Tag');
 		App::uses('EventGraphTool', 'Tools');
 		$grapher = new EventGraphTool();
 		$data = $this->request->is('post') ? $this->request->data : array();
@@ -4358,7 +4359,7 @@ class EventsController extends AppController {
 			$extended = 0;
 		}
 
-		$grapher->construct($this->Event, $this->Auth->user(), $data['filtering'], $extended);
+		$grapher->construct($this->Event, $this->Tag, $this->Auth->user(), $data['filtering'], $extended);
 		$json = $grapher->get_references($id);
 
 		array_walk_recursive($json, function(&$item, $key){
@@ -4373,6 +4374,7 @@ class EventsController extends AppController {
 	public function getEventGraphTags($id, $type = 'event') {
 		$validTools = array('event');
 		if (!in_array($type, $validTools)) throw new MethodNotAllowedException('Invalid type.');
+		$this->loadModel('Tag');
 		App::uses('EventGraphTool', 'Tools');
 		$grapher = new EventGraphTool();
 		$data = $this->request->is('post') ? $this->request->data : array();
@@ -4383,7 +4385,7 @@ class EventsController extends AppController {
 			$extended = 0;
 		}
 
-		$grapher->construct($this->Event, $this->Auth->user(), $data['filtering'], $extended);
+		$grapher->construct($this->Event, $this->Tag, $this->Auth->user(), $data['filtering'], $extended);
 		$json = $grapher->get_tags($id);
 
 		array_walk_recursive($json, function(&$item, $key){
@@ -4398,6 +4400,7 @@ class EventsController extends AppController {
 	public function getEventGraphGeneric($id, $type = 'event') {
 		$validTools = array('event');
 		if (!in_array($type, $validTools)) throw new MethodNotAllowedException('Invalid type.');
+		$this->loadModel('Tag');
 		App::uses('EventGraphTool', 'Tools');
 		$grapher = new EventGraphTool();
 		$data = $this->request->is('post') ? $this->request->data : array();
@@ -4408,7 +4411,7 @@ class EventsController extends AppController {
 			$extended = 0;
 		}
 
-		$grapher->construct($this->Event, $this->Auth->user(), $data['filtering'], $extended);
+		$grapher->construct($this->Event, $this->Tag, $this->Auth->user(), $data['filtering'], $extended);
 		if (!array_key_exists('keyType', $data)) {
 			$keyType = ''; // empty key
 		} else {

--- a/app/Lib/Tools/EventGraphTool.php
+++ b/app/Lib/Tools/EventGraphTool.php
@@ -167,6 +167,7 @@
 					'uuid' => $attr['uuid'],
 					'type' => $attr['type'],
 					'label' => $attr['value'],
+					'event_id' => $attr['event_id'],
 					'node_type' => 'attribute',
 				);
 				array_push($this->__json['items'], $toPush);
@@ -182,6 +183,7 @@
 					'node_type' => 'object',
 					'meta-category' => $obj['meta-category'],
 					'template_uuid' => $obj['template_uuid'],
+					'event_id' => $obj['event_id'],
 				);
 				array_push($this->__json['items'], $toPush);
 
@@ -198,6 +200,7 @@
 						'to' => $rel['referenced_id'],
 						'type' => $rel['relationship_type'],
 						'comment' => $rel['comment'],
+						'event_id' => $rel['event_id'],
 					);
 					array_push($this->__json['relations'], $toPush);
 				}
@@ -236,6 +239,7 @@
 					'uuid' => $attr['uuid'],
 					'type' => $attr['type'],
 					'label' => $attr['value'],
+					'event_id' => $attr['event_id'],
 					'node_type' => 'attribute',
 					//'Tag' => $Tags,
 				);
@@ -264,6 +268,7 @@
 					'node_type' => 'object',
 					'meta-category' => $obj['meta-category'],
 					'template_uuid' => $obj['template_uuid'],
+					'event_id' => $obj['event_id'],
 				);
 				array_push($this->__json['items'], $toPush);
 
@@ -342,6 +347,7 @@
 					'uuid' => $attr['uuid'],
 					'type' => $attr['type'],
 					'label' => $attr['value'],
+					'event_id' => $attr['event_id'],
 					'node_type' => 'attribute',
 				);
 				array_push($this->__json['items'], $toPush);
@@ -369,6 +375,7 @@
 					'node_type' => 'object',
 					'meta-category' => $obj['meta-category'],
 					'template_uuid' => $obj['template_uuid'],
+					'event_id' => $obj['event_id'],
 				);
 				array_push($this->__json['items'], $toPush);
 

--- a/app/Lib/Tools/EventGraphTool.php
+++ b/app/Lib/Tools/EventGraphTool.php
@@ -309,7 +309,6 @@
 					'label' => $attr['value'],
 					'event_id' => $attr['event_id'],
 					'node_type' => 'attribute',
-					//'Tag' => $Tags,
 				);
 				array_push($this->__json['items'], $toPush);
 

--- a/app/Lib/Tools/EventGraphTool.php
+++ b/app/Lib/Tools/EventGraphTool.php
@@ -82,6 +82,7 @@
 		}
 
 		// NOT OPTIMIZED: But allow clearer code
+		// perform filtering on obj_rel presence and then perform filtering on obj_rel value
 		private function __satisfy_obj_filtering($obj) {
 			// presence rule - search in the object's attribute
 			$presenceMatch = true;

--- a/app/Lib/Tools/EventGraphTool.php
+++ b/app/Lib/Tools/EventGraphTool.php
@@ -61,25 +61,24 @@
 		private function __get_filtered_event($id) {
 			$event = $this->__get_event($id);
 			if (empty($this->__filterRules)) return $event;
-			$filtered = array('Object' => array(), 'Attribute' => array());
 
 			// perform filtering
-			foreach($event['Object'] as $obj) {
+			foreach($event['Object'] as $i => $obj) {
 				$check1 = $this->__satisfy_obj_filtering($obj);
 				$check2 = $this->__satisfy_obj_tag($obj);
-				if ($check1 && $check2) {
-					array_push($filtered['Object'], $obj);
+				if (!($check1 && $check2)) {
+					unset($event['Object'][$i]);
 				}
 			}
-			foreach($event['Attribute'] as $attr) {
+			foreach($event['Attribute'] as $i => $attr) {
 				$check1 = $this->__satisfy_val_filtering($attr, false);
 				$check2 = $this->__satisfy_attr_tag($attr);
-				if ($check1 && $check2) {
-					array_push($filtered['Attribute'], $attr);
+				if (!($check1 && $check2)) {
+					unset($event['Attribute'][$i]);
 				}
 			}
 
-			return $filtered;
+			return $event;
 		}
 
 		// NOT OPTIMIZED: But allow clearer code

--- a/app/webroot/js/action_table.js
+++ b/app/webroot/js/action_table.js
@@ -203,8 +203,13 @@ class ActionTable {
 	__add_options_to_select(select, options) {
 		for(var value of options) {
 			var option = document.createElement('option');
-			option.value = value;
-			option.innerHTML = value;
+			if (Array.isArray(value)) { // array of type [value, text]
+				option.value = value[1];
+				option.innerHTML = value[1];
+			} else { // only value, text=value
+				option.value = value;
+				option.innerHTML = value;
+			}
 			select.appendChild(option);
 		}
 	}

--- a/app/webroot/js/contextual_menu.js
+++ b/app/webroot/js/contextual_menu.js
@@ -133,13 +133,14 @@ class ContextualMenu {
         document.body.appendChild(div);
         var that = this;
         this.trigger_container.tabIndex = 0; // required for the popover focus feature
+	var additional_styling = this.options.style === undefined ? "" : this.options.style;
         $(this.trigger_container).popover({
             container: 'body',
             html: true,
             placement: "bottom",
             content: function () {return $(that.menu); }, // return contextual menu htlm
             trigger: "manual",
-            template: '<div class="popover" id="popover-contextual-menu-'+this.trigger_container.id+'" role="tooltip"><div class="arrow"></div></h3><div class="popover-content"></div></div>'
+            template: '<div class="popover" id="popover-contextual-menu-'+this.trigger_container.id+'" role="tooltip" style="'+additional_styling+'"><div class="arrow"></div></h3><div class="popover-content"></div></div>'
         })
 
         // Overwrite the default popover behavior: hidding cause the popover to be detached from the DOM, making impossible to fetch input values in the form

--- a/app/webroot/js/event-graph.js
+++ b/app/webroot/js/event-graph.js
@@ -1328,58 +1328,59 @@ function drawExtendedEventHull(ctx, nodes, color, text) {
 	ctx.font="30px Verdana";
 	ctx.fillStyle = getTextColour(color);
 	ctx.fillText(text, centroid.x, centroid.y);
-	//ctx.fill();
-	//ctx.stroke();
 }
 function orientation(p, q, r) {
-    var val = (q.y - p.y) * (r.x - q.x) -
-	      (q.x - p.x) * (r.y - q.y);
-    if (val == 0) return 0;  // collinear
-    return (val > 0)? 1: 2; // clock or counterclock wise
+	var val = (q.y - p.y) * (r.x - q.x) -
+		  (q.x - p.x) * (r.y - q.y);
+    	if (val == 0) {
+		return 0;  // collinear
+    	}
+    	return val > 0 ? 1 : 2; // clock or counterclock wise
 }
 // Implementation of Gift wrapping algorithm (jarvis march in 2D)
 // Inspired from https://www.geeksforgeeks.org/convex-hull-set-1-jarviss-algorithm-or-wrapping/
 function getHullFromPoints(points) {
-    var n = points.length;
-    var l = 0;
-    var hull = [];
-    // get leftmost point
-    for (var i=0; i<n; i++) {
-	l = points[l].x > points[i].x ? l : i;
-    }
-
-    var p = l;
-    var q;
-    do {
-	hull.push(points[p]);
-
-	q = (p+1) % n;
+	var n = points.length;
+    	var l = 0;
+    	var hull = [];
+    	// get leftmost point
     	for (var i=0; i<n; i++) {
-		if (orientation(points[p], points[i], points[q]) == 2) {
-			q = i;
-		}
+    	    l = points[l].x > points[i].x ? l : i;
     	}
-	p = q;
-    } while (p != l);
-    return hull;
+
+    	var p = l;
+    	var q;
+    	do {
+		hull.push(points[p]);
+		
+		q = (p+1) % n;
+		for (var i=0; i<n; i++) {
+			if (orientation(points[p], points[i], points[q]) == 2) {
+				q = i;
+			}
+		}
+		p = q;
+    	} while (p != l);
+    	return hull;
 }
 function getCentroid(coordList) {
-    var cx = 0;
-    var cy = 0;
-    var a = 0;
-    for (var i=0; i<coordList.length; i++) {
-	var ci = coordList[i];
-	var cj = i+1 == coordList.length ? coordList[0] : coordList[i+1]; // j = i+1 AND loop around
-	var mul = (ci.x*cj.y - cj.x*ci.y);
-	cx += (ci.x + cj.x)*mul;
-	cy += (ci.y + cj.y)*mul;
-	a += mul;
-    }
-    a = a / 2;
-    cx = cx / (6*a);
-    cy = cy / (6*a);
-    return {x: cx, y: cy};
+	var cx = 0;
+	var cy = 0;
+	var a = 0;
+	for (var i=0; i<coordList.length; i++) {
+		var ci = coordList[i];
+		var cj = i+1 == coordList.length ? coordList[0] : coordList[i+1]; // j = i+1 AND loop around
+		var mul = (ci.x*cj.y - cj.x*ci.y);
+		cx += (ci.x + cj.x)*mul;
+		cy += (ci.y + cj.y)*mul;
+		a += mul;
+	}
+	a = a / 2;
+	cx = cx / (6*a);
+	cy = cy / (6*a);
+	return {x: cx, y: cy};
 }
+
 function getRandomColor() {
 	var letters = '0123456789ABCDEF';
 	var color = '#';

--- a/app/webroot/js/event-graph.js
+++ b/app/webroot/js/event-graph.js
@@ -22,6 +22,7 @@ mapping_root_id_to_type[root_id_tag] = 'tag';
 mapping_root_id_to_type[root_id_keyType] = 'keyType';
 var root_node_x_pos = 800;
 var cluster_expand_threshold = 100;
+var nodes_ask_threshold = 300;
 
 /*=========
  * CLASSES
@@ -492,7 +493,8 @@ class EventGraph {
 	}
 
 	update_graph(data) {
-		setTimeout(function() { eventGraph.network_loading(true, loadingText_creating); });
+		var that = this;
+		that.network_loading(true, loadingText_creating);
 
 		// New nodes will be automatically added
 		// removed references will be deleted
@@ -502,16 +504,16 @@ class EventGraph {
 		for(var node of data.items) {
 			var group, label;
 			if (node.event_id != scope_id) { // add node ids of extended event
-				if (this.extended_event_points[node.event_id] === undefined) {
-					this.extended_event_points[node.event_id] = [];
+				if (that.extended_event_points[node.event_id] === undefined) {
+					that.extended_event_points[node.event_id] = [];
 				}
-				this.extended_event_points[node.event_id].push(node.id);
+				that.extended_event_points[node.event_id].push(node.id);
 			}
 
 			if ( node.node_type == 'object' ) {
 				var group =  'object';
 				var label = dataHandler.generate_label(node);
-				var striped_value = this.strip_text_value(label);
+				var striped_value = that.strip_text_value(label);
 				node_conf = {
 					id: node.id,
 					uuid: node.uuid,
@@ -523,7 +525,7 @@ class EventGraph {
 					icon: {
 						color: getRandomColor(),
 						face: 'FontAwesome',
-						code: this.get_FA_icon(node['meta-category']),
+						code: that.get_FA_icon(node['meta-category']),
 					}
 				};
 				dataHandler.mapping_value_to_nodeID.set(striped_value, node.id);
@@ -554,8 +556,8 @@ class EventGraph {
 				dataHandler.mapping_value_to_nodeID.set(striped_value, node.id);
 			} else if (node.node_type == 'keyType') {
 				group = 'keyType';
-				label = this.scope_keyType + ": " + node.label;
-				var striped_value = this.strip_text_value(label);
+				label = that.scope_keyType + ": " + node.label;
+				var striped_value = that.strip_text_value(label);
 				node_conf = {
 					id: node.id,
 					label: striped_value,
@@ -566,7 +568,7 @@ class EventGraph {
 			} else {
 				group =  'attribute';
 				label = node.type + ': ' + node.label;
-				var striped_value = this.strip_text_value(label);
+				var striped_value = that.strip_text_value(label);
 				node_conf = {
 					id: node.id,
 					uuid: node.uuid,
@@ -582,7 +584,7 @@ class EventGraph {
 			newNodeIDs.push(node.id);
 		}
 		// check if nodes got deleted
-		var old_node_ids = this.nodes.getIds();
+		var old_node_ids = that.nodes.getIds();
 		for (var old_id of old_node_ids) {
 			// Ignore root node
 			if (old_id == "rootNode:attribute" || old_id == "rootNode:object" || old_id == "rootNode:tag" || old_id == "rootNode:keyType") {
@@ -590,11 +592,11 @@ class EventGraph {
 			}
 			// This old node got removed
 			if (newNodeIDs.indexOf(old_id) == -1) {
-				this.nodes.remove(old_id);
+				that.nodes.remove(old_id);
 			}
 		}
 
-		this.nodes.update(newNodes);
+		that.nodes.update(newNodes);
 
 		// New relations will be automatically added
 		// removed references will be deleted
@@ -615,46 +617,46 @@ class EventGraph {
 			newRelationIDs.push(rel.id);
 		}
 		// check if nodes got deleted
-		var old_rel_ids = this.edges.getIds();
+		var old_rel_ids = that.edges.getIds();
 		for (var old_id of old_rel_ids) {
 			// This old node got removed
 			if (newRelationIDs.indexOf(old_id) == -1) {
-				this.edges.remove(old_id);
+				that.edges.remove(old_id);
 			}
 		}
 
-		this.edges.update(newRelations);
+		that.edges.update(newRelations);
 
-		this.remove_root_nodes();
+		that.remove_root_nodes();
 		// do not clusterize if the network is filtered
-		if (!this.is_filtered) {
-		        if (this.scope_name == 'Reference') {
-		        	this.add_unreferenced_root_node();
-		        	// links unreferenced attributes and object to root nodes
-		        	if (this.first_draw) {
-		        		this.link_not_referenced_nodes();
-		        		this.first_draw = !this.first_draw
-		        	}
-		        } else if (this.scope_name == 'Tag') {
-		        	this.add_tag_root_node();
-		        	// links untagged attributes and object to root nodes
-		        	if (this.first_draw) {
-		        		this.link_not_referenced_nodes();
-		        		this.first_draw = !this.first_draw
-		        	}
-		        } else if (this.scope_name == 'Distribution') {
-		        } else if (this.scope_name == 'Correlation') {
-		        } else {
-		        	this.add_keyType_root_node();
-		        	if (this.first_draw) {
-		        		this.link_not_referenced_nodes();
-		        		this.first_draw = !this.first_draw
-		        	}
-		        }
+		if (!that.is_filtered) {
+			if (that.scope_name == 'Reference') {
+				that.add_unreferenced_root_node();
+				// links unreferenced attributes and object to root nodes
+				if (that.first_draw) {
+					that.link_not_referenced_nodes();
+					that.first_draw = !that.first_draw
+				}
+			} else if (that.scope_name == 'Tag') {
+				that.add_tag_root_node();
+				// links untagged attributes and object to root nodes
+				if (that.first_draw) {
+					that.link_not_referenced_nodes();
+					that.first_draw = !that.first_draw
+				}
+			} else if (that.scope_name == 'Distribution') {
+			} else if (that.scope_name == 'Correlation') {
+			} else {
+				that.add_keyType_root_node();
+				if (that.first_draw) {
+					that.link_not_referenced_nodes();
+					that.first_draw = !that.first_draw
+				}
+			}
 		}
 
 		eventGraph.canDrawHull = true;
-		this.network_loading(false, "");
+		that.network_loading(false, "");
 	}
 
 	strip_text_value(text) {
@@ -1132,7 +1134,15 @@ class DataHandler {
 					dataHandler.update_filtering_selectors(available_object_references, available_tags);
 					dataHandler.available_rotation_key = data.available_rotation_key;
 					eventGraph.menu_scope.add_options("input_graph_scope_jsonkey", dataHandler.available_rotation_key);
-					eventGraph.update_graph(data);
+					if (data.items.length < nodes_ask_threshold) {
+						eventGraph.update_graph(data);
+					} else if (data.items.length > nodes_ask_threshold && confirm("The network contains a lot of nodes, displaying it may slow down your browser. Continue?")) {
+						eventGraph.update_graph(data);
+					} else {
+						eventGraph.network_loading(false, "");
+						$("#eventgraph_toggle").click();
+					}
+
 					if ( stabilize === undefined || stabilize) {
 						eventGraph.reset_view_on_stabilized();
 					}

--- a/app/webroot/js/event-graph.js
+++ b/app/webroot/js/event-graph.js
@@ -146,6 +146,7 @@ class EventGraph {
 		var menu_scope = new ContextualMenu({
 			trigger_container: document.getElementById("network-scope"),
 			bootstrap_popover: true,
+			style: "z-index: 1"
 		});
 		menu_scope.add_select({
 			id: "select_graph_scope",
@@ -184,7 +185,8 @@ class EventGraph {
 	init_physic_menu() {
 		var menu_physic = new ContextualMenu({
 			trigger_container: document.getElementById("network-physic"),
-			bootstrap_popover: true
+			bootstrap_popover: true,
+			style: "z-index: 1"
 		});
 		menu_physic.add_select({
 			id: "select_physic_solver",
@@ -222,7 +224,8 @@ class EventGraph {
 	init_display_menu() {
 		var menu_display = new ContextualMenu({
 			trigger_container: document.getElementById("network-display"),
-			bootstrap_popover: true
+			bootstrap_popover: true,
+			style: "z-index: 1"
 		});
 		menu_display.add_select({
 			id: "select_display_layout",
@@ -305,7 +308,8 @@ class EventGraph {
 	init_filter_menu() {
 		var menu_filter = new ContextualMenu({
 			trigger_container: document.getElementById("network-filter"),
-			bootstrap_popover: true
+			bootstrap_popover: true,
+			style: "z-index: 1"
 		});
 		menu_filter.add_action_table({
 			id: "table_attr_presence",
@@ -373,7 +377,8 @@ class EventGraph {
 	init_canvas_menu() {
 		var menu_canvas = new ContextualMenu({
 			trigger_container: document.getElementById("eventgraph_network"),
-			right_click: true
+			right_click: true,
+			style: "z-index: 1"
 		});
 		menu_canvas.add_button({
 			label: "View/Edit",

--- a/app/webroot/js/event-graph.js
+++ b/app/webroot/js/event-graph.js
@@ -336,6 +336,29 @@ class EventGraph {
 		});
 		menu_filter.create_divider(3);
 		menu_filter.add_action_table({
+			id: "table_tag_presence",
+			container: menu_filter.menu,
+			title: "Filter on Tag presence",
+			header: ["Relation", "Tag"],
+			control_items: [
+				{
+					DOMType: "select",
+					item_options: {
+						options: ["Contains", "Do not contain"]
+					}
+				},
+				{
+					DOMType: "select",
+					item_options: {
+						id: "table_control_select_tag_presence",
+						options: []
+					}
+				},
+			],
+			data: [],
+		});
+		menu_filter.create_divider(3);
+		menu_filter.add_action_table({
 			id: "table_attr_value",
 			container: menu_filter.menu,
 			title: "Filter on Attribute value",
@@ -430,8 +453,9 @@ class EventGraph {
 
 	get_filtering_rules() {
 		var rules_presence = eventGraph.menu_filter.items["table_attr_presence"].get_data();
+		var rules_tag_presence = eventGraph.menu_filter.items["table_tag_presence"].get_data();
 		var rules_value = eventGraph.menu_filter.items["table_attr_value"].get_data();
-		var rules = { presence: rules_presence, value: rules_value };
+		var rules = { presence: rules_presence, tag_presence: rules_tag_presence, value: rules_value };
 		return rules;
 	}
 	// Graph interaction
@@ -1071,9 +1095,10 @@ class DataHandler {
 		return label;
 	}
 
-	update_available_object_references(available_object_references) {
+	update_filtering_selectors(available_object_references, available_tags) {
 		eventGraph.menu_display.add_options("select_display_object_field", available_object_references);
 		eventGraph.menu_filter.items["table_attr_presence"].add_options("table_control_select_attr_presence", available_object_references);
+		eventGraph.menu_filter.items["table_tag_presence"].add_options("table_control_select_tag_presence", available_tags);
 		eventGraph.menu_filter.items["table_attr_value"].add_options("table_control_select_attr_value", available_object_references);
 	}
 
@@ -1100,7 +1125,11 @@ class DataHandler {
 					eventGraph.first_draw = true;
 					// update object state
 					var available_object_references = Object.keys(data.existing_object_relation);
-					dataHandler.update_available_object_references(available_object_references);
+					var available_tags = Object.keys(data.existing_tags);
+					var available_tags = $.map(data.existing_tags, function(value, index) { // object to array
+						return [[index, value]];
+					});
+					dataHandler.update_filtering_selectors(available_object_references, available_tags);
 					dataHandler.available_rotation_key = data.available_rotation_key;
 					eventGraph.menu_scope.add_options("input_graph_scope_jsonkey", dataHandler.available_rotation_key);
 					eventGraph.update_graph(data);

--- a/app/webroot/js/event-graph.js
+++ b/app/webroot/js/event-graph.js
@@ -1293,6 +1293,7 @@ function orientation(p, q, r) {
     return (val > 0)? 1: 2; // clock or counterclock wise
 }
 // Implementation of Gift wrapping algorithm (jarvis march in 2D)
+// Inspired from https://www.geeksforgeeks.org/convex-hull-set-1-jarviss-algorithm-or-wrapping/:wq
 function getHullFromPoints(points) {
     var n = points.length;
     var l = 0;

--- a/app/webroot/js/event-graph.js
+++ b/app/webroot/js/event-graph.js
@@ -93,6 +93,7 @@ class EventGraph {
 			eventGraph.physics_state($('#checkbox_physics_enable').prop("checked"));
 		});
 
+		// create Hull for extending events
 		this.network.on("beforeDrawing", function (ctx) {
 			if (that.scope_name != "Reference" || !that.canDrawHull) {
 				return;
@@ -1180,7 +1181,6 @@ class MispInteraction {
 
 	add_reference(edgeData, callback) {
 		var that = mispInteraction;
-		//var uuid = dataHandler.mapping_attr_id_to_uuid.get(edgeData.to);
 		var uuid = that.nodes.get(edgeData.to).uuid;
 		if (!that.can_create_reference(edgeData.from) || !that.can_be_referenced(edgeData.to)) {
 			return;


### PR DESCRIPTION
#### What does it do?
- Visual support of extended event (draw a hull outside of nodes belonging to extended event)
- Possibility to filter on tag presence in event graph
- General improvements
#### Questions
- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [X] Minor
- [ ] Patch
