### PR TITLE
fix: Load Galaxy mappings for misp2stix2 seperately from Objects

### DIFF
--- a/app/files/scripts/stix2/misp2stix2.py
+++ b/app/files/scripts/stix2/misp2stix2.py
@@ -167,6 +167,7 @@ class StixBuilder():
             if self.objects_to_parse:
                 self.resolve_objects2parse()
         if self.misp_event.get('Galaxy'):
+            self.load_galaxy_mapping()
             for galaxy in self.misp_event['Galaxy']:
                 self.parse_galaxy(galaxy, self.report_id)
         report = self.eventReport()
@@ -203,6 +204,8 @@ class StixBuilder():
             'x509': {'observable': self.resolve_x509_observable,
                      'pattern': self.resolve_x509_pattern}
         }
+
+    def load_galaxy_mapping(self):
         self.galaxies_mapping = {'branded-vulnerability': ['vulnerability', self.add_vulnerability_from_galaxy]}
         self.galaxies_mapping.update(dict.fromkeys(attack_pattern_galaxies_list, ['attack-pattern', self.add_attack_pattern]))
         self.galaxies_mapping.update(dict.fromkeys(course_of_action_galaxies_list, ['course-of-action', self.add_course_of_action]))


### PR DESCRIPTION
#### What does it do?

It fixes a newly discovered issue I've been facing where my 'Object' key from a MISP event is empty, but the 'Galaxy' key is not. As a result, the `load_objects_mapping` function was never called, and therefore none of the Galaxies used were being included in the generated STIX2 file.

To resolve, a new function has been defined that loads the Galaxy mapping upon confirming there is data within the 'Galaxy' key of a MISP event.

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
