### PR TITLE
chg: allow symlinks for public keys in footer

### DIFF
--- a/app/View/Elements/footer.ctp
+++ b/app/View/Elements/footer.ctp
@@ -11,14 +11,14 @@
 			<div class="pull-left footerText" style="float:left;position:absolute;padding-top:12px;z-index:2;">
 				<?php
 				$gpgpath = ROOT.DS.APP_DIR.DS.WEBROOT_DIR.DS.'gpg.asc';
-				if (file_exists($gpgpath) && is_file($gpgpath)){ ?>
+				if (file_exists($gpgpath) && (is_file($gpgpath) || is_link($gpgpath))){ ?>
 					<span>Download: <?php echo $this->Html->link('GnuPG key', $this->webroot.'gpg.asc');?></span>
 				<?php } else { ?>
 					<span>Could not locate the GnuPG public key.</span>
 				<?php }
 				if (Configure::read('SMIME.enabled')):
 					$smimepath = ROOT.DS.APP_DIR.DS.WEBROOT_DIR.DS.'public_certificate.pem';
-					if (file_exists($smimepath) && is_file($smimepath)){ ?>
+					if (file_exists($smimepath) && (is_file($smimepath) || is_link($gpgpath))){ ?>
 						<span>Download: <?php echo $this->Html->link('SMIME certificate', $this->webroot.'public_certificate.pem');?></span>
 					<?php } else { ?>
 						<span>Could not locate SMIME certificate.</span>


### PR DESCRIPTION
Allows replacing public GPG & SMIME keys (gpg.asc &
public_certificate.pem) with symbolic links, to store the actual files
in another format. This allows clean separation of MISP code (in
webroot) from configuration data.

Our use case: run MISP on top of kubernetes, storing configurations and
secrets in dedicated volumes, rather than in the Docker image.

#### Questions

- [x] Does it require a DB change? -> **no**
- [x] Are you using it in production? -> **not yet**
- [x] Does it require a change in the API (PyMISP for example)? **-> no**

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
