### PR TITLE
fix: Correct X-Results-Count header

### DIFF
--- a/app/Controller/Component/RestResponseComponent.php
+++ b/app/Controller/Component/RestResponseComponent.php
@@ -428,6 +428,7 @@ class RestResponseComponent extends Component
             $headers["Access-Control-Allow-Headers"] =  "Origin, Content-Type, Authorization, Accept";
             $headers["Access-Control-Allow-Methods"] = "*";
             $headers["Access-Control-Allow-Origin"] = explode(',', Configure::read('Security.cors_origins'));
+            $headers["Access-Control-Expose-Headers"] = ["X-Result-Count"];
         }
 
         if (!empty($headers)) {

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1389,7 +1389,7 @@ class Event extends AppModel
         return $tempConditions;
     }
 
-    public function filterEventIds($user, &$params = array())
+    public function filterEventIds($user, &$params = array(), &$result_count = 0)
     {
         $conditions = $this->createEventConditions($user);
         if (isset($params['wildcard'])) {
@@ -1471,6 +1471,10 @@ class Event extends AppModel
             'recursive' => -1,
             'fields' => $fields
         );
+
+        // Get the count (but not the actual data) of results for paginators
+        $result_count = $this->find('count', $find_params);
+
         if (isset($params['limit'])) {
             $find_params['limit'] = $params['limit'];
             if (isset($params['page'])) {
@@ -5612,7 +5616,7 @@ class Event extends AppModel
             }
         }
         $filters['include_attribute_count'] = 1;
-        $eventid = $this->filterEventIds($user, $filters);
+        $eventid = $this->filterEventIds($user, $filters, $elementCounter);
         $eventCount = count($eventid);
         $eventids_chunked = $this->__clusterEventIds($exportTool, $eventid);
         unset($eventid);


### PR DESCRIPTION
Fixes #4161

#### What does it do?

Changes the `X-Result-Count` header to return the pre-pagination result count

This does add another database query, although will not return the data. Shouldn't add too much to the overall processing time

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
