### PR TITLE
fixed an issue where the referenced_type was not an integer.

### DIFF
--- a/app/Model/ObjectReference.php
+++ b/app/Model/ObjectReference.php
@@ -229,23 +229,23 @@ class ObjectReference extends AppModel
             if (empty($referencedObject)) {
                 return true;
             }
-            $referenced_type = 'Attribute';
+            $referenced_type = 0;
         } else {
-            $referenced_type = 'Object';
+            $referenced_type = 1;
         }
-        $objectTypes = array('Attribute', 'Object');
+        $referenced_type_name = array('Attribute', 'Object')[$referenced_type];
         if (!isset($sourceObject['Object']) || $sourceObject['Object']['event_id'] != $eventId) {
             return true;
         }
-        if ($referencedObject[$referenced_type]['event_id'] != $eventId) {
+        if ($referencedObject[$referenced_type_name]['event_id'] != $eventId) {
             return true;
         }
         $this->create();
         unset($reference['id']);
         $reference['referenced_type'] = $referenced_type;
         $reference['object_id'] = $sourceObject['Object']['id'];
-        $reference['referenced_id'] = $referencedObject[$referenced_type]['id'];
-        $reference['referenced_uuid'] = $referencedObject[$referenced_type]['uuid'];
+        $reference['referenced_id'] = $referencedObject[$referenced_type_name]['id'];
+        $reference['referenced_uuid'] = $referencedObject[$referenced_type_name]['uuid'];
         $reference['object_uuid'] = $sourceObject['Object']['uuid'];
         $reference['event_id'] = $eventId;
         $result = $this->save(array('ObjectReference' => $reference));


### PR DESCRIPTION
#### What does it do?
There were an issue when for a given Event containing Objects that contain an Object_reference it was throwing an sql error. 
```
2018-11-20 17:59:28 Error: [PDOException] SQLSTATE[HY000]: General error: 1366 Incorrect integer value: 'Object' for column 'referenced_type' at row 1
Request URL: /events/
Stack Trace:
#0 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Datasource/DboSource.php(472): PDOStatement->execute(Array)
#1 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Datasource/DboSource.php(438): DboSource->_execute('INSERT INTO `mi...', Array)
#2 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Datasource/DboSource.php(1092): DboSource->execute('INSERT INTO `mi...')
#3 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Model.php(1942): DboSource->create(Object(ObjectReference), Array, Array)
#4 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Model.php(1760): Model->_doSave(Array, Array)
#5 /var/www/MISP/app/Model/ObjectReference.php(251): Model->save(Array)
#6 /var/www/MISP/app/Model/Event.php(3226): ObjectReference->captureReference(Array, '49', Array, Object(Log))
#7 /var/www/MISP/app/Controller/EventsController.php(1619): Event->_add(Array, true, Array, '', NULL, false, NULL, 0, Array)
#8 [internal function]: EventsController->add()
#9 /var/www/MISP/app/Lib/cakephp/lib/Cake/Controller/Controller.php(491): ReflectionMethod->invokeArgs(Object(EventsController), Array)
#10 /var/www/MISP/app/Lib/cakephp/lib/Cake/Routing/Dispatcher.php(193): Controller->invokeAction(Object(CakeRequest))
#11 /var/www/MISP/app/Lib/cakephp/lib/Cake/Routing/Dispatcher.php(167): Dispatcher->_invoke(Object(EventsController), Object(CakeRequest))
#12 /var/www/MISP/app/webroot/index.php(92): Dispatcher->dispatch(Object(CakeRequest), Object(CakeResponse))
#13 {main}

```

The issue was that the query was trying to use a string instead of an integer for the referenced_type. It was using "Attribute" instead of "0" and "Object" instead of "1".

The SQL query generated :

```
INSERT INTO `misp`.`object_references` (`timestamp`, `referenced_type`, `deleted`, `referenced_uuid`, `relationship_type`, `source_uuid`, `object_id`, `referenced_id`, `event_id`, `uuid`, `comment`)
VALUES (1542736902, 'Object', '0', 'someUUID', 'connects-to', 'someUUID', 233, 237, 50, 'someUUID', '')
```

The solution is to use an integer instead of a string.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
