### PR TITLE
fix: [UI] Row description in View Warninglists

### DIFF
--- a/app/View/Warninglists/view.ctp
+++ b/app/View/Warninglists/view.ctp
@@ -13,10 +13,10 @@
         array('key' => __('Type'), 'value' => $data['type']),
         array('key' => __('Accepted attribute types'), 'value' => $text),
         array(
-            'key' => __('Accepted attribute types'),
+            'key' => __('Enabled'),
             'boolean' => $data['enabled'],
             'html' => sprintf(
-                '(<a href="%s/warninglists/enableWarninglist/%s%s" title="%s">%s</a>)',
+                ' (<a href="%s/warninglists/enableWarninglist/%s%s" title="%s">%s</a>)',
                 $baseurl,
                 h($warninglist['Warninglist']['id']),
                 $data['enabled'] ? '' : '/1',


### PR DESCRIPTION
## What does it do?

Fixes row description in View Warninglists. Originally it looks like this: 

<img width="988" alt="Snímek obrazovky 2019-08-04 v 9 58 41" src="https://user-images.githubusercontent.com/163343/62421311-dddfd580-b69f-11e9-95ae-24c728eee118.png">

This fix changes the second description from 'Accepted attribute types' to 'Enabled' and adds space between Yes and (disable).

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch