### PR TITLE
Issues 1643 -- Fix publish_without_email when an event is modified

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -2880,7 +2880,20 @@ class Event extends AppModel {
 								'user_id' => $user['id'],
 								'title' => 'Event edited from Server(' . $server['Server']['id'] . ') - "' . $server['Server']['name'] . '" - Notification by mail ' . $st,
 								'change' => ''
+                        ));
+				} else {
+				        $this->Log->create();
+						$this->Log->save(array(
+								'org' => $user['Organisation']['name'],
+								'model' => 'Event',
+								'model_id' => $saveResult['Event']['id'],
+								'email' => $user['email'],
+								'action' => 'add',
+								'user_id' => $user['id'],
+								'title' => 'Event edited (locally)',
+								'change' => ''
 						));
+                }
 				// do the necessary actions to publish the event (email, upload,...)
 				if (true != Configure::read('MISP.disablerestalert')) {
 					$this->sendAlertEmailRouter($id, $user, $existingEvent['Event']['publish_timestamp']);

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -2865,6 +2865,22 @@ class Event extends AppModel {
 										'Server.publish_without_email'
 								)
 						));
+						if ($server['Server']['publish_without_email'] == 0) {
+						    $st = "enabled";
+						} else {
+						    $st = "disabled";
+						}
+						$this->Log->create();
+						$this->Log->save(array(
+								'org' => $user['Organisation']['name'],
+								'model' => 'Event',
+								'model_id' => $saveResult['Event']['id'],
+								'email' => $user['email'],
+								'action' => 'add',
+								'user_id' => $user['id'],
+								'title' => 'Event edited from Server(' . $server['Server']['id'] . ') - "' . $server['Server']['name'] . '" - Notification by mail ' . $st,
+								'change' => ''
+						));
 				// do the necessary actions to publish the event (email, upload,...)
 				if (true != Configure::read('MISP.disablerestalert')) {
 					$this->sendAlertEmailRouter($id, $user, $existingEvent['Event']['publish_timestamp']);

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -2850,49 +2850,49 @@ class Event extends AppModel {
 			}
 			// if published -> do the actual publishing
             if ((!empty($data['Event']['published']) && 1 == $data['Event']['published'])) {
-				// The edited event is from a remote server ?
+			    // The edited event is from a remote server ?
 				if ($passAlong) {
-						$this->Server = ClassRegistry::init('Server');
-						$server = $this->Server->find('first', array(
-								'conditions' => array(
-										'Server.id' => $passAlong
+					$this->Server = ClassRegistry::init('Server');
+					$server = $this->Server->find('first', array(
+					    'conditions' => array(
+						    'Server.id' => $passAlong
 						),
-								'recursive' => -1,
-								'fields' => array(
-										'Server.name',
-										'Server.id',
-										'Server.unpublish_event',
-										'Server.publish_without_email'
-								)
-						));
-						if ($server['Server']['publish_without_email'] == 0) {
-						    $st = "enabled";
-						} else {
-						    $st = "disabled";
-						}
-						$this->Log->create();
-						$this->Log->save(array(
-								'org' => $user['Organisation']['name'],
-								'model' => 'Event',
-								'model_id' => $saveResult['Event']['id'],
-								'email' => $user['email'],
-								'action' => 'add',
-								'user_id' => $user['id'],
-								'title' => 'Event edited from Server(' . $server['Server']['id'] . ') - "' . $server['Server']['name'] . '" - Notification by mail ' . $st,
-								'change' => ''
-                        ));
+						'recursive' => -1,
+						'fields' => array(
+						    'Server.name',
+							'Server.id',
+							'Server.unpublish_event',
+							'Server.publish_without_email'
+						)
+					));
+					if ($server['Server']['publish_without_email'] == 0) {
+					    $st = "enabled";
+					} else {
+					    $st = "disabled";
+					}
+					$this->Log->create();
+					$this->Log->save(array(
+					    'org' => $user['Organisation']['name'],
+						'model' => 'Event',
+						'model_id' => $saveResult['Event']['id'],
+						'email' => $user['email'],
+						'action' => 'add',
+						'user_id' => $user['id'],
+						'title' => 'Event edited from Server(' . $server['Server']['id'] . ') - "' . $server['Server']['name'] . '" - Notification by mail ' . $st,
+						'change' => ''
+                    ));
 				} else {
-				        $this->Log->create();
-						$this->Log->save(array(
-								'org' => $user['Organisation']['name'],
-								'model' => 'Event',
-								'model_id' => $saveResult['Event']['id'],
-								'email' => $user['email'],
-								'action' => 'add',
-								'user_id' => $user['id'],
-								'title' => 'Event edited (locally)',
-								'change' => ''
-						));
+				    $this->Log->create();
+					$this->Log->save(array(
+						'org' => $user['Organisation']['name'],
+						'model' => 'Event',
+					    'model_id' => $saveResult['Event']['id'],
+						'email' => $user['email'],
+						'action' => 'add',
+						'user_id' => $user['id'],
+						'title' => 'Event edited (locally)',
+						'change' => ''
+					));
                 }
 				// do the necessary actions to publish the event (email, upload,...)
 				if ((true != Configure::read('MISP.disablerestalert')) && (empty($server) || $server['Server']['publish_without_email'] == 0)) {

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -2722,7 +2722,7 @@ class Event extends AppModel {
 		}
 	}
 
-	public function _edit(&$data, $user, $id, $jobId = null) {
+	public function _edit(&$data, $user, $id, $jobId = null, $passAlong = null) {
 		$data = $this->cleanupEventArrayFromXML($data);
 		unset($this->Attribute->validate['event_id']);
 		unset($this->Attribute->validate['value']['unique']); // otherwise gives bugs because event_id is not set
@@ -2849,7 +2849,22 @@ class Event extends AppModel {
 				}
 			}
 			// if published -> do the actual publishing
-			if ((!empty($data['Event']['published']) && 1 == $data['Event']['published'])) {
+            if ((!empty($data['Event']['published']) && 1 == $data['Event']['published'])) {
+				// The edited event is from a remote server ?
+				if ($passAlong) {
+						$this->Server = ClassRegistry::init('Server');
+						$server = $this->Server->find('first', array(
+								'conditions' => array(
+										'Server.id' => $passAlong
+						),
+								'recursive' => -1,
+								'fields' => array(
+										'Server.name',
+										'Server.id',
+										'Server.unpublish_event',
+										'Server.publish_without_email'
+								)
+						));
 				// do the necessary actions to publish the event (email, upload,...)
 				if (true != Configure::read('MISP.disablerestalert')) {
 					$this->sendAlertEmailRouter($id, $user, $existingEvent['Event']['publish_timestamp']);

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -2895,7 +2895,7 @@ class Event extends AppModel {
 						));
                 }
 				// do the necessary actions to publish the event (email, upload,...)
-				if (true != Configure::read('MISP.disablerestalert')) {
+				if ((true != Configure::read('MISP.disablerestalert')) && (empty($server) || $server['Server']['publish_without_email'] == 0)) {
 					$this->sendAlertEmailRouter($id, $user, $existingEvent['Event']['publish_timestamp']);
 				}
 				$this->publish($existingEvent['Event']['id']);

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1844,10 +1844,10 @@ class Server extends AppModel {
 						$event['Event']['user_id'] = $user['id'];
 						// check if the event already exist (using the uuid)
 						$existingEvent = null;
-						$existingEvent = $eventModel->find('first', array('conditions' => array('Event.uuid' => $event['Event']['uuid'])));
+                        $existingEvent = $eventModel->find('first', array('conditions' => array('Event.uuid' => $event['Event']['uuid'])));
+                        $passAlong = $server['Server']['id'];
 						if (!$existingEvent) {
 							// add data for newly imported events
-							$passAlong = $server['Server']['id'];
 							$result = $eventModel->_add($event, true, $user, $server['Server']['org_id'], $passAlong, true, $jobId);
 							if ($result) $successes[] = $eventId;
 							else {
@@ -1857,7 +1857,7 @@ class Server extends AppModel {
 						} else {
 							$tempUser = $user;
 							$tempUser['Role']['perm_site_admin'] = 0;
-							$result = $eventModel->_edit($event, $tempUser, $existingEvent['Event']['id'], $jobId);
+							$result = $eventModel->_edit($event, $tempUser, $existingEvent['Event']['id'], $jobId, $passAlong);
 							if ($result === true) $successes[] = $eventId;
 							else if (isset($result['error'])) $fails[$eventId] = $result['error'];
 							else $fails[$eventId] = json_encode($result);


### PR DESCRIPTION
Hello all,

I push this quickly & unclean PR to fix the following issue/bug: MISP shouldn't send emails when a remote event if modified, published and pulled (Sync) with the option ```publish_without_email``` enable.

Indeed, when an event is modified (remotely), published and pulled (Sync), the local MISP instance doesn't take account of the option ```publish_without_email``` and send automatically emails.

This issue doesn't occur when the event is new (added via https://github.com/MISP/MISP/blob/2.4/app/Model/Event.php#L2503), thanks to @lucamemini (#2991) and #1643

Don't hesitate to contact me if you need some help and if you have some question.

devnull-


#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
