### PR TITLE
Control CakeResque Redis connection

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -816,7 +816,6 @@ class AppController extends Controller
         $result = false;
         if (Configure::read('Plugin.CustomAuth_enable')) {
             $header = Configure::read('Plugin.CustomAuth_header') ? Configure::read('Plugin.CustomAuth_header') : 'Authorization';
-            $header = strtoupper($header);
             $authName = Configure::read('Plugin.CustomAuth_name') ? Configure::read('Plugin.CustomAuth_name') : 'External authentication';
             $headerNamespace = Configure::read('Plugin.CustomAuth_use_header_namespace') ? (Configure::read('Plugin.CustomAuth_header_namespace') ? Configure::read('Plugin.CustomAuth_header_namespace') : 'HTTP_') : '';
             if (isset($server[$headerNamespace . $header]) && !empty($server[$headerNamespace . $header])) {


### PR DESCRIPTION
Adds `CakeResque.Redis.*` settings under `MISP` in server settings and maintenance. Currently has to do a bit of array flattening to deal with nested array settings, but seems to not break everything 

Also a misc fix in which attachments_dir was tested for writable failing when it was set to s3:// 

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
