### PR TITLE
fix: allow x-frames in apache configs

### DIFF
--- a/INSTALL/apache.24.misp.ssl
+++ b/INSTALL/apache.24.misp.ssl
@@ -23,7 +23,7 @@
 
     Header always set Strict-Transport-Security "max-age=31536000; includeSubdomains;"
     Header always set X-Content-Type-Options nosniff
-    Header always set X-Frame-Options DENY
+    Header always set X-Frame-Options SAMEORIGIN 
     Header always unset "X-Powered-By"
 
     # TODO: Think about X-XSS-Protection, Content-Security-Policy, Referrer-Policy & Feature-Policy

--- a/INSTALL/apache.misp.centos7
+++ b/INSTALL/apache.misp.centos7
@@ -24,7 +24,7 @@
     ServerSignature Off
 
     Header always set X-Content-Type-Options nosniff
-    Header always set X-Frame-Options DENY
+    Header always set X-Frame-Options SAMEORIGIN 
     Header always unset "X-Powered-By"
 
     # TODO: Think about X-XSS-Protection, Content-Security-Policy, Referrer-Policy & Feature-Policy

--- a/INSTALL/apache.misp.centos7.ssl
+++ b/INSTALL/apache.misp.centos7.ssl
@@ -47,7 +47,7 @@
 
     Header always set Strict-Transport-Security "max-age=31536000; includeSubdomains;"
     Header always set X-Content-Type-Options nosniff
-    Header always set X-Frame-Options DENY
+    Header always set X-Frame-Options SAMEORIGIN 
     Header always unset "X-Powered-By"
 
     # TODO: Think about X-XSS-Protection, Content-Security-Policy, Referrer-Policy & Feature-Policy

--- a/INSTALL/apache.misp.ubuntu
+++ b/INSTALL/apache.misp.ubuntu
@@ -16,7 +16,7 @@
     ServerSignature Off
 
     Header always set X-Content-Type-Options nosniff
-    Header always set X-Frame-Options DENY
+    Header always set X-Frame-Options SAMEORIGIN 
     Header always unset "X-Powered-By"
 
     # TODO: Think about X-XSS-Protection, Content-Security-Policy, Referrer-Policy & Feature-Policy


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2016-06-03: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

With the X-Frames option set to DENY as is done in the current Apache configuration files, there are errors in pages that use X-Frames such as `https://yourmispinstance/templates/populateEventFromTemplate/id1/id2`
Here's an example of such an error : `Load denied by X-Frame-Options: "https://yourmispinstance/" does not permit framing`
This commit fixes this by allowing X-Frames from the same origin.

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [x] Patch
