### PR TITLE
fix: re-add CORS headers on REST Response

### DIFF
--- a/app/Controller/Component/RestResponseComponent.php
+++ b/app/Controller/Component/RestResponseComponent.php
@@ -423,14 +423,23 @@ class RestResponseComponent extends Component
             $type = 'json';
         }
         $cakeResponse = new CakeResponse(array('body'=> $response, 'status' => $code, 'type' => $type));
+
+        if (Configure::read('Security.allow_cors')) {
+            $headers["Access-Control-Allow-Headers"] =  "Origin, Content-Type, Authorization, Accept";
+            $headers["Access-Control-Allow-Methods"] = "*";
+            $headers["Access-Control-Allow-Origin"] = explode(',', Configure::read('Security.cors_origins'));
+        }
+
         if (!empty($headers)) {
             foreach ($headers as $key => $value) {
                 $cakeResponse->header($key, $value);
             }
         }
+
         if ($download) {
             $cakeResponse->download($download);
         }
+
         return $cakeResponse;
     }
 


### PR DESCRIPTION
Aaand another one really quickly

On REST response, all headers previously set were being purged, this re-adds CORS-related ones

There's likely a neater way of doing this, but it'll do for now

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
