### PR TITLE
enable misp-backup where MySQL datastore isn't on localhost

### DIFF
--- a/tools/misp-backup/misp-backup.sh
+++ b/tools/misp-backup/misp-backup.sh
@@ -199,7 +199,7 @@ cp -p $PATH_TO_MISP/app/Config/database.php $TmpDir/Config
 echo "MySQL Dump"
 MySQLRUser=${MySQLRUser:-$MySQLUUser}
 MySQLRPass=${MySQLRPass:-$MySQLUPass}
-mysqldump --opt -u $MySQLRUser -p$MySQLRPass $MISPDB > $TmpDir/MISPbackupfile.sql
+mysqldump --opt --host $MISPDBHost -u $MySQLRUser -p$MySQLRPass $MISPDB > $TmpDir/MISPbackupfile.sql
 if [[ "$?" != "0" ]]; then
   echo "MySQLdump failed, abort." && exit 1
 fi


### PR DESCRIPTION
The misp-backup script grabs the MYSQL host parameter from database.conf but it wasn't included in the call to mysqldump.
