### PR TITLE
I am (g)root!

### DIFF
--- a/INSTALL/INSTALL.sh
+++ b/INSTALL/INSTALL.sh
@@ -403,7 +403,7 @@ ask_o () {
 # Check if misp user is present and if run as root
 checkID () {
   debug "Checking if run as root and $MISP_USER is present"
-  if [[ $EUID == 0 ]]; then
+  if [[ $EUID -ne 0 ]]; then
     echo "This script cannot be run as a root"
     exit 1
   elif [[ $(id $MISP_USER >/dev/null; echo $?) -ne 0 ]]; then


### PR DESCRIPTION
Apparently a freshly installed Ubuntu 18.04.2 is as 1337 as Kali so $EUID == 0 is a lie 

Before I was getting:
Next step: Checking if run as root and misp is present
This script cannot be run as a root

with $EUID -ne 0 I'm getting:
Next step: Checking if run as root and misp is present
id: ‘misp’: no such user
There is NO user called 'misp' create a user 'misp' (y) or continue as root (n)? (y/n) 
y
User misp added, password is: ....
.... and all the rest of the install.

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2016-06-03: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

If it fixes an existing issue, please use github syntax: `#<IssueID>`

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
