### PR TITLE
Fixes Issue #3633 - Returned XML has application/json Content-Type header

### DIFF
--- a/app/Controller/Component/RestResponseComponent.php
+++ b/app/Controller/Component/RestResponseComponent.php
@@ -342,7 +342,7 @@ class RestResponseComponent extends Component
 
     private function __sendResponse($response, $code, $format = false, $raw = false, $download = false)
     {
-        if (strtolower($format) === 'application/xml') {
+        if (strtolower($format) === 'application/xml' || strtolower($format) === 'xml') {
             if (!$raw) {
                 if (isset($response[0])) {
                     if (count(array_keys($response[0])) == 1) {


### PR DESCRIPTION


#### Questions
- [X] Are you using it in production?

#### Release Type:
- [X] Patch

### General
Created a patch to fix issue #3633, which affects the MISP XML output via "Download as" on an Event. 

Issue appears to stem from the fact that _sendResponse was checking the $format against "application/xml". it appears the RestSearches obtain the format via:

https://github.com/MISP/MISP/blob/6b60f3fa5c9900c82c9a966811ceba4580a9679d/app/Controller/AttributesController.php#L1725
https://github.com/MISP/MISP/blob/6b60f3fa5c9900c82c9a966811ceba4580a9679d/app/Controller/AttributesController.php#L1744

Where index 0 is simply 'xml':
https://github.com/MISP/MISP/blob/7a01de535928b52ebc7c219dcbba7fd82edb6b7b/app/Model/Attribute.php#L120-L130

However, other functions that use _sendResponse I believe do pass "application/xml", so both are necessary.