### PR TITLE
fix: [api] editing organisation attributes, other than name

### DIFF
--- a/app/Controller/OrganisationsController.php
+++ b/app/Controller/OrganisationsController.php
@@ -171,8 +171,8 @@ class OrganisationsController extends AppController
                     } else {
                         $temp['Organisation'][$field] = $existingOrg['Organisation'][$field];
                     }
-                    $this->request->data = $temp;
                 }
+                $this->request->data = $temp;
             }
             $this->request->data['Organisation']['id'] = $id;
             if ($this->Organisation->save($this->request->data)) {


### PR DESCRIPTION
#### What does it do?

Editing any organisation attribute other than name was not possible via API. This should fix it.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch