### PR TITLE
fix: [AdminShell] CentOS/RHEL use 'apache' by default

### DIFF
--- a/app/Console/Command/AdminShell.php
+++ b/app/Console/Command/AdminShell.php
@@ -309,7 +309,7 @@ class AdminShell extends AppShell
 
     public function updateDatabase() {
         $whoami = exec('whoami');
-        if ($whoami === 'httpd' || $whoami === 'www-data') {
+        if ($whoami === 'httpd' || $whoami === 'www-data' || $whoami === 'apache') {
             echo 'Executing all updates to bring the database up to date with the current version.' . PHP_EOL;
             $this->Server->runUpdates(true);
             echo 'All updates completed.' . PHP_EOL;

--- a/app/Console/Command/AdminShell.php
+++ b/app/Console/Command/AdminShell.php
@@ -311,6 +311,7 @@ class AdminShell extends AppShell
         $whoami = exec('whoami');
         if ($whoami === 'httpd' || $whoami === 'www-data' || $whoami === 'apache') {
             echo 'Executing all updates to bring the database up to date with the current version.' . PHP_EOL;
+            echo 'You tried to run this command as: ' . $whoami . PHP_EOL;
             $this->Server->runUpdates(true);
             echo 'All updates completed.' . PHP_EOL;
         } else {


### PR DESCRIPTION
chg: [AdminShell] Let the user know as which user he exectued the script