### PR TITLE
RPZ - Add additional policy actions

### DIFF
--- a/app/Lib/Export/RPZExport.php
+++ b/app/Lib/Export/RPZExport.php
@@ -23,6 +23,16 @@ class RPZExport
                     'action' => 'rpz-drop.',
                     'setting_id' => 0,
             ),
+            'PASSTHRU' => array(
+                    'explanation' => 'lets queries through, but allows for logging the hits (useful for testing).',
+                    'action' => 'rpz-passthru.',
+                    'setting_id' => 4,
+            ),
+            'TCP-only' => array(
+                    'explanation' => 'force the client to use TCP.',
+                    'action' => 'rpz-tcp-only.',
+                    'setting_id' => 5,
+            ),
     );
 
 	private $__items = array();
@@ -33,7 +43,7 @@ class RPZExport
 
 	private $__rpzSettings = array();
 
-	private $__valid_policies = array('NXDOMAIN', 'NODATA', 'DROP', 'walled-garden');
+	private $__valid_policies = array('NXDOMAIN', 'NODATA', 'DROP', 'walled-garden', 'PASSTHRU', 'TCP-only');
 
 	private $__server = null;
 
@@ -100,7 +110,7 @@ class RPZExport
 		$lookupData = array('policy', 'walled_garden', 'ns', 'ns_alt', 'email', 'serial', 'refresh', 'retry', 'expiry', 'minimum_ttl', 'ttl');
 		foreach ($lookupData as $v) {
 			if ($v === 'policy' && isset($options['filters'][$v])) {
-				if (!in_array($options['filters'][$v], array('NXDOMAIN', 'NODATA', 'DROP', 'walled-garden'))) {
+				if (!in_array($options['filters'][$v], array('NXDOMAIN', 'NODATA', 'DROP', 'walled-garden', 'PASSTHRU', 'TCP-only'))) {
 					unset($options['filters'][$v]);
 				} else {
 					$options['filters'][$v] = $this->getIdByPolicy($options['filters'][$v]);
@@ -162,6 +172,8 @@ class RPZExport
             'NXDOMAIN' => 'return NXDOMAIN (name does not exist) irrespective of actual result received.',
             'NODATA' => 'returns NODATA (name exists but no answers returned) irrespective of actual result received.',
             'DROP' => 'timeout.',
+            'PASSTHRU' => 'lets queries through, but allows for logging the hits (useful for testing).',
+            'TCP-only' => 'force the client to use TCP.',
         );
         return $explanations[$type] . $this->__policies[$policy]['explanation'] . PHP_EOL;
     }

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1206,7 +1206,7 @@ class Server extends AppModel
                             'errorMessage' => '',
                             'test' => 'testForRPZBehaviour',
                             'type' => 'numeric',
-                            'options' => array(0 => 'DROP', 1 => 'NXDOMAIN', 2 => 'NODATA', 3 => 'walled-garden'),
+                            'options' => array(0 => 'DROP', 1 => 'NXDOMAIN', 2 => 'NODATA', 3 => 'walled-garden', 4 => 'PASSTHRU', 5 => 'TCP-only' ),
                         ),
                         'RPZ_walled_garden' => array(
                             'level' => 2,


### PR DESCRIPTION
#### What does it do?
Add the last (missing) policy actions from the RPZ draft.
* PASSTHRU allows for testing without applying changes on the returned answer.
* TCP-only forces the client over to use TCP.

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
