### PR TITLE
Fix STIX export corner cases

### DIFF
--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -303,7 +303,7 @@ class StixBuilder(object):
                 pass
             indicator.add_valid_time_position(ValidTime())
             observable = self.handle_attribute(attribute)
-	    if(observable):
+            if observable:
               indicator.add_observable(observable)
             if 'data' in attribute and attribute.type == "malware-sample":
                 artifact = self.create_artifact_object(attribute)
@@ -312,7 +312,7 @@ class StixBuilder(object):
             incident.related_indicators.append(related_indicator)
         else:
             observable = self.handle_attribute(attribute)
-	    if(observable):
+        if observable:
               related_observable = RelatedObservable(observable, relationship=attribute.category)
               incident.related_observables.append(related_observable)
             if 'data' in  attribute and attribute.type == "malware-sample":

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -173,17 +173,13 @@ class StixBuilder(object):
         self.stix_package = stix_package
 
     def saveFile(self):
-        try:
-            outputfile = "{}.out".format(self.filename)
-            with open(outputfile, 'wb') as f:
-                if self.args[2] == 'json':
-                    f.write('{"package": %s}' % self.stix_package.to_json())
-                else:
-                    f.write(self.stix_package.to_xml(include_namespaces=False, include_schemalocs=False,
-                                                     encoding='utf8'))
-        except:
-            print(json.dumps({'success' : 0, 'message' : 'The STIX file could not be written'}))
-            sys.exit(1)
+        outputfile = "{}.out".format(self.filename)
+        with open(outputfile, 'wb') as f:
+            if self.args[2] == 'json':
+                f.write('{"package": %s}' % self.stix_package.to_json())
+            else:
+                f.write(self.stix_package.to_xml(include_namespaces=False, include_schemalocs=False,
+                                                 encoding='utf8'))
 
     def generate_stix_objects(self):
         incident_id = "{}:incident-{}".format(namespace[1], self.misp_event.uuid)

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -315,7 +315,7 @@ class StixBuilder(object):
         if observable:
               related_observable = RelatedObservable(observable, relationship=attribute.category)
               incident.related_observables.append(related_observable)
-            if 'data' in  attribute and attribute.type == "malware-sample":
+              if 'data' in attribute and attribute.type == "malware-sample":
                 artifact = self.create_artifact_object(attribute)
                 related_artifact = RelatedObservable(artifact)
                 incident.related_observables.append(related_artifact)

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -303,7 +303,8 @@ class StixBuilder(object):
                 pass
             indicator.add_valid_time_position(ValidTime())
             observable = self.handle_attribute(attribute)
-            indicator.add_observable(observable)
+	    if(observable):
+              indicator.add_observable(observable)
             if 'data' in attribute and attribute.type == "malware-sample":
                 artifact = self.create_artifact_object(attribute)
                 indicator.add_observable(artifact)
@@ -311,8 +312,9 @@ class StixBuilder(object):
             incident.related_indicators.append(related_indicator)
         else:
             observable = self.handle_attribute(attribute)
-            related_observable = RelatedObservable(observable, relationship=attribute.category)
-            incident.related_observables.append(related_observable)
+	    if(observable):
+              related_observable = RelatedObservable(observable, relationship=attribute.category)
+              incident.related_observables.append(related_observable)
             if 'data' in  attribute and attribute.type == "malware-sample":
                 artifact = self.create_artifact_object(attribute)
                 related_artifact = RelatedObservable(artifact)

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -462,7 +462,7 @@ class StixBuilder(object):
             observable_property = self.simple_type_to_method[attribute_type](attribute)
         except KeyError:
             return False
-        if isinstance(observable_property, Observable):
+        if not observable_property or isinstance(observable_property, Observable):
             return observable_property
         observable_property.condition = "Equals"
         observable_object = Object(observable_property)

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -547,8 +547,8 @@ class StixBuilder(object):
             indicator = self.generate_indicator(attribute, tags)
             indicator.add_indicator_type("Malware Artifacts")
             indicator.add_valid_time_position(ValidTime())
-            indicator.test_mechanisms = [tm]
-            related_indicator = RelatedIndicator(indicator, relationship=category)
+            indicator.add_test_mechanism(tm)
+            related_indicator = RelatedIndicator(indicator, relationship=attribute.category)
             incident.related_indicators.append(related_indicator)
 
     def generate_ttp(self, attribute, tags):

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -174,12 +174,13 @@ class StixBuilder(object):
 
     def saveFile(self):
         outputfile = "{}.out".format(self.filename)
-        with open(outputfile, 'wb') as f:
-            if self.args[2] == 'json':
-                f.write('{"package": %s}' % self.stix_package.to_json())
-            else:
-                f.write(self.stix_package.to_xml(include_namespaces=False, include_schemalocs=False,
-                                                 encoding='utf8'))
+        if self.args[2] == 'json':
+          with open(outputfile, 'w') as f:
+            f.write('{"package": %s}' % self.stix_package.to_json())
+        else:
+          with open(outputfile, 'wb') as f:
+            f.write(self.stix_package.to_xml(include_namespaces=False, include_schemalocs=False,
+                                             encoding='utf8'))
 
     def generate_stix_objects(self):
         incident_id = "{}:incident-{}".format(namespace[1], self.misp_event.uuid)

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -6,7 +6,7 @@ from stix.indicator import Indicator
 from stix.indicator.valid_time import ValidTime
 from stix.ttp import TTP, Behavior
 from stix.ttp.malware_instance import MalwareInstance
-from stix.incident import Incident, Time, ImpactAssessment, ExternalID, AffectedAsset
+from stix.incident import Incident, Time, ImpactAssessment, ExternalID, AffectedAsset, AttributedThreatActors
 from stix.exploit_target import ExploitTarget, Vulnerability
 from stix.incident.history import JournalEntry, History, HistoryItem
 from stix.threat_actor import ThreatActor
@@ -341,8 +341,12 @@ class StixBuilder(object):
                 incident.leveraged_ttps.append(self.append_ttp(attribute_category, ttp))
             elif attribute_category == "Attribution":
                 ta = self.generate_threat_actor(attribute)
-                rta = RelatedThreatActor(ta, relationship="Attribution")
-                incident.attributed_threat_actors.append(rta)
+                ata = AttributedThreatActors()
+                ata.append(ta)
+                if incident.attributed_threat_actors:
+                    incident.attributed_threat_actors.append(ata)
+                else:
+                    incident.attributed_threat_actors = ata
             else:
                 entry_line = "attribute[{}][{}]: {}".format(attribute_category, attribute_type, attribute.value)
                 self.add_journal_entry(incident, entry_line)

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -341,11 +341,12 @@ class StixBuilder(object):
                 incident.leveraged_ttps.append(self.append_ttp(attribute_category, ttp))
             elif attribute_category == "Attribution":
                 ta = self.generate_threat_actor(attribute)
-                ata = AttributedThreatActors()
-                ata.append(ta)
+                rta = RelatedThreatActor(ta, relationship="Attribution")
                 if incident.attributed_threat_actors:
-                    incident.attributed_threat_actors.append(ata)
+                    incident.attributed_threat_actors.append(rta)
                 else:
+                    ata = AttributedThreatActors()
+                    ata.append(rta)
                     incident.attributed_threat_actors = ata
             else:
                 entry_line = "attribute[{}][{}]: {}".format(attribute_category, attribute_type, attribute.value)


### PR DESCRIPTION
We had a lot of problems getting the new STIX exporter to work on real data. With these changes all MISP events in https://www.circl.lu/doc/misp/feed-osint can be exported without errors.