### PR TITLE
make the filter checks for the event index API call case-insensitive

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -275,16 +275,25 @@ class EventsController extends AppController
         $urlparams = "";
         $overrideAbleParams = array('all', 'attribute', 'published', 'eventid', 'datefrom', 'dateuntil', 'org', 'eventinfo', 'tag', 'tags', 'distribution', 'sharinggroup', 'analysis', 'threatlevel', 'email', 'hasproposal', 'timestamp', 'publishtimestamp', 'publish_timestamp', 'minimal');
         $passedArgs = $this->passedArgs;
+
         if (isset($this->request->data)) {
             if (isset($this->request->data['request'])) {
                 $this->request->data = $this->request->data['request'];
             }
-            foreach ($overrideAbleParams as $oap) {
-                if (isset($this->request->data['search' . $oap])) {
-                    $this->request->data[$oap] = $this->request->data['search' . $oap];
-                }
-                if (isset($this->request->data[$oap])) {
-                    $passedArgs['search' . $oap] = $this->request->data[$oap];
+            foreach ($this->request->data as $rd => $val) {
+                $rdlowercase = strtolower($rd);
+                if (substr($rdlowercase, 0, 6) === 'search'){
+                    $searchTerm = substr($rdlowercase, 6);
+                    if (in_array($searchTerm, $overrideAbleParams)) {
+                        $this->request->data[$searchTerm] = $this->request->data[$rd];
+                        $passedArgs['search' . $searchTerm] = $this->request->data[$rd];
+                    }
+                } else {
+                    if (in_array($rdlowercase, $overrideAbleParams)) {
+                        $this->request->data[$rdlowercase] = $this->request->data[$rd];
+                        $passedArgs['search' . $rdlowercase] = $this->request->data[$rd];
+                        
+                    }
                 }
             }
         }


### PR DESCRIPTION
#### What does it do?

Fixes #3855 as well as making all filters sent to this api call case-insensitive.
There is already a `strtolower()` call on filters in this method , but it gets called after filters are checked against a whitelist. I fiddled with the checking so filters are first changed to lowercase, then compared to the whitelist.

I've tested the code by calling the API with a bunch of different filters, some non-existent, some existent but with capital letters... it works, but please double-check my code. Thanks!

#### Questions

- [ ] Does it require a DB change? No
- [ ] Are you using it in production? Yes (Sandbox server)

- [ ] Does it require a change in the API (PyMISP for example)?
No, but it does fix a bug in the API that was introduced with b4f084f9fe66547d65bb1d9187aa56bd8c9b2dc3 .

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
