### PR TITLE
Add $time for Plugin.RPZ_serial

### DIFF
--- a/app/Lib/Export/RPZExport.php
+++ b/app/Lib/Export/RPZExport.php
@@ -169,6 +169,7 @@ class RPZExport
     public function buildHeader($rpzSettings)
     {
         $rpzSettings['serial'] = str_replace('$date', date('Ymd'), $rpzSettings['serial']);
+        $rpzSettings['serial'] = str_replace('$time', time(), $rpzSettings['serial']);
         $header = '';
         $header .= '$TTL ' . $rpzSettings['ttl'] . ';' . PHP_EOL;
         $header .= '@               SOA ' . $rpzSettings['ns'] . ' ' . $rpzSettings['email'] . ' ('  . $rpzSettings['serial'] . ' ' . $rpzSettings['refresh'] . ' ' . $rpzSettings['retry'] . ' ' . $rpzSettings['expiry'] . ' ' . $rpzSettings['minimum_ttl'] . ')' . PHP_EOL;


### PR DESCRIPTION
Add $time for generating unixtime as serial

#### What does it do?

Fix 1) in https://github.com/MISP/MISP/issues/4311

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
