### PR TITLE
Match EDNS packets with snort rules

### DIFF
--- a/app/Lib/Export/NidsExport.php
+++ b/app/Lib/Export/NidsExport.php
@@ -344,7 +344,7 @@ class NidsExport
     {
         $overruled = $this->checkWhitelist($attribute['value']);
         $attribute['value'] = NidsExport::replaceIllegalChars($attribute['value']);  // substitute chars not allowed in rule
-        $content = 'content:"|01 00 00 01 00 00 00 00 00 00|"; depth:10; offset:2; content:"' . NidsExport::dnsNameToRawFormat($attribute['value'], 'hostname') . '"; fast_pattern; nocase;';
+        $content = 'content:"|01 00 00 01 00 00 00 00 00 01|"; depth:10; offset:2; content:"' . NidsExport::dnsNameToRawFormat($attribute['value'], 'hostname') . '"; fast_pattern; nocase;';
         $this->rules[] = sprintf(
             $ruleFormat,
                 ($overruled) ? '#OVERRULED BY WHITELIST# ' : '',
@@ -400,7 +400,7 @@ class NidsExport
     {
         $overruled = $this->checkWhitelist($attribute['value']);
         $attribute['value'] = NidsExport::replaceIllegalChars($attribute['value']);  // substitute chars not allowed in rule
-        $content = 'content:"|01 00 00 01 00 00 00 00 00 00|"; depth:10; offset:2; content:"' . NidsExport::dnsNameToRawFormat($attribute['value']) . '"; fast_pattern; nocase;';
+        $content = 'content:"|01 00 00 01 00 00 00 00 00 01|"; depth:10; offset:2; content:"' . NidsExport::dnsNameToRawFormat($attribute['value']) . '"; fast_pattern; nocase;';
         $this->rules[] = sprintf(
             $ruleFormat,
                 ($overruled) ? '#OVERRULED BY WHITELIST# ' : '',
@@ -565,7 +565,7 @@ class NidsExport
 
     /**
      * Converts a DNS name to a raw format usable in NIDS like Snort.
-     *   example host: foobar.com becomes |00||06|foobar|03|com|00|
+     *   example host: foobar.com becomes |01||06|foobar|03|com|00|
      *   example domain: foobar.com becomes |06|foobar|03|com|00|
      * @param string $name dns name to be converted
      * @param string $type the type of dns name - domain (default) or hostname
@@ -575,7 +575,7 @@ class NidsExport
     {
         $rawName = "";
         if ('hostname' == $type) {
-            $rawName = '|00|';
+            $rawName = '|01|';
         }
         // explode using the dot
         $explodedNames = explode('.', $name);


### PR DESCRIPTION
Since DNS Flag Day all DNS answers have the additional OPT RR set. As a result none of the snort rules generated by MISP match anything anymore. This patch fixes that.