### PR TITLE
Default sort order for timestamp in attribute view

### DIFF
--- a/app/View/Elements/eventattribute.ctp
+++ b/app/View/Elements/eventattribute.ctp
@@ -173,7 +173,7 @@
 			?>
 			<th class="context hidden"><?php echo $this->Paginator->sort('id');?></th>
 			<th class="context hidden">UUID</th>
-			<th><?php echo $this->Paginator->sort('timestamp', 'Date');?></th>
+			<th><?php echo $this->Paginator->sort('timestamp', 'Date', array('direction' => 'desc'));?></th>
 			<?php
 				if ($extended):
 			?>


### PR DESCRIPTION
#### What does it do?

It copies the fix applied in #2723 for the listing of attributes within an event

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [X] Minor
- [X] Patch
