### PR TITLE
fix: misp-restore.sh incorrectly validating 'BackupFile' from the com…

### DIFF
--- a/tools/misp-backup/misp-restore.sh
+++ b/tools/misp-backup/misp-restore.sh
@@ -26,7 +26,7 @@ echo '-- Starting MISP restore process'
 
 FILE=./misp-backup.conf
 
-if [ -f $1 ];
+if [ ! -z $1 ] && [ -f $1 ];
 then 
     BackupFile=$1
 else


### PR DESCRIPTION
…mand line


#### What does it do?
The patch fixes the validation of the 'BackupFile' that should be required as command line argument.


#### Questions

- [NO ] Does it require a DB change?
- [YES ] Are you using it in production?
- [NO ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
