### PR TITLE
Add timestamp to outer STIX_Package

### DIFF
--- a/app/files/scripts/misp2stix_framing.py
+++ b/app/files/scripts/misp2stix_framing.py
@@ -138,6 +138,7 @@ def main(args):
     stix_header.package_intents="Threat Report"
     stix_package.stix_header = stix_header
     stix_package.version = "1.1.1"
+    stix_package.timestamp = datetime.datetime.now()
 
     if args[3] == 'json':
         stix_string = stix_package.to_json()[:-1]


### PR DESCRIPTION
Currently there is no place where the time of export is saved. This used to be the outer STIX_Package timestamp. This patch brings it back.