### PR TITLE
Fix CSV filename #3740

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -2716,6 +2716,8 @@ class EventsController extends AppController
         if ($user === false) {
             return $exception;
         }
+        $filename = 'misp.csv.event' . $eventid . '.csv';
+
 		$final = $this->Event->restSearch($user, 'csv', $filters);
         // if it's a search, grab the attributeIDList from the session and get the IDs from it. Use those as the condition
         // We don't need to look out for permissions since that's filtered by the search itself
@@ -2746,7 +2748,7 @@ class EventsController extends AppController
             }
         }
         $responseType = 'csv';
-        return $this->RestResponse->viewData($final, $responseType, false, true, 'download.csv');
+        return $this->RestResponse->viewData($final, $responseType, false, true, $filename);
     }
 
     public function _addIOCFile($id)


### PR DESCRIPTION
Hello all,

Tiny PR for fixing filename when you select CSV format in "Download as" functions (to download attributes). Filename proposed is misp.eventXXXX.csv.

Don't hesitate to contact me if you need some help and if you have some question.

devnull-


#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch (tested and validated)