### PR TITLE
Honour `MISP.completely_disable_correlation` on attribute/event save/delete action

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -1617,7 +1617,7 @@ class Attribute extends AppModel {
 	}
 
 	public function __afterSaveCorrelation($a, $full = false, $event = false) {
-		if (!empty($a['disable_correlation'])) {
+		if (!empty($a['disable_correlation']) || Configure::read('MISP.completely_disable_correlation')) {
 			return true;
 		}
 		// Don't do any correlation if the type is a non correlating type

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -423,7 +423,7 @@ class Event extends AppModel {
 	}
 
 	public function afterSave($created, $options = array()) {
-		if (!$created) {
+		if (!Configure::read('MISP.completely_disable_correlation') && !$created) {
 			$this->Correlation = ClassRegistry::init('Correlation');
 			$db = $this->getDataSource();
 			if (isset($this->data['Event']['date'])) {
@@ -1206,16 +1206,6 @@ class Event extends AppModel {
 				'value' => $id
 			),
 			array(
-				'table' => 'correlations',
-				'foreign_key' => 'event_id',
-				'value' => $id
-			),
-			array(
-				'table' => 'correlations',
-				'foreign_key' => '1_event_id',
-				'value' => $id
-			),
-			array(
 				'table' => 'sightings',
 				'foreign_key' => 'event_id',
 				'value' => $id
@@ -1241,6 +1231,21 @@ class Event extends AppModel {
 				'table' => 'posts',
 				'foreign_key' => 'thread_id',
 				'value' => $thread_id
+			);
+		}
+		if (!Configure::read('MISP.completely_disable_correlation')) {
+			array_push(
+				$relations,
+				array(
+					'table' => 'correlations',
+					'foreign_key' => 'event_id',
+					'value' => $id
+				),
+				array(
+					'table' => 'correlations',
+					'foreign_key' => '1_event_id',
+					'value' => $id
+				)
 			);
 		}
 		App::uses('QueryTool', 'Tools');


### PR DESCRIPTION
#### What does it do?

Even if `MISP.completely_disable_correlation` is enabled, correlations are still saved to the database.
This prevents that.

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
