### PR TITLE
Import of 'b64encode' is not used.

### DIFF
--- a/app/files/scripts/stix2/stix2misp.py
+++ b/app/files/scripts/stix2/stix2misp.py
@@ -24,7 +24,6 @@ import uuid
 import io
 import re
 import stix2
-from base64 import b64encode
 from stix2misp_mapping import *
 from collections import defaultdict
 


### PR DESCRIPTION
Think that line is not needed.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
