### PR TITLE
chg: Do not log ForbiddenException by default

### DIFF
--- a/app/Config/core.default.php
+++ b/app/Config/core.default.php
@@ -76,6 +76,7 @@ Configure::write('Exception', array(
 	'log'      => true,
 	'skipLog'  => array(
 		'NotFoundException',
+		'ForbiddenException',
 	)
 ));
 


### PR DESCRIPTION
## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
