### PR TITLE
Tempopary fix galaxy_matrix heatmap (mitre-attack)

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -4714,10 +4714,7 @@ class EventsController extends AppController
                 $clusterValue = $predicateValue[1];
                 $mappedTag = '';
                 $mappingWithoutExternalId = array();
-                if ($predicate == 'mitre-attack-pattern'
-                    || $predicate == 'mitre-mobile-attack-pattern'
-                    || $predicate == 'mitre-pre-attack-pattern'
-                ) {
+                if ($predicate == 'mitre-attack-pattern') {
                     $mappedTag = $tag;
                     $name = explode(" ", $tag);
                     $name = join(" ", array_slice($name, 0, -2)); // remove " - external_id"

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -1876,6 +1876,51 @@ class UsersController extends AppController
         }
         $maxScore = max($scoresDataAttr['maxScore'], $scoresDataEvent['maxScore']);
         $scores = $scoresData;
+        // FIXME: temporary fix: add the score of deprecated mitre galaxies to the new one (for the stats)
+        if ($matrixData['galaxy']['id'] == $galaxy_id) {
+            $mergedScore = array();
+            foreach ($scoresData as $tag => $v) {
+                $predicateValue = explode(':', $tag, 2)[1];
+                $predicateValue = explode('=', $predicateValue, 2);
+                $predicate = $predicateValue[0];
+                $clusterValue = $predicateValue[1];
+                $mappedTag = '';
+                $mappingWithoutExternalId = array();
+                if ($predicate == 'mitre-attack-pattern'
+                    || $predicate == 'mitre-mobile-attack-pattern'
+                    || $predicate == 'mitre-pre-attack-pattern'
+                ) {
+                    $mappedTag = $tag;
+                    $name = explode(" ", $tag);
+                    $name = join(" ", array_slice($name, 0, -2)); // remove " - external_id"
+                    $mappingWithoutExternalId[$name] = $tag;
+                } else {
+                    $name = explode(" ", $clusterValue);
+                    $name = join(" ", array_slice($name, 0, -2)); // remove " - external_id"
+                    if (isset($mappingWithoutExternalId[$name])) {
+                        $mappedTag = $mappingWithoutExternalId[$name];
+                    } else {
+                        $adjustedTagName = $this->Galaxy->GalaxyCluster->find('list', array(
+                            'group' => array('GalaxyCluster.id', 'GalaxyCluster.tag_name'),
+                            'conditions' => array('GalaxyCluster.tag_name LIKE' => 'misp-galaxy:mitre-attack-pattern=' . $name . '% T%'),
+                            'fields' => array('GalaxyCluster.tag_name')
+                        ));
+                        $adjustedTagName = array_values($adjustedTagName)[0];
+                        $mappingWithoutExternalId[$name] = $adjustedTagName;
+                        $mappedTag = $mappingWithoutExternalId[$name];
+                    }
+                }
+
+                if (isset($mergedScore[$mappedTag])) {
+                    $mergedScore[$mappedTag] += $v;
+                } else {
+                    $mergedScore[$mappedTag] = $v;
+                }
+            }
+            $scores = $mergedScore;
+            $maxScore = max(array_values($mergedScore));
+        }
+        // end FIXME
 
         if ($this->_isRest()) {
             $json = array('matrix' => $tabs, 'scores' => $scores, 'instance-uuid' => $instanceUUID);

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -1886,10 +1886,7 @@ class UsersController extends AppController
                 $clusterValue = $predicateValue[1];
                 $mappedTag = '';
                 $mappingWithoutExternalId = array();
-                if ($predicate == 'mitre-attack-pattern'
-                    || $predicate == 'mitre-mobile-attack-pattern'
-                    || $predicate == 'mitre-pre-attack-pattern'
-                ) {
+                if ($predicate == 'mitre-attack-pattern') {
                     $mappedTag = $tag;
                     $name = explode(" ", $tag);
                     $name = join(" ", array_slice($name, 0, -2)); // remove " - external_id"

--- a/app/Model/Galaxy.php
+++ b/app/Model/Galaxy.php
@@ -434,7 +434,7 @@ class Galaxy extends AppModel
                     $cluster['external_id'] = $element['value'];
                 }
                 if ($toBeAdded) {
-                    array_push($matrixData['matrixTags'], $cluster['tag_name']);
+                    $matrixData['matrixTags'][$cluster['tag_name']] = 1;
                 }
             }
         }
@@ -450,6 +450,23 @@ class Galaxy extends AppModel
                     }
                 );
             }
+        }
+
+        // #FIXME temporary fix: retreive tag name of deprecated mitre galaxies (for the stats)
+        if ($galaxy['Galaxy']['id'] == $this->getMitreAttackGalaxyId()) {
+            $names = array('Enterprise Attack - Attack Pattern', 'Pre Attack - Attack Pattern', 'Mobile Attack - Attack Pattern');
+            $tag_names = array();
+            $gals = $this->find('all', array(
+                    'recursive' => -1,
+                    'contain' => array('GalaxyCluster.tag_name'),
+                    'conditions' => array('Galaxy.name' => $names)
+            ));
+            foreach ($gals as $gal => $temp) {
+                foreach ($temp['GalaxyCluster'] as $value) {
+                    $matrixData['matrixTags'][$value['tag_name']] = 1;
+                }
+            }
+            $matrixData['matrixTags'] = array_keys($matrixData['matrixTags']);
         }
 
         return $matrixData;

--- a/app/Model/Galaxy.php
+++ b/app/Model/Galaxy.php
@@ -466,9 +466,10 @@ class Galaxy extends AppModel
                     $matrixData['matrixTags'][$value['tag_name']] = 1;
                 }
             }
-            $matrixData['matrixTags'] = array_keys($matrixData['matrixTags']);
         }
+        // end FIXME
 
+        $matrixData['matrixTags'] = array_keys($matrixData['matrixTags']);
         return $matrixData;
     }
 }


### PR DESCRIPTION
While we are in the transition phase where the ``fixMitreTags`` function is not live and running, this PR tries to merge the scores of both the deprecated and ``mitre-attack`` galaxies (so that the heatmap on the matrix is preserved).
This PR should be reverted (or delete the code) once ``fixMitreTags`` written by @cvandeplas will be integrated.

This unoptmized code is inefficient and may be inaccurate in case of name collision. However, it is needed as technique IDs changed over time (see attached screenshot for an example for ``Application Discovery``).
![id-mitre](https://user-images.githubusercontent.com/6977223/52861288-54107000-3132-11e9-9e39-2318d483a428.png)

