### PR TITLE
[add] MalSilo feeds tracking commodity malware

### DIFF
--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -1549,5 +1549,57 @@
       "headers": "",
       "caching_enabled": true
     }
-  }
+  },
+  {
+    "Feed": {
+        "id": "77",
+        "name": "malsilo.url",
+        "provider": "MalSilo",
+        "url": "https:\/\/malsilo.gitlab.io\/feeds\/dumps\/url_list.txt",
+        "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]}}",
+        "enabled": false,
+        "distribution": "3",
+        "sharing_group_id": "0",
+        "tag_id": "0",
+        "default": false,
+        "source_format": "csv",
+        "fixed_event": true,
+        "delta_merge": false,
+        "event_id": "0",
+        "publish": false,
+        "override_ids": false,
+        "settings": "{\"csv\":{\"value\":\"3\",\"delimiter\":\",\"},\"common\":{\"excluderegex\":\"\"}}",
+        "input_source": "network",
+        "delete_local_file": false,
+        "lookup_visible": true,
+        "headers": "",
+        "caching_enabled": true
+    }
+  },
+  {
+    "Feed": {
+        "id": "78",
+        "name": "malsilo.ipv4",
+        "provider": "MalSilo",
+        "url": "https:\/\/malsilo.gitlab.io\/feeds\/dumps\/ip_list.txt",
+        "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]}}",
+        "enabled": false,
+        "distribution": "3",
+        "sharing_group_id": "0",
+        "tag_id": "0",
+        "default": false,
+        "source_format": "csv",
+        "fixed_event": true,
+        "delta_merge": false,
+        "event_id": "0",
+        "publish": false,
+        "override_ids": false,
+        "settings": "{\"csv\":{\"value\":\"3\",\"delimiter\":\",\"},\"common\":{\"excluderegex\":\"\"}}",
+        "input_source": "network",
+        "delete_local_file": false,
+        "lookup_visible": true,
+        "headers": "",
+        "caching_enabled": true
+    }
+}
 ]


### PR DESCRIPTION
Added two new feeds to the default set (covering url and ipv4), from the MalSilo project (https://raw-data.gitlab.io/post/feeds/).

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2016-06-03: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?
If it fixes an existing issue, please use github syntax: #<IssueID>

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
