### PR TITLE
new: [eventview] quick edits are triggered by clicking a button

### DIFF
--- a/app/View/Elements/Events/View/row_attribute.ctp
+++ b/app/View/Elements/Events/View/row_attribute.ctp
@@ -99,13 +99,16 @@
         <?php echo h($object['type']); ?>
       </div>
     </td>
-    <td id="Attribute_<?php echo h($object['id']); ?>_container" class="showspaces limitedWidth shortish">
-      <div id="Attribute_<?php echo $object['id']; ?>_value_placeholder" class="inline-field-placeholder"></div>
-      <?php
-        if ('attachment' !== $object['type'] && 'malware-sample' !== $object['type']) $editable = ' ondblclick="activateField(\'' . $editScope . '\', \'' . $object['id'] . '\', \'value\', \'' . $event['Event']['id'] . '\');"';
-        else $editable = '';
-      ?>
-      <div id = "Attribute_<?php echo $object['id']; ?>_value_solid" class="inline-field-solid" <?php echo $editable; ?>>
+    <?php
+        if ('attachment' !== $object['type'] && 'malware-sample' !== $object['type']):
+            $editable = ' onmouseenter="quickEditHover(this, \'' . $editScope . '\', \'' . $object['id'] . '\', \'value\', \'' . $event['Event']['id'] . '\' );"';
+        else:
+            $editable = '';
+        endif;
+    ?>
+    <td id="Attribute_<?php echo h($object['id']); ?>_container" class="showspaces limitedWidth shortish" <?php echo $editable; ?>>
+    <div id="Attribute_<?php echo $object['id']; ?>_value_placeholder" class="inline-field-placeholder"></div>
+      <div id = "Attribute_<?php echo $object['id']; ?>_value_solid" class="inline-field-solid">
         <span>
         <?php
 			$spanExtra = '';

--- a/app/webroot/css/main.css
+++ b/app/webroot/css/main.css
@@ -2078,6 +2078,35 @@ table tr:hover .down-expand-button {
 	}
 }
 
+.label-icon {
+    left: 5px;
+    position: relative;
+}
+
+.fa-as-icon {
+    font-size: 20px;
+    padding-left: 2px;
+    padding-top: 2px;
+    width: 18px;
+    height: 20px;
+    cursor: pointer;
+    background-image: unset;
+    text-shadow: -1px 0 white, 0 1px white, 1px 0 white, 0 -1px white;
+    transition: background .2s linear;
+    color: black;
+}
+.fa-as-icon:hover {
+    text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
+    font-weight: 900;
+    font-size: 22px;
+    color: white;
+}
+
+.quick-edit-row-div {
+    display: inline-block;
+    position: relative;
+}
+
 #attackmatrix_div {
     border-color: #363636;
     overflow: visible;

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -453,6 +453,26 @@ function postActivationScripts(name, type, id, field, event) {
 	$(name + '_solid').hide();
 }
 
+function quickEditHover(td, type, id, field, event) {
+    $td = $(td);
+    $td.find('#quickEditButton').remove(); // clean all similar if exist
+    $div = $('<div id="quickEditButton"></div>');
+    $div.addClass('quick-edit-row-div');
+    $span = $('<span></span>');
+    $span.addClass('fa-as-icon fa fa-edit');
+    $span.css('font-size', '12px');
+    $div.append($span);
+    $td.find("[id*=value_solid]").append($div);
+
+    $span.click(function() {
+        activateField(type, id, field, event);
+    });
+
+    $td.off('mouseleave').on('mouseleave', function(e) {
+        $div.remove();
+    });
+}
+
 function addSighting(type, attribute_id, event_id, page) {
 	$('#Sighting_' + attribute_id + '_type').val(type);
 	$.ajax({


### PR DESCRIPTION
This PR replace the double-click quick-edit feature.
Currently, it is only applied on Attribute's value, but can be easily extend to other fields if required (just ask in a comment to this PR).
Upon hover, it shows a small edit icon that the user can click; this is the only way to quick edit a value.

Ref: issue #3937
#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
