### PR TITLE
Make the submit button focusable (tabindex) in the matrix view. 

### DIFF
--- a/app/View/Elements/view_galaxy_matrix.ctp
+++ b/app/View/Elements/view_galaxy_matrix.ctp
@@ -73,7 +73,7 @@ foreach($tabs as $tabName => $column):
 </div>
 
 <div class="attack-matrix-options matrix-div-submit submit-container">
-    <span class="btn btn-inverse btn-matrix-submit" role="button" style="padding: 1px 5px !important;font-size: 12px !important;font-weight: bold;"><?php echo __('Submit'); ?></span>
+    <span class="btn btn-inverse btn-matrix-submit" role="button" tabindex="0" style="padding: 1px 5px !important;font-size: 12px !important;font-weight: bold;"><?php echo __('Submit'); ?></span>
 </div>
 
 <div class="attack-matrix-options">


### PR DESCRIPTION
Make the submit button focusable (tabindex) in the matrix view. This is necessary  for use with screen readers.