### PR TITLE
Default sort order for timestamp / date reversed on click for Feed preview index

### DIFF
--- a/app/View/Feeds/preview_index.ctp
+++ b/app/View/Feeds/preview_index.ctp
@@ -30,11 +30,11 @@
 		<tr>
 			<th class="filter"><?php echo $this->Paginator->sort('Org', 'org'); ?></th>
 			<th class="filter">Tags</th>
-			<th class="filter"><?php echo $this->Paginator->sort('date');?></th>
+			<th class="filter"><?php echo $this->Paginator->sort('date', null, array('direction' => 'desc'));?></th>
 			<th class="filter" title="<?php echo $eventDescriptions['threat_level_id']['desc'];?>"><?php echo $this->Paginator->sort('threat_level_id');?></th>
 			<th class="filter" title="<?php echo $eventDescriptions['analysis']['desc']; ?>"><?php echo $this->Paginator->sort('analysis');?></th>
 			<th class="filter"><?php echo $this->Paginator->sort('info');?></th>
-			<th class="filter"><?php echo $this->Paginator->sort('timestamp');?></th>
+			<th class="filter"><?php echo $this->Paginator->sort('timestamp', null, array('direction' => 'desc'));?></th>
 			<th class="actions"><?php echo __('Actions');?></th>
 
 		</tr>


### PR DESCRIPTION
#### What does it do?

It copies the fix applied in #2723 for the Feed preview page.


#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [X] Minor
- [X] Patch
