### PR TITLE
fix: check also event.org_id when validating event ownership in order to fetch attributes. Fixes #1918

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -2898,7 +2898,7 @@ class Attribute extends AppModel
             $params['group'] = empty($options['group']) ? $options['group'] : false;
         }
         if (Configure::read('MISP.unpublishedprivate')) {
-            $params['conditions']['AND'][] = array('OR' => array('Event.published' => 1, 'Event.orgc_id' => $user['org_id']));
+            $params['conditions']['AND'][] = array('OR' => array('Event.published' => 1, 'Event.orgc_id' => $user['org_id'], 'Event.org_id' => $user['org_id']));
         }
         if (!empty($options['list'])) {
             if (!empty($options['event_ids'])) {


### PR DESCRIPTION
Fixes #1918

#### What does it do?
Check also event.org_id when validating event ownership in order to fetch attributes. Fixes #1918

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
