### PR TITLE
Update MYSQL.sql

### DIFF
--- a/INSTALL/MYSQL.sql
+++ b/INSTALL/MYSQL.sql
@@ -613,7 +613,7 @@ CREATE TABLE IF NOT EXISTS `object_template_elements` (
 -- Table structure for table `organisations`
 --
 
-CREATE TABLE `organisations` (
+CREATE TABLE IF NOT EXISTS `organisations` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) COLLATE utf8_bin NOT NULL,
   `date_created` datetime NOT NULL,


### PR DESCRIPTION
## Fixed MYSQL.sql scheme file for table `organization`
If you install the MISP scheme and want to do it a second time. Then it hangs always at table `organization`. This PR fix this problem.