### PR TITLE
Make error clearer when canPush bit is missing

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -2561,7 +2561,7 @@ class Server extends AppModel
         $url = $this->data['Server']['url'];
         $push = $this->checkVersionCompatibility($id, $user);
         if (isset($push['canPush']) && !$push['canPush']) {
-            $push = 'Remote instance is outdated.';
+            $push = 'Remote instance is outdated or no permission to push.';
         }
         if (!is_array($push)) {
             $message = sprintf('Push to server %s failed. Reason: %s', $id, $push);


### PR DESCRIPTION
The canPush permission was introduced in a81894f14ca74a060f4d50713c6cf64f4243f954 a year ago. Today the missing bit actually means you are not allowed to push data. 