### PR TITLE
fix: Replace not exists MethodNotFoundException with NotFoundException

### DIFF
--- a/app/Controller/LogsController.php
+++ b/app/Controller/LogsController.php
@@ -173,7 +173,7 @@ class LogsController extends AppController
             )
         );
         if (empty($event)) {
-            throw new MethodNotFoundException('Invalid event.');
+            throw new NotFoundException('Invalid event.');
         }
         $event = $event[0];
         $attribute_ids = array();

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -4240,10 +4240,6 @@ class Attribute extends AppModel
         if ($paramsOnly) {
             return $params;
         }
-        if (!isset($this->validFormats[$returnFormat])) {
-            // this is where the new code path for the export modules will go
-            throw new MethodNotFoundException('Invalid export format.');
-        }
         if (method_exists($exportTool, 'modify_params')) {
             $params = $exportTool->modify_params($user, $params);
         }

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -2897,6 +2897,9 @@ class Event extends AppModel
     public function sendAlertEmail($id, $senderUser, $oldpublish = null, $processId = null)
     {
         $event = $this->fetchEvent($senderUser, array('eventid' => $id, 'includeAllTags' => true));
+        if (empty($event)) {
+            throw new NotFoundException('Invalid Event.');
+        }
         $this->NotificationLog = ClassRegistry::init('NotificationLog');
         if (!$this->NotificationLog->check($event[0]['Event']['orgc_id'], 'publish')) {
             if ($processId) {
@@ -2905,9 +2908,6 @@ class Event extends AppModel
                 $this->Job->saveField('message', 'Mails blocked by org alert threshold.');
             }
             return true;
-        }
-        if (empty($event)) {
-            throw new MethodNotFoundException('Invalid Event.');
         }
         $userConditions = array('autoalert' => 1);
         $this->User = ClassRegistry::init('User');

--- a/app/Model/EventDelegation.php
+++ b/app/Model/EventDelegation.php
@@ -51,7 +51,7 @@ class EventDelegation extends AppModel
     {
         $event = $this->Event->fetchEvent($user, array('eventid' => $delegation['EventDelegation']['event_id']));
         if (empty($event)) {
-            throw new MethodNotFoundException('Invalid event.');
+            throw new NotFoundException('Invalid event.');
         }
         $event = $event[0];
         $event['Event']['user_id'] = $user['id'];

--- a/app/Model/Sighting.php
+++ b/app/Model/Sighting.php
@@ -574,7 +574,7 @@ class Sighting extends AppModel
 
         if (!isset($this->validFormats[$returnFormat])) {
             // this is where the new code path for the export modules will go
-            throw new MethodNotFoundException('Invalid export format.');
+            throw new NotFoundException('Invalid export format.');
         }
 
         $exportToolParams = array(


### PR DESCRIPTION
Hi, this pull request:
* replace `MethodNotFoundException` with `NotFoundException`, because in MISP codebase, the `MethodNotFoundException` is not defined.
* in `app/Model/Attribute.php` it remove format check, because the check is redundant https://github.com/MISP/MISP/blob/cf6bc6f2047284597aa3290f48235f91d2adef3e/app/Model/Attribute.php#L4177-L4181
* in `app/Model/Event.php` move the existence check, because in the code before check is accessed `$event` array

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch