### PR TITLE
Allow SSL verification to be disabled with config

### DIFF
--- a/tools/misp_retention.py
+++ b/tools/misp_retention.py
@@ -7,7 +7,7 @@ from pymisp import PyMISP, MISPEvent
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 import re
-from keys import misp_url, misp_key
+from keys import misp_url, misp_key, misp_verifycert
 
 # pip install pymisp python-dateutil
 
@@ -20,7 +20,7 @@ class misphelper(object):
     def __init__(self):
         self.misp = PyMISP(url=misp_url,
                            key=misp_key,
-                           ssl=True,
+                           ssl=misp_verifycert,
                            out_type="json")
         self.taxonomyId = self.searchTaxonomy()
 


### PR DESCRIPTION
Allow SSL verification to be disabled with config. If I understand this right this will need to be scheduled with a cronjob if the expiration framework is wanted?


#### What does it do?
Allows for SSL verification for misp_retention.py to be configured.

#### Questions

- [N] Does it require a DB change?
- [Y] Are you using it in production?
- [N] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
