### PR TITLE
Fixing bug when exporting to Bro MISP attributes from events that contain a percentage sign inside the event info

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -2390,7 +2390,7 @@ class Attribute extends AppModel
                 'conditions' => $conditions, // array of conditions
                 'order' => 'Attribute.value' . $valueField . ' ASC',
                 'recursive' => -1, // int
-                'fields' => array('Attribute.id', 'Attribute.event_id', 'Attribute.type', 'Attribute.comment', 'Attribute.value' . $valueField . " as value"),
+                'fields' => array('Attribute.id', 'Attribute.event_id', 'Attribute.type', 'Attribute.category', 'Attribute.comment', 'Attribute.to_ids', 'Attribute.value', 'Attribute.value' . $valueField),
                 'contain' => array('Event' => array('fields' => array('Event.id', 'Event.threat_level_id', 'Event.orgc_id', 'Event.uuid'))),
                 'group' => array('Attribute.type', 'Attribute.value' . $valueField), // fields to GROUP BY
                 'enforceWarninglist' => $enforceWarninglist


### PR DESCRIPTION
#### What does it do?

This patch is fixing a bug when exporting to Bro MISP attributes from events that contain a percentage sign inside the event info. The event info used to be part of the export rule format, but of course % has a special meaning inside the sprintf rule format.

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
