### PR TITLE
Accessibility: added roles and aria labels for many icons/links

### DIFF
--- a/app/View/Elements/Events/View/row_attribute.ctp
+++ b/app/View/Elements/Events/View/row_attribute.ctp
@@ -357,7 +357,7 @@
       <?php
             endif;
       ?>
-            <a href="<?php echo $baseurl;?>/shadow_attributes/edit/<?php echo $object['id']; ?>" title="<?php echo __('Propose Edit');?>" class="fa fa-comment useCursorPointer"></a>
+            <a href="<?php echo $baseurl;?>/shadow_attributes/edit/<?php echo $object['id']; ?>" title="<?php echo __('Propose Edit');?>" aria-label="<?php echo __('Propose Edit');?>" class="fa fa-comment useCursorPointer"></a>
             <span class="fa fa-trash useCursorPointer" title="<?php echo __('Propose Deletion');?>" role="button" tabindex="0" aria-label="Propose deletion" onClick="deleteObject('shadow_attributes', 'delete', '<?php echo h($object['id']); ?>', '<?php echo h($event['Event']['id']); ?>');"></span>
       <?php
             if ($isSiteAdmin):
@@ -377,7 +377,7 @@
       <?php
             endif;
       ?>
-            <a href="<?php echo $baseurl;?>/attributes/edit/<?php echo $object['id']; ?>" title="<?php echo __('Edit');?>" class="fa fa-edit useCursorPointer"></a>
+            <a href="<?php echo $baseurl;?>/attributes/edit/<?php echo $object['id']; ?>" title="<?php echo __('Edit');?>" aria-label="<?php echo __('Edit');?>" class="fa fa-edit useCursorPointer"></a>
           <?php
             if (empty($event['Event']['publish_timestamp'])):
           ?>

--- a/app/View/Elements/Events/View/row_object.ctp
+++ b/app/View/Elements/Events/View/row_object.ctp
@@ -116,7 +116,7 @@
     <?php
       if ($mayModify && empty($object['deleted'])) {
         echo sprintf(
-          '<a href="%s/objects/edit/%s" title="Edit" class="fa fa-edit icon-white useCursorPointer"></a>',
+          '<a href="%s/objects/edit/%s" title="Edit" aria-label="Edit" class="fa fa-edit icon-white useCursorPointer"></a>',
           $baseurl,
           h($object['id'])
         );

--- a/app/View/Elements/TagCollections/index_row.ctp
+++ b/app/View/Elements/TagCollections/index_row.ctp
@@ -44,7 +44,7 @@
                     echo $this->Form->postLink('', array('action' => 'delete', $item['TagCollection']['id']), array('class' => 'fa fa-trash', 'title' => __('Delete')), __('Are you sure you want to delete "%s"?', $item['TagCollection']['name']));
                 }
                 echo sprintf(
-                    '<a href="%s/tag_collections/view/%s.json" class="fa fa-cloud-download black" title="%s" download="tag_collection_%s.json"></a>',
+                    '<a href="%s/tag_collections/view/%s.json" class="fa fa-cloud-download black" title="%s" aria-label="%s" download="tag_collection_%s.json"></a>',
                     $baseurl,
                     h($item['TagCollection']['id']),
                     __('Download configuration'),

--- a/app/View/Elements/Users/userIndexTable.ctp
+++ b/app/View/Elements/Users/userIndexTable.ctp
@@ -87,11 +87,11 @@
                     ?>
                             <span role="button" tabindex="0" aria-label="Initiate password refresh" title="<?php echo __('Initiate password refresh');?>" class="fa fa-sync useCursorPointer" onClick="initiatePasswordReset('<?php echo $user['User']['id']; ?>');" title="<?php echo __('Create new credentials and inform user');?>" role="button" tabindex="0" aria-label="<?php echo __('Create new credentials and inform user');?>"></span>
                     <?php
-                            echo $this->Html->link('', array('admin' => true, 'action' => 'edit', $user['User']['id']), array('class' => 'fa fa-edit', 'title' => __('Edit')));
-                            echo $this->Form->postLink('', array('admin' => true, 'action' => 'delete', $user['User']['id']), array('class' => 'fa fa-trash', 'title' => __('Delete')), __('Are you sure you want to delete # %s? It is highly recommended to never delete users but to disable them instead.', $user['User']['id']));
+                            echo $this->Html->link('', array('admin' => true, 'action' => 'edit', $user['User']['id']), array('class' => 'fa fa-edit', 'title' => __('Edit'), 'aria-label' => __('Edit')));
+                            echo $this->Form->postLink('', array('admin' => true, 'action' => 'delete', $user['User']['id']), array('class' => 'fa fa-trash', 'title' => __('Delete'), 'aria-label' => __('Delete')), __('Are you sure you want to delete # %s? It is highly recommended to never delete users but to disable them instead.', $user['User']['id']));
                         endif;
                     ?>
-                    <?php echo $this->Html->link('', array('admin' => true, 'action' => 'view', $user['User']['id']), array('class' => 'fa fa-eye', 'title' => __('View'))); ?>
+                    <?php echo $this->Html->link('', array('admin' => true, 'action' => 'view', $user['User']['id']), array('class' => 'fa fa-eye', 'title' => __('View'), 'aria-label' => __('View'))); ?>
                 </td>
             </tr>
     <?php

--- a/app/View/Elements/eventdiscussion.ctp
+++ b/app/View/Elements/eventdiscussion.ctp
@@ -90,14 +90,14 @@
                                                 echo $this->Form->postLink('', array('controller' => 'posts', 'action' => 'delete', h($post['id']), h($context)), array('class' => 'fa fa-trash', 'title' => __('Delete')), __('Are you sure you want to delete this post?'));
                                             } else {
             ?>
-                                                <a href="<?php echo $baseurl.'/posts/add/post/'.h($post['id']); ?>" class="icon-comment" title = "<?php echo __('Reply');?>"></a>
+                                                <a href="<?php echo $baseurl.'/posts/add/post/'.h($post['id']); ?>" class="icon-comment" title = "<?php echo __('Reply');?>" aria-label = "<?php echo __('Reply');?>"></a>
             <?php
                                             }
                                         } else {
                                             echo $this->Html->link('', array('controller' => 'posts', 'action' => 'edit', h($post['id']), h($context)), array('class' => 'fa fa-edit', 'title' => __('Edit')));
                                             echo $this->Form->postLink('', array('controller' => 'posts', 'action' => 'delete', h($post['id']), h($context)), array('class' => 'fa fa-trash', 'title' => 'Delete'), __('Are you sure you want to delete this post?'));
             ?>
-                                                <a href = "<?php echo $baseurl.'/posts/add/post/'.h($post['id']); ?>" class="icon-comment" title = "<?php echo __('Reply');?>"></a>
+                                                <a href = "<?php echo $baseurl.'/posts/add/post/'.h($post['id']); ?>" class="icon-comment" title = "<?php echo __('Reply');?>" aria-label = "<?php echo __('Reply');?>"></a>
             <?php
 
                                         }

--- a/app/View/Elements/galaxyQuickView.ctp
+++ b/app/View/Elements/galaxyQuickView.ctp
@@ -5,7 +5,7 @@
         <div style="margin-left:10px;">
             <span title="<?php echo isset($galaxy['description']) ? h($galaxy['description']) : h($galaxy['name']);?>" class="bold blue" style="font-size:14px;">
                 <?php echo h($galaxy['name']); ?>&nbsp;
-                <a href="<?php echo $baseurl; ?>/galaxies/view/<?php echo h($galaxy['id']); ?>" class="fa fa-search" title="<?php echo __('View details about this galaxy');?>"></a>
+                <a href="<?php echo $baseurl; ?>/galaxies/view/<?php echo h($galaxy['id']); ?>" class="fa fa-search" title="<?php echo __('View details about this galaxy');?>" aria-label="<?php echo __('View galaxy');?>"></a>
             </span>
     <?php
         foreach ($galaxy['GalaxyCluster'] as $cluster):
@@ -16,8 +16,8 @@
                         <span class="collapse-status" style="font-size: 16px;">+</span>
                     </span>
                     <span><?php echo h($cluster['value']); ?></span>
-                    <a href="<?php echo $baseurl; ?>/galaxy_clusters/view/<?php echo h($cluster['id']); ?>" class="fa fa-search" title="<?php echo __('View details about this cluster');?>"></a>&nbsp;
-                    <a href="<?php echo $baseurl; ?>/events/index/searchtag:<?php echo h($cluster['tag_id']); ?>" class="fa fa-list" title="<?php echo __('View all events containing this cluster.');?>"></a>
+                    <a href="<?php echo $baseurl; ?>/galaxy_clusters/view/<?php echo h($cluster['id']); ?>" class="fa fa-search" title="<?php echo __('View details about this cluster');?>" aria-label="<?php echo __('View cluster');?>"></a>&nbsp;
+                    <a href="<?php echo $baseurl; ?>/events/index/searchtag:<?php echo h($cluster['tag_id']); ?>" class="fa fa-list" title="<?php echo __('View all events containing this cluster.');?>" aria-label="<?php echo __('View all events containing this cluster.');?>"></a>
                     <?php
                         if ($isSiteAdmin || ($mayModify && $isAclTagger)) {
                             echo $this->Form->create(false, array('url' => $baseurl . '/galaxy_clusters/detach/' . ucfirst(h($target_id)) . '/' . h($target_type) . '/' . $cluster['tag_id'], 'style' => 'display: inline-block; margin: 0px;'));

--- a/app/View/Elements/galaxyQuickViewMini.ctp
+++ b/app/View/Elements/galaxyQuickViewMini.ctp
@@ -66,8 +66,8 @@
                 <span class="bold blue expandable useCursorPointer" data-toggle="popover" data-content="<?php echo h($popover_data); ?>">
                     <?php echo h($cluster['value']); ?>
                 </span>&nbsp;
-                <a href="<?php echo $baseurl; ?>/galaxy_clusters/view/<?php echo h($cluster['id']); ?>" class="fa fa-search" title="<?php echo __('View details about this cluster');?>"></a>&nbsp;
-                <a href="<?php echo $baseurl; ?>/events/index/searchtag:<?php echo h($cluster['tag_id']); ?>" class="fa fa-list" title="<?php echo __('View all events containing this cluster.');?>"></a>
+                <a href="<?php echo $baseurl; ?>/galaxy_clusters/view/<?php echo h($cluster['id']); ?>" class="fa fa-search" title="<?php echo __('View details about this cluster');?>" aria-label="<?php echo __('View cluster');?>"></a>&nbsp;
+                <a href="<?php echo $baseurl; ?>/events/index/searchtag:<?php echo h($cluster['tag_id']); ?>" class="fa fa-list" title="<?php echo __('View all events containing this cluster.');?>" aria-label="<?php echo __('View all events containing this cluster.');?>"></a>
                 <?php
                     if ($isSiteAdmin || ($mayModify && $isAclTagger)) {
                         echo $this->Form->create(false, array('url' => $baseurl . '/galaxy_clusters/detach/' . ucfirst(h($target_id)) . '/' . h($target_type) . '/' . h($cluster['tag_id']), 'style' => 'display: inline-block; margin: 0px;'));

--- a/app/View/Elements/genericElements/ListTopBar/element_embedded.ctp
+++ b/app/View/Elements/genericElements/ListTopBar/element_embedded.ctp
@@ -30,7 +30,7 @@
         }
         $dataFields = implode(' ', $dataFields);
         echo sprintf(
-            '<li><a class="%s %s" id="%s" href="%s" %s %s %s>%s%s%s</a></li>',
+            '<li><a class="%s %s" id="%s" href="%s" %s %s %s %s>%s%s%s</a></li>',
             empty($data['class']) ? '' : h($data['class']),
             empty($data['active']) ? '' : 'background-blue',   // Change the default class for highlighted/active toggles here
             empty($data['id']) ? '' : 'id="' . h($data['id']) . '"',
@@ -38,6 +38,7 @@
             empty($onClick) ? '' : $onClick,    // pass $data['onClick'] for the function name to call and $data['onClickParams'] for the parameter list
             empty($dataFields) ? '' : $dataFields,
             empty($data['title']) ? '' : sprintf('title="%s"', h($data['title'])),
+            !empty($data['text']) ? '' : !empty($data['title']) ? sprintf('aria-label="%s"', h($data['title'])) : '',	    	    
             empty($data['fa-icon']) ? '' : sprintf('<i class="fa fa-%s"></i>', $data['fa-icon']),  // this has to be sanitised beforehand!
             empty($data['html']) ? '' : $data['html'],  // this has to be sanitised beforehand!
             empty($data['text']) ? '' : h($data['text'])

--- a/app/View/Elements/genericElements/ListTopBar/element_group.ctp
+++ b/app/View/Elements/genericElements/ListTopBar/element_group.ctp
@@ -18,11 +18,12 @@
             }
         }
         echo sprintf(
-            '<a class="btn btn-small btn-dropdown-toggle %s %s" %s data-toggle="dropdown" href="#" %s>%s%s%s <span class="caret"></span></a><ul class="dropdown-menu">%s</ul>',
+            '<a class="btn btn-small btn-dropdown-toggle %s %s" %s %s data-toggle="dropdown" href="#" %s>%s%s%s <span class="caret"></span></a><ul class="dropdown-menu">%s</ul>',
             empty($data['class']) ? '' : h($data['class']),
             empty($data['active']) ? 'btn-inverse' : 'btn-primary',   // Change the default class for highlighted/active toggles here
             empty($data['id']) ? '' : 'id="' . h($data['id']) . '"',
             empty($data['title']) ? '' : sprintf('title="%s"', h($data['title'])),
+            !empty($data['text']) ? '' : !empty($data['title']) ? sprintf('aria-label="%s"', h($data['title'])) : '',	    
             empty($data['fa-icon']) ? '' : sprintf('<i class="fa fa-%s"></i>', $data['fa-icon']),  // this has to be sanitised beforehand!
             empty($data['html']) ? '' : $data['html'],  // this has to be sanitised beforehand!
             empty($data['text']) ? '' : h($data['text']),

--- a/app/View/Elements/genericElements/ListTopBar/element_simple.ctp
+++ b/app/View/Elements/genericElements/ListTopBar/element_simple.ctp
@@ -34,7 +34,7 @@
         }
         $dataFields = implode(' ', $dataFields);
         echo sprintf(
-            '<a class="btn btn-small %s %s" %s href="%s" %s %s %s>%s%s%s</a>',
+            '<a class="btn btn-small %s %s" %s href="%s" %s %s %s %s>%s%s%s</a>',
             empty($data['class']) ? '' : h($data['class']),
             empty($data['active']) ? 'btn-inverse' : 'btn-primary',   // Change the default class for highlighted/active toggles here
             empty($data['id']) ? '' : 'id="' . h($data['id']) . '"',
@@ -42,6 +42,7 @@
             empty($onClick) ? '' : $onClick,    // pass $data['onClick'] for the function name to call and $data['onClickParams'] for the parameter list
             empty($dataFields) ? '' : $dataFields,
             empty($data['title']) ? '' : sprintf('title="%s"', h($data['title'])),
+            !empty($data['text']) ? '' : !empty($data['title']) ? sprintf('aria-label="%s"', h($data['title'])) : '',	    
             empty($data['fa-icon']) ? '' : sprintf(
                 '<i class="%s fa-%s"></i> ',
                 empty($data['fa-source']) ? 'fas' : h($data['fa-source']),

--- a/app/View/Events/proposal_event_index.ctp
+++ b/app/View/Events/proposal_event_index.ctp
@@ -42,11 +42,11 @@
                 <?php
                 if ($event['Event']['published'] == 1) {
                 ?>
-                    <a href="<?php echo $baseurl."/events/view/".$event['Event']['id'] ?>" class = "icon-ok" title = "<?php echo __('View');?>"></a>
+                    <a href="<?php echo $baseurl."/events/view/".$event['Event']['id'] ?>" class = "icon-ok" title = "<?php echo __('View');?>" aria-label = "<?php echo __('View');?>"></a>
                 <?php
                 } else {
                 ?>
-                    <a href="<?php echo $baseurl."/events/view/".$event['Event']['id'] ?>" class = "icon-remove" title = "<?php echo __('View');?>"></a>
+                    <a href="<?php echo $baseurl."/events/view/".$event['Event']['id'] ?>" class = "icon-remove" title = "<?php echo __('View');?>" aria-label = "<?php echo __('View');?>"></a>
                 <?php
                 }?>&nbsp;
             </td>

--- a/app/View/Feeds/preview_index.ctp
+++ b/app/View/Feeds/preview_index.ctp
@@ -70,7 +70,7 @@
             <td ondblclick="document.location.href ='<?php echo $eventViewURL . h($uuid);?>'" class="short"><?php echo h($event['timestamp']); ?></td>
             <td class="short action-links">
                 <?php if ($feed['Feed']['enabled'] && $isSiteAdmin) echo $this->Form->postLink('', '/feeds/getEvent/' . $id . '/' . $uuid, array('class' => 'fa fa-arrow-circle-down', 'title' => __('Fetch the event')), __('Are you sure you want to fetch and save this event on your instance?', $this->Form->value('Feed.id'))); ?>
-                <a href='<?php echo $eventViewURL . h($uuid);?>' class = "fa fa-eye" title = "<?php echo __('View');?>"></a>
+                <a href='<?php echo $eventViewURL . h($uuid);?>' class = "fa fa-eye" title = "<?php echo __('View');?>" aria-label = "<?php echo __('View');?>"></a>
             </td>
         </tr>
         <?php endforeach; ?>

--- a/app/View/Galaxies/index.ctp
+++ b/app/View/Galaxies/index.ctp
@@ -55,8 +55,8 @@
             );
             $row .= sprintf(
                 '<td class="short action-links">%s%s</td></tr>',
-                $this->Form->postLink('', array('action' => 'delete', $item['Galaxy']['id']), array('class' => 'fa fa-trash', 'title' => __('Delete')), sprintf(__('Are you sure you want to delete the Galaxy (%s)?'), $item['Galaxy']['name'])),
-                $this->Html->link('', array('action' => 'view', $item['Galaxy']['id']), array('class' => 'fa fa-eye', 'title' => __('View')))
+                $this->Form->postLink('', array('action' => 'delete', $item['Galaxy']['id']), array('class' => 'fa fa-trash', 'title' => __('Delete'), 'aria-label' => __('Delete')), sprintf(__('Are you sure you want to delete the Galaxy (%s)?'), $item['Galaxy']['name'])),
+                $this->Html->link('', array('action' => 'view', $item['Galaxy']['id']), array('class' => 'fa fa-eye', 'title' => __('View'), 'aria-label' => __('View')))
             );
             echo $row;
         }

--- a/app/View/News/index.ctp
+++ b/app/View/News/index.ctp
@@ -19,7 +19,7 @@
                                 echo nl2br(preg_replace('#https?:\/\/[^\s]*#i', '<a href="$0">$0</a>', $message));
                                 if ($isSiteAdmin):
                             ?>
-                                    <br /><a href="<?php echo $baseurl; ?>/news/edit/<?php echo h($newsItem['News']['id']);?>" class="fa fa-edit" title="<?php echo __('Edit news message');?>"></a>
+                                    <br /><a href="<?php echo $baseurl; ?>/news/edit/<?php echo h($newsItem['News']['id']);?>" class="fa fa-edit" title="<?php echo __('Edit news message');?>" aria-label="<?php echo __('Edit');?>"></a>
                             <?php
                                     echo $this->Form->postLink('', array('action' => 'delete', $newsItem['News']['id']), array('class' => 'fa fa-trash', 'title' => __('Delete')), __('Are you sure you want to delete news item # %s?', $newsItem['News']['id']));
                                 endif;

--- a/app/View/Noticelists/index.ctp
+++ b/app/View/Noticelists/index.ctp
@@ -60,10 +60,10 @@
                 } else {
                     $onClick = 'disabled';
                 }
-                $input = '<input id="checkBox_' . h($item['Noticelist']['id']) . '" type="checkbox" ' . $onClick . ' ' . ($item['Noticelist']['enabled'] ? 'checked' : '') . ' />';
+                $input = '<input id="checkBox_' . h($item['Noticelist']['id']) . '" type="checkbox" aria-label="' . __('Enabled') . '" ' . $onClick . ' ' . ($item['Noticelist']['enabled'] ? 'checked' : '') . ' />';
                 echo '<td class="short" id="checkbox_row_' . h($item['Noticelist']['id']) . '">' . $input . '</td>';
                 $actions = '';
-                $actions .= '<a href="' . $baseurl . "/noticelists/view/" . h($item['Noticelist']['id']) . '" class="fa fa-eye" title="' . __('View') . '"></a>';
+                $actions .= '<a href="' . $baseurl . "/noticelists/view/" . h($item['Noticelist']['id']) . '" class="fa fa-eye" title="' . __('View') . '" aria-label="' . __('View') . '"></a>';
                 echo '<td class="short action-links">' . $actions . '</td>';
                 echo '</tr>';
 

--- a/app/View/ObjectTemplates/index.ctp
+++ b/app/View/ObjectTemplates/index.ctp
@@ -112,7 +112,7 @@ foreach ($list as $template):
             ?>
         </td>
         <td class="short action-links">
-            <a href='/objectTemplates/view/<?php echo $template['ObjectTemplate']['id']; ?>' class = "fa fa-eye" title = "<?php echo __('View');?>"></a>
+            <a href='/objectTemplates/view/<?php echo $template['ObjectTemplate']['id']; ?>' class = "fa fa-eye" title = "<?php echo __('View');?>" aria-label = "<?php echo __('View');?>"></a>
             <?php
                 if ($isSiteAdmin):
                     echo $this->Form->postLink('', array('action' => 'update', $template['ObjectTemplate']['name'], 1), array('class' => 'fa fa-sync', 'title' => 'Force update'), __('Are you sure you want to force an update for template # %s?', $template['ObjectTemplate']['id']));

--- a/app/View/Organisations/index.ctp
+++ b/app/View/Organisations/index.ctp
@@ -135,7 +135,7 @@ foreach ($orgs as $org): ?>
         </td>
         <td class="short action-links">
             <?php if ($isSiteAdmin): ?>
-                <a href='/admin/organisations/edit/<?php echo $org['Organisation']['id'];?>' class = "fa fa-edit" title = "<?php echo __('Edit');?>"</a>
+                <a href='/admin/organisations/edit/<?php echo $org['Organisation']['id'];?>' class = "fa fa-edit" title = "<?php echo __('Edit');?>" aria-label = "<?php echo __('Edit');?>"></a>
                 <?php
                     echo $this->Form->postLink('', array('admin' => true, 'action' => 'delete', $org['Organisation']['id']), array('class' => 'fa fa-trash', 'title' => __('Delete')), __('Are you sure you want to delete %s?', $org['Organisation']['name']));
                 ?>

--- a/app/View/Regexp/admin_index.ctp
+++ b/app/View/Regexp/admin_index.ctp
@@ -31,8 +31,8 @@ foreach ($list as $item):?>
         <td><?php echo h($item['Regexp']['replacement']);?>&nbsp;</td>
         <td class="short"><?php echo h($item['Regexp']['type']);?>&nbsp;</td>
         <td class="short action-links">
-            <?php echo $this->Html->link('', array('admin' => true, 'action' => 'edit', $item['Regexp']['id']), array('class' => 'fa fa-edit', 'title' => __('Edit')));?>
-            <?php echo $this->Form->postLink('', array('admin' => true, 'action' => 'delete', $item['Regexp']['id']), array('class' => 'fa fa-trash', 'title' => __('Delete')), __('Are you sure you want to delete %s?', h($item['Regexp']['regexp'])));?>
+            <?php echo $this->Html->link('', array('admin' => true, 'action' => 'edit', $item['Regexp']['id']), array('class' => 'fa fa-edit', 'title' => __('Edit'), 'aria-label' => __('Edit')));?>
+            <?php echo $this->Form->postLink('', array('admin' => true, 'action' => 'delete', $item['Regexp']['id']), array('class' => 'fa fa-trash', 'title' => __('Delete'), 'aria-label' => __('Delete')), __('Are you sure you want to delete %s?', h($item['Regexp']['regexp'])));?>
         </td>
     </tr><?php
 endforeach;?>

--- a/app/View/Roles/admin_index.ctp
+++ b/app/View/Roles/admin_index.ctp
@@ -37,16 +37,17 @@
 foreach ($list as $item): ?>
     <tr>
         <td><?php echo $this->Html->link(h($item['Role']['id']), array('admin' => true, 'action' => 'edit', $item['Role']['id'])); ?>&nbsp;</td>
-        <td class="short" style="text-align:center;width:20px;"><input class="servers_default_role_checkbox" type="checkbox" data-id="<?php echo h($item['Role']['id']); ?>" <?php if ($default_role_id && $default_role_id == $item['Role']['id']) echo 'checked'; ?>></td>
+        <td class="short" style="text-align:center;width:20px;"><input class="servers_default_role_checkbox" type="checkbox" aria-label="<?php echo __('Default role'); ?>" data-id="<?php echo h($item['Role']['id']); ?>" <?php if ($default_role_id && $default_role_id == $item['Role']['id']) echo 'checked'; ?>></td>
         <td><?php echo h($item['Role']['name']); ?>&nbsp;</td>
-        <td class="short"><span class="<?php if ($item['Role']['restricted_to_site_admin']) echo 'icon-ok'; ?>"></span>&nbsp;</td>
+        <td class="short"><span class="<?php if ($item['Role']['restricted_to_site_admin']) echo 'icon-ok'; ?>" role="img" aria-label="<?php echo $item['Role']['restricted_to_site_admin'] ? __('Yes') : __('No'); ?>"></span>&nbsp;</td>
         <td><?php echo h($options[$item['Role']['permission']]); ?>&nbsp;</td>
         <?php
             foreach ($permFlags as $k => $flags) {
                 $flagName = Inflector::Humanize(substr($k, 5));
                 echo sprintf(
-                    '<td class="short"><span class="%s" title="%s"></span>&nbsp;</td>',
+                    '<td class="short"><span class="%s" role="img" aria-label="%s" title="%s"></span>&nbsp;</td>',
                     ($item['Role'][$k]) ? 'icon-ok' : '',
+                    ($item['Role'][$k]) ? __('Yes') : __('No'),		    
                     sprintf(
                         __('%s permission %s'),
                         h($flagName),
@@ -75,8 +76,8 @@ foreach ($list as $item): ?>
             ?>
         </td>
         <td class="short action-links">
-            <?php echo $this->Html->link('', array('admin' => true, 'action' => 'edit', $item['Role']['id']), array('class' => 'fa fa-edit', 'title' => __('Edit'))); ?>
-            <?php echo $this->Form->postLink('', array('admin' => true, 'action' => 'delete', $item['Role']['id']), array('class' => 'fa fa-trash', 'title' => __('Delete')), __('Are you sure you want to delete %s?', $item['Role']['name'])); ?>
+            <?php echo $this->Html->link('', array('admin' => true, 'action' => 'edit', $item['Role']['id']), array('class' => 'fa fa-edit', 'title' => __('Edit'), 'aria-label' => __('Edit'))); ?>
+            <?php echo $this->Form->postLink('', array('admin' => true, 'action' => 'delete', $item['Role']['id']), array('class' => 'fa fa-trash', 'title' => __('Delete'), 'aria-label' => __('Delete')), __('Are you sure you want to delete %s?', $item['Role']['name'])); ?>
         </td>
     </tr><?php
 endforeach; ?>

--- a/app/View/Roles/index.ctp
+++ b/app/View/Roles/index.ctp
@@ -33,15 +33,16 @@
 foreach ($list as $item): ?>
     <tr>
         <td class="short"><?php echo h($item['Role']['id']); ?>&nbsp;</td>
-        <td class="short" style="text-align:center;width:20px;"><div class="icon-<?php echo $default_role_id == $item['Role']['id'] ? __('ok') : __('remove') ?>"></div></td>
+        <td class="short" style="text-align:center;width:20px;"><div class="icon-<?php echo $default_role_id == $item['Role']['id'] ? __('ok') : __('remove') ?>" role="img" aria-label="<?php echo $default_role_id == $item['Role']['id'] ? __('Yes') : __('No') ?>"></div></td>
         <td><?php echo h($item['Role']['name']); ?>&nbsp;</td>
         <td class="short"><?php echo h($options[$item['Role']['permission']]); ?>&nbsp;</td>
         <?php
             foreach ($permFlags as $k => $flags) {
                 $flagName = Inflector::Humanize(substr($k, 5));
                 echo sprintf(
-                    '<td class="short"><span class="%s" title="%s"></span>&nbsp;</td>',
+                    '<td class="short"><span class="%s" role="img" aria-label="%s" title="%s"></span>&nbsp;</td>',
                     ($item['Role'][$k]) ? 'icon-ok' : '',
+	            ($item['Role'][$k]) ? __('Granted') : __('Not granted'),
                     sprintf(
                         __('%s permission %s'),
                         h($flagName),

--- a/app/View/Servers/index.ctp
+++ b/app/View/Servers/index.ctp
@@ -70,9 +70,10 @@ foreach ($servers as $server):
             ?>
         </td>
         <td id="connection_test_<?php echo $server['Server']['id'];?>"><span role="button" tabindex="0" aria-label="<?php echo __('Test the connection to the remote instance');?>" title="<?php echo __('Test the connection to the remote instance');?>" class="btn btn-primary" style="line-height:10px; padding: 4px 4px;" onClick="testConnection('<?php echo $server['Server']['id'];?>');"><?php echo __('Run');?></span></td>
-        <td><span class="<?php echo ($server['Server']['internal']? 'icon-ok' : 'icon-remove'); ?>" title="<?php echo ($server['Server']['internal']? __('Internal instance that ignores distribution level degradation *WARNING: Only use this setting if you have several internal instances and the sync link is to an internal extension of the current MISP community*') : __('Normal sync link to an external MISP instance. Distribution degradation will follow the normal rules.')); ?>"></span></td>
-        <td><span class="<?php echo ($server['Server']['push']? 'icon-ok' : 'icon-remove'); ?>"></span><span class="short <?php if (!$server['Server']['push'] || empty($ruleDescription['push'])) echo "hidden"; ?>" data-toggle="popover" title="Distribution List" data-content="<?php echo $ruleDescription['push']; ?>"> (<?php echo __('Rules');?>)</span></td>
-        <td><span class="<?php echo ($server['Server']['pull']? 'icon-ok' : 'icon-remove'); ?>"></span><span class="short <?php if (!$server['Server']['pull'] || empty($ruleDescription['pull'])) echo "hidden"; ?>" data-toggle="popover" title="Distribution List" data-content="<?php echo $ruleDescription['pull']; ?>"> (<?php echo __('Rules');?>)</span></td>
+
+<td><span class="<?php echo ($server['Server']['internal']? 'icon-ok' : 'icon-remove'); ?>" role="img" aria-label="<?php echo ($server['Server']['internal']? __('Yes') : __('No')); ?>" title="<?php echo ($server['Server']['internal']? __('Internal instance that ignores distribution level degradation *WARNING: Only use this setting if you have several internal instances and the sync link is to an internal extension of the current MISP community*') : __('Normal sync link to an external MISP instance. Distribution degradation will follow the normal rules.')); ?>"></span></td>
+        <td><span class="<?php echo ($server['Server']['push']? 'icon-ok' : 'icon-remove'); ?>" role="img" aria-label="<?php echo ($server['Server']['push']? __('Yes') : __('No')); ?>"></span><span class="short <?php if (!$server['Server']['push'] || empty($ruleDescription['push'])) echo "hidden"; ?>" data-toggle="popover" title="Distribution List" data-content="<?php echo $ruleDescription['push']; ?>"> (<?php echo __('Rules');?>)</span></td>
+        <td><span class="<?php echo ($server['Server']['pull']? 'icon-ok' : 'icon-remove'); ?>" role="img" aria-label="<?php echo ($server['Server']['pull']? __('Yes') : __('No')); ?>"></span><span class="short <?php if (!$server['Server']['pull'] || empty($ruleDescription['pull'])) echo "hidden"; ?>" data-toggle="popover" title="Distribution List" data-content="<?php echo $ruleDescription['pull']; ?>"> (<?php echo __('Rules');?>)</span></td>
         <td>
             <?php
                 if ($server['Server']['caching_enabled']) {
@@ -104,36 +105,36 @@ foreach ($servers as $server):
                         );
                     }
                 } else {
-                    echo '<span class="icon-remove"></span>';
+                    echo '<span class="icon-remove" role="img" aria-label="' . __('No') . '"></span>';
                 }
             ?>
         </td>
-        <td class="short"><span class="<?php echo ($server['Server']['unpublish_event'] ? 'icon-ok' : 'icon-remove'); ?>"></span></td>
-        <td class="short"><span class="<?php echo ($server['Server']['publish_without_email'] ? 'icon-ok' : 'icon-remove'); ?>"></span></td>
+        <td class="short"><span class="<?php echo ($server['Server']['unpublish_event'] ? 'icon-ok' : 'icon-remove'); ?>" role="img" aria-label="<?php echo ($server['Server']['unpublish_event'] ? __('Yes') : __('No')); ?>"></span></td>
+        <td class="short"><span class="<?php echo ($server['Server']['publish_without_email'] ? 'icon-ok' : 'icon-remove'); ?>" role="img" aria-label="<?php echo ($server['Server']['publish_without_email'] ? __('Yes') : __('No')); ?>"></span></td>
         <td><?php echo h($server['Server']['url']); ?>&nbsp;</td>
         <td><a href="/organisations/view/<?php echo h($server['RemoteOrg']['id']); ?>"><?php echo h($server['RemoteOrg']['name']); ?></a></td>
         <td class="short"><?php echo h($server['Server']['cert_file']); ?>&nbsp;</td>
         <td class="short"><?php echo h($server['Server']['client_cert_file']); ?>&nbsp;</td>
-        <td class="short"><span class="<?php echo ($server['Server']['self_signed'] ? 'icon-ok' : 'icon-remove'); ?>"></span></td>
-        <td class="short"><span class="<?php echo ($server['Server']['skip_proxy'] ? 'icon-ok' : 'icon-remove'); ?>"></span></td>
+        <td class="short"><span class="<?php echo ($server['Server']['self_signed'] ? 'icon-ok' : 'icon-remove'); ?>" role="img" aria-label="<?php echo ($server['Server']['self_signed'] ? __('Yes') : __('No')); ?>"></span></td>
+        <td class="short"><span class="<?php echo ($server['Server']['skip_proxy'] ? 'icon-ok' : 'icon-remove'); ?>" role="img" aria-label="<?php echo ($server['Server']['skip_proxy'] ? __('Yes') : __('No')); ?>"></span></td>
         <td class="short"><a href="/organisations/view/<?php echo h($server['Organisation']['id']); ?>"><?php echo h($server['Organisation']['name']); ?></a></td>
         <td class="short action-links">
             <?php
-                echo sprintf('<a href="%s" title="%s" class="%s"></a>', $baseurl . '/servers/previewIndex/' . h($server['Server']['id']), __('Explore'), 'fa fa-search');
+                echo sprintf('<a href="%s" title="%s" aria-label="%s" class="%s"></a>', $baseurl . '/servers/previewIndex/' . h($server['Server']['id']), __('Explore'), __('Explore'), 'fa fa-search');
                 if ($server['Server']['pull']) {
-                    echo sprintf('<a href="%s" title="%s" class="%s"></a>', $baseurl . '/servers/pull/' . h($server['Server']['id']) . '/update', __('Pull updates to events that already exist locally'), 'fa fa-sync');
-                    echo sprintf('<a href="%s" title="%s" class="%s"></a>', $baseurl . '/servers/pull/' . h($server['Server']['id']) . '/full', __('Pull all'), 'fa fa-arrow-circle-down');
+                    echo sprintf('<a href="%s" title="%s" aria-label="%s" class="%s"></a>', $baseurl . '/servers/pull/' . h($server['Server']['id']) . '/update', __('Pull updates to events that already exist locally'), __('Pull updates'), 'fa fa-sync');
+                    echo sprintf('<a href="%s" title="%s" aria-label="%s" class="%s"></a>', $baseurl . '/servers/pull/' . h($server['Server']['id']) . '/full', __('Pull all'), __('Pull all'), 'fa fa-arrow-circle-down');
                 }
                 if ($server['Server']['push']) {
-                    echo sprintf('<a href="%s" title="%s" class="%s"></a>', $baseurl . '/servers/push/' . h($server['Server']['id']) . '/full', __('Push all'), 'fa fa-arrow-circle-up');
+                    echo sprintf('<a href="%s" title="%s" aria-label="%s" class="%s"></a>', $baseurl . '/servers/push/' . h($server['Server']['id']) . '/full', __('Push all'), __('Push all'), 'fa fa-arrow-circle-up');
                 }
                 if ($server['Server']['caching_enabled']) {
-                        echo sprintf('<a href="%s" title="%s" class="%s"></a>', $baseurl . '/servers/cache/' . h($server['Server']['id']), __('Cache instance'), 'fa fa-memory');
+                        echo sprintf('<a href="%s" title="%s" aria-label="%s" class="%s"></a>', $baseurl . '/servers/cache/' . h($server['Server']['id']), __('Cache instance'), __('Cache instance'), 'fa fa-memory');
                 }
                 $mayModify = ($isSiteAdmin);
                 if ($mayModify) {
-                    echo sprintf('<a href="%s" title="%s"class="%s"></a>', $baseurl . '/servers/edit/' . h($server['Server']['id']), __('Edit'), 'fa fa-edit');
-                    echo $this->Form->postLink('', array('action' => 'delete', $server['Server']['id']), array('class' => 'fa fa-trash', 'title' => __('Delete')), __('Are you sure you want to delete # %s?', $server['Server']['id']));
+                    echo sprintf('<a href="%s" title="%s" aria-label="%s" class="%s"></a>', $baseurl . '/servers/edit/' . h($server['Server']['id']), __('Edit'), __('Edit'), 'fa fa-edit');
+                    echo $this->Form->postLink('', array('action' => 'delete', $server['Server']['id']), array('class' => 'fa fa-trash', 'title' => __('Delete'), 'aria-label' => __('Delete')), __('Are you sure you want to delete # %s?', $server['Server']['id']));
                 }
             ?>
 

--- a/app/View/Tags/index.ctp
+++ b/app/View/Tags/index.ctp
@@ -79,8 +79,8 @@
 foreach ($list as $k => $item): ?>
     <tr>
         <td class="short"><?php echo h($item['Tag']['id']); ?>&nbsp;</td>
-        <td class="short"><span class="<?php echo ($item['Tag']['exportable'] ? 'icon-ok' : 'icon-remove'); ?>"></span></td>
-        <td class="short"><span class="icon-<?php echo $item['Tag']['hide_tag'] ? 'ok' : 'remove'; ?>"></span></td>
+        <td class="short"><span class="<?php echo ($item['Tag']['exportable'] ? 'icon-ok' : 'icon-remove'); ?>" role="img" aria-label="<?php echo ($item['Tag']['exportable'] ? 'Yes' : 'No'); ?>"></span></td>
+        <td class="short"><span class="icon-<?php echo $item['Tag']['hide_tag'] ? 'ok' : 'remove'; ?>" role="img" aria-label="<?php echo $item['Tag']['hide_tag'] ? 'Yes' : 'No'; ?>"></span></td>
         <td><a href="<?php echo $baseurl . "/events/index/searchtag:" . $item['Tag']['id']; ?>" class="tag" style="background-color: <?php echo h($item['Tag']['colour']); ?>;color:<?php echo $this->TextColour->getTextColour($item['Tag']['colour']); ?>" title="<?php echo isset($item['Tag']['Taxonomy']['expanded']) ? h($item['Tag']['Taxonomy']['expanded']) : h($item['Tag']['name']); ?>"><?php echo h($item['Tag']['name']); ?></a></td>
         <td class="short">
             <?php if ($item['Tag']['org_id']): ?>
@@ -116,13 +116,13 @@ foreach ($list as $k => $item): ?>
             <?php echo $this->element('sparkline', array('id' => $item['Tag']['id'], 'csv' => isset($csv[$k]) ? $csv[$k] : $emptyDate)); ?>
         </td>
         <td class="short" id ="checkbox_row_<?php echo h($item['Tag']['id']);?>">
-            <input id="checkBox_<?php echo h($item['Tag']['id']); ?>" type="checkbox" onClick="toggleSetting(event, 'favourite_tag', '<?php echo h($item['Tag']['id']); ?>')" <?php echo $item['Tag']['favourite'] ? 'checked' : ''; ?>/>
+            <input id="checkBox_<?php echo h($item['Tag']['id']); ?>" type="checkbox" aria-label="<?php echo __('Favourite'); ?>" onClick="toggleSetting(event, 'favourite_tag', '<?php echo h($item['Tag']['id']); ?>')" <?php echo $item['Tag']['favourite'] ? 'checked' : ''; ?>/>
         </td>
         <?php if ($isSiteAdmin): ?>
         <td class="short action-links">
-            <?php echo $this->Html->link('', array('controller' => 'tags', 'action' => 'viewGraph', $item['Tag']['id']), array('class' => 'fa fa-share-alt', 'title' => __('View graph')));?>
-            <?php echo $this->Html->link('', array('action' => 'edit', $item['Tag']['id']), array('class' => 'fa fa-edit', 'title' => __('Edit')));?>
-            <?php echo $this->Form->postLink('', array('action' => 'delete', $item['Tag']['id']), array('class' => 'fa fa-trash', 'title' => __('Delete')), __('Are you sure you want to delete "%s"?', $item['Tag']['name']));?>
+            <?php echo $this->Html->link('', array('controller' => 'tags', 'action' => 'viewGraph', $item['Tag']['id']), array('class' => 'fa fa-share-alt', 'title' => __('View graph'), 'aria-label' => __('View graph')));?>
+            <?php echo $this->Html->link('', array('action' => 'edit', $item['Tag']['id']), array('class' => 'fa fa-edit', 'title' => __('Edit'), 'aria-label' => __('Edit')));?>
+            <?php echo $this->Form->postLink('', array('action' => 'delete', $item['Tag']['id']), array('class' => 'fa fa-trash', 'title' => __('Delete'), 'aria-label' => __('Delete')), __('Are you sure you want to delete "%s"?', $item['Tag']['name']));?>
         </td>
         <?php endif; ?>
     </tr><?php

--- a/app/View/Taxonomies/index.ctp
+++ b/app/View/Taxonomies/index.ctp
@@ -46,7 +46,7 @@ foreach ($taxonomies as $item): ?>
                     }
                 }
             ?>
-            <a href='<?php echo $baseurl."/taxonomies/view/". h($item['Taxonomy']['id']);?>' class = "fa fa-eye" title = "<?php echo __('View');?>"></a>
+            <a href='<?php echo $baseurl."/taxonomies/view/". h($item['Taxonomy']['id']);?>' class = "fa fa-eye" title = "<?php echo __('View');?>" aria-label = "<?php echo __('View');?>"></a>
             <span class="fa fa-trash useCursorPointer" title="<?php echo __('Delete taxonomy');?>" role="button" tabindex="0" aria-label="<?php echo __('Delete taxonomy');?>" onClick="deleteObject('taxonomies', 'delete', '<?php echo h($item['Taxonomy']['id']); ?>', '<?php echo h($item['Taxonomy']['id']); ?>');"></span>
         </td>
     </tr><?php

--- a/app/View/Templates/index.ctp
+++ b/app/View/Templates/index.ctp
@@ -41,8 +41,8 @@ foreach ($list as $item): ?>
         <td onclick="document.location.href ='<?php echo $baseurl."/templates/view/".$item['Template']['id']; ?>'"><?php echo h($item['Template']['description']); ?>&nbsp;</td>
         <?php if ($isAclTemplate): ?>
         <td class="short action-links">
-            <?php echo $this->Html->link('', array('action' => 'edit', $item['Template']['id']), array('class' => 'fa fa-edit', 'title' => 'Edit'));?>
-            <?php echo $this->Form->postLink('', array('action' => 'delete', $item['Template']['id']), array('class' => 'fa fa-trash', 'title' => 'Delete'), __('Are you sure you want to delete Template #' . $item['Template']['id'] . '?'));?>
+            <?php echo $this->Html->link('', array('action' => 'edit', $item['Template']['id']), array('class' => 'fa fa-edit', 'title' => 'Edit', 'aria-label' => 'Edit'));?>
+            <?php echo $this->Form->postLink('', array('action' => 'delete', $item['Template']['id']), array('class' => 'fa fa-trash', 'title' => 'Delete', 'aria-label' => 'Delete'), __('Are you sure you want to delete Template #' . $item['Template']['id'] . '?'));?>
         </td>
         <?php endif; ?>
     </tr><?php

--- a/app/View/Warninglists/index.ctp
+++ b/app/View/Warninglists/index.ctp
@@ -57,7 +57,7 @@ foreach ($warninglists as $k => $item): ?>
             <input id="checkBox_<?php echo h($item['Warninglist']['id']); ?>" type="checkbox" <?php echo $onClick; ?> <?php echo $item['Warninglist']['enabled'] ? 'checked' : ''; ?>/>
         </td>
         <td class="short action-links">
-            <a href='<?php echo $baseurl."/warninglists/view/". h($item['Warninglist']['id']);?>' class = "fa fa-eye" title = "<?php echo __('View');?>"></a>
+            <a href='<?php echo $baseurl."/warninglists/view/". h($item['Warninglist']['id']);?>' class = "fa fa-eye" title = "<?php echo __('View');?>" aria-label = "<?php echo __('View');?>"></a>
             <span class="fa fa-trash useCursorPointer" title="<?php echo __('Delete Warninglist');?>" role="button" tabindex="0" aria-label="<?php echo __('Delete warninglist');?>" onClick="deleteObject('warninglists', 'delete', '<?php echo h($item['Warninglist']['id']); ?>', '<?php echo h($item['Warninglist']['id']); ?>');"></span>
         </td>
     </tr><?php

--- a/app/View/Whitelists/admin_index.ctp
+++ b/app/View/Whitelists/admin_index.ctp
@@ -28,8 +28,8 @@ foreach ($list as $item):?>
         <td class="short"><?php echo h($item['Whitelist']['id']);?>&nbsp;</td>
         <td><?php echo h($item['Whitelist']['name']);?>&nbsp;</td>
         <td class="short action-links">
-            <?php echo $this->Html->link('', array('admin' => true, 'action' => 'edit', $item['Whitelist']['id']), array('class' => 'fa fa-edit', 'title' => __('Edit')));?>
-            <?php echo $this->Form->postLink('', array('admin' => true, 'action' => 'delete', $item['Whitelist']['id']), array('class' => 'fa fa-trash', 'title' => __('Delete')), __('Are you sure you want to delete "%s"?', $item['Whitelist']['name']));?>
+            <?php echo $this->Html->link('', array('admin' => true, 'action' => 'edit', $item['Whitelist']['id']), array('class' => 'fa fa-edit', 'title' => __('Edit'), 'aria-label' => __('Edit')));?>
+            <?php echo $this->Form->postLink('', array('admin' => true, 'action' => 'delete', $item['Whitelist']['id']), array('class' => 'fa fa-trash', 'title' => __('Delete'), 'aria-label' => __('Delete')), __('Are you sure you want to delete "%s"?', $item['Whitelist']['name']));?>
         </td>
     </tr><?php
 endforeach;?>


### PR DESCRIPTION
This affected the index pages for: servers, tags, users, roles, attributes, warning lists, signatures, regexps, galaxies, templates  ...

There is still much work to be done. But we are on the road.

Ideally, and in order to avoid code dupplicates, we should have some utility functions to generate a proper and accessible yes/no icon, an accessible icon link, etc. This would prevent the code from being filled with "aria-label" tags, since the "title" and "aria-label" properties are identical 99% of the time.