### PR TITLE
Add updateUser to default config

### DIFF
--- a/app/Config/config.default.php
+++ b/app/Config/config.default.php
@@ -160,6 +160,7 @@ $config = array(
 			'ldapDefaultOrg'     => '1',      // uses 1st local org in MISP if undefined,
 			'ldapAllowReferrals' => true,   // allow or disallow chasing LDAP referrals
 			//'ldapEmailField' => array('emailAddress, 'mail'), // Optional : fields from which the email address should be retrieved. Default to 'mail' only. If more than one field is set (e.g. 'emailAddress' and 'mail' in this example), only the first one will be used.
+			//'updateUser' => true, // Optional : Will update user on LDAP login to update user fields (e.g. role)
 		),
 	*/
 );


### PR DESCRIPTION
#### What does it do?

Add `updateUser` configuration to default config since this option is missing which fixes #4389 

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
