### PR TITLE
Add correct PyMISP_dir to sys.path

### DIFF
--- a/app/files/scripts/stix2/stix2misp.py
+++ b/app/files/scripts/stix2/stix2misp.py
@@ -29,7 +29,7 @@ from stix2misp_mapping import *
 from collections import defaultdict
 
 _MISP_dir = "/".join([p for p in os.path.dirname(os.path.realpath(__file__)).split('/')[:-4]])
-_PyMISP_dir = '{_MISP_dir}/PyMISP/pymisp'.format(_MISP_dir=_MISP_dir)
+_PyMISP_dir = '{_MISP_dir}/PyMISP'.format(_MISP_dir=_MISP_dir)
 _MISP_objects_path = '{_MISP_dir}/app/files/misp-objects/objects'.format(_MISP_dir=_MISP_dir)
 sys.path.append(_PyMISP_dir)
 from pymisp.mispevent import MISPEvent, MISPObject, MISPAttribute
@@ -38,7 +38,7 @@ TAG_REGEX = re.compile(r"\(.+\) .+ = .+")
 special_parsing = ('relationship', 'report', 'galaxy', 'marking-definition')
 galaxy_types = {'attack-pattern': 'Attack Pattern', 'intrusion-set': 'Intrusion Set',
                 'malware': 'Malware', 'threat-actor': 'Threat Actor', 'tool': 'Tool'}
-with open('{_PyMISP_dir}/data/describeTypes.json'.format(_PyMISP_dir=_PyMISP_dir), 'r') as f:
+with open('{_PyMISP_dir}/pymisp/data/describeTypes.json'.format(_PyMISP_dir=_PyMISP_dir), 'r') as f:
     misp_types = json.loads(f.read())['result'].get('types')
 
 class StixParser():

--- a/app/files/scripts/stix2misp.py
+++ b/app/files/scripts/stix2misp.py
@@ -28,7 +28,7 @@ from stix.core import STIXPackage
 from collections import defaultdict
 
 _MISP_dir = "/".join([p for p in os.path.dirname(os.path.realpath(__file__)).split('/')[:-3]])
-_PyMISP_dir = '{_MISP_dir}/PyMISP/pymisp'.format(_MISP_dir=_MISP_dir)
+_PyMISP_dir = '{_MISP_dir}/PyMISP'.format(_MISP_dir=_MISP_dir)
 _MISP_objects_path = '{_MISP_dir}/app/files/misp-objects/objects'.format(_MISP_dir=_MISP_dir)
 sys.path.append(_PyMISP_dir)
 from pymisp.mispevent import MISPEvent, MISPObject, MISPAttribute
@@ -40,7 +40,7 @@ cybox_to_misp_object = {"Account": "credential", "AutonomousSystem": "asn",
 
 threat_level_mapping = {'High': '1', 'Medium': '2', 'Low': '3', 'Undefined': '4'}
 
-with open("{_PyMISP_dir}/data/describeTypes.json".format(_PyMISP_dir=_PyMISP_dir), 'r') as f:
+with open("{_PyMISP_dir}/pymisp/data/describeTypes.json".format(_PyMISP_dir=_PyMISP_dir), 'r') as f:
     categories = json.loads(f.read())['result'].get('categories')
 
 class StixParser():


### PR DESCRIPTION
The clever hack of loading pymisp from the MISP install directory didn't work. Now it does.