### PR TITLE
Add "manage workers" option.

### DIFF
--- a/INSTALL/misp-workers.service
+++ b/INSTALL/misp-workers.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=misp-workers
+After=network.target apache2.service
+
+[Service]
+Type=forking
+KillMode=none
+User=www-data
+Group=misp-server
+ExecStart=/bin/bash -c "/opt/misp-server/misp/app/Console/worker/start.sh"
+ExecStop=/bin/bash -c "/opt/misp-server/misp/app/Console/cake CakeResque.CakeResque stop --all"
+WorkingDirectory=%h
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+

--- a/app/Config/config.default.php
+++ b/app/Config/config.default.php
@@ -36,6 +36,7 @@ $config = array(
 			'take_ownership_xml_import'      => false,
 			'unpublishedprivate'             => false,
 			'disable_emailing'               => false,
+			'manage_workers'                 => true,
 			'Attributes_Values_Filter_In_Event' => 'id, uuid, value, comment, type, category, Tag.name',
 		),
 	'GnuPG'            =>

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -844,6 +844,14 @@ class Server extends AppModel
                             'test' => null,
                             'type' => 'string',
                         ),
+                        'manage_workers' => array(
+                                'level' => 2,
+                                'description' => __('Set this to false if you would like to disable MISP managing its own worker processes (for example, if you are managing the workers with a systemd unit).'),
+                                'value' => true,
+                                'errorMessage' => '',
+                                'test' => 'testBool',
+                                'type' => 'boolean'
+                        ),
                         'deadlock_avoidance' => array(
                                 'level' => 1,
                                 'description' => __('Only enable this if you have some tools using MISP with extreme high concurency. General performance will be lower as normal as certain transactional queries are avoided in favour of shorter table locks.'),
@@ -3737,6 +3745,7 @@ class Server extends AppModel
             }
         }
         $worker_array['proc_accessible'] = $procAccessible;
+        $worker_array['controls'] = Configure::read('MISP.manage_workers');
         return $worker_array;
     }
 

--- a/app/View/Elements/healthElements/workers.ctp
+++ b/app/View/Elements/healthElements/workers.ctp
@@ -2,11 +2,16 @@
     <?php
         if (!$worker_array['proc_accessible']):
     ?>
-        <div style="background-color:red !important;color:white;"><b><?php echo __('Warning');?></b>: <?php echo __('MISP cannot access your /proc directory to check the status of the worker processes, which means that dead workers will not be detected by the diagnostic tool. If you would like to regain this functionality, make sure that the open_basedir directive is not set, or that /proc is included in it.');?></div>
-    <?php
+	<div style="background-color:red !important;color:white;"><b><?php echo __('Warning');?></b>: <?php echo __('MISP cannot access your /proc directory to check the status of the worker processes, which means that dead workers will not be detected by the diagnostic tool. If you would like to regain this functionality, make sure that the open_basedir directive is not set, or that /proc is included in it.');?></div>
+<?php
+	endif;
+	if (!$worker_array['controls']):
+?>
+	<div><b><?php echo __('Note:');?></b>: <?php echo  __('You have set the "control_workers" variable to "false", therefore worker controls have been disabled.');?></div>
+<?php
         endif;
         foreach ($worker_array as $type => $data):
-        if ($type == 'proc_accessible') continue;
+        if ($type == 'proc_accessible' or $type == 'controls') continue;
         $queueStatusMessage = __("Issues prevent jobs from being processed. Please resolve them below.");
         $queueStatus = false;
         if ($data['ok']) {
@@ -32,7 +37,7 @@
         <span><b><?php echo __('Jobs in the queue: ');?></b>
             <?php
                 echo h($data['jobCount']);
-                if ($data['jobCount'] > 0) {
+                if ($data['jobCount'] > 0 && $worker_array['controls']) {
                     echo $this->Form->postLink('<span class="icon-trash useCursorPointer"></span>', $baseurl . '/servers/clearWorkerQueue/' . h($type), array('escape' => false, 'inline' => true, 'style' => 'margin-left:2px;'));
                 }
             ?>
@@ -96,8 +101,10 @@
             <td class="short" style="<?php echo $style; ?>"><?php echo $process; ?></td>
             <td style="<?php echo $style; ?>"><?php echo $message; ?></td>
             <td class="actions short" style="<?php echo $style; ?>">
-            <?php
-                echo $this->Form->postLink('', '/servers/stopWorker/' . h($worker['pid']), array('class' => 'icon-trash' . $icon_modifier, 'title' => __('Stop (if still running) and remove this worker. This will immediately terminate any jobs that are being executed by it.')));
+<?php
+		if ($worker_array['controls']) {
+			echo $this->Form->postLink('', '/servers/stopWorker/' . h($worker['pid']), array('class' => 'icon-trash' . $icon_modifier, 'title' => __('Stop (if still running) and remove this worker. This will immediately terminate any jobs that are being executed by it.')));
+		}
             ?>
             </td>
         </tr>
@@ -107,15 +114,20 @@
     ?>
     </table>
     <?php
-            echo $this->Form->create('Server', array('url' => '/servers/startWorker/' . h($type)));
-            echo $this->Form->button(__('Start a worker'), array('class' => 'btn btn-inverse'));
-            echo $this->Form->end();
+	    if ($worker_array['controls']) {
+		    echo $this->Form->create('Server', array('url' => '/servers/startWorker/' . h($type)));
+		    echo $this->Form->button(__('Start a worker'), array('class' => 'btn btn-inverse'));
+		    echo $this->Form->end();
+	    }
         endforeach;
     ?>
 
 </div>
 
-<?php echo $this->Form->create('Server', array('url' => '/servers/restartWorkers'));
-echo $this->Form->button(__('Restart all workers'), array('class' => 'btn btn-primary'));
-echo $this->Form->end();
+<?php
+if ($worker_array['controls']) {
+	echo $this->Form->create('Server', array('url' => '/servers/restartWorkers'));
+	echo $this->Form->button(__('Restart all workers'), array('class' => 'btn btn-primary'));
+	echo $this->Form->end();
+}
 ?>


### PR DESCRIPTION
#### What does it do?

Adds a boolean option to toggle MISP managing its own worker processes.

This is enabled by default, which replicates the current behaviour of having controls to start, stop and restart workers in the server settings page.
When set to disabled, these controls are hidden, which allows server administrators to manage the worker processes externally, e.g. via systemd.

A sample systemd unit file has also been included into the INSTALL directory.

#### Questions

- [ ] Does it require a DB change? No
- [ ] Are you using it in production? Yes, on our sandbox/development server
- [ ] Does it require a change in the API (PyMISP for example)? Not as far as I know.

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
