### PR TITLE
chg: [tools] Added the option to have Python Virtualenv support

### DIFF
--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -921,7 +921,8 @@ class ServersController extends AppController
             if ($tab == 'diagnostics' || $tab == 'download') {
                 $php_ini = php_ini_loaded_file();
                 $this->set('php_ini', $php_ini);
-                $advanced_attachments = shell_exec('python3 ' . APP . 'files/scripts/generate_file_objects.py -c');
+                $advanced_attachments = shell_exec($this->Server->getPythonVersion() . ' ' . APP . 'files/scripts/generate_file_objects.py -c');
+
                 try {
                     $advanced_attachments = json_decode($advanced_attachments, true);
                 } catch (Exception $e) {

--- a/app/Lib/Tools/PubSubTool.php
+++ b/app/Lib/Tools/PubSubTool.php
@@ -84,7 +84,8 @@ class PubSubTool
 
     public function checkIfPythonLibInstalled()
     {
-        $result = trim(shell_exec('python3 ' . APP . 'files' . DS . 'scripts' . DS . 'mispzmq' . DS . 'mispzmqtest.py'));
+        $my_server = ClassRegistry::init('Server');
+        $result = trim(shell_exec($my_server->getPythonVersion() . ' ' . APP . 'files' . DS . 'scripts' . DS . 'mispzmq' . DS . 'mispzmqtest.py'));
         if ($result === "OK") {
             return true;
         }
@@ -94,9 +95,10 @@ class PubSubTool
     private function __setupPubServer()
     {
         App::uses('File', 'Utility');
+        $my_server = ClassRegistry::init('Server');
         $settings = $this->__getSetSettings();
         if ($this->checkIfRunning() === false) {
-            shell_exec('python3 ' . APP . 'files' . DS . 'scripts' . DS . 'mispzmq' . DS . 'mispzmq.py > ' . APP . 'tmp' . DS . 'logs' . DS . 'mispzmq.log 2> ' . APP . 'tmp' . DS . 'logs' . DS . 'mispzmq.error.log &');
+            shell_exec($my_server->getPythonVersion() . ' ' . APP . 'files' . DS . 'scripts' . DS . 'mispzmq' . DS . 'mispzmq.py > ' . APP . 'tmp' . DS . 'logs' . DS . 'mispzmq.log 2> ' . APP . 'tmp' . DS . 'logs' . DS . 'mispzmq.error.log &');
         }
         return $settings;
     }

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -1206,6 +1206,15 @@ class AppModel extends Model
         return $version_array;
     }
 
+    public function getPythonVersion()
+    {
+        if (!empty(Configure::read('MISP.python_bin'))) {
+            return Configure::read('MISP.python_bin');
+        } else {
+            return 'python3';
+        }
+    }
+
     public function validateAuthkey($value)
     {
         if (empty($value['authkey'])) {

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -3358,7 +3358,7 @@ class Attribute extends AppModel
     {
         $execRetval = '';
         $execOutput = array();
-        $result = shell_exec('python3 ' . APP . 'files/scripts/generate_file_objects.py -p ' . $tmpfile->path);
+        $result = shell_exec($this->Server->getPythonVersion() . ' ' . APP . 'files/scripts/generate_file_objects.py -p ' . $tmpfile->path);
         if (!empty($result)) {
             $result = json_decode($result, true);
             if (isset($result['objects'])) {

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -3737,6 +3737,7 @@ class Event extends AppModel
 
     public function stix2($id, $tags, $attachments, $user, $returnType = 'json', $from = false, $to = false, $last = false, $jobId = false, $returnFile = false)
     {
+        $my_server = ClassRegistry::init('Server');
         $eventIDs = $this->Attribute->dissectArgs($id);
         $tagIDs = $this->Attribute->dissectArgs($tags);
         $idList = $this->getAccessibleEventIds($eventIDs[0], $eventIDs[1], $tagIDs[0], $tagIDs[1]);
@@ -3746,7 +3747,7 @@ class Event extends AppModel
         }
         $randomFileName = $this->generateRandomFileName();
         $tmpDir = APP . "files" . DS . "scripts";
-        $stix2_framing_cmd = 'python3 ' . $tmpDir . DS . 'misp_framing.py stix2 ' . escapeshellarg(CakeText::uuid()) . ' 2>' . APP . 'tmp/logs/exec-errors.log';
+        $stix2_framing_cmd = $my_server->getPythonVersion() . ' ' . $tmpDir . DS . 'misp_framing.py stix2 ' . escapeshellarg(CakeText::uuid()) . ' 2>' . APP . 'tmp/logs/exec-errors.log';
         $stix2_framing = json_decode(shell_exec($stix2_framing_cmd), true);
         if (empty($stix2_framing)) {
             return array('success' => 0, 'message' => 'There was an issue generating the STIX 2.0 export.');
@@ -3782,7 +3783,7 @@ class Event extends AppModel
                 $tempFile->write($event);
                 unset($event);
                 $scriptFile = APP . "files" . DS . "scripts" . DS . "stix2" . DS . "misp2stix2.py";
-                $result = shell_exec('python3 ' . $scriptFile . ' ' . $tempFile->path . $ORGs . '2>' . APP . 'tmp/logs/exec-errors.log');
+                $result = shell_exec($my_server->getPythonVersion() . ' ' . $scriptFile . ' ' . $tempFile->path . $ORGs . '2>' . APP . 'tmp/logs/exec-errors.log');
                 $decoded = json_decode($result, true);
                 if (isset($decoded['success']) && $decoded['success'] == 1) {
                     if (isset($decoded['org'])) {
@@ -3818,6 +3819,7 @@ class Event extends AppModel
 
     public function stix($id, $tags, $attachments, $user, $returnType = 'xml', $from = false, $to = false, $last = false, $jobId = false, $returnFile = false)
     {
+        $my_server = ClassRegistry::init('Server');
         $eventIDs = $this->Attribute->dissectArgs($id);
         $tagIDs = $this->Attribute->dissectArgs($tags);
         $idList = $this->getAccessibleEventIds($eventIDs[0], $eventIDs[1], $tagIDs[0], $tagIDs[1]);
@@ -3827,7 +3829,7 @@ class Event extends AppModel
         }
         $randomFileName = $this->generateRandomFileName();
         $tmpDir = APP . "files" . DS . "scripts";
-        $stix_framing_cmd = 'python3 ' . $tmpDir . DS . 'misp_framing.py stix ' . escapeshellarg(Configure::read('MISP.baseurl')) . ' ' . escapeshellarg(Configure::read('MISP.org')) . ' ' . escapeshellarg($returnType) . ' 2>' . APP . 'tmp/logs/exec-errors.log';
+        $stix_framing_cmd = $my_server->getPythonVersion() . ' ' . $tmpDir . DS . 'misp_framing.py stix ' . escapeshellarg(Configure::read('MISP.baseurl')) . ' ' . escapeshellarg(Configure::read('MISP.org')) . ' ' . escapeshellarg($returnType) . ' 2>' . APP . 'tmp/logs/exec-errors.log';
         $stix_framing = json_decode(shell_exec($stix_framing_cmd), true);
         if (empty($stix_framing)) {
             return array('success' => 0, 'message' => 'There was an issue generating the STIX export.');
@@ -3874,7 +3876,7 @@ class Event extends AppModel
                 $tempFile->write($event);
                 unset($event);
                 $scriptFile = APP . "files" . DS . "scripts" . DS . "misp2stix.py";
-                $result = shell_exec('python3 ' . $scriptFile . ' ' . $randomFileName . ' ' . escapeshellarg($returnType) . ' ' . escapeshellarg(Configure::read('MISP.baseurl')) . ' ' . escapeshellarg(Configure::read('MISP.org')) . ' 2>' . APP . 'tmp/logs/exec-errors.log');
+                $result = shell_exec($my_server->getPythonVersion() . ' ' . $scriptFile . ' ' . $randomFileName . ' ' . escapeshellarg($returnType) . ' ' . escapeshellarg(Configure::read('MISP.baseurl')) . ' ' . escapeshellarg(Configure::read('MISP.org')) . ' 2>' . APP . 'tmp/logs/exec-errors.log');
                 // The result of the script will be a returned JSON object with 2 variables: success (boolean) and message
                 // If success = 1 then the temporary output file was successfully written, otherwise an error message is passed along
                 $decoded = json_decode($result, true);
@@ -4811,12 +4813,12 @@ class Event extends AppModel
         if ($stix_version == '2') {
             $scriptFile = APP . 'files/scripts/stix2/stix2misp.py';
             $tempFilePath = APP . 'files/scripts/tmp/' . $filename;
-            $shell_command = 'python3 ' . $scriptFile . ' ' . $tempFilePath;
+            $shell_command = $this->Server->getPythonVersion() . ' ' . $scriptFile . ' ' . $tempFilePath;
             $output_path = $tempFilePath . '.stix2';
         } elseif ($stix_version == '1' || $stix_version == '1.1' || $stix_version == '1.2') {
             $scriptFile = APP . 'files/scripts/stix2misp.py';
             $tempFilePath = APP . 'files/scripts/tmp/' . $filename;
-            $shell_command = 'python3 ' . $scriptFile . ' ' . $filename;
+            $shell_command = $this->Server->getPythonVersion() . ' ' . $scriptFile . ' ' . $filename;
             $output_path = $tempFilePath . '.json';
         } else {
             throw new MethodNotAllowedException('Invalid STIX version');
@@ -5099,7 +5101,7 @@ class Event extends AppModel
 					}
 					$AttributSave = $this->$objectType->save($attribute);
 					if ($AttributSave) {
-						// If Tags, attache each tags to attribut
+						// If Tags, attach each tags to attribute
 						if (!empty($attribute['tags'])) {
 							foreach (explode(",", $attribute['tags']) as $tagName) {
 								$this->loadModel('Tag');

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -168,10 +168,11 @@ class Server extends AppModel
                         'python_bin' => array(
                                 'level' => 1,
                                 'description' => __('It is highly recommended to install all the python dependencies in a virtualenv. The recommended location is: %s/venv', ROOT),
-                                'value' =>  ROOT . '/venv/bin/python', # GUI display purpose only.
+                                'value' => false,
                                 'errorMessage' => '',
                                 'null' => false,
-                                'test' => 'testForEmpty',
+                                'test' => 'testForBinExec',
+                                'beforeHook' => 'beforeHookBinExec',
                                 'type' => 'string',
                         ),
                         'disable_auto_logout' => array(
@@ -2674,6 +2675,30 @@ class Server extends AppModel
             return true;
         }
         return 'Invalid characters in the path.';
+    }
+
+    public function beforeHookBinExec($setting, $value)
+    {
+        return $this->testForBinExec($value);
+    }
+
+    public function testForBinExec($value)
+    {
+        $finfo = finfo_open(FILEINFO_MIME_TYPE);
+        if ($value === '') {
+            return true;
+        }
+        if (is_executable($value)) {
+            if (finfo_file($finfo, $value) == "application/x-executable") {
+                finfo_close($finfo);
+                return true;
+            } else {
+                return 'Binary file not executable.';
+            }
+        }
+        else {
+            return false;
+       }
     }
 
     public function testForWritableDir($value)

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -165,6 +165,15 @@ class Server extends AppModel
                                 'type' => 'boolean',
                                 'null' => true
                         ),
+                        'python_bin' => array(
+                                'level' => 1,
+                                'description' => __('It is highly recommended to install all the python dependencies in a virtualenv. The recommended location is: %s/venv', ROOT),
+                                'value' =>  ROOT . '/venv/bin/python', # GUI display purpose only.
+                                'errorMessage' => '',
+                                'null' => false,
+                                'test' => 'testForEmpty',
+                                'type' => 'string',
+                        ),
                         'disable_auto_logout' => array(
                                 'level' => 1,
                                 'description' => __('In some cases, a heavily used MISP instance can generate unwanted blackhole errors due to a high number of requests hitting the server. Disable the auto logout functionality to ease the burden on the system.'),
@@ -3531,7 +3540,7 @@ class Server extends AppModel
         $result = array();
         $expected = array('stix' => '1.2.0.6', 'cybox' => '2.1.0.18.dev0', 'mixbox' => '1.0.3', 'maec' => '4.1.0.14', 'pymisp' => '>2.4.93');
         // check if the STIX and Cybox libraries are working using the test script stixtest.py
-        $scriptResult = shell_exec('python3 ' . APP . 'files' . DS . 'scripts' . DS . 'stixtest.py');
+        $scriptResult = shell_exec($this->getPythonVersion() . ' ' . APP . 'files' . DS . 'scripts' . DS . 'stixtest.py');
         $scriptResult = json_decode($scriptResult, true);
         if ($scriptResult == null) {
             return array('operational' => 0, 'stix' => array('expected' => $expected['stix']), 'cybox' => array('expected' => $expected['cybox']), 'mixbox' => array('expected' => $expected['mixbox']), 'maec' => array('expected' => $expected['maec']), 'pymisp' => array('expected' => $expected['pymisp']));

--- a/app/Model/Sighting.php
+++ b/app/Model/Sighting.php
@@ -323,7 +323,7 @@ class Sighting extends AppModel
         $tempFile->close();
         $scriptFile = APP . "files" . DS . "scripts" . DS . "stixsighting2misp.py";
         // Execute the python script and point it to the temporary filename
-        $result = shell_exec('python3 ' . $scriptFile . ' ' . $randomFileName);
+        $result = shell_exec($this->Server->getPythonVersion() . ' ' . $scriptFile . ' ' . $randomFileName);
         // The result of the script will be a returned JSON object with 2 variables: success (boolean) and message
         // If success = 1 then the temporary output file was successfully written, otherwise an error message is passed along
         $result = json_decode($result, true);


### PR DESCRIPTION
- [ ] Are you using it in production?

Tested it somewhat. Seems to work.

#### Release Type:
- [X] Patch

You now have a new configurable: MISP.python_bin that is empty by default (which resorts to the code using the 'python3' command) But when set to the python binary where your virtualenv is installed, will use that instead, e.g: /var/www/MISP/venv/bin/python

Also introduced a new check 'testForBinExec' which tests for a binary executable.