### PR TITLE
Install python dependencies via Pipfile instead of manually cloning / installing them

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,12 +6,11 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-pymisp = {git = "https://github.com/MISP/PyMISP.git", ref = "64bcaad0e578129543cdffad532a232722615f6c"}
 mixbox = "*"
 cybox = "*"
 stix = "*"
 maec = "*"
-stix2 = {git = "https://github.com/MISP/cti-python-stix2", ref = "407f346eb8118d57b43035ef0da47e2ff77ed00e"}
-python-magic = "*"
-lief = {file = "https://github.com/lief-project/packages/raw/lief-master-latest/pylief-0.9.0.dev.zip"}
+
+pymisp = {git = "https://github.com/MISP/PyMISP.git", ref = "a68bd80ab9dceaee9674bd9a2b0bffc4f387fcdc", extras=["fileobjects"]}
+stix2 = {git = "https://github.com/MISP/cti-python-stix2", ref = "61e9fc0748691f6b768acf47c18ef01b5dc0a854"}
 pydeep = {git = "https://github.com/kbandla/pydeep.git"}

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,17 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+pymisp = {git = "https://github.com/MISP/PyMISP.git", ref = "64bcaad0e578129543cdffad532a232722615f6c"}
+mixbox = "*"
+cybox = "*"
+stix = "*"
+maec = "*"
+stix2 = {git = "https://github.com/MISP/cti-python-stix2", ref = "407f346eb8118d57b43035ef0da47e2ff77ed00e"}
+python-magic = "*"
+lief = {file = "https://github.com/lief-project/packages/raw/lief-master-latest/pylief-0.9.0.dev.zip"}
+pydeep = {git = "https://github.com/kbandla/pydeep.git"}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7a6ddeb923d52e723cb879b1e50154001ba42316df7e9d987caf195d3f21acbc"
+            "sha256": "c927ad078b97ebe317e66dbdddb57f5288db85a0d954dfa88f3d724ae9f954db"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -20,9 +20,6 @@
             ],
             "index": "pypi",
             "version": "==2.1.0.17"
-        },
-        "lief": {
-            "file": "https://github.com/lief-project/packages/raw/lief-master-latest/pylief-0.9.0.dev.zip"
         },
         "lxml": {
             "hashes": [
@@ -83,8 +80,11 @@
             "ref": "bc0d33bff4b45718b4c5f2c79d4715d92a427eda"
         },
         "pymisp": {
+            "extras": [
+                "fileobjects"
+            ],
             "git": "https://github.com/MISP/PyMISP.git",
-            "ref": "64bcaad0e578129543cdffad532a232722615f6c"
+            "ref": "a68bd80ab9dceaee9674bd9a2b0bffc4f387fcdc"
         },
         "python-dateutil": {
             "hashes": [
@@ -92,14 +92,6 @@
                 "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
             ],
             "version": "==2.8.0"
-        },
-        "python-magic": {
-            "hashes": [
-                "sha256:f2674dcfad52ae6c49d4803fa027809540b130db1dec928cfbb9240316831375",
-                "sha256:f3765c0f582d2dfc72c15f3b5a82aecfae9498bd29ca840d72f37d7bd38bfcd5"
-            ],
-            "index": "pypi",
-            "version": "==0.4.15"
         },
         "six": {
             "hashes": [
@@ -117,7 +109,7 @@
         },
         "stix2": {
             "git": "https://github.com/MISP/cti-python-stix2",
-            "ref": "407f346eb8118d57b43035ef0da47e2ff77ed00e"
+            "ref": "61e9fc0748691f6b768acf47c18ef01b5dc0a854"
         }
     },
     "develop": {}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,124 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "7a6ddeb923d52e723cb879b1e50154001ba42316df7e9d987caf195d3f21acbc"
+        },
+        "pipfile-spec": 6,
+        "requires": {},
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "cybox": {
+            "hashes": [
+                "sha256:dc41405bd2ae14ddb2ca4ead00ed82b5cc098e079896d0c77c85a14560d00f04"
+            ],
+            "index": "pypi",
+            "version": "==2.1.0.17"
+        },
+        "lief": {
+            "file": "https://github.com/lief-project/packages/raw/lief-master-latest/pylief-0.9.0.dev.zip"
+        },
+        "lxml": {
+            "hashes": [
+                "sha256:03984196d00670b2ab14ae0ea83d5cc0cfa4f5a42558afa9ab5fa745995328f5",
+                "sha256:0815b0c9f897468de6a386dc15917a0becf48cc92425613aa8bbfc7f0f82951f",
+                "sha256:175f3825f075cf02d15099eb52658457cf0ff103dcf11512b5d2583e1d40f58b",
+                "sha256:30e14c62d88d1e01a26936ecd1c6e784d4afc9aa002bba4321c5897937112616",
+                "sha256:3210da6f36cf4b835ff1be853962b22cc354d506f493b67a4303c88bbb40d57b",
+                "sha256:40f60819fbd5bad6e191ba1329bfafa09ab7f3f174b3d034d413ef5266963294",
+                "sha256:43b26a865a61549919f8a42e094dfdb62847113cf776d84bd6b60e4e3fc20ea3",
+                "sha256:4a03dd682f8e35a10234904e0b9508d705ff98cf962c5851ed052e9340df3d90",
+                "sha256:62f382cddf3d2e52cf266e161aa522d54fd624b8cc567bc18f573d9d50d40e8e",
+                "sha256:7b98f0325be8450da70aa4a796c4f06852949fe031878b4aa1d6c417a412f314",
+                "sha256:846a0739e595871041385d86d12af4b6999f921359b38affb99cdd6b54219a8f",
+                "sha256:a3080470559938a09a5d0ec558c005282e99ac77bf8211fb7b9a5c66390acd8d",
+                "sha256:ad841b78a476623955da270ab8d207c3c694aa5eba71f4792f65926dc46c6ee8",
+                "sha256:afdd75d9735e44c639ffd6258ce04a2de3b208f148072c02478162d0944d9da3",
+                "sha256:b4fbf9b552faff54742bcd0791ab1da5863363fb19047e68f6592be1ac2dab33",
+                "sha256:b90c4e32d6ec089d3fa3518436bdf5ce4d902a0787dbd9bb09f37afe8b994317",
+                "sha256:b91cfe4438c741aeff662d413fd2808ac901cc6229c838236840d11de4586d63",
+                "sha256:bdb0593a42070b0a5f138b79b872289ee73c8e25b3f0bea6564e795b55b6bcdd",
+                "sha256:c4e4bca2bb68ce22320297dfa1a7bf070a5b20bcbaec4ee023f83d2f6e76496f",
+                "sha256:cec4ab14af9eae8501be3266ff50c3c2aecc017ba1e86c160209bb4f0423df6a",
+                "sha256:e83b4b2bf029f5104bc1227dbb7bf5ace6fd8fabaebffcd4f8106fafc69fc45f",
+                "sha256:e995b3734a46d41ae60b6097f7c51ba9958648c6d1e0935b7e0ee446ee4abe22",
+                "sha256:f679d93dec7f7210575c85379a31322df4c46496f184ef650d3aba1484b38a2d",
+                "sha256:fd213bb5166e46974f113c8228daaef1732abc47cb561ce9c4c8eaed4bd3b09b",
+                "sha256:fdcb57b906dbc1f80666e6290e794ab8fb959a2e17aa5aee1758a85d1da4533f",
+                "sha256:ff424b01d090ffe1947ec7432b07f536912e0300458f9a7f48ea217dd8362b86"
+            ],
+            "version": "==4.3.3"
+        },
+        "maec": {
+            "hashes": [
+                "sha256:03e8f1396ae9357cab2ad43dc3784c4e659dc74222327eac75bc61a045cd4008",
+                "sha256:9e997ec9457a7a4bb8626a3f1374939ef20f793755f18accab5579f48114eb75"
+            ],
+            "index": "pypi",
+            "version": "==4.1.0.14"
+        },
+        "mixbox": {
+            "hashes": [
+                "sha256:53aca8c1038f09229a07f40553d9cbe33f9c81a89053dcd0853ce910e32cec40",
+                "sha256:dafff15018ac8906d1ee92fa4d3729e2385c438e8acdbfe67eb535e703ef3c4b"
+            ],
+            "index": "pypi",
+            "version": "==1.0.3"
+        },
+        "ordered-set": {
+            "hashes": [
+                "sha256:41c7ba85e7619cd4c71e38d4cd434f84de8473b826919eb79274b3a11b940b4d",
+                "sha256:f9b703ea9aa9c1db44412c5ba1c16cf8b7ad7ef37a685e4da2fd3754b40f8f6a"
+            ],
+            "version": "==3.1"
+        },
+        "pydeep": {
+            "git": "https://github.com/kbandla/pydeep.git",
+            "ref": "bc0d33bff4b45718b4c5f2c79d4715d92a427eda"
+        },
+        "pymisp": {
+            "git": "https://github.com/MISP/PyMISP.git",
+            "ref": "64bcaad0e578129543cdffad532a232722615f6c"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
+                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
+            ],
+            "version": "==2.8.0"
+        },
+        "python-magic": {
+            "hashes": [
+                "sha256:f2674dcfad52ae6c49d4803fa027809540b130db1dec928cfbb9240316831375",
+                "sha256:f3765c0f582d2dfc72c15f3b5a82aecfae9498bd29ca840d72f37d7bd38bfcd5"
+            ],
+            "index": "pypi",
+            "version": "==0.4.15"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
+        },
+        "stix": {
+            "hashes": [
+                "sha256:fc662e9378a6c2c802cf2ffd2857ba3dac66e1c7bd455d2a373a0af010d001b7"
+            ],
+            "index": "pypi",
+            "version": "==1.2.0.6"
+        },
+        "stix2": {
+            "git": "https://github.com/MISP/cti-python-stix2",
+            "ref": "407f346eb8118d57b43035ef0da47e2ff77ed00e"
+        }
+    },
+    "develop": {}
+}


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2016-06-03: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

As discusses on gitter, it would be really nice if one could install python dependencies via a requirements.txt or Pipfile. I choose Pipfile as you are already using pipenv in travis and for PyMISP so I suppose this is the preferred way.
I used exactly the same sources and versions (any, specific refs, ...) as is defined in git submodules or documentation.

Ideally one would replace git refs by tags or pypi versions where possible.

Using pipenv a user simply does "pipenv sync" to put his virtualenv to the state the developers intended it to be. So this would be a win-win for users and developers :-).


#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
