### PR TITLE
chg: [warning-list] Filter CIDR warning list before eval

### DIFF
--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -257,6 +257,33 @@ class Warninglist extends AppModel
         return $entries;
     }
 
+    private function filterCidrList($inputValues)
+    {
+        $outputValues = [];
+        foreach ($inputValues as $v) {
+            $parts = explode('/', $v, 2);
+            if (filter_var($parts[0], FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+                $maximumNetmask = 32;
+            } else if (filter_var($parts[0], FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+                $maximumNetmask = 128;
+            } else {
+                // IP address part of CIDR is invalid
+                continue;
+            }
+
+            if (!isset($parts[1])) {
+                // If CIDR doesnt contains '/', we will consider CIDR as /32 for IPv4 or /128 for IPv6
+                $v = "$v/$maximumNetmask";
+            } else if ($parts[1] > $maximumNetmask || $parts[1] < 0) {
+                // Netmask part of CIDR is invalid
+                continue;
+            }
+
+            $outputValues[] = $v;
+        }
+        return $outputValues;
+    }
+
     public function fetchForEventView()
     {
         $warninglists = $this->getWarninglists(array('enabled' => 1));
@@ -270,10 +297,12 @@ class Warninglist extends AppModel
                 foreach ($t['values'] as $vk => $v) {
                     $t['values'][$vk] = rtrim($v, '.');
                 }
-            }
-            if ($t['Warninglist']['type'] == 'string' || $t['Warninglist']['type'] == 'hostname') {
+            } else if ($t['Warninglist']['type'] == 'string' || $t['Warninglist']['type'] == 'hostname') {
                 $t['values'] = array_combine($t['values'], $t['values']);
+            } else if ($t['Warninglist']['type'] === 'cidr') {
+                $t['values'] = $this->filterCidrList($t['values']);
             }
+
             foreach ($t['WarninglistType'] as &$wt) {
                 $t['types'][] = $wt['type'];
             }
@@ -411,10 +440,9 @@ class Warninglist extends AppModel
         $ipv6cidrlist = array();
         // separate the CIDR list into IPv4 and IPv6
         foreach ($listValues as $lv) {
-            $base = substr($lv, 0, strpos($lv, '/'));
-            if (filter_var($base, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+            if (strpos($lv, '.') !== false) { // IPv4 address must contain dot
                 $ipv4cidrlist[] = $lv;
-            } elseif (filter_var($base, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+            } else {
                 $ipv6cidrlist[] = $lv;
             }
         }


### PR DESCRIPTION
Hello, 

even after patches from https://github.com/MISP/MISP/pull/4951 and https://github.com/MISP/MISP/pull/4949, CIDR warning lists are still slow.

One of the reason is, that CIDR warning lists are filtered for every IP in an event again and again. This patch changes the logic and list is filtered just once.

It also changes the comparison behavior, because before if CIDR warning list contains IP address without netmask part (for example just `1.1.1.1`), it was filtered out. Now this IP address is considered as `/32` for IPv4 or `/128` for IPv6.

After this change, loading times drop for one event with thousands of IP attributes from 261 seconds to 194 seconds and for another event with hundreds of IP attributes from 13 seconds to 10 seconds.

## Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:

- [ ] Major
- [ ] Minor
- [x] Patch