### PR TITLE
Trim spaces from source_id in merge form

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -1814,7 +1814,7 @@ class EventsController extends AppController
         }
         $this->Event->insertLock($this->Auth->user(), $target_id);
         if ($this->request->is('post')) {
-            $source_id = $this->request->data['Event']['source_id'];
+            $source_id = trim($this->request->data['Event']['source_id']);
             $to_ids = $this->request->data['Event']['to_ids'];
             if (!is_numeric($source_id)) {
                 $this->Flash->error(__('Invalid event ID entered.'));


### PR DESCRIPTION
Spaces get added when copy-pasting event ID's, it's very annoying to have to remove them by hand.