### PR TITLE
fix typo in event export to XML code

### DIFF
--- a/app/Lib/Export/XmlExport.php
+++ b/app/Lib/Export/XmlExport.php
@@ -10,7 +10,7 @@ class XmlExport
 		if ($options['scope'] === 'Attribute') {
 			return $this->__attributeHandler($data, $options);
 		} else if($options['scope'] === 'Event') {
-			return $this->__eventsHandler($data, $options);
+			return $this->__eventHandler($data, $options);
 		} else if($options['scope'] === 'Sighting') {
 			return $this->__sightingsHandler($data, $options);
 		}


### PR DESCRIPTION
fixes #3904 .

#### What does it do?

Fixes an issue with event export/download in XML format, due to a misspelt method/function call.

#### Questions

- [ ] Does it require a DB change? No
- [ ] Are you using it in production? Yes, i've deployed this change to our instances.
- [ ] Does it require a change in the API (PyMISP for example)? No

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
