### PR TITLE
Remove leading tab

### DIFF
--- a/app/Controller/GalaxiesController.php
+++ b/app/Controller/GalaxiesController.php
@@ -1,4 +1,4 @@
-	<?php
+<?php
 App::uses('AppController', 'Controller');
 
 class GalaxiesController extends AppController {


### PR DESCRIPTION
#### What does it do?

Remove leading tab character which will cause `Headers already sent` error.

The error occurs when output_buffering is set to "0" or no value  in `php.ini`.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
