### PR TITLE
Unify url for modules, make them usable behind proxies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -35,5 +35,5 @@
 	url = https://github.com/MISP/misp-noticelist
 [submodule "Plugin/DebugKit"]
 	path = Plugin/DebugKit
-	url = git://github.com/cakephp/debug_kit.git
+	url = https://github.com/cakephp/debug_kit.git
 	branch = 2.2


### PR DESCRIPTION
#### What does it do?

Let's people using git behind proxies, get all the submodules.

#### Questions

- [ NO] Does it require a DB change?
- [ TRYING] Are you using it in production?
- [ NO] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [X] Patch
