### PR TITLE
Prevent STIX export crash

### DIFF
--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -962,7 +962,7 @@ class StixBuilder(object):
         n_attribute = len(attributes_dict)
         whois_object = WhoisEntry()
         for attribute in attributes_dict:
-            if "registrant-" in attribute:
+            if attribute and "registrant-" in attribute:
                 whois_object.registrants = self.fill_whois_registrants(attributes_dict)
                 break
         if  'registrar' in attributes_dict:


### PR DESCRIPTION
attribute can be None which causes the STIX conversion to crash
