### PR TITLE
misp-wipe ; delete all non-default orgs & users

### DIFF
--- a/tools/misp-wipe/misp-wipe.sh
+++ b/tools/misp-wipe/misp-wipe.sh
@@ -67,6 +67,9 @@ rm -f $MISPPath/app/tmp/cache/models/myapp_*
 rm -f $MISPPath/app/tmp/cache/persistent/myapp_*
 
 echo "Wiping MySQL tables"
+echo "Removes all users and organizations, except default (id=1)"
+echo " - Change DELETE FROM to > 0 in misp-wipe.sql to also remove default ones"
+echo " - Defaults are created on first login"
 MySQLRUser=${MySQLRUser:-$MySQLUUser}
 MySQLRPass=${MySQLRPass:-$MySQLUPass}
 mysql -u $MySQLRUser -p$MySQLRPass $MISPDB < $SQL

--- a/tools/misp-wipe/misp-wipe.sql
+++ b/tools/misp-wipe/misp-wipe.sql
@@ -60,7 +60,7 @@ TRUNCATE `template_element_files`;
 TRUNCATE `template_element_texts`;
 
 -- Remove entries from tables and reset index
-DELETE FROM `users` WHERE id > 3;
-ALTER TABLE `users` AUTO_INCREMENT = 4;
-DELETE FROM `organisations` WHERE id > 2;
-ALTER TABLE `organisations` AUTO_INCREMENT = 3;
+DELETE FROM `users` WHERE id > 1;
+ALTER TABLE `users` AUTO_INCREMENT = 2;
+DELETE FROM `organisations` WHERE id > 1;
+ALTER TABLE `organisations` AUTO_INCREMENT = 2;


### PR DESCRIPTION
#### What does it do?

misp-wipe : delete all non-default orgs & users
https://github.com/MISP/MISP/issues/4625

#### Questions

- [No ] Does it require a DB change?
- [ Yes] Are you using it in production? 
- [ No] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
