### PR TITLE
Fix: AWS Errors when given empty array of elements

### DIFF
--- a/app/Lib/Tools/AWSS3Client.php
+++ b/app/Lib/Tools/AWSS3Client.php
@@ -77,18 +77,25 @@ class AWSS3Client
     }
 
     public function deleteDirectory($prefix) {
-        $keys = $s3->listObjects([
+        $keys = $this->__client->listObjectsV2([
             'Bucket' => $this->__settings['bucket_name'],
             'Prefix' => $prefix
-        ]) ->getPath('Contents/*/Key');
-
-        $s3->deleteObjects([
-            'Bucket'  => $bucket,
-            'Delete' => [
-                'Objects' => array_map(function ($key) {
-                    return ['Key' => $key];
-                }, $keys)
-            ],
         ]);
+
+        $toDelete = array_map(
+            function ($key) {
+                return ['Key' => $key['Key']];
+            },
+            is_array($keys['Contents'])?$keys['Contents']:[]
+        );
+
+        if (sizeof($toDelete) != 0) {
+            $this->__client->deleteObjects([
+                'Bucket'  => $this->__settings['bucket_name'],
+                'Delete' => [
+                    'Objects' => $toDelete
+                ]
+            ]);
+        }
     }
 }


### PR DESCRIPTION
#### What does it do?

Fixes an error on deleting an event when S3 is enabled - if given `[]` to delete, AWS will just kill itself instead of deleting nothing. Funny, huh?

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
