### PR TITLE
Add config mapping for 'gpgconf' option in Crypt_GPG library.

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -3187,7 +3187,7 @@ class Server extends AppModel {
 			$continue = true;
 			try {
 				require_once 'Crypt/GPG.php';
-				$gpg = new Crypt_GPG(array('homedir' => Configure::read('GnuPG.homedir'), 'binary' => (Configure::read('GnuPG.binary') ? Configure::read('GnuPG.binary') : '/usr/bin/gpg')));
+				$gpg = new Crypt_GPG(array('homedir' => Configure::read('GnuPG.homedir'), 'gpgconf' => Configure::read('GnuPG.gpgconf'), 'binary' => (Configure::read('GnuPG.binary') ? Configure::read('GnuPG.binary') : '/usr/bin/gpg')));
 			} catch (Exception $e) {
 				$gpgStatus = 2;
 				$continue = false;

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -306,7 +306,7 @@ class User extends AppModel {
 		// key is entered
 		try {
 			require_once 'Crypt/GPG.php';
-			$gpg = new Crypt_GPG(array('homedir' => Configure::read('GnuPG.homedir'), 'binary' => (Configure::read('GnuPG.binary') ? Configure::read('GnuPG.binary') : '/usr/bin/gpg')));
+			$gpg = new Crypt_GPG(array('homedir' => Configure::read('GnuPG.homedir'), 'gpgconf' => Configure::read('GnuPG.gpgconf'), 'binary' => (Configure::read('GnuPG.binary') ? Configure::read('GnuPG.binary') : '/usr/bin/gpg')));
 			try {
 				$keyImportOutput = $gpg->importKey($check['gpgkey']);
 				if (!empty($keyImportOutput['fingerprint'])) {
@@ -473,7 +473,7 @@ class User extends AppModel {
 		if (!$gpg) {
 			try {
 				require_once 'Crypt/GPG.php';
-				$gpg = new Crypt_GPG(array('homedir' => Configure::read('GnuPG.homedir'), 'binary' => (Configure::read('GnuPG.binary') ? Configure::read('GnuPG.binary') : '/usr/bin/gpg')));
+				$gpg = new Crypt_GPG(array('homedir' => Configure::read('GnuPG.homedir'), 'gpgconf' => Configure::read('GnuPG.gpgconf'), 'binary' => (Configure::read('GnuPG.binary') ? Configure::read('GnuPG.binary') : '/usr/bin/gpg')));
 			} catch (Exception $e) {
 				$result[2] ='GnuPG is not configured on this system.';
 				$result[0] = true;
@@ -525,7 +525,7 @@ class User extends AppModel {
 			'recursive' => -1,
 		));
 		if (empty($users)) return $results;
-		$gpg = new Crypt_GPG(array('homedir' => Configure::read('GnuPG.homedir'), 'binary' => (Configure::read('GnuPG.binary') ? Configure::read('GnuPG.binary') : '/usr/bin/gpg')));
+		$gpg = new Crypt_GPG(array('homedir' => Configure::read('GnuPG.homedir'), 'gpgconf' => Configure::read('GnuPG.gpgconf'), 'binary' => (Configure::read('GnuPG.binary') ? Configure::read('GnuPG.binary') : '/usr/bin/gpg')));
 		foreach ($users as $k => $user) {
 			$results[$user['User']['id']] = $this->verifySingleGPG($user, $gpg);
 
@@ -739,7 +739,7 @@ class User extends AppModel {
 			// Sign the body
 			require_once 'Crypt/GPG.php';
 			try {
-				$gpg = new Crypt_GPG(array('homedir' => Configure::read('GnuPG.homedir'), 'binary' => (Configure::read('GnuPG.binary') ? Configure::read('GnuPG.binary') : '/usr/bin/gpg'), 'debug'));	// , 'debug' => true
+				$gpg = new Crypt_GPG(array('homedir' => Configure::read('GnuPG.homedir'), 'gpgconf' => Configure::read('GnuPG.gpgconf'), 'binary' => (Configure::read('GnuPG.binary') ? Configure::read('GnuPG.binary') : '/usr/bin/gpg'), 'debug'));	// , 'debug' => true
                 if (Configure::read('GnuPG.sign')) {
                     $gpg->addSignKey(Configure::read('GnuPG.email'), Configure::read('GnuPG.password'));
                     $body = $gpg->sign($body, Crypt_GPG::SIGN_MODE_CLEAR);


### PR DESCRIPTION
This commit creates a mapping for an extra variable, 'gpgconf', in the config in config.php to parameters passed to the Crypt_GPG object which is used to perform GPG operations in MISP.

This option not only sets the location of the gpgconf binary, but
if set to false, disables behaviour that shuts down running agents
when a Crypt_GPG object is destroyed. This behaviour would also
kill any long-running or daemonised agents that are running and
configured in the gpg.homedir directory.

We recently experienced issues with our GPG agents dying while browsing to the diagnostics page in admin settings, which this commit fixes.

I have not made any changes to the default config - this allows the existing behaviour to continue by default, but setting the 'gpgconf' variable to 'false' explicitly in the config will enable the new behaviour (no killing of agents). I have left it this way so as to create minimal issues for current users/installs.

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2016-06-03: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

If it fixes an existing issue, please use github syntax: `#<IssueID>`

#### Questions

- [ ] Does it require a DB change? No.
- [X] Are you using it in production? Yes.
- [ ] Does it require a change in the API (PyMISP for example)? No.

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
