### PR TITLE
Fixes #3907, enrich event job not marked as completed.

### DIFF
--- a/app/Console/Command/EventShell.php
+++ b/app/Console/Command/EventShell.php
@@ -558,12 +558,24 @@ class EventShell extends AppShell
 			$this->Job->save($data);
 			$jobId = $this->Job->id;
 		}
+		$job = $this->Job->read(null, $jobId)
 		$options = array(
 			'user' => $user,
 			'event_id' => $eventId,
 			'modules' => $modules
 		);
 		$result = $this->Event->enrichment($options);
+		$job['Job']['progress'] = 100;
+		$job['Job']['date_modified'] = date("y-m-d H:i:s");
+		if ($result) {
+			$job['Job']['message'] = 'Added ' . $result . ' attribute' . ($result > 1 ? 's.' : '.')
+		} else {
+			$job['Job']['message'] = 'Enrichment finished, but no attributes added.';
+		}
+		$this->Job->save($job);
+		$log = ClassRegistry::init('Log');
+		$log->create();
+		$log->createLogEntry($user, 'enrichment', 'Event', $eventId, 'Event (' . $eventId . '): enriched.', 'enriched () => (1)');
 	}
 
 	public function processfreetext() {


### PR DESCRIPTION
The enrichment background process did not do anything to update the job
after completing its task.  I used the same logic as the adjcacent
'publish' function to record progress, update the message and create a
log entry.

## Generic requirements in order to contribute to MISP:

* Please make sure Travis CI works on this request, or update the test cases if needed
Not sure about this one... How would I do this?


#### What does it do?

Fixes #3907 

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
