### PR TITLE
Add LDAP network timeout

### DIFF
--- a/app/Config/config.default.php
+++ b/app/Config/config.default.php
@@ -134,6 +134,7 @@ $config = array(
 			'apacheEnv'          => 'REMOTE_USER',           // If proxy variable = HTTP_REMOTE_USER
 			'ldapServer'         => 'ldap://example.com',   // FQDN or IP
 			'ldapProtocol'       => 3,
+			'ldapNetworkTimeout' => -1,  // use -1 for unlimited network timeout
 			'ldapReaderUser'     => 'cn=userWithReadAccess,ou=users,dc=example,dc=com', // DN ou RDN LDAP with reader user right
 			'ldapReaderPassword' => 'UserPassword', // the LDAP reader user password
 			'ldapDN'             => 'dc=example,dc=com',

--- a/app/Controller/Component/Auth/ApacheAuthenticate.php
+++ b/app/Controller/Component/Auth/ApacheAuthenticate.php
@@ -51,7 +51,9 @@ class ApacheAuthenticate extends BaseAuthenticate
         $ldaprdn = Configure::read('ApacheSecureAuth.ldapReaderUser');     // DN ou RDN LDAP
         $ldappass = Configure::read('ApacheSecureAuth.ldapReaderPassword');
         $ldapSearchFilter = Configure::read('ApacheSecureAuth.ldapSearchFilter');
+
         // LDAP connection
+        ldap_set_option(NULL, LDAP_OPT_NETWORK_TIMEOUT, Configure::read('ApacheSecureAuth.ldapNetworkTimeout', -1));
         $ldapconn = ldap_connect(Configure::read('ApacheSecureAuth.ldapServer'))
                 or die('LDAP server connection failed');
 


### PR DESCRIPTION
#### What does it do?

Adds an option to timeout during an LDAP connection, if the server doesn't respond.
By default, it sets the network timeout to -1, meaning infinite timeout, same behavior as before this change.

Reference for the LDAP option: https://linux.die.net/man/3/ldap_set_option
> **LDAP_OPT_NETWORK_TIMEOUT**
> Sets/gets the network timeout value after which poll(2)/select(2) following a connect(2) returns in case of no activity. outvalue must be a struct timeval ** (the caller has to free *outvalue), and invalue must be a const struct timeval *. They cannot be NULL. Using a struct with seconds set to -1 results in an infinite timeout, which is the default. This option is OpenLDAP specific.

This option is supported since PHP 5.3.0

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
