### PR TITLE
chg: More efficient Warninglist::__evalCIDR

### DIFF
--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -429,14 +429,10 @@ class Warninglist extends AppModel
 
     private function __evalCIDR($value, $listValues, $function)
     {
-        $found = false;
         foreach ($listValues as $lv) {
             if ($this->$function($value, $lv)) {
-                $found = true;
+                return true;
             }
-        }
-        if ($found) {
-            return true;
         }
         return false;
     }


### PR DESCRIPTION
## What does it do?

Currently, the foreach loop in `__evalCIDR` function is going trough whole array even when the value is already found. With this change, after first match, the method returns `true` immediately .

We notice PHP timeout in this code area in events with a lot of attributes, so I hope this change can help.

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch