### PR TITLE
fix: Customauth Headers are case-sentitive, do not strtoupper

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -816,7 +816,6 @@ class AppController extends Controller
         $result = false;
         if (Configure::read('Plugin.CustomAuth_enable')) {
             $header = Configure::read('Plugin.CustomAuth_header') ? Configure::read('Plugin.CustomAuth_header') : 'Authorization';
-            $header = strtoupper($header);
             $authName = Configure::read('Plugin.CustomAuth_name') ? Configure::read('Plugin.CustomAuth_name') : 'External authentication';
             $headerNamespace = Configure::read('Plugin.CustomAuth_use_header_namespace') ? (Configure::read('Plugin.CustomAuth_header_namespace') ? Configure::read('Plugin.CustomAuth_header_namespace') : 'HTTP_') : '';
             if (isset($server[$headerNamespace . $header]) && !empty($server[$headerNamespace . $header])) {


### PR DESCRIPTION
In the CustomAuth plugin, headers are auto-uppercase'd

Some authentication systems, like [mod_auth_openidc](https://github.com/zmartzone/mod_auth_openidc) store their claims in lower-case header names. Auto-uppercasing breaks compatibility in this case.



#### What does it do?

Removes a statement forcing Authentication headers in CustomAuth to be uppercase

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
