### PR TITLE
Change test URL for proxy

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -3894,7 +3894,7 @@ class Server extends AppModel
             $syncTool = new SyncTool();
             try {
                 $HttpSocket = $syncTool->setupHttpSocket();
-                $proxyResponse = $HttpSocket->get('http://www.example.com/');
+                $proxyResponse = $HttpSocket->get('https://www.github.com/');
             } catch (Exception $e) {
                 $proxyStatus = 2;
             }


### PR DESCRIPTION
#### What does it do?

Some proxies only allow access to a very restricted set of URLs. As such, it makes sense for MISP to test the proxy settings using the URL of a resource that MISP will need to use later so that an extra URL does not need to be whitelisted on the proxy for the test to be successful.
Since github.com needs to be accessed for updates to work, using https://github.com for the proxy test makes more sense than using http://example.com ( although ideally there would be a config setting allow the administrators to change the test URL but I haven't figured out how to do it yet ).

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
