### PR TITLE
Fix session_destroy errors

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -505,7 +505,7 @@ class AppController extends Controller
             echo json_encode($this->Log->getDataSource()->getLog(false, false), JSON_PRETTY_PRINT);
         }
         if ($this->isApiAuthed && $this->_isRest()) {
-            session_destroy();
+            $this->Session->destroy();
         }
     }
 


### PR DESCRIPTION
Fixes #4808 probably because the CakeSession is already destroyed when this is called. But Cake can handle that, php cannot.