### PR TITLE
fix: [sightings] Remove unused method

### DIFF
--- a/app/View/Users/statistics_sightings.ctp
+++ b/app/View/Users/statistics_sightings.ctp
@@ -64,8 +64,3 @@
 <?php
     echo $this->element('/genericElements/SideMenu/side_menu', array('menuList' => 'globalActions', 'menuItem' => 'statistics'));
 ?>
-<script type="text/javascript">
-$(document).ready(function () {
-    loadSightingsData();
-});
-</script>

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -3679,28 +3679,6 @@ function loadTagTreemap() {
     });
 }
 
-function loadSightingsData(timestamp) {
-    url = "/sightings/toplist";
-    if (timestamp != undefined) {
-        url = url + '/' + timestamp;
-    }
-    $.ajax({
-        async:true,
-        beforeSend: function (XMLHttpRequest) {
-            $(".loading").show();
-        },
-        success:function (data, textStatus) {
-            $(".sightingsdiv").html(data);
-        },
-        complete:function() {
-            $(".loading").hide();
-        },
-        type:"get",
-        cache: false,
-        url: url,
-    });
-}
-
 function quickEditEvent(id, field) {
     $.ajax({
         async:true,


### PR DESCRIPTION
In the PHP code there is no controller that can handle request to `/sightings/toplist` URL, so this method just generates 404 error in log. 

This patch removes `loadSightingsData` method from JS code. 

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch