### PR TITLE
chg: [eventview] changed default attribute sorting to timestamp->desc

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -1268,7 +1268,8 @@ class EventsController extends AppController
                 }
             }
         }
-        $params = $this->Event->rearrangeEventForView($event);
+        $passedArgs = array('sort' => 'timestamp', 'direction' => 'desc');
+        $params = $this->Event->rearrangeEventForView($event, $passedArgs);
         $this->params->params['paging'] = array($this->modelClass => $params);
         $this->set('event', $event);
         $dataForView = array(


### PR DESCRIPTION
Changed default behavior in ``events/view`` UI's attribute table.
Default sorting is done on ``timestamp->desc`` instead of ``category->asc``