### PR TITLE
fix: Make IE11 compliant by adding startsWith polyfill

### DIFF
--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -2,6 +2,13 @@ String.prototype.ucfirst = function() {
 	return this.charAt(0).toUpperCase() + this.slice(1);
 }
 
+if (!String.prototype.startsWith) {
+  String.prototype.startsWith = function(searchString, position) {
+    position = position || 0;
+    return this.indexOf(searchString, position) === position;
+  };
+}
+
 function deleteObject(type, action, id, event) {
 	var destination = 'attributes';
 	var alternateDestinations = ['shadow_attributes', 'template_elements', 'taxonomies', 'galaxy_clusters', 'objects', 'object_references'];


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:

#### What does it do?

Oh and one more fix for `#3939`. You happy to polyfill the startsWith prototype? Otherwise we'll have to switch startsWith for indexOf in the code on this line:
https://github.com/MISP/MISP/blob/3f07d8367eb8dbd64fe2ffbaa8ff69ce1e0c95b6/app/webroot/js/misp.js#L3541

#### Questions
- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
