### PR TITLE
fix: some PostgreSQL issues

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -3037,7 +3037,7 @@ class AttributesController extends AppController
         if ($id === 'selected') {
             $idList = json_decode($this->request->data['attribute_ids'], true);
         }
-        $local = !empty($this->params['named']['local']);
+        $local = empty($this->params['named']['local']) ? 0 : 1;
         if (!$this->request->is('post')) {
             $this->set('local', $local);
             $this->set('object_id', $id);

--- a/app/Controller/SharingGroupsController.php
+++ b/app/Controller/SharingGroupsController.php
@@ -72,6 +72,8 @@ class SharingGroupsController extends AppController
                 }
             }
             $this->SharingGroup->create();
+            $sg['active'] = $sg['active'] ? 1: 0;
+            $sg['roaming'] = $sg['roaming'] ? 1: 0;
             $sg['organisation_uuid'] = $this->Auth->user('Organisation')['uuid'];
             $sg['local'] = 1;
             $sg['org_id'] = $this->Auth->user('org_id');

--- a/app/Lib/Tools/QueryTool.php
+++ b/app/Lib/Tools/QueryTool.php
@@ -14,7 +14,7 @@ class QueryTool
     {
         $db = $model->getDataSource();
         $connection = $db->getConnection();
-        $query = $connection->prepare('DELETE FROM ' . $table . ' WHERE ' . $field . ' = :value');
+        $query = $connection->prepare('DELETE FROM "' . $table . '" WHERE "' . $field . '" = :value');
         $query->bindValue(':value', $value, $this->__pdoMap[$db->introspectType($value)]);
         $query->execute();
     }

--- a/app/Lib/Tools/QueryTool.php
+++ b/app/Lib/Tools/QueryTool.php
@@ -14,7 +14,11 @@ class QueryTool
     {
         $db = $model->getDataSource();
         $connection = $db->getConnection();
-        $query = $connection->prepare('DELETE FROM ' . $table . ' WHERE "' . $field . '" = :value');
+        if ($db->config['datasource'] == 'Database/Mysql' ) {
+            $query = $connection->prepare('DELETE FROM ' . $table . ' WHERE ' . $field . ' = :value');
+        } elseif ($db->config['datasource'] == 'Database/Postgres' ) {
+            $query = $connection->prepare('DELETE FROM "' . $table . '" WHERE "' . $field . '" = :value');
+        }
         $query->bindValue(':value', $value, $this->__pdoMap[$db->introspectType($value)]);
         $query->execute();
     }

--- a/app/Lib/Tools/QueryTool.php
+++ b/app/Lib/Tools/QueryTool.php
@@ -14,7 +14,7 @@ class QueryTool
     {
         $db = $model->getDataSource();
         $connection = $db->getConnection();
-        $query = $connection->prepare('DELETE FROM "' . $table . '" WHERE "' . $field . '" = :value');
+        $query = $connection->prepare('DELETE FROM ' . $table . ' WHERE "' . $field . '" = :value');
         $query->bindValue(':value', $value, $this->__pdoMap[$db->introspectType($value)]);
         $query->execute();
     }

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -3685,6 +3685,8 @@ class Attribute extends AppModel
         }
         $attribute['event_id'] = $eventId;
         $attribute['object_id'] = $objectId ? $objectId : 0;
+        $attribute['to_ids'] = $attribute['to_ids'] ? 1 : 0;
+        $attribute['disable_correlation'] = $attribute['disable_correlation'] ? 1 : 0;
         unset($attribute['id']);
         if (isset($attribute['encrypt'])) {
             $result = $this->handleMaliciousBase64($eventId, $attribute['value'], $attribute['data'], array('md5'));

--- a/app/Model/EventTag.php
+++ b/app/Model/EventTag.php
@@ -190,7 +190,7 @@ class EventTag extends AppModel
                         'conditions' => array('name' => $allowedTags)
                     )
                 ),
-                'group' => 'tag_id',
+                'group' => array('tag_id', 'Tag.name', 'Tag.id'),
                 'fields' => array('Tag.name', 'EventTag.tag_id', 'count(EventTag.tag_id) as score')
             ));
         }

--- a/app/View/Attributes/add.ctp
+++ b/app/View/Attributes/add.ctp
@@ -74,6 +74,7 @@
             <?php
             echo $this->Form->input('to_ids', array(
                         'label' => __('for Intrusion Detection System'),
+                        'type' => 'checkbox'
             ));
             echo $this->Form->input('batch_import', array(
                     'type' => 'checkbox'

--- a/app/View/Elements/Events/eventIndexTable.ctp
+++ b/app/View/Elements/Events/eventIndexTable.ctp
@@ -190,7 +190,7 @@
                 <span style=" white-space: nowrap;"><?php echo $post_count?></span>&nbsp;
             </td>
         <?php endif;?>
-        <?php if ('true' == $isSiteAdmin): ?>
+        <?php if ($isSiteAdmin): ?>
             <td class="short" ondblclick="location.href ='<?php echo $baseurl."/events/view/".$event['Event']['id'];?>'">
                 <?php echo h($event['User']['email']); ?>&nbsp;
             </td>

--- a/app/View/Users/admin_add.ctp
+++ b/app/View/Users/admin_add.ctp
@@ -85,7 +85,7 @@
     ?>
         <div class="clear"></div>
     <?php
-        echo $this->Form->input('disabled', array('label' => __('Disable this user account')));
+        echo $this->Form->input('disabled', array('type' => 'checkbox', 'label' => __('Disable this user account')));
         echo $this->Form->input('notify', array(
             'label' => __('Send credentials automatically'),
             'type' => 'checkbox',

--- a/app/View/Users/admin_edit.ctp
+++ b/app/View/Users/admin_edit.ctp
@@ -66,7 +66,7 @@
         <div class="clear"><span role="button" tabindex="0" aria-label="<?php echo __('Fetch the user\'s GnuPG key');?>" onClick="lookupPGPKey('UserEmail');" class="btn btn-inverse" style="margin-bottom:10px;"><?php echo __('Fetch GnuPG key');?></span></div>
     <?php
         if (Configure::read('SMIME.enabled')) echo $this->Form->input('certif_public', array('label' => __('SMIME key'), 'div' => 'clear', 'class' => 'input-xxlarge', 'placeholder' => __('Paste the user\'s SMIME public key in PEM format here.')));
-        echo $this->Form->input('termsaccepted', array('label' => __('Terms accepted')));
+        echo $this->Form->input('termsaccepted', array('type' => 'checkbox', 'label' => __('Terms accepted')));
         echo $this->Form->input('change_pw', array('type' => 'checkbox', 'label' => __('Change Password')));
         echo $this->Form->input('autoalert', array('label' => __('Receive alerts when events are published'), 'type' => 'checkbox'));
         echo $this->Form->input('contactalert', array('label' => __('Receive alerts from "contact reporter" requests'), 'type' => 'checkbox'));
@@ -75,7 +75,7 @@
     ?>
         <div class="clear"></div>
     <?php
-        echo $this->Form->input('disabled', array('label' => __('Disable this user account')));
+        echo $this->Form->input('disabled', array('type' => 'checkbox', 'label' => __('Disable this user account')));
 
     ?>
     </fieldset>


### PR DESCRIPTION
Closes: #3066, #3067
Fixes issues:
- wrong boolean and smallint conversion;
- postgresql table and field naming (field 1_event_id is wrong name for
field for example, so lets escape this with doublequotes);
- postgresql grouping (you cannot select columns without grouping them,
so lets add columns to group by);
- wrong checkbox rendering without keyword "checkbox".

I've checked it on pre-installed MariaDB and PostgreSQL 10.9-0ubuntu0.18.04.1
Conversion from MariaDB to PostgreSQL by [your docs](https://github.com/MISP/MISP/blob/2.4/docs/xINSTALL.debian9-postgresql.md)

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
