### PR TITLE
quickfix: editing an attribute was resetting its distribution level

### DIFF
--- a/app/View/Attributes/add.ctp
+++ b/app/View/Attributes/add.ctp
@@ -31,12 +31,16 @@
 			?>
 				<div class="input clear"></div>
 			<?php
-
-			echo $this->Form->input('distribution', array(
+			$distArray = array(
 				'options' => array($distributionLevels),
 				'label' => __('Distribution ') . $this->element('formInfo', array('type' => 'distribution')),
-				'selected' => $initialDistribution,
-			));
+			);
+
+			if ($action == 'add') {
+				$distArray['selected'] = $initialDistribution;
+			}
+
+			echo $this->Form->input('distribution', $distArray);
 			?>
 				<div id="SGContainer" style="display:none;">
 			<?php


### PR DESCRIPTION
#### What does it do?

Temporary fix:

Editing an attribute was not setting the distribution level to the previously saved value. It was alway forcing the value to be equals to ``5`` or ``MISP.default_attribute_distribution``.
This issue was occurring because the ``AttributeController/edit`` was using the ``add`` template instead of the ``edit`` (which wasn't setting the saved distribution level).

We may consider to use again the ``edit``  template.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [X] Minor
- [X] Patch
