### PR TITLE
fix: [js] fixes #4678 and javascript errors

### DIFF
--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -4148,6 +4148,8 @@ function checkIfLoggedIn() {
             if (data.slice(-2) !== 'OK') {
                 window.location.replace(baseurl + "/users/login");
             }
+        }).fail(function() {
+                window.location.replace(baseurl + "/users/login"); 
         });
     }
     setTimeout(function() { checkIfLoggedIn(); }, 5000);


### PR DESCRIPTION
This fixes a minor bug with the `checkIfLoggedIn()` function.
When logged out the function will throw an error. This is now caught by the `.fail()` function.

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
