### PR TITLE
fix: Revert the fetchOrg to include the 'Organisation' root key

### DIFF
--- a/app/Model/Organisation.php
+++ b/app/Model/Organisation.php
@@ -376,7 +376,7 @@ class Organisation extends AppModel
             'conditions' => $conditions,
             'recursive' => -1
         ));
-        return (empty($org)) ? false : $org[$this->alias];
+        return (empty($org)) ? false : $org;
     }
 
     public function attachOrgsToEvent($event, $fields)


### PR DESCRIPTION
#### What does it do?

This fixes the issue #4040, relating to being unable to add an organisation to an existing sharing group through the `addOrg` endpoint.

This code was changed back in Oct 2018 as part of the following commit:
https://github.com/MISP/MISP/commit/0fabffd5edb66db6eba468a64266c784c35d266d

However it may have been incorrect, as the other code changes don't use this endpoint. In addition, it seems the SharingGroup functionality is the only thing using the fetchOrg.

Issue is that it was dropping the 'Organisation' key but the addOrg depended on this.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
