### PR TITLE
Debian Testing install

### DIFF
--- a/INSTALL/INSTALL.debian_testing.txt
+++ b/INSTALL/INSTALL.debian_testing.txt
@@ -72,7 +72,7 @@ sudo mkdir /var/www/MISP
 sudo chown www-data:www-data /var/www/MISP
 cd /var/www/MISP
 sudo -u www-data git clone https://github.com/MISP/MISP.git /var/www/MISP
-sudo -u www-data git checkout tags/$(git describe --tags `git rev-list --tags --max-count=1`)
+##sudo -u www-data git checkout tags/$(git describe --tags `git rev-list --tags --max-count=1`)
 # if the last shortcut doesn't work, specify the latest version manually
 # example: git checkout tags/v2.4.XY
 # the message regarding a "detached HEAD state" is expected behaviour

--- a/INSTALL/INSTALL.debian_testing.txt
+++ b/INSTALL/INSTALL.debian_testing.txt
@@ -57,9 +57,9 @@ sudo a2dissite 000-default
 sudo a2ensite default-ssl
 
 # Install PHP and dependencies
-sudo apt-get install -y libapache2-mod-php7.0 php7.0 php7.0-cli php7.0-dev php7.0-json php7.0-xml php7.0-mysql php7.0-readline php-redis php7.0-mbstring php-pear
+sudo apt-get install -y libapache2-mod-php7.2 php7.2 php7.2-cli php7.2-gnupg php7.2-dev php7.2-json php7.2-xml php7.2-mysql php7.2-opcache php7.2-readline php7.2-redis php7.2-mbstring php-pear
 sudo pear install Crypt_GPG
-sudo a2enmod php7.0
+sudo a2enmod php7.2
 
 # Apply all changes
 sudo systemctl restart apache2
@@ -153,9 +153,6 @@ sudo -u www-data sh -c "mysql -u misp -p misp < /var/www/MISP/INSTALL/MYSQL.sql"
 -----------------------
 # Now configure your Apache webserver with the DocumentRoot /var/www/MISP/app/webroot/
 
-# If the apache version is 2.2:
-sudo cp /var/www/MISP/INSTALL/apache.22.misp.ssl /etc/apache2/sites-available/misp-ssl.conf
-
 # If the apache version is 2.4:
 sudo cp /var/www/MISP/INSTALL/apache.24.misp.ssl /etc/apache2/sites-available/misp-ssl.conf
 
@@ -209,7 +206,7 @@ sudo openssl req -newkey rsa:4096 -days 365 -nodes -x509 \
 sudo a2dissite default-ssl
 sudo a2ensite misp-ssl
 
-# Recommended: Change some PHP settings in /etc/php/7.0/apache2/php.ini
+# Recommended: Change some PHP settings in /etc/php/7.2/apache2/php.ini
 # max_execution_time = 300
 # memory_limit = 512M
 # upload_max_filesize = 50M
@@ -278,9 +275,13 @@ sudo -u www-data sh -c "gpg --homedir /var/www/MISP/.gnupg --export --armor YOUR
 
 # To make the background workers start on boot
 sudo chmod +x /var/www/MISP/app/Console/worker/start.sh
-sudo vim /etc/rc.local
-# Add the following line before the last line (exit 0). Make sure that you replace www-data with your apache user:
-sudo -u www-data bash /var/www/MISP/app/Console/worker/start.sh
+if [ ! -e /etc/rc.local ]
+then
+    echo '#!/bin/sh -e' | sudo tee -a /etc/rc.local
+    echo 'exit 0' | sudo tee -a /etc/rc.local
+    sudo chmod u+x /etc/rc.local
+fi
+
 
 # Now log in using the webinterface:
 # The default user/pass = admin@admin.test/admin
@@ -291,9 +292,45 @@ sudo -u www-data bash /var/www/MISP/app/Console/worker/start.sh
 
 # Don't forget to change the email, password and authentication key after installation.
 
-# Start the workers
+# Set MISP Live
+sudo /var/www/MISP/app/Console/cake Live 1
 
-/var/www/MISP/app/Console/worker/start.sh
+# Enable ZeroMQ for misp-dashboard
+sudo /var/www/MISP/app/Console/cake Admin setSetting "Plugin.ZeroMQ_enable" true
+sudo /var/www/MISP/app/Console/cake Admin setSetting "Plugin.ZeroMQ_event_notifications_enable" true
+sudo /var/www/MISP/app/Console/cake Admin setSetting "Plugin.ZeroMQ_object_notifications_enable" true
+sudo /var/www/MISP/app/Console/cake Admin setSetting "Plugin.ZeroMQ_object_reference_notifications_enable" true
+sudo /var/www/MISP/app/Console/cake Admin setSetting "Plugin.ZeroMQ_attribute_notifications_enable" true
+sudo /var/www/MISP/app/Console/cake Admin setSetting "Plugin.ZeroMQ_sighting_notifications_enable" true
+sudo /var/www/MISP/app/Console/cake Admin setSetting "Plugin.ZeroMQ_user_notifications_enable" true
+sudo /var/www/MISP/app/Console/cake Admin setSetting "Plugin.ZeroMQ_organisation_notifications_enable" true
+
+# Add the following lines before the last line (exit 0). Make sure that you replace www-data with your apache user:
+sudo -u www-data bash /var/www/MISP/app/Console/worker/start.sh
+sudo sed -i -e '$i \echo never > /sys/kernel/mm/transparent_hugepage/enabled\n' /etc/rc.local
+sudo sed -i -e '$i \echo 1024 > /proc/sys/net/core/somaxconn\n' /etc/rc.local
+sudo sed -i -e '$i \sysctl vm.overcommit_memory=1\n' /etc/rc.local
+sudo sed -i -e '$i \sudo -u www-data bash /var/www/MISP/app/Console/worker/start.sh\n' /etc/rc.local
+sudo sed -i -e '$i \sudo -u www-data misp-modules -l 0.0.0.0 -s &\n' /etc/rc.local
+sudo sed -i -e '$i \sudo -u www-data bash /var/www/misp-dashboard/start_all.sh\n' /etc/rc.local
+
+# Installing MISP modules…
+sudo apt-get install -y python3-dev python3-pip libpq5 libjpeg-dev libfuzzy-dev > /dev/null 2>&1
+cd /usr/local/src/
+sudo git clone https://github.com/MISP/misp-modules.git
+cd misp-modules
+# pip3 install
+sudo pip3 install -I -r REQUIREMENTS > /dev/null 2>&1
+sudo pip3 install -I . > /dev/null 2>&1
+sudo pip3 install lief 2>&1
+sudo pip3 install pymisp python-magic > /dev/null 2>&1
+sudo pip3 install git+https://github.com/kbandla/pydeep.git > /dev/null 2>&1
+# pip2 install
+sudo pip install pymisp python-magic > /dev/null 2>&1
+sudo pip install git+https://github.com/kbandla/pydeep.git > /dev/null 2>&1
+sudo pip install lief 2>&1
+# install STIX2.0 library to support STIX 2.0 export:
+sudo pip3 install stix2 > /dev/null 2>&1
 
 # Once done, have a look at the diagnostics
 

--- a/INSTALL/INSTALL.debian_testing.txt
+++ b/INSTALL/INSTALL.debian_testing.txt
@@ -296,6 +296,20 @@ fi
 # Set MISP Live
 sudo /var/www/MISP/app/Console/cake Live 1
 
+AUTH_KEY=$(mysql -u misp -pPassword1234 misp -e "SELECT authkey FROM users;" | tail -1)
+
+# Update the galaxies…
+curl --header "Authorization: $AUTH_KEY" --header "Accept: application/json" --header "Content-Type: application/json" -o /dev/null -s -X POST http://127.0.0.1/galaxies/update
+
+# Updating the taxonomies… ---"
+curl --header "Authorization: $AUTH_KEY" --header "Accept: application/json" --header "Content-Type: application/json" -o /dev/null -s -X POST http://127.0.0.1/taxonomies/update
+
+# Updating the warning lists… ---"
+curl --header "Authorization: $AUTH_KEY" --header "Accept: application/json" --header "Content-Type: application/json" -o /dev/null -s -X POST http://127.0.0.1/warninglists/update
+
+# Updating the object templates… ---"
+curl --header "Authorization: $AUTH_KEY" --header "Accept: application/json" --header "Content-Type: application/json" -o /dev/null -s -X POST http://127.0.0.1/objectTemplates/update
+
 # Enable ZeroMQ for misp-dashboard
 sudo /var/www/MISP/app/Console/cake Admin setSetting "Plugin.ZeroMQ_enable" true
 sudo /var/www/MISP/app/Console/cake Admin setSetting "Plugin.ZeroMQ_event_notifications_enable" true

--- a/INSTALL/INSTALL.debian_testing.txt
+++ b/INSTALL/INSTALL.debian_testing.txt
@@ -359,39 +359,15 @@ Recommended actions
 - Keep your software up2date (OS, MISP, CakePHP and everything else)
 - Log and audit
 
-
 Optional features
 -------------------
-# MISP has a new pub/sub feature, using ZeroMQ. To enable it, simply run the following commands
 
-# ZeroMQ depends on the Python client for Redis
-sudo pip install redis
+# Install misp-dashboard
 
-# Debian has an ancient version of ZeroMQ, so manually install a current version
-
-## Install ZeroMQ and prerequisites
-sudo apt-get install pkg-config
-cd /usr/local/src/
-sudo git clone git://github.com/jedisct1/libsodium.git
-cd libsodium
-sudo ./autogen.sh
-sudo ./configure
-sudo make check
-sudo make
-sudo make install
-sudo ldconfig
-cd /usr/local/src/
-sudo wget https://archive.org/download/zeromq_4.1.5/zeromq-4.1.5.tar.gz
-sudo tar -xvf zeromq-4.1.5.tar.gz
-cd zeromq-4.1.5/
-sudo ./autogen.sh
-sudo ./configure
-sudo make check
-sudo make
-sudo make install
-sudo ldconfig
-
-## install pyzmq
-sudo pip install pyzmq
-
-
+cd /var/www
+sudo mkdir misp-dashboard
+sudo chown www-data:www-data misp-dashboard
+sudo -u www-data git clone https://github.com/SteveClement/misp-dashboard.git
+cd misp-dashboard
+sudo /var/www/misp-dashboard/install_dependencies.sh
+sudo sed -i "s/^host\ =\ localhost/host\ =\ 0.0.0.0/g" /var/www/misp-dashboard/config/config.cfg

--- a/INSTALL/INSTALL.debian_testing.txt
+++ b/INSTALL/INSTALL.debian_testing.txt
@@ -315,22 +315,22 @@ sudo sed -i -e '$i \sudo -u www-data misp-modules -l 0.0.0.0 -s &\n' /etc/rc.loc
 sudo sed -i -e '$i \sudo -u www-data bash /var/www/misp-dashboard/start_all.sh\n' /etc/rc.local
 
 # Installing MISP modules…
-sudo apt-get install -y python3-dev python3-pip libpq5 libjpeg-dev libfuzzy-dev > /dev/null 2>&1
+sudo apt-get install -y python3-dev python3-pip libpq5 libjpeg-dev libfuzzy-dev
 cd /usr/local/src/
 sudo git clone https://github.com/MISP/misp-modules.git
 cd misp-modules
 # pip3 install
-sudo pip3 install -I -r REQUIREMENTS > /dev/null 2>&1
-sudo pip3 install -I . > /dev/null 2>&1
-sudo pip3 install lief 2>&1
-sudo pip3 install pymisp python-magic > /dev/null 2>&1
-sudo pip3 install git+https://github.com/kbandla/pydeep.git > /dev/null 2>&1
+sudo pip3 install -I -r REQUIREMENTS
+sudo pip3 install -I .
+sudo pip3 install lief
+sudo pip3 install pymisp python-magic
+sudo pip3 install git+https://github.com/kbandla/pydeep.git
 # pip2 install
-sudo pip install pymisp python-magic > /dev/null 2>&1
-sudo pip install git+https://github.com/kbandla/pydeep.git > /dev/null 2>&1
-sudo pip install lief 2>&1
+sudo pip install pymisp python-magic
+sudo pip install git+https://github.com/kbandla/pydeep.git
+sudo pip install lief
 # install STIX2.0 library to support STIX 2.0 export:
-sudo pip3 install stix2 > /dev/null 2>&1
+sudo pip3 install stix2
 
 # Once done, have a look at the diagnostics
 

--- a/INSTALL/INSTALL.debian_testing.txt
+++ b/INSTALL/INSTALL.debian_testing.txt
@@ -1,0 +1,360 @@
+INSTALLATION INSTRUCTIONS
+------------------------- for Debian testing "buster" server
+
+0/ MISP testing dev install
+---------------------------
+
+This is mostly the install [@SteveClement](https://twitter.com/SteveClement)
+uses for testing, qc and random development.
+
+1/ Minimal Debian install
+-------------------------
+
+# Install a minimal Debian testing "buster" server system with the software:
+- OpenSSH server
+- Web server, apache FTW!
+- This guide assumes a user name of 'misp'
+
+# install sudo and etckeeper
+su -
+apt install etckeeper
+apt install sudo
+adduser -aG sudo misp
+
+# Make sure your system is up2date:
+sudo apt-get update
+sudo apt-get upgrade
+
+
+# install postfix, there will be some questions.
+sudo apt-get install postfix
+# Postfix Configuration: Satellite system
+# change the relay server later with:
+sudo postconf -e 'relayhost = example.com'
+sudo postfix reload
+
+
+2/ Install LAMP & dependencies
+------------------------------
+Once the system is installed you can perform the following steps:
+
+# Install the dependencies: (some might already be installed)
+sudo apt-get install curl gcc git gnupg-agent make python openssl redis-server neovim zip
+
+# Install MariaDB (a MySQL fork/alternative)
+sudo apt-get install mariadb-client mariadb-server
+
+# Secure the MariaDB installation (especially by setting a strong root password)
+sudo mysql_secure_installation
+
+# Install Apache2
+sudo apt-get install apache2 apache2-doc apache2-utils
+
+# Enable modules, settings, and default of SSL in Apache
+sudo a2dismod status
+sudo a2enmod ssl rewrite
+sudo a2dissite 000-default
+sudo a2ensite default-ssl
+
+# Install PHP and dependencies
+sudo apt-get install -y libapache2-mod-php7.0 php7.0 php7.0-cli php7.0-dev php7.0-json php7.0-xml php7.0-mysql php7.0-readline php-redis php7.0-mbstring php-pear
+sudo pear install Crypt_GPG
+sudo a2enmod php7.0
+
+# Apply all changes
+sudo systemctl restart apache2
+
+
+3/ MISP code
+------------
+# Download MISP using git in the /var/www/ directory.
+sudo mkdir /var/www/MISP
+sudo chown www-data:www-data /var/www/MISP
+cd /var/www/MISP
+sudo -u www-data git clone https://github.com/MISP/MISP.git /var/www/MISP
+sudo -u www-data git checkout tags/$(git describe --tags `git rev-list --tags --max-count=1`)
+# if the last shortcut doesn't work, specify the latest version manually
+# example: git checkout tags/v2.4.XY
+# the message regarding a "detached HEAD state" is expected behaviour
+# (you only have to create a new branch, if you want to change stuff and do a pull request for example)
+
+# Make git ignore filesystem permission differences
+sudo -u www-data git config core.filemode false
+
+# install Mitre's STIX and its dependencies by running the following commands:
+sudo apt-get install python-dev python-pip libxml2-dev libxslt1-dev zlib1g-dev python-setuptools
+cd /var/www/MISP/app/files/scripts
+sudo -u www-data git clone https://github.com/CybOXProject/python-cybox.git
+sudo -u www-data git clone https://github.com/STIXProject/python-stix.git
+cd /var/www/MISP/app/files/scripts/python-cybox
+sudo -u www-data git checkout v2.1.0.12
+sudo python setup.py install
+cd /var/www/MISP/app/files/scripts/python-stix
+sudo -u www-data git checkout v1.1.1.4
+sudo python setup.py install
+
+# install mixbox to accomodate the new STIX dependencies:
+cd /var/www/MISP/app/files/scripts/
+sudo -u www-data git clone https://github.com/CybOXProject/mixbox.git
+cd /var/www/MISP/app/files/scripts/mixbox
+sudo -u www-data git checkout v1.0.2
+sudo python setup.py install
+
+4/ CakePHP
+-----------
+# CakePHP is included as a submodule of MISP, execute the following commands to let git fetch it:
+cd /var/www/MISP
+sudo -u www-data git submodule init
+sudo -u www-data git submodule update
+# Make git ignore filesystem permission differences for submodules
+sudo -u www-data git submodule foreach git config core.filemode false
+
+# Once done, install CakeResque along with its dependencies if you intend to use the built in background jobs:
+cd /var/www/MISP/app
+sudo -u www-data php composer.phar require kamisama/cake-resque:4.1.2
+sudo -u www-data php composer.phar config vendor-dir Vendor
+sudo -u www-data php composer.phar install
+
+# Enable CakeResque with php-redis
+sudo phpenmod redis
+
+# To use the scheduler worker for scheduled tasks, do the following:
+sudo -u www-data cp -fa /var/www/MISP/INSTALL/setup/config.php /var/www/MISP/app/Plugin/CakeResque/Config/config.php
+
+
+5/ Set the permissions
+----------------------
+
+# Check if the permissions are set correctly using the following commands:
+sudo chown -R www-data:www-data /var/www/MISP
+sudo chmod -R 750 /var/www/MISP
+sudo chmod -R g+ws /var/www/MISP/app/tmp
+sudo chmod -R g+ws /var/www/MISP/app/files
+sudo chmod -R g+ws /var/www/MISP/app/files/scripts/tmp
+
+
+6/ Create a database and user
+-----------------------------
+# Enter the mysql shell
+sudo mysql -u root -p
+
+MariaDB [(none)]> create database misp;
+MariaDB [(none)]> grant usage on *.* to misp@localhost identified by 'XXXXdbpasswordhereXXXXX';
+MariaDB [(none)]> grant all privileges on misp.* to misp@localhost;
+MariaDB [(none)]> flush privileges;
+MariaDB [(none)]> exit
+
+# Import the empty MISP database from MYSQL.sql
+sudo -u www-data sh -c "mysql -u misp -p misp < /var/www/MISP/INSTALL/MYSQL.sql"
+# enter the password you set previously
+
+
+7/ Apache configuration
+-----------------------
+# Now configure your Apache webserver with the DocumentRoot /var/www/MISP/app/webroot/
+
+# If the apache version is 2.2:
+sudo cp /var/www/MISP/INSTALL/apache.22.misp.ssl /etc/apache2/sites-available/misp-ssl.conf
+
+# If the apache version is 2.4:
+sudo cp /var/www/MISP/INSTALL/apache.24.misp.ssl /etc/apache2/sites-available/misp-ssl.conf
+
+# Be aware that the configuration files for apache 2.4 and up have changed.
+# The configuration file has to have the .conf extension in the sites-available directory
+# For more information, visit http://httpd.apache.org/docs/2.4/upgrading.html
+
+# If a valid SSL certificate is not already created for the server, create a self-signed certificate:
+sudo openssl req -newkey rsa:4096 -days 365 -nodes -x509 \
+-subj "/C=<Country>/ST=<State>/L=<Locality>/O=<Organization>/OU=<Organizational Unit Name>/CN=<QDN.here>/emailAddress=admin@<your.FQDN.here>" \
+-keyout /etc/ssl/private/misp.local.key -out /etc/ssl/private/misp.local.crt
+
+# Otherwise, copy the SSLCertificateFile, SSLCertificateKeyFile, and SSLCertificateChainFile to /etc/ssl/private/. (Modify path and config to fit your environment)
+
+============================================= Begin sample working SSL config for MISP
+<VirtualHost <IP, FQDN, or *>:80>
+        ServerName <your.FQDN.here>
+
+        Redirect permanent / https://<your.FQDN.here>
+
+        LogLevel warn
+        ErrorLog /var/log/apache2/misp.local_error.log
+        CustomLog /var/log/apache2/misp.local_access.log combined
+        ServerSignature Off
+</VirtualHost>
+
+<VirtualHost <IP, FQDN, or *>:443>
+        ServerAdmin admin@<your.FQDN.here>
+        ServerName <your.FQDN.here>
+        DocumentRoot /var/www/MISP/app/webroot
+        <Directory /var/www/MISP/app/webroot>
+                Options -Indexes
+                AllowOverride all
+                Order allow,deny
+                allow from all
+        </Directory>
+
+        SSLEngine On
+        SSLCertificateFile /etc/ssl/private/misp.local.crt
+        SSLCertificateKeyFile /etc/ssl/private/misp.local.key
+#        SSLCertificateChainFile /etc/ssl/private/misp-chain.crt
+
+        LogLevel warn
+        ErrorLog /var/log/apache2/misp.local_error.log
+        CustomLog /var/log/apache2/misp.local_access.log combined
+        ServerSignature Off
+</VirtualHost>
+============================================= End sample working SSL config for MISP
+
+# activate new vhost
+sudo a2dissite default-ssl
+sudo a2ensite misp-ssl
+
+# Recommended: Change some PHP settings in /etc/php/7.0/apache2/php.ini
+# max_execution_time = 300
+# memory_limit = 512M
+# upload_max_filesize = 50M
+# post_max_size = 50M
+
+# Restart apache
+sudo systemctl restart apache2
+
+8/ Log rotation
+---------------
+# MISP saves the stdout and stderr of its workers in /var/www/MISP/app/tmp/logs
+# To rotate these logs install the supplied logrotate script:
+
+sudo cp /var/www/MISP/INSTALL/misp.logrotate /etc/logrotate.d/misp
+
+9/ MISP configuration
+---------------------
+# There are 4 sample configuration files in /var/www/MISP/app/Config that need to be copied
+sudo -u www-data cp -a /var/www/MISP/app/Config/bootstrap.default.php /var/www/MISP/app/Config/bootstrap.php
+sudo -u www-data cp -a /var/www/MISP/app/Config/database.default.php /var/www/MISP/app/Config/database.php
+sudo -u www-data cp -a /var/www/MISP/app/Config/core.default.php /var/www/MISP/app/Config/core.php
+sudo -u www-data cp -a /var/www/MISP/app/Config/config.default.php /var/www/MISP/app/Config/config.php
+
+# Configure the fields in the newly created files:
+sudo -u www-data vim /var/www/MISP/app/Config/database.php
+# DATABASE_CONFIG has to be filled
+# With the default values provided in section 6, this would look like:
+# class DATABASE_CONFIG {
+#   public $default = array(
+#       'datasource' => 'Database/Mysql',
+#       'persistent' => false,
+#       'host' => 'localhost',
+#       'login' => 'misp', // grant usage on *.* to misp@localhost
+#       'port' => 3306,
+#       'password' => 'XXXXdbpasswordhereXXXXX', // identified by 'XXXXdbpasswordhereXXXXX';
+#       'database' => 'misp', // create database misp;
+#       'prefix' => '',
+#       'encoding' => 'utf8',
+#   );
+#}
+
+# Important! Change the salt key in /var/www/MISP/app/Config/config.php
+# The salt key must be a string at least 32 bytes long.
+# The admin user account will be generated on the first login, make sure that the salt is changed before you create that user
+# If you forget to do this step, and you are still dealing with a fresh installation, just alter the salt,
+# delete the user from mysql and log in again using the default admin credentials (admin@admin.test / admin)
+# e.g. https://pythontips.com/2013/07/28/generating-a-random-string/
+
+# Change base url in config.php
+sudo -u www-data vim /var/www/MISP/app/Config/config.php
+# example: 'baseurl' => 'https://<your.FQDN.here>',
+# alternatively, you can leave this field empty if you would like to use relative pathing in MISP
+# 'baseurl' => '',
+
+# and make sure the file permissions are still OK
+sudo chown -R www-data:www-data /var/www/MISP/app/Config
+sudo chmod -R 750 /var/www/MISP/app/Config
+
+# Generate a GPG encryption key.
+sudo gpg --homedir /var/www/MISP/.gnupg --gen-key
+sudo chown -R www-data:www-data /var/www/MISP/.gnupg
+# The email address should match the one set in the config.php / set in the configuration menu in the administration menu configuration file
+
+# And export the public key to the webroot
+sudo -u www-data sh -c "gpg --homedir /var/www/MISP/.gnupg --export --armor YOUR-KEYS-EMAIL-HERE > /var/www/MISP/app/webroot/gpg.asc"
+
+# To make the background workers start on boot
+sudo chmod +x /var/www/MISP/app/Console/worker/start.sh
+sudo vim /etc/rc.local
+# Add the following line before the last line (exit 0). Make sure that you replace www-data with your apache user:
+sudo -u www-data bash /var/www/MISP/app/Console/worker/start.sh
+
+# Now log in using the webinterface:
+# The default user/pass = admin@admin.test/admin
+
+# Using the server settings tool in the admin interface (Administration -> Server Settings), set MISP up to your preference
+# It is especially vital that no critical issues remain!
+# start the workers by navigating to the workers tab and clicking restart all workers
+
+# Don't forget to change the email, password and authentication key after installation.
+
+# Start the workers
+
+/var/www/MISP/app/Console/worker/start.sh
+
+# Once done, have a look at the diagnostics
+
+# If any of the directories that MISP uses to store files is not writeable to the apache user, change the permissions
+# you can do this by running the following commands:
+
+sudo chmod -R 750 /var/www/MISP/<directory path with an indicated issue>
+sudo chown -R www-data:www-data /var/www/MISP/<directory path with an indicated issue>
+
+# Make sure that the STIX libraries and GnuPG work as intended, if not, refer to INSTALL.txt's paragraphs dealing with these two items
+
+# If anything goes wrong, make sure that you check MISP's logs for errors:
+# /var/www/MISP/app/tmp/logs/error.log
+# /var/www/MISP/app/tmp/logs/resque-worker-error.log
+# /var/www/MISP/app/tmp/logs/resque-scheduler-error.log
+# /var/www/MISP/app/tmp/logs/resque-2015-01-01.log // where the actual date is the current date
+
+
+Recommended actions
+-------------------
+- By default CakePHP exposes its name and version in email headers. Apply a patch to remove this behavior.
+
+- You should really harden your OS
+- You should really harden the configuration of Apache
+- You should really harden the configuration of MySQL/MariaDB
+- Keep your software up2date (OS, MISP, CakePHP and everything else)
+- Log and audit
+
+
+Optional features
+-------------------
+# MISP has a new pub/sub feature, using ZeroMQ. To enable it, simply run the following commands
+
+# ZeroMQ depends on the Python client for Redis
+sudo pip install redis
+
+# Debian has an ancient version of ZeroMQ, so manually install a current version
+
+## Install ZeroMQ and prerequisites
+sudo apt-get install pkg-config
+cd /usr/local/src/
+sudo git clone git://github.com/jedisct1/libsodium.git
+cd libsodium
+sudo ./autogen.sh
+sudo ./configure
+sudo make check
+sudo make
+sudo make install
+sudo ldconfig
+cd /usr/local/src/
+sudo wget https://archive.org/download/zeromq_4.1.5/zeromq-4.1.5.tar.gz
+sudo tar -xvf zeromq-4.1.5.tar.gz
+cd zeromq-4.1.5/
+sudo ./autogen.sh
+sudo ./configure
+sudo make check
+sudo make
+sudo make install
+sudo ldconfig
+
+## install pyzmq
+sudo pip install pyzmq
+
+

--- a/INSTALL/INSTALL.debian_testing.txt
+++ b/INSTALL/INSTALL.debian_testing.txt
@@ -39,7 +39,8 @@ sudo postfix reload
 Once the system is installed you can perform the following steps:
 
 # Install the dependencies: (some might already be installed)
-sudo apt-get install curl gcc git gnupg-agent make python openssl redis-server neovim zip
+sudo apt-get install curl gcc git gnupg-agent make python openssl redis-server neovim zip libyara-dev python3-yara
+sudo ln -s /usr/lib/x86_64-linux-gnu/libyara.so.3.7.1 /usr/lib/libyara.so
 
 # Install MariaDB (a MySQL fork/alternative)
 sudo apt-get install mariadb-client mariadb-server

--- a/INSTALL/INSTALL.debian_testing.txt
+++ b/INSTALL/INSTALL.debian_testing.txt
@@ -299,16 +299,19 @@ sudo /var/www/MISP/app/Console/cake Live 1
 AUTH_KEY=$(mysql -u misp -pPassword1234 misp -e "SELECT authkey FROM users;" | tail -1)
 
 # Update the galaxies…
-curl --header "Authorization: $AUTH_KEY" --header "Accept: application/json" --header "Content-Type: application/json" -o /dev/null -s -X POST http://127.0.0.1/galaxies/update
+curl --header "Authorization: $AUTH_KEY" --header "Accept: application/json" --header "Content-Type: application/json" -k -X POST https://127.0.0.1/galaxies/update
 
-# Updating the taxonomies… ---"
-curl --header "Authorization: $AUTH_KEY" --header "Accept: application/json" --header "Content-Type: application/json" -o /dev/null -s -X POST http://127.0.0.1/taxonomies/update
+# Updating the taxonomies…
+curl --header "Authorization: $AUTH_KEY" --header "Accept: application/json" --header "Content-Type: application/json" -k -X POST https://127.0.0.1/taxonomies/update
 
-# Updating the warning lists… ---"
-curl --header "Authorization: $AUTH_KEY" --header "Accept: application/json" --header "Content-Type: application/json" -o /dev/null -s -X POST http://127.0.0.1/warninglists/update
+# Updating the warning lists…
+curl --header "Authorization: $AUTH_KEY" --header "Accept: application/json" --header "Content-Type: application/json" -k -X POST https://127.0.0.1/warninglists/update
 
-# Updating the object templates… ---"
-curl --header "Authorization: $AUTH_KEY" --header "Accept: application/json" --header "Content-Type: application/json" -o /dev/null -s -X POST http://127.0.0.1/objectTemplates/update
+# Updating the notice lists…
+curl --header "Authorization: $AUTH_KEY" --header "Accept: application/json" --header "Content-Type: application/json" -k -X POST https://127.0.0.1/noticelists/update
+
+# Updating the object templates…
+curl --header "Authorization: $AUTH_KEY" --header "Accept: application/json" --header "Content-Type: application/json" -k -X POST https://127.0.0.1/objectTemplates/update
 
 # Enable ZeroMQ for misp-dashboard
 sudo /var/www/MISP/app/Console/cake Admin setSetting "Plugin.ZeroMQ_enable" true


### PR DESCRIPTION
Install document for Debian testing.

Includes:

zmq
misp-dashboard
cake CLI commands
gpg
ssl