### PR TITLE
rpz: Local-Data

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -2236,8 +2236,8 @@ class AttributesController extends AppController
     {
         // request handler for POSTed queries. If the request is a post, the parameters (apart from the key) will be ignored and replaced by the terms defined in the posted json or xml object.
         // The correct format for both is a "request" root element, as shown by the examples below:
-        // For Json: {"request":{"policy": "walled-garden","garden":"garden.example.com"}}
-        // For XML: <request><policy>walled-garden</policy><garden>garden.example.com</gargen></request>
+        // For Json: {"request":{"policy": "Local-Data","walled_garden":"my.stop.page.net"}}
+        // For XML: <request><policy>Local-Data</policy><walled_garden>my.stop.page.net</walled_garden></request>
         // the response type is used to determine the parsing method (xml/json)
         if ($this->request->is('post')) {
             if ($this->request->input('json_decode', true)) {
@@ -2264,7 +2264,7 @@ class AttributesController extends AppController
                 ${$sF} = false;
             }
         }
-        if (!in_array($policy, array('NXDOMAIN', 'NODATA', 'DROP', 'walled-garden'))) {
+        if (!in_array($policy, array('NXDOMAIN', 'NODATA', 'DROP', 'Local-Data'))) {
             $policy = false;
         }
         App::uses('RPZExport', 'Export');

--- a/app/Lib/Export/RPZExport.php
+++ b/app/Lib/Export/RPZExport.php
@@ -3,7 +3,7 @@
 class RPZExport
 {
     private $__policies = array(
-            'walled-garden' => array(
+            'Local-Data' => array(
                     'explanation' => 'returns the defined alternate location.',
                     'action' => '$walled_garden',
                     'setting_id' => 3,
@@ -43,7 +43,7 @@ class RPZExport
 
 	private $__rpzSettings = array();
 
-	private $__valid_policies = array('NXDOMAIN', 'NODATA', 'DROP', 'walled-garden', 'PASSTHRU', 'TCP-only');
+	private $__valid_policies = array('NXDOMAIN', 'NODATA', 'DROP', 'Local-Data', 'PASSTHRU', 'TCP-only');
 
 	private $__server = null;
 
@@ -110,7 +110,7 @@ class RPZExport
 		$lookupData = array('policy', 'walled_garden', 'ns', 'ns_alt', 'email', 'serial', 'refresh', 'retry', 'expiry', 'minimum_ttl', 'ttl');
 		foreach ($lookupData as $v) {
 			if ($v === 'policy' && isset($options['filters'][$v])) {
-				if (!in_array($options['filters'][$v], array('NXDOMAIN', 'NODATA', 'DROP', 'walled-garden', 'PASSTHRU', 'TCP-only'))) {
+				if (!in_array($options['filters'][$v], array('NXDOMAIN', 'NODATA', 'DROP', 'Local-Data', 'PASSTHRU', 'TCP-only'))) {
 					unset($options['filters'][$v]);
 				} else {
 					$options['filters'][$v] = $this->getIdByPolicy($options['filters'][$v]);
@@ -168,7 +168,7 @@ class RPZExport
             'hostname' => '; The following hostnames will '
         );
         $policy_explanations = array(
-            'walled-garden' => 'returns the defined alternate location.',
+            'Local-Data' => 'returns the defined alternate location.',
             'NXDOMAIN' => 'return NXDOMAIN (name does not exist) irrespective of actual result received.',
             'NODATA' => 'returns NODATA (name exists but no answers returned) irrespective of actual result received.',
             'DROP' => 'timeout.',
@@ -201,7 +201,7 @@ class RPZExport
         $result = $this->buildHeader($rpzSettings);
         $policy = $this->getPolicyById($rpzSettings['policy']);
         $action = $this->__policies[$policy]['action'];
-        if ($policy == 'walled-garden') {
+        if ($policy == 'Local-Data') {
             $action = str_replace('$walled_garden', $rpzSettings['walled_garden'], $action);
         }
 

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1239,7 +1239,7 @@ class Server extends AppModel
                         ),
                         'RPZ_walled_garden' => array(
                             'level' => 2,
-                            'description' => __('The default walled garden used by the RPZ export if the walled garden setting is picked for the export.'),
+                            'description' => __('The default walled garden used by the RPZ export if the Local-Data policy setting is picked for the export.'),
                             'value' => '127.0.0.1',
                             'errorMessage' => '',
                             'test' => 'testForEmpty',

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1235,7 +1235,7 @@ class Server extends AppModel
                             'errorMessage' => '',
                             'test' => 'testForRPZBehaviour',
                             'type' => 'numeric',
-                            'options' => array(0 => 'DROP', 1 => 'NXDOMAIN', 2 => 'NODATA', 3 => 'walled-garden', 4 => 'PASSTHRU', 5 => 'TCP-only' ),
+                            'options' => array(0 => 'DROP', 1 => 'NXDOMAIN', 2 => 'NODATA', 3 => 'Local-Data', 4 => 'PASSTHRU', 5 => 'TCP-only' ),
                         ),
                         'RPZ_walled_garden' => array(
                             'level' => 2,

--- a/app/View/Events/automation.ctp
+++ b/app/View/Events/automation.ctp
@@ -100,8 +100,8 @@
     <p><?php echo __('To override the above values, either use the url parameters as described below');?>:</p>
     <pre><?php echo $baseurl;?>/attributes/rpz/download/[tags]/[eventId]/[from]/[to]/[policy]/[walled_garden]/[ns]/[email]/[serial]/[refresh]/[retry]/[expiry]/[minimum_ttl]/[ttl]</pre>
     <p><?php echo __('or POST an XML or JSON object with the above listed options');?>: </p>
-    <code><?php echo h('<request><tags>OSINT&&!OUTDATED</tags><policy>walled-garden</policy><walled_garden>teamliquid.net</walled_garden><refresh>5h</refresh></request>');?></code><br /><br />
-    <code>{"request": {"tags": ["OSINT", "!OUTDATED"], "policy": "walled-garden", "walled_garden": "teamliquid.net", "refresh": "5h"}</code>
+    <code><?php echo h('<request><tags>OSINT&&!OUTDATED</tags><policy>Local-Data</policy><walled_garden>my.stop.page.net</walled_garden><refresh>5h</refresh></request>');?></code><br /><br />
+    <code>{"request": {"tags": ["OSINT", "!OUTDATED"], "policy": "Local-Data", "walled_garden": "my.stop.page.net", "refresh": "5h"}</code>
 
     <h3><?php echo __('Bro IDS export');?></h3>
     <p><?php echo __('An export of all attributes of a specific bro type to a formatted plain text file. By default only published and IDS flagged attributes are exported.');?></p>

--- a/app/View/Events/legacy_automation.ctp
+++ b/app/View/Events/legacy_automation.ctp
@@ -180,8 +180,8 @@
     <p><?php echo __('To override the above values, either use the url parameters as described below');?>:</p>
     <pre><?php echo $baseurl;?>/attributes/rpz/download/[tags]/[eventId]/[from]/[to]/[policy]/[walled_garden]/[ns]/[email]/[serial]/[refresh]/[retry]/[expiry]/[minimum_ttl]/[ttl]</pre>
     <p><?php echo __('or POST an XML or JSON object with the above listed options');?>: </p>
-    <code><?php echo h('<request><tags>OSINT&&!OUTDATED</tags><policy>walled-garden</policy><walled_garden>teamliquid.net</walled_garden><refresh>5h</refresh></request>');?></code><br /><br />
-    <code>{"request": {"tags": ["OSINT", "!OUTDATED"], "policy": "walled-garden", "walled_garden": "teamliquid.net", "refresh": "5h"}</code>
+    <code><?php echo h('<request><tags>OSINT&&!OUTDATED</tags><policy>Local-Data</policy><walled_garden>my.stop.page.net</walled_garden><refresh>5h</refresh></request>');?></code><br /><br />
+    <code>{"request": {"tags": ["OSINT", "!OUTDATED"], "policy": "Local-Data", "walled_garden": "my.stop.page.net", "refresh": "5h"}</code>
 
     <h3><?php echo __('Text export');?></h3>
     <p<?php echo __('>An export of all attributes of a specific type to a plain text file. By default only published and IDS flagged attributes are exported.');?></p>


### PR DESCRIPTION
Rename action policy "walled-garden" to --> Local-Data (as this is the term used in the draft and other RPZ documentation. (note that the data part input is still named "walled_garden") 
Fixes 2) in issue #4594

#### Release Type:
- [X] Patch
