### PR TITLE
chg: Case insensitive sort of organisation list

### DIFF
--- a/app/Controller/OrganisationsController.php
+++ b/app/Controller/OrganisationsController.php
@@ -12,9 +12,10 @@ class OrganisationsController extends AppController {
 	public $paginate = array(
 			'limit' => 60,
 			'maxLimit' => 9999,	// LATER we will bump here on a problem once we have more than 9999 events <- no we won't, this is the max a user van view/page.
-			'order' => array(
-					'Organisation.name' => 'ASC'
-			),
+            'order' => 'LOWER(Organisation.name)'
+			//'order' => array(
+			//		'Organisation.name' => 'ASC'
+			//),
 	);
 
 	public function index() {


### PR DESCRIPTION
#### What does it do?

In organisation list default view sort organisations case insensitive.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [X] Minor
- [ ] Patch
