### PR TITLE
fix: [warning-list] Split value just if type is malware-sample or contains `|` char

### DIFF
--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -358,7 +358,7 @@ class Warninglist extends AppModel
 
     private function __checkValue($listValues, $value, $type, $listType, $returnVerboseValue = false)
     {
-        if (strpos($type, '|') || $type = 'malware-sample') {
+        if ($type === 'malware-sample' || strpos($type, '|') !== false) {
             $value = explode('|', $value);
         } else {
             $value = array($value);
@@ -382,9 +382,8 @@ class Warninglist extends AppModel
             if (!empty($result)) {
                 if ($returnVerboseValue) {
                     return $value[$component];
-                } else {
                 }
-                    return ($component + 1);
+                return ($component + 1);
             }
         }
         return false;


### PR DESCRIPTION
This pull request simplifies WarningList::__checkValue:
* It removes checking if value contains `|` chars, because the same do also `explode` method
* Also removes `$type` variable, because now it is not necessary and in previous implementation it was also buggy (look at comparison just with one `=`, so the condition was always true)
* Also removes empty `else` block

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch