### PR TITLE
Return event publish info in attribute restapi

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -3836,7 +3836,7 @@ class Attribute extends AppModel
         $conditions = $this->buildFilterConditions($user, $filters);
         $params = array(
                 'conditions' => $conditions,
-                'fields' => array('Attribute.*', 'Event.org_id', 'Event.distribution'),
+                'fields' => array('Attribute.*', 'Event.org_id', 'Event.published', 'Event.publish_timestamp', 'Event.distribution'),
                 'withAttachments' => !empty($filters['withAttachments']) ? $filters['withAttachments'] : 0,
                 'enforceWarninglist' => !empty($filters['enforceWarninglist']) ? $filters['enforceWarninglist'] : 0,
                 'includeAllTags' => !empty($filters['includeAllTags']) ? $filters['includeAllTags'] : 0,


### PR DESCRIPTION
#### What does it do?
Returns published and publish_timestamp of Event when searching attributes through restapi

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [X] Minor
- [ ] Patch
