### PR TITLE
Fix checking of incorrect flags when publishing to ZMQ

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -354,7 +354,7 @@ class Event extends AppModel
             $orgc = $this->Orgc->find('first', array('conditions' => array('Orgc.id' => $this->data['Event']['orgc_id']), 'recursive' => -1, 'fields' => array('Orgc.name')));
             $this->EventBlacklist->save(array('event_uuid' => $this->data['Event']['uuid'], 'event_info' => $this->data['Event']['info'], 'event_orgc' => $orgc['Orgc']['name']));
             if (!empty($this->data['Event']['id'])) {
-                if (Configure::read('Plugin.ZeroMQ_enable') && Configure::read('Plugin.ZeroMQ_attribute_notifications_enable')) {
+                if (Configure::read('Plugin.ZeroMQ_enable') && Configure::read('Plugin.ZeroMQ_event_notifications_enable')) {
                     $pubSubTool = $this->getPubSubTool();
                     $pubSubTool->event_save(array('Event' => $this->data['Event']), 'delete');
                 }

--- a/app/Model/Log.php
+++ b/app/Model/Log.php
@@ -256,7 +256,7 @@ class Log extends AppModel
 
     public function logData($data)
     {
-        if (Configure::read('Plugin.ZeroMQ_enable') && Configure::read('Plugin.ZeroMQ_user_notifications_enable')) {
+        if (Configure::read('Plugin.ZeroMQ_enable') && Configure::read('Plugin.ZeroMQ_audit_notifications_enable')) {
             $pubSubTool = $this->getPubSubTool();
             $pubSubTool->publish($data, 'audit', 'log');
         }

--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -92,7 +92,7 @@ class MispObject extends AppModel
 
     public function afterSave($created, $options = array())
     {
-        if (Configure::read('Plugin.ZeroMQ_enable') && Configure::read('Plugin.ZeroMQ_attribute_notifications_enable')) {
+        if (Configure::read('Plugin.ZeroMQ_enable') && Configure::read('Plugin.ZeroMQ_object_notifications_enable')) {
             if (empty($this->data['Object']['skip_zmq'])) {
                 $pubSubTool = $this->getPubSubTool();
                 $object = $this->find('first', array(


### PR DESCRIPTION
In some places, before publishing something to ZeroMQ, the wrong flag is checked.

* Check `Plugin.ZeroMQ_event_notifications_enable` instead of `Plugin.ZeroMQ_attribute_notifications_enable` in Event.php
* Check `Plugin.ZeroMQ_audit_notifications_enable` instead of `Plugin.ZeroMQ_user_notifications_enable` in Log.php
* Check `Plugin.ZeroMQ_object_notifications_enable` instead of `Plugin.ZeroMQ_attribute_notifications_enable` in MispObject.php

Signed-off-by: Nikos Filippakis <nikolaos.filippakis@cern.ch>

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
