### PR TITLE
fix: Do not append popover content (from event graph) into body

### DIFF
--- a/app/webroot/js/contextual_menu.js
+++ b/app/webroot/js/contextual_menu.js
@@ -2,6 +2,7 @@ class ContextualMenu {
     constructor(options) {
         this.options = options;
         this.trigger_container = options.trigger_container;
+        this.container = options.container;
         this.bootstrap_popover = options.bootstrap_popover;
         this.right_click = options.right_click;
         this.has_been_shown_once = false;
@@ -103,7 +104,7 @@ class ContextualMenu {
         var div = document.createElement('div');
         div.classList.add("contextual-menu");
         div.classList.add("contextual-menu-styling");
-        document.body.appendChild(div);
+        this.container.appendChild(div);
         // register on click for the trigger_container
         var that = this;
         if (this.right_click) {
@@ -130,7 +131,7 @@ class ContextualMenu {
     __create_menu_div_bootstrap_popover() {
         var div = document.createElement('div');
         div.classList.add("contextual-menu");
-        document.body.appendChild(div);
+        this.container.appendChild(div);
         var that = this;
         this.trigger_container.tabIndex = 0; // required for the popover focus feature
 	var additional_styling = this.options.style === undefined ? "" : this.options.style;

--- a/app/webroot/js/event-graph.js
+++ b/app/webroot/js/event-graph.js
@@ -148,7 +148,8 @@ class EventGraph {
 		var menu_scope = new ContextualMenu({
 			trigger_container: document.getElementById("network-scope"),
 			bootstrap_popover: true,
-			style: "z-index: 1"
+			style: "z-index: 1",
+			container: document.getElementById("eventgraph_div")
 		});
 		menu_scope.add_select({
 			id: "select_graph_scope",
@@ -188,7 +189,8 @@ class EventGraph {
 		var menu_physic = new ContextualMenu({
 			trigger_container: document.getElementById("network-physic"),
 			bootstrap_popover: true,
-			style: "z-index: 1"
+			style: "z-index: 1",
+			container: document.getElementById("eventgraph_div")
 		});
 		menu_physic.add_select({
 			id: "select_physic_solver",
@@ -227,7 +229,8 @@ class EventGraph {
 		var menu_display = new ContextualMenu({
 			trigger_container: document.getElementById("network-display"),
 			bootstrap_popover: true,
-			style: "z-index: 1"
+			style: "z-index: 1",
+			container: document.getElementById("eventgraph_div")
 		});
 		menu_display.add_select({
 			id: "select_display_layout",
@@ -311,7 +314,8 @@ class EventGraph {
 		var menu_filter = new ContextualMenu({
 			trigger_container: document.getElementById("network-filter"),
 			bootstrap_popover: true,
-			style: "z-index: 1"
+			style: "z-index: 1",
+			container: document.getElementById("eventgraph_div")
 		});
 		menu_filter.add_action_table({
 			id: "table_attr_presence",
@@ -403,7 +407,8 @@ class EventGraph {
 		var menu_canvas = new ContextualMenu({
 			trigger_container: document.getElementById("eventgraph_network"),
 			right_click: true,
-			style: "z-index: 1"
+			style: "z-index: 1",
+			container: document.getElementById("eventgraph_div")
 		});
 		menu_canvas.add_button({
 			label: "View/Edit",


### PR DESCRIPTION
Possibility to specify the container in which to append the contextual menu, thus allowing not to use ``body`` as the container. 

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
