### PR TITLE
fix: [doc] Add an option to checkout submodules recursively

### DIFF
--- a/INSTALL/INSTALL.FreeBSD.txt
+++ b/INSTALL/INSTALL.FreeBSD.txt
@@ -177,10 +177,9 @@ sudo python3 setup.py install
 -----------
 # CakePHP is included as a submodule of MISP, execute the following commands to let git fetch it:
 cd /usr/local/www/MISP
-sudo -u www git submodule init
-sudo -u www git submodule update
+sudo -u www git submodule update --init --recursive
 # Make git ignore filesystem permission differences for submodules
-sudo -u www git submodule foreach git config core.filemode false
+sudo -u www git submodule foreach --recursive git config core.filemode false
 
 # Once done, install CakeResque along with its dependencies if you intend to use the built in background jobs:
 cd /usr/local/www/MISP/app

--- a/INSTALL/INSTALL.OpenBSD.txt
+++ b/INSTALL/INSTALL.OpenBSD.txt
@@ -272,10 +272,9 @@ doas pip3.6 install stix2
 ```
 # CakePHP is included as a submodule of MISP, execute the following commands to let git fetch it:
 cd /var/www/htdocs/MISP
-doas -u www git submodule init
-doas -u www git submodule update
+doas -u www git submodule update --init --recursive
 # Make git ignore filesystem permission differences for submodules
-doas -u www git submodule foreach git config core.filemode false
+doas -u www git submodule foreach --recursive git config core.filemode false
 
 # Once done, install CakeResque along with its dependencies if you intend to use the built in background jobs:
 cd /var/www/htdocs/MISP/app

--- a/INSTALL/INSTALL.debian9.txt
+++ b/INSTALL/INSTALL.debian9.txt
@@ -162,10 +162,9 @@ cd $PATH_TO_MISP/app/files/scripts/mixbox
 sudo pip3 install .
 
 cd $PATH_TO_MISP
-sudo -u www-data git submodule init
-sudo -u www-data git submodule update
+sudo -u www-data git submodule update --init --recursive
 # Make git ignore filesystem permission differences for submodules
-sudo -u www-data git submodule foreach git config core.filemode false
+sudo -u www-data git submodule foreach --recursive git config core.filemode false
 
 # install PyMISP
 cd $PATH_TO_MISP/PyMISP
@@ -678,8 +677,7 @@ sudo apt-get install -y libssl-dev swig python3-ssdeep p7zip-full unrar-free sql
 sudo pip3 install SQLAlchemy PrettyTable python-magic
 sudo git clone https://github.com/viper-framework/viper.git
 cd viper
-sudo git submodule init
-sudo git submodule update
+sudo git submodule update --init --recursive
 sudo pip3 install -r requirements.txt
 sudo pip3 uninstall yara -y
 /usr/local/src/viper/viper-cli -h

--- a/INSTALL/INSTALL.debian_testing.txt
+++ b/INSTALL/INSTALL.debian_testing.txt
@@ -174,10 +174,9 @@ cd $PATH_TO_MISP/app/files/scripts/mixbox
 sudo pip3 install .
 
 cd $PATH_TO_MISP
-sudo -u www-data git submodule init
-sudo -u www-data git submodule update
+sudo -u www-data git submodule update --init --recursive
 # Make git ignore filesystem permission differences for submodules
-sudo -u www-data git submodule foreach git config core.filemode false
+sudo -u www-data git submodule foreach --recursive git config core.filemode false
 
 # install PyMISP
 cd $PATH_TO_MISP/PyMISP
@@ -701,8 +700,7 @@ sudo apt-get install -y libssl-dev swig python3-ssdeep p7zip-full unrar-free sql
 sudo pip3 install SQLAlchemy PrettyTable python-magic
 sudo git clone https://github.com/viper-framework/viper.git
 cd viper
-sudo git submodule init
-sudo git submodule update
+sudo git git submodule update --init --recursive
 sudo pip3 install -r requirements.txt
 sudo pip3 uninstall yara -y
 /usr/local/src/viper/viper-cli -h

--- a/INSTALL/INSTALL.kali.txt
+++ b/INSTALL/INSTALL.kali.txt
@@ -149,10 +149,9 @@ function installMISPonKali() {
   pip3 install .
 
   cd $PATH_TO_MISP
-  $SUDO_WWW git submodule init
-  $SUDO_WWW git submodule update
+  $SUDO_WWW git submodule update --init --recursive
   # Make git ignore filesystem permission differences for submodules
-  $SUDO_WWW git submodule foreach git config core.filemode false
+  $SUDO_WWW git submodule foreach --recursive git config core.filemode false
 
   # install PyMISP
   cd $PATH_TO_MISP/PyMISP
@@ -515,8 +514,7 @@ function installMISPonKali() {
   git clone https://github.com/viper-framework/viper.git
   chown -R $MISP_USER:$MISP_USER viper
   cd viper
-  $SUDO git submodule init
-  $SUDO git submodule update
+  $SUDO git submodule update --init --recursive
   pip3 install -r requirements.txt
   pip3 uninstall yara -y
   $SUDO /usr/local/src/viper/viper-cli -h > /dev/null

--- a/INSTALL/INSTALL.rhel7.txt
+++ b/INSTALL/INSTALL.rhel7.txt
@@ -152,10 +152,9 @@ systemctl restart rh-php71-php-fpm.service
 4.01/ CakePHP is now included as a submodule of MISP, execute the following commands to let git fetch it ignore this
 message: No submodule mapping found in .gitmodules for path 'app/Plugin/CakeResque'
 cd /var/www/MISP
-git submodule init
-git submodule update
+git submodule update --init --recursive
 # Make git ignore filesystem permission differences for submodules
-git submodule foreach git config core.filemode false
+git submodule foreach --recursive git config core.filemode false
 
 4.02/ Install CakeResque along with its dependencies if you intend to use the built in background jobs
 cd /var/www/MISP/app

--- a/INSTALL/INSTALL.ubuntu1804.txt
+++ b/INSTALL/INSTALL.ubuntu1804.txt
@@ -56,10 +56,9 @@ sudo mkdir /var/www/MISP
 sudo chown www-data:www-data /var/www/MISP
 cd /var/www/MISP
 sudo -u www-data git clone https://github.com/MISP/MISP.git /var/www/MISP
-sudo -u www-data git submodule init
-sudo -u www-data git submodule update
+sudo -u www-data git submodule update --init --recursive
 # Make git ignore filesystem permission differences for submodules
-sudo -u www-data git submodule foreach git config core.filemode false
+sudo -u www-data git submodule foreach --recursive git config core.filemode false
 
 # Make git ignore filesystem permission differences
 sudo -u www-data git config core.filemode false

--- a/INSTALL/INSTALL.ubuntu1804.with.webmin.txt
+++ b/INSTALL/INSTALL.ubuntu1804.with.webmin.txt
@@ -80,11 +80,10 @@ git checkout tags/$(git describe --tags `git rev-list --tags --max-count=1`)
 # the message regarding a "detached HEAD state" is expected behaviour
 # (you only have to create a new branch, if you want to change stuff and do a pull request for example)
 
-git submodule init
-git submodule update
+git submodule update --init --recursive
 
 # Make git ignore filesystem permission differences
-git submodule foreach git config core.filemode false
+git submodule foreach --recursive git config core.filemode false
 
 # install Mitre's STIX and its dependencies by running the following commands:
 sudo apt-get install python3-dev python3-pip libxml2-dev libxslt1-dev zlib1g-dev python-setuptools python-pip

--- a/INSTALL/xINSTALL.centos6.txt
+++ b/INSTALL/xINSTALL.centos6.txt
@@ -115,10 +115,9 @@ umask $UMASK
 # No submodule mapping found in .gitmodules for path 'app/Plugin/CakeResque'
 
 cd /var/www/MISP
-git submodule init
-git submodule update
+git submodule update --init --recursive
 # Make git ignore filesystem permission differences for submodules
-git submodule foreach git config core.filemode false
+git submodule foreach --recursive git config core.filemode false
 
 # Once done, install CakeResque along with its dependencies if you intend to use the built in background jobs:
 cd /var/www/MISP/app

--- a/INSTALL/xINSTALL.centos7.txt
+++ b/INSTALL/xINSTALL.centos7.txt
@@ -131,10 +131,9 @@ sudo git config core.filemode false
 
 # Fetch submodules
 cd /var/www/MISP
-sudo git submodule init
-sudo git submodule update
+sudo git submodule update --init --recursive
 # Make git ignore filesystem permission differences for submodules
-sudo git submodule foreach git config core.filemode false
+sudo git submodule foreach --recursive git config core.filemode false
 
 # install Mitre's STIX and its dependencies by running the following commands:
 sudo yum install python-importlib python-lxml python-dateutil python-six -y


### PR DESCRIPTION
#### What does it do?

Some submodules such as PyMISP have submodule in it. We need to pass `--recursive` option to recursively init and update submodules in order to make those submodules work properly.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
