### PR TITLE
fix: Views invalid marker content fixed

### DIFF
--- a/app/View/Elements/Events/View/related_event.ctp
+++ b/app/View/Elements/Events/View/related_event.ctp
@@ -20,7 +20,7 @@
                     <td style="line-height: 14px; padding-left: 2px;">
                         <i><?php echo h($related['date']); ?></i>
                         <?php if (isset($relatedEventCorrelationCount[$related['id']])): ?>
-                            <b style="margin-left: 5px; float: right; cursor: help;" title="<?php echo __(sprintf('This related event contains %s unique correlation(s)', h($relatedEventCorrelationCount[$related['id']]))); ?>"> <?php echo h($relatedEventCorrelationCount[$related['id']]) ?></b>
+                            <b style="margin-left: 5px; float: right; cursor: help;" title="<?php echo sprintf(__('This related event contains %s unique correlation(s)'), h($relatedEventCorrelationCount[$related['id']])); ?>"> <?php echo h($relatedEventCorrelationCount[$related['id']]) ?></b>
                         <?php endif; ?>
                     </td>
                 </tr>

--- a/app/View/Elements/Objects/object_similarities.ctp
+++ b/app/View/Elements/Objects/object_similarities.ctp
@@ -99,13 +99,13 @@ if (!isset($simple_flattened_attribute_noval) || !isset($simple_flattened_attrib
                     <?php switch ($field):
                         case 'id': ?>
                             <div>
-                                <span class="bold"><?php echo h(__(Inflector::humanize($field))) . ':'; ?></span>
+                                <span class="bold"><?php echo h(Inflector::humanize($field)) . ':'; ?></span>
                                 <a href="<?php echo $baseurl . '/objects/edit/' . h($object['Object'][$field]); ?>" style="color: white;"><?php echo h($object['Object'][$field]); ?></a>
                             </div>
                             <?php break; ?>
                         <?php case 'distribution': ?>
                             <div>
-                                <span class="bold"><?php echo h(__(Inflector::humanize($field))) . ':'; ?></span>
+                                <span class="bold"><?php echo h(Inflector::humanize($field)) . ':'; ?></span>
                                 <span>
                                     <?php
                                         echo h($distributionLevels[$object['Object'][$field]])
@@ -123,13 +123,13 @@ if (!isset($simple_flattened_attribute_noval) || !isset($simple_flattened_attrib
                                 }
                             ?>
                             <div style="<?php echo $temp_style ?> border-radius: 3px;" data-templatecomparison="<?php echo $temp_comparison; ?>" title="<?php echo __('The template version used by this object.'); ?>">
-                                <span class="bold"><?php echo h(__(Inflector::humanize($field))) . ':'; ?></span>
+                                <span class="bold"><?php echo h(Inflector::humanize($field)) . ':'; ?></span>
                                 <span ><?php echo h($object['Object'][$field]); ?></span>
                             </div>
                             <?php break; ?>
                         <?php default: ?>
                             <div>
-                                <span class="bold"><?php echo h(__(Inflector::humanize($field))) . ':'; ?></span>
+                                <span class="bold"><?php echo h(Inflector::humanize($field)) . ':'; ?></span>
                                 <span><?php echo h($object['Object'][$field]); ?></span>
                             </div>
                             <?php break; ?>


### PR DESCRIPTION
Views fixed to avoid errors during POT file generating:

Invalid marker content in
/var/www/MISP/app/View/Elements/Events/View/related_event.ctp:23
* __(
sprintf('This related event contains %s unique
correlation(s)',h($relatedEventCorrelationCount[$related['id']])))

Invalid marker content in
/var/www/MISP/app/View/Elements/Objects/object_similarities.ctp:102
* __(
Inflector::humanize($field))

Invalid marker content in
/var/www/MISP/app/View/Elements/Objects/object_similarities.ctp:108
* __(
Inflector::humanize($field))

Invalid marker content in
/var/www/MISP/app/View/Elements/Objects/object_similarities.ctp:126
* __(
Inflector::humanize($field))

Invalid marker content in
/var/www/MISP/app/View/Elements/Objects/object_similarities.ctp:132
* __(
Inflector::humanize($field))

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
