### PR TITLE
fix: [installer] added missing python zmq lib

### DIFF
--- a/INSTALL/INSTALL.tpl.sh
+++ b/INSTALL/INSTALL.tpl.sh
@@ -465,6 +465,9 @@ installMISPonKali () {
   # install python-magic
   $SUDO_WWW ${PATH_TO_MISP}/venv/bin/pip install python-magic 2> /dev/null > /dev/null
 
+  # install zmq needed by mispzmq
+  $SUDO_WWW ${PATH_TO_MISP}/venv/bin/pip install zmq 2> /dev/null > /dev/null
+
   # Install Crypt_GPG and Console_CommandLine
   debug "Installing pear Console_CommandLine"
   pear install ${PATH_TO_MISP}/INSTALL/dependencies/Console_CommandLine/package.xml


### PR DESCRIPTION
This PR fixes a missing library causing the following error to be thrown:
```
Traceback (most recent call last):
  File "/var/www/MISP/app/files/scripts/mispzmq/mispzmq.py", line 3, in <module>
    import zmq
ModuleNotFoundError: No module named 'zmq'
tail: mispzmq.error.log: file truncated
Traceback (most recent call last):
  File "/var/www/MISP/app/files/scripts/mispzmq/mispzmq.py", line 3, in <module>
    import zmq
ModuleNotFoundError: No module named 'zmq'
```
This was present following a clean install using `./INSTALL.sh -c -M`