### PR TITLE
Clean cached-exports

### DIFF
--- a/tools/misp-wipe/misp-wipe.sh
+++ b/tools/misp-wipe/misp-wipe.sh
@@ -81,7 +81,7 @@ rm -f $TMP
 echo "Wiping files"
 git clean -f -x app/webroot/img/orgs
 #git clean -f -x app/webroot/img/custom
-git clean -f -x app/tmp/logs/
+git clean -f -d -x app/tmp
 git clean -f -d -x app/files
 
 echo "Updating taxonomies"


### PR DESCRIPTION
My training instance was getting quite large because someone enabled cached exports. We need to wipe all the tmp files after a training! :-)