### PR TITLE
Use original orgname at stix-header:title

### DIFF
--- a/app/files/scripts/misp2stix_framing.py
+++ b/app/files/scripts/misp2stix_framing.py
@@ -110,7 +110,7 @@ def main(args):
         idgen.set_id_namespace(Namespace(baseURL, orgname, "MISP"))
     stix_package = STIXPackage()
     stix_header = STIXHeader()
-    stix_header.title="Export from {} MISP".format(orgname)
+    stix_header.title="Export from {} MISP".format(args[2])
     stix_header.package_intents="Threat Report"
     stix_package.stix_header = stix_header
     stix_package.version = "1.1.1"


### PR DESCRIPTION
Since f4ff165e367833c727aeda453e55eca6757da3ae the stix-header:title uses to mangled orgname. This patch preserves the original orgname as set in MISP.