### PR TITLE
fix: [tools] misp-restore.sh incorrectly validating 'BackupFile' from…

### DIFF
--- a/tools/misp-backup/misp-restore.sh
+++ b/tools/misp-backup/misp-restore.sh
@@ -26,7 +26,7 @@ echo '-- Starting MISP restore process'
 
 FILE=./misp-backup.conf
 
-if [ -f $1 ];
+if [ ! -z $1 ] && [ -f $1 ];
 then 
     BackupFile=$1
 else


### PR DESCRIPTION
… the command line


#### What does it do?

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
