### PR TITLE
Fix error handling in Server.php

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -3415,7 +3415,7 @@ class Server extends AppModel
         try {
             $response = $HttpSocket->get($uri, '', $request);
         } catch (Exception $e) {
-            $error = $e->getMessage;
+            $error = $e->getMessage();
         }
         if (!isset($response) || $response->code != '200') {
             $this->Log = ClassRegistry::init('Log');


### PR DESCRIPTION
according to http://php.net/manual/de/exception.getmessage.php , the parenthesis are required

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
