### PR TITLE
Allow HTTPD to send Emails

### DIFF
--- a/docs/xINSTALL.centos7.md
+++ b/docs/xINSTALL.centos7.md
@@ -371,6 +371,9 @@ sudo chcon -R -t httpd_sys_rw_content_t /var/www/MISP/app/tmp
 # Allow httpd to connect to the redis server and php-fpm over tcp/ip
 sudo setsebool -P httpd_can_network_connect on
 
+# Allow httpd to send emails from php
+sudo setsebool -P httpd_can_sendmail on
+
 # Enable and start the httpd service
 sudo systemctl enable httpd.service
 sudo systemctl start  httpd.service


### PR DESCRIPTION
Update to allow httpd to send emails. I noticed in my fresh install of MISP on CentOS that emails were not being sent. After looking at the logs, I discovered that SELinux was preventing Apache from using sendmail. After setting "setsebool -P httpd_can_sendmail on," this problem was fixed. 

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2016-06-03: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

If it fixes an existing issue, please use github syntax: None

#### Questions

- [ No ] Does it require a DB change?
- [ Yes ] Are you using it in production?
- [ No ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
