### PR TITLE
new: Add CORS settings for external integration

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -103,6 +103,21 @@ class AppController extends Controller
 
     public function beforeFilter()
     {
+        if (Configure::read('Security.allow_cors')) {
+            // Add CORS headers
+            $this->response->cors($this->request,
+                    explode(',', Configure::read('Security.cors_origins')),
+                    ['*'],
+                    ['Origin', 'Content-Type', 'Authorization', 'Accept']);
+
+            if ($this->request->is('options')) {
+                // Stop here!
+                // CORS only needs the headers
+                $this->response->send();    
+                $this->_stop();
+            }
+        }
+
         if (!empty($this->params['named']['sql'])) {
             $this->sql_dump = 1;
         }

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1105,6 +1105,24 @@ class Server extends AppModel
                             'test' => 'testBoolFalse',
                             'type' => 'boolean',
                             'null' => true
+                        ),
+                        'allow_cors' => array(
+                            'level' => 1,
+                            'description' => __('Allow cross-origin requests to this instance, matching origins given in Security.cors_origins. Set to false to totally disable'),
+                            'value' => false,
+                            'errorMessage' => '',
+                            'test' => 'testBool',
+                            'type' => 'boolean',
+                            'null' => true
+                        ),
+                        'cors_origins' => array(
+                            'level' => 1,
+                            'description' => __('Set the origins from which MISP will allow cross-origin requests. Useful for external integration. Comma seperate if you need more than one.'),
+                            'value' => '',
+                            'errorMessage' => '',
+                            'test' => 'testForEmpty',
+                            'type' => 'string',
+                            'null' => true
                         )
                 ),
                 'SecureAuth' => array(


### PR DESCRIPTION
Fixes #3996 

Implements a response for HTTP `OPTIONS` which will return a standard empty response, and if the user so desires, allow CORS requests from one or more specified origins

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
