### PR TITLE
chg: [bug] Fixed wrong event lookup in case the uuid is passed as an eventId.

### DIFF
--- a/app/Controller/ObjectsController.php
+++ b/app/Controller/ObjectsController.php
@@ -105,7 +105,7 @@ class ObjectsController extends AppController
         $eventFindParams = array(
             'recursive' => -1,
             'fields' => array('Event.id', 'Event.uuid', 'Event.orgc_id'),
-            'conditions' => array('Event.id' => $eventId)
+            'conditions' => array()
         );
 
         if (!empty($templateId) && Validation::uuid($templateId)) {


### PR DESCRIPTION
#### What does it do?

It fixes the code that had two mutually exclusive conditions `Event.id = uuid and Event.uuid = uuid` so we were getting `Invalid event.` error

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [X] Patch
