### PR TITLE
Use python3 interpreter for STIX exports

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -3170,9 +3170,9 @@ class Server extends AppModel {
 
 	public function stixDiagnostics(&$diagnostic_errors, &$stixVersion, &$cyboxVersion, &$mixboxVersion) {
 		$result = array();
-		$expected = array('stix' => '1.1.1.4', 'cybox' => '2.1.0.12', 'mixbox' => '1.0.2');
+		$expected = array('stix' => '1.2.0.6', 'cybox' => '2.1.0.18.dev0', 'mixbox' => '1.0.3');
 		// check if the STIX and Cybox libraries are working using the test script stixtest.py
-		$scriptResult = shell_exec('python ' . APP . 'files' . DS . 'scripts' . DS . 'stixtest.py');
+		$scriptResult = shell_exec('python3 ' . APP . 'files' . DS . 'scripts' . DS . 'stixtest.py');
 		$scriptResult = json_decode($scriptResult, true);
 		if ($scriptResult !== null) {
 			$scriptResult['operational'] = $scriptResult['success'];

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -175,12 +175,12 @@ class StixBuilder(object):
     def saveFile(self):
         try:
             outputfile = "{}.out".format(self.filename)
-            with open(outputfile, 'w') as f:
+            with open(outputfile, 'wb') as f:
                 if self.args[2] == 'json':
                     f.write('{"package": %s}' % self.stix_package.to_json())
                 else:
                     f.write(self.stix_package.to_xml(include_namespaces=False, include_schemalocs=False,
-                                                     encoding=None))
+                                                     encoding='utf8'))
         except:
             print(json.dumps({'success' : 0, 'message' : 'The STIX file could not be written'}))
             sys.exit(1)


### PR DESCRIPTION
See #3260 : since pymisp is now used, Python 3.5 is a minimum requirement.