### PR TITLE
Fix broken "List Tags" link

### DIFF
--- a/app/View/Elements/global_menu.ctp
+++ b/app/View/Elements/global_menu.ctp
@@ -47,7 +47,7 @@
                     ),
                     array(
                         'text' => __('List Tags'),
-                        'url' => 'tags/index'
+                        'url' => '/tags/index'
                     ),
                     array(
                         'text' => __('List Tag Collections'),


### PR DESCRIPTION
The "List Tags" link on the event view page was broken.