### PR TITLE
fix: Events index filter button i18n bug

### DIFF
--- a/app/Locale/cze/LC_MESSAGES/default.po
+++ b/app/Locale/cze/LC_MESSAGES/default.po
@@ -6624,6 +6624,10 @@ msgstr ""
 msgid "Quickfilter"
 msgstr ""
 
+#: View/Events/index.ctp:95
+msgid "Enter value to search"
+msgstr ""
+
 #: View/Events/index.ctp:44
 #: View/Organisations/index.ctp:59
 #: View/Servers/preview_index.ctp:45

--- a/app/Locale/dan/LC_MESSAGES/default.po
+++ b/app/Locale/dan/LC_MESSAGES/default.po
@@ -6632,6 +6632,10 @@ msgstr "Slet valgte Events"
 msgid "Quickfilter"
 msgstr "Quickfilter"
 
+#: View/Events/index.ctp:95
+msgid "Enter value to search"
+msgstr ""
+
 #: View/Events/index.ctp:44
 #: View/Organisations/index.ctp:59
 #: View/Servers/preview_index.ctp:45

--- a/app/Locale/default.pot
+++ b/app/Locale/default.pot
@@ -6872,6 +6872,10 @@ msgstr ""
 msgid "Quickfilter"
 msgstr ""
 
+#: View/Events/index.ctp:95
+msgid "Enter value to search"
+msgstr ""
+
 #: View/Events/index.ctp:44
 #: View/Organisations/index.ctp:59
 #: View/Servers/preview_index.ctp:45

--- a/app/Locale/deu/LC_MESSAGES/default.po
+++ b/app/Locale/deu/LC_MESSAGES/default.po
@@ -6624,6 +6624,10 @@ msgstr ""
 msgid "Quickfilter"
 msgstr ""
 
+#: View/Events/index.ctp:95
+msgid "Enter value to search"
+msgstr ""
+
 #: View/Events/index.ctp:44
 #: View/Organisations/index.ctp:59
 #: View/Servers/preview_index.ctp:45

--- a/app/Locale/fra/LC_MESSAGES/default.po
+++ b/app/Locale/fra/LC_MESSAGES/default.po
@@ -6643,6 +6643,10 @@ msgstr "Supprimer les événements sélectionnés"
 msgid "Quickfilter"
 msgstr "Filtre rapide"
 
+#: View/Events/index.ctp:95
+msgid "Enter value to search"
+msgstr ""
+
 #: View/Events/index.ctp:44
 #: View/Organisations/index.ctp:59
 #: View/Servers/preview_index.ctp:45

--- a/app/Locale/hun/LC_MESSAGES/default.po
+++ b/app/Locale/hun/LC_MESSAGES/default.po
@@ -6624,6 +6624,10 @@ msgstr ""
 msgid "Quickfilter"
 msgstr ""
 
+#: View/Events/index.ctp:95
+msgid "Enter value to search"
+msgstr ""
+
 #: View/Events/index.ctp:44
 #: View/Organisations/index.ctp:59
 #: View/Servers/preview_index.ctp:45

--- a/app/Locale/ita/LC_MESSAGES/default.po
+++ b/app/Locale/ita/LC_MESSAGES/default.po
@@ -6629,6 +6629,10 @@ msgstr "Cancella gli eventi selezionati"
 msgid "Quickfilter"
 msgstr "Filtro rapido"
 
+#: View/Events/index.ctp:95
+msgid "Enter value to search"
+msgstr ""
+
 #: View/Events/index.ctp:44
 #: View/Organisations/index.ctp:59
 #: View/Servers/preview_index.ctp:45

--- a/app/Locale/jpn/LC_MESSAGES/default.po
+++ b/app/Locale/jpn/LC_MESSAGES/default.po
@@ -6638,6 +6638,10 @@ msgstr "選択したイベントを削除"
 msgid "Quickfilter"
 msgstr "クイックフィルタ"
 
+#: View/Events/index.ctp:95
+msgid "Enter value to search"
+msgstr ""
+
 #: View/Events/index.ctp:44
 #: View/Organisations/index.ctp:59
 #: View/Servers/preview_index.ctp:45

--- a/app/Locale/kor/LC_MESSAGES/default.po
+++ b/app/Locale/kor/LC_MESSAGES/default.po
@@ -6624,6 +6624,10 @@ msgstr ""
 msgid "Quickfilter"
 msgstr ""
 
+#: View/Events/index.ctp:95
+msgid "Enter value to search"
+msgstr ""
+
 #: View/Events/index.ctp:44
 #: View/Organisations/index.ctp:59
 #: View/Servers/preview_index.ctp:45

--- a/app/Locale/pt_BR/LC_MESSAGES/default.po
+++ b/app/Locale/pt_BR/LC_MESSAGES/default.po
@@ -6624,6 +6624,10 @@ msgstr ""
 msgid "Quickfilter"
 msgstr ""
 
+#: View/Events/index.ctp:95
+msgid "Enter value to search"
+msgstr ""
+
 #: View/Events/index.ctp:44
 #: View/Organisations/index.ctp:59
 #: View/Servers/preview_index.ctp:45

--- a/app/Locale/rus/LC_MESSAGES/default.po
+++ b/app/Locale/rus/LC_MESSAGES/default.po
@@ -6624,6 +6624,10 @@ msgstr ""
 msgid "Quickfilter"
 msgstr ""
 
+#: View/Events/index.ctp:95
+msgid "Enter value to search"
+msgstr ""
+
 #: View/Events/index.ctp:44
 #: View/Organisations/index.ctp:59
 #: View/Servers/preview_index.ctp:45

--- a/app/Locale/spa/LC_MESSAGES/default.po
+++ b/app/Locale/spa/LC_MESSAGES/default.po
@@ -6624,6 +6624,10 @@ msgstr ""
 msgid "Quickfilter"
 msgstr ""
 
+#: View/Events/index.ctp:95
+msgid "Enter value to search"
+msgstr ""
+
 #: View/Events/index.ctp:44
 #: View/Organisations/index.ctp:59
 #: View/Servers/preview_index.ctp:45

--- a/app/Locale/ukr/LC_MESSAGES/default.po
+++ b/app/Locale/ukr/LC_MESSAGES/default.po
@@ -6624,6 +6624,10 @@ msgstr ""
 msgid "Quickfilter"
 msgstr ""
 
+#: View/Events/index.ctp:95
+msgid "Enter value to search"
+msgstr ""
+
 #: View/Events/index.ctp:44
 #: View/Organisations/index.ctp:59
 #: View/Servers/preview_index.ctp:45

--- a/app/Locale/zh-s/LC_MESSAGES/default.po
+++ b/app/Locale/zh-s/LC_MESSAGES/default.po
@@ -6897,6 +6897,10 @@ msgstr ""
 msgid "Quickfilter"
 msgstr ""
 
+#: View/Events/index.ctp:95
+msgid "Enter value to search"
+msgstr ""
+
 #: View/Events/index.ctp:44
 #: View/Organisations/index.ctp:59
 #: View/Servers/preview_index.ctp:45

--- a/app/View/Events/index.ctp
+++ b/app/View/Events/index.ctp
@@ -91,8 +91,8 @@
                 ),
                 array(
                     'type' => 'search',
-                    'button' => 'Filter',
-                    'placeholder' => 'Enter value to search',
+                    'button' => __('Filter'),
+                    'placeholder' => __('Enter value to search'),
                     'data' => '',
                 )
             )

--- a/app/View/Organisations/index.ctp
+++ b/app/View/Organisations/index.ctp
@@ -72,8 +72,8 @@
                 ),
                 array(
                     'type' => 'search',
-                    'button' => 'Filter',
-                    'placeholder' => 'Enter value to search',
+                    'button' => __('Filter'),
+                    'placeholder' => __('Enter value to search'),
                     'data' => '',
                 )
             )

--- a/app/View/Servers/preview_index.ctp
+++ b/app/View/Servers/preview_index.ctp
@@ -61,8 +61,8 @@
                 ),
                 array(
                     'type' => 'search',
-                    'button' => 'Filter',
-                    'placeholder' => 'Enter value to search',
+                    'button' => __('Filter'),
+                    'placeholder' => __('Enter value to search'),
                     'data' => '',
                 )
             )


### PR DESCRIPTION
Small fix to Events index template.
Button "Filter" and "Search field" were without correct i18n usage.
Also added new record in default.pot file
