### PR TITLE
Enable python3 for php-fpm for RHEL/CentOS

### DIFF
--- a/INSTALL/INSTALL.rhel7.txt
+++ b/INSTALL/INSTALL.rhel7.txt
@@ -136,6 +136,12 @@ git config core.filemode false
 scl enable rh-python36 'python3 setup.py install'
 umask $UMASK
 
+3.05/ Enable python3 for php-fpm
+
+echo 'source scl_source enable rh-python36' >> /etc/opt/rh/rh-php71/sysconfig/php-fpm
+sed -i.org -e 's/^;\(clear_env = no\)/\1/' /etc/opt/rh/rh-php71/php-fpm.d/www.conf
+systemctl restart rh-php71-php-fpm.service
+
 +---------------------+
 |   4/ CakePHP        |
 +---------------------+

--- a/INSTALL/UPDATE.txt
+++ b/INSTALL/UPDATE.txt
@@ -59,7 +59,14 @@ cd /var/www/MISP/PyMISP
 python3 setup.py install
 
 
-# 6. Update CakeResque and its dependencies
+# 6. For RHEL/CentOS: enable python3 for php-fpm
+
+echo 'source scl_source enable rh-python36' >> /etc/opt/rh/rh-php71/sysconfig/php-fpm
+sed -i.org -e 's/^;\(clear_env = no\)/\1/' /etc/opt/rh/rh-php71/php-fpm.d/www.conf
+systemctl restart rh-php71-php-fpm.service
+
+
+# 7. Update CakeResque and its dependencies
 
 cd /var/www/MISP/app
 
@@ -76,21 +83,21 @@ php composer.phar update
 cp -fa /var/www/MISP/INSTALL/setup/config.php /var/www/MISP/app/Plugin/CakeResque/Config/config.php
 
 
-# 7. Make sure all file permissions are set correctly
+# 8. Make sure all file permissions are set correctly
 
 find /var/www/MISP -type d -exec chmod g=rx {} \;
 chmod -R g+r,o= /var/www/MISP/
 chown -R www-data:www-data /var/www/MISP/
 
 
-# 8. Restart the CakeResque workers
+# 9. Restart the CakeResque workers
 
 su - www-data -s /bin/bash -c 'bash /var/www/MISP/app/Console/worker/start.sh'
 
 # You can also do this using the MISP application by navigating to the workers tab in the server settings and clicking on the "Restart all workers" button.
 
 
-# 9. Add any new dependencies that might have been added since you've last updated (shown below)
+# 10. Add any new dependencies that might have been added since you've last updated (shown below)
 
-# 10. Add requirements for the pubsub optional feature
+# 11. Add requirements for the pubsub optional feature
 pip install pyzmq

--- a/INSTALL/xINSTALL.centos6.txt
+++ b/INSTALL/xINSTALL.centos6.txt
@@ -101,6 +101,11 @@ python3 setup.py install
 cd /var/www/MISP/PyMISP
 python3 setup.py install
 
+# Enable python3 for php-fpm
+echo 'source scl_source enable rh-python36' >> /etc/opt/rh/rh-php56/sysconfig/php-fpm
+sed -i.org -e 's/^;\(clear_env = no\)/\1/' /etc/opt/rh/rh-php56/php-fpm.d/www.conf
+service rh-php56-php-fpm restart
+
 umask $UMASK
 
 4/ CakePHP

--- a/INSTALL/xINSTALL.centos7.txt
+++ b/INSTALL/xINSTALL.centos7.txt
@@ -104,6 +104,11 @@ python3 setup.py install
 cd /var/www/MISP/PyMISP
 python3 setup.py install
 
+# Enable python3 for php-fpm
+echo 'source scl_source enable rh-python36' >> /etc/opt/rh/rh-php56/sysconfig/php-fpm
+sed -i.org -e 's/^;\(clear_env = no\)/\1/' /etc/opt/rh/rh-php56/php-fpm.d/www.conf
+systemctl restart rh-php56-php-fpm.service
+
 umask $UMASK
 
 4/ CakePHP


### PR DESCRIPTION
The documentation was missing a crucial step for RHEL/CentOS: enable the use of python3 from within php.