### PR TITLE
Fix broken timestamps by using 24 hour clock and ISO 8601 date format

### DIFF
--- a/app/Lib/Tools/IOCExportTool.php
+++ b/app/Lib/Tools/IOCExportTool.php
@@ -55,7 +55,7 @@ class IOCExportTool
     {
         $temp = '';
         // We will start adding all the components that will be in the xml file here
-        $date = date("Y-m-d\Th:i:s");
+        $date = date("Y-m-d\TH:i:s");
         $temp .= '<?xml version="1.0" encoding="utf-8"?>' . PHP_EOL;
         $temp .= '<ioc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" id="' . CakeText::uuid() . '" last-modified="' . $date . '" xmlns="http://schemas.mandiant.com/2010/ioc">' . PHP_EOL;
         $temp .= '  <short_description>Filtered indicator list</short_description>' . PHP_EOL;

--- a/app/View/Events/view.ctp
+++ b/app/View/Events/view.ctp
@@ -170,7 +170,7 @@
                 <dd><?php echo h($attribute_count);?></dd>
                 <dt><?php echo __('Last change');?></dt>
                 <dd>
-                    <?php echo date('Y/m/d h:i:s', $event['Event']['timestamp']);; ?>
+                    <?php echo date('Y-m-d H:i:s', $event['Event']['timestamp']);; ?>
                     &nbsp;
                 </dd>
                 <dt><?php echo __('Extends');?></dt>


### PR DESCRIPTION
#### What does it do?

The event view shows a wrong "Last change", e.g. "2018/08/23 06:01:45"
for "2018/08/23 18:01:45".  The same problem affects the timestamp in
the XML generated by IOCExportTool.php.  Fix by correcting the PHP
date() code "h" to "H".

While here, also switch to a clearer ISO 8601 date representation for
"Last change", using dashes instead of slashes for separation of year,
month and day.

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:

- [ ] Major
- [ ] Minor
- [X] Patch
