### PR TITLE
Add a permission check to the change password page.

### DIFF
--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -164,6 +164,9 @@ class UsersController extends AppController
 
     public function change_pw()
     {
+        if (!$this->_isAdmin() && Configure::read('MISP.disableUserSelfManagement')) {
+            throw new MethodNotAllowedException('User self-management has been disabled on this instance.');
+        }
         $id = $this->Auth->user('id');
         $user = $this->User->find('first', array(
             'conditions' => array('User.id' => $id),


### PR DESCRIPTION
Fixes #3554.

The 'MISP.disableUserSelfManagement' config variable is checked
when rendering the link to the change password page, but is not checked
when rendering the page itself. This could lead to unauthorised
password changes by users with existing accounts on the MISP
instance.

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2016-06-03: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

If it fixes an existing issue, please use github syntax: `#<IssueID>`

#### Questions

- [ ] Does it require a DB change? No.
- [X] Are you using it in production? Yes, on our internal/sandbox server.
- [ ] Does it require a change in the API (PyMISP for example)? No.

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
