### PR TITLE
Fix errors on NIDS export when whitelist is empty

### DIFF
--- a/app/Lib/Export/NidsExport.php
+++ b/app/Lib/Export/NidsExport.php
@@ -647,7 +647,7 @@ class NidsExport
 
     public function checkWhitelist($value)
     {
-		if ($this->checkWhitelist) {
+		if ($this->checkWhitelist && is_array($this->whitelist)) {
 	        foreach ($this->whitelist as $wlitem) {
 	            if (preg_match($wlitem, $value)) {
 	                return true;


### PR DESCRIPTION
Get rid of these annoying errors:
```
2019-07-17 12:20:19 Warning: Warning (2): Invalid argument supplied for foreach() in [/var/www/MISP/app/Lib/Export/NidsExport.php, line 651]
Trace:
ErrorHandler::handleError() - APP/Lib/cakephp/lib/Cake/Error/ErrorHandler.php, line 230
NidsExport::checkWhitelist() - APP/Lib/Export/NidsExport.php, line 651
NidsSuricataExport::domainRule() - APP/Lib/Export/NidsSuricataExport.php, line 58
NidsExport::export() - APP/Lib/Export/NidsExport.php, line 174
NidsSuricataExport::export() - APP/Lib/Export/NidsSuricataExport.php, line 11
Attribute::nids() - APP/Model/Attribute.php, line 2206
EventsController::nids() - APP/Controller/EventsController.php, line 2978
ReflectionMethod::invokeArgs() - [internal], line ??
Controller::invokeAction() - APP/Lib/cakephp/lib/Cake/Controller/Controller.php, line 499
Dispatcher::_invoke() - APP/Lib/cakephp/lib/Cake/Routing/Dispatcher.php, line 193
Dispatcher::dispatch() - APP/Lib/cakephp/lib/Cake/Routing/Dispatcher.php, line 167
[main] - APP/webroot/index.php, line 92
```