### PR TITLE
Use AWS S3 as an attachment storage

### DIFF
--- a/INSTALL/INSTALL.s3-attachments.txt
+++ b/INSTALL/INSTALL.s3-attachments.txt
@@ -16,6 +16,17 @@ There's a massive caveat here so let me make this incredibly clear
 #      THEIR EXPLICIT PERMISSION             #
 ##############################################      
 
+0. Installing Dependencies
+--------------------------
+
+Install the AWS PHP SDK
+
+```bash
+cd /var/www/MISP/app
+sudo -u www-data php composer.phar config vendor-dir Vendor
+sudo -u www-data php composer.phar require aws/aws-sdk-php
+```
+
 1. Creating an S3 bucket
 -------------------------
 

--- a/INSTALL/INSTALL.s3-attachments.txt
+++ b/INSTALL/INSTALL.s3-attachments.txt
@@ -1,0 +1,86 @@
+Using S3 as an attachment store
+===============================
+
+It is possible to use Amazon's Simple Storage Service (S3) to store event attachments
+to allow for a stateless MISP setup (i.e for containerisation)
+
+There's a massive caveat here so let me make this incredibly clear
+
+##############################################
+#        WARNING WARNING WARNING             #
+#                                            #
+#    Storing malware is against amazon's     #
+#            terms of service.               #
+#                                            #
+#    DO NOT USE THIS UNLESS YOU HAVE         # 
+#      THEIR EXPLICIT PERMISSION             #
+##############################################      
+
+1. Creating an S3 bucket
+-------------------------
+
+Go to https://s3.console.aws.amazon.com/s3/home
+
+And create a bucket. It has to have a globally unique name, and
+this cannot be changed later on.
+
+2a. Using an EC2 instance for MISP
+-----------------------------------
+
+If you run MISP on EC2, this will be super duper easy peasy.
+
+Simply create an IAM role with the following permissions and assign it to the instance
+by right-clicking and selecting "Instance Settings -> Attach/Replace IAM role"
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+        "Sid": "PermitMISPAttachmentsToS3",
+        "Effect": "Allow",
+        "Action": [
+            "s3:*"
+        ],
+        "Resource": [
+            "arn:aws:s3:::your-bucket-name"
+        ]
+    }
+  ]
+}
+```
+
+2b. Using AWS access keys
+-------------------------
+
+This is not recommended, but it works I think.
+
+Create a new programmatic access user via IAM and apply the same
+policy outlined above.
+
+Copy the access keys and save them for the next step
+
+3. Setting up MISP
+------------------
+
+In Administration -> Server Settings & Maintenance -> MISP settings
+
+    Set MISP.attachments_dir to "s3://"
+
+In Administration -> Server Settings & Maintenance -> Plugin Settings -> S3
+
+    Set S3_enable to True
+    Set S3_bucket-name to the bucket you created earlier
+    Set S3_region to your region
+    
+    ONLY IF YOU DID NOT USE THE EC2 METHOD
+        Set aws_access_key and aws_secret_key to the ones you created in 2b
+
+Now theoretically it should work.
+
+Addendum
+========
+
+If you are migrating a server currently in use, simply copy the directory structure from
+the attachments folder (usually /var/www/MISP/app/files) to S3 and everything should 
+continue to work.

--- a/app/Lib/Tools/AWSS3Client.php
+++ b/app/Lib/Tools/AWSS3Client.php
@@ -46,25 +46,49 @@ class AWSS3Client
 
         $this->__client = $s3;
         $this->__settings = $settings;
-        return $client;
+        return $s3;
     }
 
     public function upload($key, $data)
     {
-        $this->__client.putObject([
-            'Bucket' => $this.__settings['bucket_name'],
+        $this->__client->putObject([
+            'Bucket' => $this->__settings['bucket_name'],
             'Key' => $key,
             'Body' => $data
-        ]);
+       ]);
     }
 
     public function download($key)
     {
-        $result = $this->__client.getObject([
-            'Bucket' => $this.__settings['bucket_name'],
+        $result = $this->__client->getObject([
+            'Bucket' => $this->__settings['bucket_name'],
             'Key' => $key
         ]);
 
         return $result['Body'];
+    }
+
+    public function delete($key)
+    {
+        $this->__client->deleteObject([
+            'Bucket' => $this->__settings['bucket_name'],
+            'Key' => $key
+        ]);
+    }
+
+    public function deleteDirectory($prefix) {
+        $keys = $s3->listObjects([
+            'Bucket' => $this->__settings['bucket_name'],
+            'Prefix' => $prefix
+        ]) ->getPath('Contents/*/Key');
+
+        $s3->deleteObjects([
+            'Bucket'  => $bucket,
+            'Delete' => [
+                'Objects' => array_map(function ($key) {
+                    return ['Key' => $key];
+                }, $keys)
+            ],
+        ]);
     }
 }

--- a/app/Lib/Tools/S3Client.php
+++ b/app/Lib/Tools/S3Client.php
@@ -1,0 +1,70 @@
+<?php
+
+use Aws\S3\S3Client;
+
+class AWSS3Client
+{
+    private $__settings = false;
+    private $__client = false;
+
+    private function __getSetSettings()
+    {
+        $settings = array(
+                'enabled' => false,
+                'bucket_name' => 'my-malware-bucket',
+                'region' => 'eu-west-1',
+                'aws_access_key' => '',
+                'aws_secret_key' => ''
+        );
+
+        // We have 2 situations
+        // Either we're running on EC2 and we can assume an IAM role
+        // Or we're not and need explicitly set AWS key
+        if (strlen($settings['aws_access_key']) > 0) {
+            putenv('AWS_ACCESS_KEY_ID='.$settings['aws_access_key']);
+        }
+        if (strlen($settings['aws_secret_key']) > 0) {
+            putenv('AWS_SECRET_ACCESS_KEY='.$settings['aws_secret_key']);
+        }
+
+        foreach ($settings as $key => $setting) {
+            $temp = Configure::read('Plugin.S3_' . $key);
+            if ($temp) {
+                $settings[$key] = $temp;
+            }
+        }
+        return $settings;
+    }
+
+    public function initTool()
+    {
+        $settings = $this->__getSetSettings();
+        $s3 = new Aws\S3\S3Client([
+            'version' => 'latest',
+            'region' => $settings['region']
+        ]);
+
+        $this->__client = $s3;
+        $this->__settings = $settings;
+        return $client;
+    }
+
+    public function upload($key, $data)
+    {
+        $this->__client.putObject([
+            'Bucket' => $this.__settings['bucket_name'],
+            'Key' => $key,
+            'Body' => $data
+        ]);
+    }
+
+    public function download($key)
+    {
+        $result = $this->__client.getObject([
+            'Bucket' => $this.__settings['bucket_name'],
+            'Key' => $key
+        ]);
+
+        return $result['Body'];
+    }
+}

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -38,6 +38,7 @@ class AppModel extends Model
     private $__profiler = array();
 
     public $elasticSearchClient = false;
+    public $s3Client = false;
 
     public function __construct($id = false, $table = null, $ds = null)
     {
@@ -1455,6 +1456,26 @@ class AppModel extends Model
         $client = new ElasticSearchClient();
         $client->initTool();
         $this->elasticSearchClient = $client;
+    }
+
+    public function getS3Client() {
+        if (!$this->s3Client) {
+            $this->s3Client = $this->loadS3Client();
+        }
+
+        return $this->s3Client;
+    }
+
+    public function loadS3Client() {
+        App::uses('AWSS3Client', 'Tools');
+        $client = new AWSS3Client();
+        $client->initTool();
+        return $client;
+    }
+
+    public function attachmentDirIsS3() {
+        // Naive way to detect if we're working in S3
+        return substr(Configure::read('MISP.attachments_dir'), 0, 2) === "s3";
     }
 
     public function checkVersionRequirements($versionString, $minVersion)

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1386,6 +1386,46 @@ class Server extends AppModel
                             'test' => 'testForEmpty',
                             'type' => 'string'
                         ),
+                        'S3_enable' => array(
+                            'level' => 2,
+                            'description' => __('Enables or disables uploading of malware samples to S3 rather than to disk (WARNING: Get permission from amazon first!)'),
+                            'value' => false,
+                            'errorMessage' => '',
+                            'test' => 'testBool',
+                            'type' => 'boolean'
+                        ),
+                        'S3_bucket_name' => array(
+                            'level' => 2,
+                            'description' => __('Bucket name to upload to'),
+                            'value' => '',
+                            'errorMessage' => '',
+                            'test' => 'testForEmpty',
+                            'type' => 'string'
+                        ),
+                        'S3_region' => array(
+                            'level' => 2,
+                            'description' => __('Region in which your S3 bucket resides'),
+                            'value' => '',
+                            'errorMessage' => '',
+                            'test' => 'testForEmpty',
+                            'type' => 'string'
+                        ),
+                        'S3_aws_access_key' => array(
+                            'level' => 2,
+                            'description' => __('AWS key to use when uploading samples (WARNING: It\' highly recommended that you use EC2 IAM roles if at all possible)'),
+                            'value' => '',
+                            'errorMessage' => '',
+                            'test' => 'testForEmpty',
+                            'type' => 'string'
+                        ),
+                        'S3_aws_secret_key' => array(
+                            'level' => 2,
+                            'description' => __('AWS secret key to use when uploading samples'),
+                            'value' => '',
+                            'errorMessage' => '',
+                            'test' => 'testForEmpty',
+                            'type' => 'string'
+                        ),
                         'Sightings_policy' => array(
                             'level' => 1,
                             'description' => __('This setting defines who will have access to seeing the reported sightings. The default setting is the event owner alone (in addition to everyone seeing their own contribution) with the other options being Sighting reporters (meaning the event owner and anyone that provided sighting data about the event) and Everyone (meaning anyone that has access to seeing the event / attribute).'),
@@ -3979,6 +4019,11 @@ class Server extends AppModel
     public function getDefaultAttachments_dir()
     {
         return APP . 'files';
+    }
+
+    public function getDefaultTmp_dir() 
+    {
+        return sys_get_temp_dir();
     }
 
     public function fetchServer($id)

--- a/app/composer.json
+++ b/app/composer.json
@@ -7,6 +7,7 @@
         "pear/net_geoip": "@dev"
     },
     "suggest": {
-        "elasticsearch/elasticsearch": "For logging to elasticsearch"
+        "elasticsearch/elasticsearch": "For logging to elasticsearch",
+        "aws/aws-sdk-php": "To upload samples to S3"
     }
 }


### PR DESCRIPTION
#### What does it do?

Adds a setting to offload `attachments_dir` to an S3 bucket

Shouldn't interfere with standard non-s3 installations 

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
