### PR TITLE
fix: [javascript] Fixed JS broken in IE11 #3306

### DIFF
--- a/app/webroot/js/event-distribution-graph.js
+++ b/app/webroot/js/event-distribution-graph.js
@@ -30,7 +30,7 @@ function generate_additional_info(info) {
 		var to_ret = "\n\nInvolved:\n";
 		var sel = document.createElement('select');
 		sel.classList.add('distributionInfo');
-		for (var i of info) {
+		for (var i in info) {
 			var opt = document.createElement('option');
 			opt.val = i;
 			opt.innerHTML = i;

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -1297,7 +1297,7 @@ function choicePopup(legend, list) {
 		popupHtml += '<div class="popover_choice_main" id ="popover_choice_main">';
 			popupHtml += '<table style="width:100%;" id="MainTable">';
 				popupHtml += '<tbody>';
-					for (var item of list) {
+					for (var item in list) {
 						popupHtml += '<tr style="border-bottom:1px solid black;" class="templateChoiceButton">';
 							popupHtml += '<td role="button" tabindex="0" aria-label="All meta-categories" title="'+item.text+'" style="padding-left:10px;padding-right:10px; text-align:center;width:100%;" onClick="'+item.onclick+';">'+item.text+'</td>';
 						popupHtml += '</tr>';


### PR DESCRIPTION
Fixes #3306 partially.
The JS functionality now works again, however it looks like the JavaScript classes are not supported in IE11. See https://stackoverflow.com/a/46283975 proposing to use Babel (http://babeljs.io/) to cleanup and convert the javascript to something that works everywhere.

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
