### PR TITLE
Fix rhel7 diagnostics page

### DIFF
--- a/docs/INSTALL.rhel7.md
+++ b/docs/INSTALL.rhel7.md
@@ -190,11 +190,7 @@ systemctl restart rh-php71-php-fpm.service
 ## 3.06/ Enable dependencies detection in the diagnostics page
 Add the following content to `/etc/opt/rh/rh-php71/php-fpm.d/www.conf` :
 ```
-env[PATH] = /usr/bin:/opt/rh/rh-php71/root/usr/bin:/opt/rh/rh-php71/root/usr/sbin:/opt/rh/rh-python36/root/usr/bin
-env[LD_LIBRARY_PATH] = /opt/rh/rh-php71/root/usr/lib64:/opt/rh/rh-python36/root/usr/lib64
-env[MANPATH] = /opt/rh/rh-php71/root/usr/share/man:/opt/rh/rh-python36/root/usr/share/man
-env[PKG_CONFIG_PATH] = /opt/rh/rh-python36/root/usr/lib64/pkgconfig
-env[XDG_DATA_DIRS] = /opt/rh/rh-python36/root/usr/share
+env[PATH] =/opt/rh/rh-redis32/root/usr/bin:/opt/rh/rh-python36/root/usr/bin:/opt/rh/rh-php71/root/usr/bin:/usr/local/bin:/usr/bin:/bin
 ```
 Then run `systemctl restart rh-php71-php-fpm.service`.
 This allows MISP to detect GnuPG, the Python modules' versions and to read the PHP settings.
@@ -513,10 +509,7 @@ scl enable rh-python36 python3
 ```
 
 # 12/ Known Issues
-## 12.01/ PHP CLI cannot determine version
-PHP CLI Version cannot be determined. Possibly due to PHP being installed through SCL
-
-## 12.02/ Workers cannot be started or restarted from the web page
+## 12.01/ Workers cannot be started or restarted from the web page
 Possible also due to package being installed via SCL, attempting to start workers through the web page will result in
 error. Worker's can be restarted via the CLI using the following command.
 ```bash

--- a/docs/INSTALL.rhel7.md
+++ b/docs/INSTALL.rhel7.md
@@ -240,16 +240,9 @@ sudo -H -u www-data pear install ${PATH_TO_MISP}/INSTALL/dependencies/Crypt_GPG/
 # 5/ Set file permissions
 ## 5.01/ Make sure the permissions are set correctly using the following commands as root:
 ```bash
-chown -R root:apache /var/www/MISP
+chown -R apache:apache /var/www/MISP
 find /var/www/MISP -type d -exec chmod g=rx {} \;
 chmod -R g+r,o= /var/www/MISP
-chown apache:apache /var/www/MISP/app/files
-chown apache:apache /var/www/MISP/app/files/terms
-chown apache:apache /var/www/MISP/app/files/scripts/tmp
-chown apache:apache /var/www/MISP/app/Plugin/CakeResque/tmp
-chown -R apache:apache /var/www/MISP/app/tmp
-chown -R apache:apache /var/www/MISP/app/webroot/img/orgs
-chown -R apache:apache /var/www/MISP/app/webroot/img/custom
 ```
 
 # 6/ Create database and user

--- a/docs/INSTALL.rhel7.md
+++ b/docs/INSTALL.rhel7.md
@@ -187,6 +187,18 @@ sed -i.org -e 's/^;\(clear_env = no\)/\1/' /etc/opt/rh/rh-php71/php-fpm.d/www.co
 systemctl restart rh-php71-php-fpm.service
 ```
 
+## 3.06/ Enable dependencies detection in the diagnostics page
+Add the following content to `/etc/opt/rh/rh-php71/php-fpm.d/www.conf` :
+```
+env[PATH] = /usr/bin:/opt/rh/rh-php71/root/usr/bin:/opt/rh/rh-php71/root/usr/sbin:/opt/rh/rh-python36/root/usr/bin
+env[LD_LIBRARY_PATH] = /opt/rh/rh-php71/root/usr/lib64:/opt/rh/rh-python36/root/usr/lib64
+env[MANPATH] = /opt/rh/rh-php71/root/usr/share/man:/opt/rh/rh-python36/root/usr/share/man
+env[PKG_CONFIG_PATH] = /opt/rh/rh-python36/root/usr/lib64/pkgconfig
+env[XDG_DATA_DIRS] = /opt/rh/rh-python36/root/usr/share
+```
+Then run `systemctl restart rh-php71-php-fpm.service`.
+This allows MISP to detect GnuPG, the Python modules' versions and to read the PHP settings.
+
 # 4/ CakePHP
 
 ## 4.01/ CakePHP is now included as a submodule of MISP


### PR DESCRIPTION
#### What does it do?

Fixes issues with the diagnotics page in RHEL7 and most likely CentOS 7 : 
* #4084 : with this commit the diagnostics page now detects, GPG, the PHP settings and the Python modules' versions properly without causing git not to be detected ( #4134 )
* allows the update through the web interface without permission issues by assigning ownership of /var/www/MISP to apache:apache instead of root:apache like what is done in other installation procedures ( Debian 9's, Ubuntu's... ).

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
