### PR TITLE
fix: export events csv with CR (fix #3458)

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -2555,7 +2555,7 @@ class EventsController extends AppController {
 					if ($includeContext) {
 						foreach ($this->Event->csv_event_context_fields_to_fetch as $header => $field) {
 							if ($field['object']) $line .= ',' . $attribute['Event'][$field['object']][$field['var']];
-							else $line .= ',' . $attribute['Event'][$field['var']];
+							else $line .= ',' . str_replace(array("\n","\t","\r")," ",$attribute['Event'][$field['var']]);
 						}
 					}
 					$final[] = $line;


### PR DESCRIPTION
Export using automation functionality for ids does not clean the special char like CRLF.
When there is a carriage return in the event info, the csv is broken.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)? 

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
