### PR TITLE
[fix] Correct X-Result-Count

### DIFF
--- a/app/Controller/Component/RestResponseComponent.php
+++ b/app/Controller/Component/RestResponseComponent.php
@@ -428,6 +428,7 @@ class RestResponseComponent extends Component
             $headers["Access-Control-Allow-Headers"] =  "Origin, Content-Type, Authorization, Accept";
             $headers["Access-Control-Allow-Methods"] = "*";
             $headers["Access-Control-Allow-Origin"] = explode(',', Configure::read('Security.cors_origins'));
+            $headers["Access-Control-Expose-Headers"] = ["X-Result-Count"];
         }
 
         if (!empty($headers)) {

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1389,7 +1389,7 @@ class Event extends AppModel
         return $tempConditions;
     }
 
-    public function filterEventIds($user, &$params = array())
+    public function filterEventIds($user, &$params = array(), &$result_count = 0)
     {
         $conditions = $this->createEventConditions($user);
         if (isset($params['wildcard'])) {
@@ -1471,6 +1471,10 @@ class Event extends AppModel
             'recursive' => -1,
             'fields' => $fields
         );
+
+        // Get the count (but not the actual data) of results for paginators
+        $result_count = $this->find('count', $find_params);
+
         if (isset($params['limit'])) {
             $find_params['limit'] = $params['limit'];
             if (isset($params['page'])) {
@@ -5612,7 +5616,7 @@ class Event extends AppModel
             }
         }
         $filters['include_attribute_count'] = 1;
-        $eventid = $this->filterEventIds($user, $filters);
+        $eventid = $this->filterEventIds($user, $filters, $elementCounter);
         $eventCount = count($eventid);
         $eventids_chunked = $this->__clusterEventIds($exportTool, $eventid);
         unset($eventid);

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -5657,7 +5657,6 @@ class Event extends AppModel
             );
             if (!empty($result)) {
                 foreach ($result as $event) {
-                    $elementCounter++;
                     if ($jobId && $i%10 == 0) {
                         $this->Job->saveField('progress', intval((100 * $i) / $eventCount));
                         $this->Job->saveField('message', 'Converting Event ' . $i . '/' . $eventCount . '.');


### PR DESCRIPTION
#### What does it do?

Fixes #4161 

Also fixes my idiocy in #4163 (I forgot to remove the previously existing incrementing count :<)

Anyhow, it sets the `X-Result-Count` header to the pre-paginated result count, to allow for clients to display a "page count" 

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
