### PR TITLE
fix: dev: attempt to set resque redis backend based on redis config details

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -69,6 +69,11 @@ class AppController extends Controller
         $name = str_replace('sController', '', $name);
         $name = str_replace('Controller', '', $name);
         $this->defaultModel = $name;
+
+	Resque::setBackend(
+	    Configure::read('MISP.redis_host') . ":" . Configure::read('MISP.redis_port'),
+	    Configure::read('MISP.redis_database')
+	);
     }
 
     public $components = array(


### PR DESCRIPTION

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2016-06-03: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

Attempts to configure the Resque redis backend with redis details from MISP configuration.

This allows us to dynamically configure a non-localhost-based Redis instance

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
