### PR TITLE
fix: Make IE11 compliant by removing default param value from ES2015

### DIFF
--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -631,7 +631,10 @@ function handleAjaxEditResponse(data, name, type, id, field, event) {
 	}
 }
 
-function handleGenericAjaxResponse(data, skip_reload = false) {
+function handleGenericAjaxResponse(data, skip_reload) {
+	if (typeof skip_reload === "undefined") {
+        skip_reload = false;
+    }
 	if (typeof data == 'string') {
 		responseArray = JSON.parse(data);
 	} else {

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -3222,7 +3222,10 @@ function quickSubmitGalaxyForm(event_id, cluster_id) {
 	return false;
 }
 
-function checkAndSetPublishedInfo(skip_reload=false) {
+function checkAndSetPublishedInfo(skip_reload) {
+	if (typeof skip_reload === "undefined") {
+		skip_reload = false;
+	}
 	var id = $('#hiddenSideMenuData').data('event-id');
 	if (id !== 'undefined' && !skip_reload) {
 		$.get( "/events/checkPublishedStatus/" + id, function(data) {


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:
#### What does it do?
More fixed for issue `#3939`, relating to ES2015 default parameter support on IE11. 

I should have checked that default params weren't in place elsewhere, whoops!

#### Questions
- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [X] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
