### PR TITLE
fix: Typo in tag ID query

### DIFF
--- a/app/Controller/TagsController.php
+++ b/app/Controller/TagsController.php
@@ -293,7 +293,7 @@ class TagsController extends AppController
             if ($this->Tag->save($this->request->data)) {
                 if ($this->_isRest()) {
                     $tag = $this->Tag->find('first', array(
-                        'contidions' => array(
+                        'conditions' => array(
                             'Tag.id' => $id
                         ),
                         'recursive' => -1


### PR DESCRIPTION
In the REST `/tags/edit/:id` endpoint there was a typo causing the response to always be the tag with the lowest ID

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
