### PR TITLE
new: restSearch: add parameter value_exact to improve performance.

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -2134,7 +2134,7 @@ class AttributesController extends AppController
             if (!isset($data['request'])) {
                 $data['request'] = $data;
             }
-            $paramArray = array('value', 'type', 'category', 'org', 'tags', 'from', 'to', 'last', 'eventid', 'uuid', 'published', 'publish_timestamp', 'timestamp', 'enforceWarninglist', 'to_ids', 'deleted', 'includeEventUuid', 'event_timestamp', 'threat_level_id');
+            $paramArray = array('value', 'value_exact', 'type', 'category', 'org', 'tags', 'from', 'to', 'last', 'eventid', 'uuid', 'published', 'publish_timestamp', 'timestamp', 'enforceWarninglist', 'to_ids', 'deleted', 'includeEventUuid', 'event_timestamp', 'threat_level_id');
             foreach ($paramArray as $p) {
                 if (isset($data['request'][$p])) {
                     ${$p} = $data['request'][$p];
@@ -2163,7 +2163,7 @@ class AttributesController extends AppController
         $subcondition = array();
         $this->loadModel('Attribute');
         // add the values as specified in the 2nd parameter to the conditions
-        $parameters = array('value', 'type', 'category', 'org', 'eventid', 'uuid');
+        $parameters = array('value', 'value_exact', 'type', 'category', 'org', 'eventid', 'uuid');
         foreach ($parameters as $k => $param) {
             if (isset(${$parameters[$k]}) && ${$parameters[$k]} !== false) {
                 $conditions = $this->Attribute->Event->setSimpleConditions($parameters[$k], ${$parameters[$k]}, $conditions);

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -3103,7 +3103,7 @@ class EventsController extends AppController
             if (!isset($data['request'])) {
                 $data['request'] = $data;
             }
-            $paramArray = array('value', 'type', 'category', 'org', 'tag', 'tags', 'searchall', 'from', 'to', 'last', 'eventid', 'withAttachments', 'metadata', 'uuid', 'published', 'publish_timestamp', 'timestamp', 'enforceWarninglist', 'sgReferenceOnly');
+            $paramArray = array('value', 'value_exact', 'type', 'category', 'org', 'tag', 'tags', 'searchall', 'from', 'to', 'last', 'eventid', 'withAttachments', 'metadata', 'uuid', 'published', 'publish_timestamp', 'timestamp', 'enforceWarninglist', 'sgReferenceOnly');
             foreach ($paramArray as $p) {
                 if (isset($data['request'][$p])) {
                     ${$p} = $data['request'][$p];
@@ -3143,8 +3143,8 @@ class EventsController extends AppController
         if (isset($searchall) && ($searchall == 1 || $searchall === true || $searchall == 'true')) {
             $eventIds = $this->__quickFilter($value);
         } else {
-            $parameters = array('value', 'type', 'category', 'org', 'uuid', 'eventid');
-            $attributeLevelFilters = array('value', 'type', 'category', 'uuid');
+            $parameters = array('value', 'value_exact', 'type', 'category', 'org', 'uuid', 'eventid');
+            $attributeLevelFilters = array('value', 'value_exact', 'type', 'category', 'uuid');
             $preFilterLevel = 'event';
             foreach ($parameters as $k => $param) {
                 if (${$parameters[$k]} !== null && ${$parameters[$k]} !== false) {

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -4303,8 +4303,16 @@ class Event extends AppModel
                             $subcondition['AND'][] = array('Attribute.event_id !=' => substr($v, 1));
                         }
                     } elseif ($parameterKey === 'uuid') {
+
                         $subcondition['AND'][] = array('Event.uuid !=' => substr($v, 1));
                         $subcondition['AND'][] = array('Attribute.uuid !=' => substr($v, 1));
+                    } else if ($parameterKey === 'value_exact') {
+                        // value* fields are indexed, so bypassing the virtualField
+                        // Value (generates "CONCAT") + avoiding leading '%'
+                        // wildcard leads to great performance improvements (8s ->
+                        // 0.01s)
+                        $subcondition['OR'][] = array('Attribute.value1 LIKE' => $v);
+                        $subcondition['OR'][] = array('Attribute.value2 LIKE' => $v);
                     } else {
                         $subcondition['AND'][] = array('Attribute.' . $parameterKey . ' NOT LIKE' => '%'.substr($v, 1).'%');
                     }
@@ -4336,6 +4344,13 @@ class Event extends AppModel
                     } elseif ($parameterKey === 'uuid') {
                         $subcondition['OR'][] = array('Attribute.uuid' => $v);
                         $subcondition['OR'][] = array('Event.uuid' => $v);
+                    } else if ($parameterKey === 'value_exact') {
+                        // value* fields are indexed, so bypassing the virtualField
+                        // Value (generates "CONCAT") + avoiding leading '%'
+                        // wildcard leads to great performance improvements (8s ->
+                        // 0.01s)
+                        $subcondition['OR'][] = array('Attribute.value1 LIKE' => $v);
+                        $subcondition['OR'][] = array('Attribute.value2 LIKE' => $v);
                     } else {
                         if (!empty($v)) {
                             $subcondition['OR'][] = array('Attribute.' . $parameterKey . ' LIKE' => '%'.$v.'%');


### PR DESCRIPTION
#### What does it do?
In order to take advantage of the index on the value1 & value2 fields:
* Get rid of the complex virtualField, filter on both value1 and value2
  instead.
* Get rid of the leading wildcard '%', which enables mysqld to use the
  index.

Observed improvements: on a typical SHA256 search, search performed
using PyMISP goes from 8s to 0.5s. The actual SELECT queries that
fetches results now executes in ~0.01s.

If you accept this commit, I will add support in PyMISP and open a pull request there as well.

#### Questions

- [x] Does it require a DB change? no
- [x] Are you using it in production? pre-prod
- [x] Does it require a change in the API (PyMISP for example)? Required to take advantage of the new feature only, everything else is unmodified (no breaking change)

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
