### PR TITLE
fix: options were not passed to set_filter_tags when producing text d…

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -2194,7 +2194,7 @@ class Attribute extends AppModel
             $conditions['AND'][] = array('Event.id' => $eventId);
         } elseif ($tags !== false) {
 			$passed_param = array('tags' => $tags);
-            $conditions = $this->set_filter_tags($passed_params, $conditions);
+            $conditions = $this->set_filter_tags($passed_params, $conditions, $options);
         }
         $attributes = $this->fetchAttributes($user, array(
                 'conditions' => $conditions,


### PR DESCRIPTION
…ump of attributes

#### What does it do?

Doesn't seem to be an existing github issue, but discovered that when producing a dump using the automation endpoint of:
`https://<base_misp_url>/attributes/text/download/domain/<tag>/`, a 500 error was thrown as set_filter_tags in the "text" function wasn't passing $options. Doesn't really matter what's in here, options seems to be used or the scope to determine it it's an attribute or event level. If empty (or null), assumes it's Attribute level (which is what we want here). Same bug does snot affect Events.php model.

#### Questions
- [X] Are you using it in production?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
