### PR TITLE
Fix blank $PATH_TO_MISP

### DIFF
--- a/tools/misp-backup/misp-backup.sh
+++ b/tools/misp-backup/misp-backup.sh
@@ -127,11 +127,11 @@ if [[ -z $PATH_TO_MISP ]]; then
   if [[ "$(locate > /dev/null 2> /dev/null ; echo $?)" != "127" ]]; then
     if [[ "$(locate MISP/app/webroot/index.php |wc -l)" > 1 ]]; then
       echo "We located more then 1 MISP/app/webroot, reverting to manual"
-      PATH_TO_MISP=${PATH_TO_MISP:-$(locate MISP/app/webroot/index.php|sed 's/\/app\/webroot\/index\.php//')}
       echo -n 'Please enter the base path of your MISP install (e.g /var/www/MISP): '
       read PATH_TO_MISP
       space
     fi
+   PATH_TO_MISP=${PATH_TO_MISP:-$(locate MISP/app/webroot/index.php|sed 's/\/app\/webroot\/index\.php//')}
   fi
 fi
 


### PR DESCRIPTION
Move  PATH_TO_MISP=${PATH_TO_MISP:-$(locate MISP/app/webroot/index.php|sed 's/\/app\/webroot\/index\.php//')} outside of if statement checking if manual input is required otherwise is only executed if locate is unable to determine path.

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2016-06-03: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

If it fixes an existing issue, please use github syntax: `#<IssueID>`
`#<4415>`

#### Questions

- [ X] Does it require a DB change?
- [ Y] Are you using it in production?
- [X ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
