### PR TITLE
Keep CIDR subnet size in STIX export

### DIFF
--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -1464,7 +1464,6 @@ class StixBuilder(object):
         if '|' in attribute_value:
             attribute_value = attribute_value.split('|')[0]
         if '/' in attribute_value:
-            attribute_value = attribute_value.split('/')[0]
             address_object.category = "cidr"
             condition = "Contains"
         else:


### PR DESCRIPTION
This seems to have been broken for months (since d1c23720b4dda56e7d06c94a12a1d568c5066a1a). The CIDR subnet info needs to be maintained in the export.