### PR TITLE
fix: create temp folder if it doesn't exist in EventsController::expo…

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -2335,7 +2335,7 @@ class EventsController extends AppController
                             ),
                         'order' => array('Job.id' => 'desc')
                 ));
-                $dir = new Folder(APP . 'tmp/cached_exports/' . $k);
+                $dir = new Folder(APP . 'tmp/cached_exports/' . $k, true);
                 if ($k === 'text') {
                     // Since all of the text export files are generated together, we might as well just check for a single one md5.
                     $file = new File($dir->pwd() . DS . 'misp.text_md5.' . $org_name . $type['extension']);


### PR DESCRIPTION
#### What does it do?

Fix bug in EventsController: temp folder was not created at https://github.com/MISP/MISP/blob/f3558fb18aaedc803d471409e747c54758bf50b2/app/Controller/EventsController.php#L2338, which caused `$dir` to be empty; then, the next call to `Folder()` was applied to "/", which is not allowed in my `open_basedir`, of course.


#### Questions

- [x] Does it require a DB change? no
- [x] Are you using it in production? yes
- [x] Does it require a change in the API (PyMISP for example)? no

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
