### PR TITLE
Support empty attribute type in IOC import

### DIFF
--- a/app/Controller/Component/IOCImportComponent.php
+++ b/app/Controller/Component/IOCImportComponent.php
@@ -262,7 +262,12 @@ class IOCImportComponent extends Component
     private function __analyseIndicator($attribute)
     {
         $attribute['distribution'] = $this->distribution;
-        $temp = $this->__checkType($attribute['search'], $attribute['type']);
+        if (isset($attribute['type'])) {
+            $type = $attribute['type'];
+        } else {
+            $type = '';
+        }
+        $temp = $this->__checkType($attribute['search'], $type);
         if ($attribute['condition'] !== 'containsnot') {
             if (!$temp) {
                 return false;


### PR DESCRIPTION
Without this some of the IOC files we receive will not import (php will error out).