### PR TITLE
fix: fixes variable initialization inconsistency in Server push

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -2335,10 +2335,10 @@ class Server extends AppModel
         $this->syncProposals($HttpSocket, $this->data, null, null, $this->Event);
 
         if (!isset($successes)) {
-            $successes = null;
+            $successes = array();
         }
         if (!isset($fails)) {
-            $fails = null;
+            $fails = array();
         }
         $this->Log = ClassRegistry::init('Log');
         $this->Log->create();


### PR DESCRIPTION
Fixes issues like: Warning (2): count(): Parameter must be an array or an object that implements Countable in [/var/www/MISP/app/Model/Server.php, line 2353]

#### Release Type:
- [X] Patch
