### PR TITLE
fix: working directory in update function

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -4315,17 +4315,18 @@ class Server extends AppModel
     public function update($status)
     {
         $final = '';
+        $workingDirectoryPrefix = 'cd $(git rev-parse --show-toplevel) && ';
         $cleanup_commands = array(
             // (>^-^)> [hacky]
-            'git checkout app/composer.json 2>&1'
+            $workingDirectoryPrefix . 'git checkout app/composer.json 2>&1'
         );
         foreach ($cleanup_commands as $cleanup_command) {
             $final .= $cleanup_command . "\n\n";
             exec($cleanup_command, $output);
             $final .= implode("\n", $output) . "\n\n";
         }
-        $command1 = 'git pull origin ' . $status['branch'] . ' 2>&1';
-        $command2 = 'git submodule update --init --recursive 2>&1';
+        $command1 = $workingDirectoryPrefix . 'git pull origin ' . $status['branch'] . ' 2>&1';
+        $command2 = $workingDirectoryPrefix . 'git submodule update --init --recursive 2>&1';
         $final .= $command1 . "\n\n";
         exec($command1, $output);
         $final .= implode("\n", $output) . "\n\n=================================\n\n";


### PR DESCRIPTION
#### What does it do?

The commands in the update function were executed in the folder $MISP_ROOT/app/webroot which lead to the following bugs :
* `error: pathspec 'app/composer.json' did not match any file(s) known to git` When checking out app/composer.json, see #3528
* an error message along the lines of `this command must be executed from the root of the project` when executing `git submodule update`

This commit fixes these issues by making sure all the commands are executed in the project's root folder ( which is found using `git rev-parse --show-toplevel` )

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
