### PR TITLE
Redis optimisations

### DIFF
--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -1776,18 +1776,20 @@ class AppModel extends Model
 
     public function setupRedis()
     {
-        if (class_exists('Redis')) {
-            if ($this->__redisConnection) {
-                return $this->__redisConnection;
-            }
-            $redis = new Redis();
-        } else {
+        if ($this->__redisConnection) {
+            return $this->__redisConnection;
+        }
+
+        if (!class_exists('Redis')) {
             return false;
         }
-        $host = Configure::read('MISP.redis_host') ? Configure::read('MISP.redis_host') : '127.0.0.1';
-        $port = Configure::read('MISP.redis_port') ? Configure::read('MISP.redis_port') : 6379;
-        $database = Configure::read('MISP.redis_database') ? Configure::read('MISP.redis_database') : 13;
+
+        $host = Configure::read('MISP.redis_host') ?: '127.0.0.1';
+        $port = Configure::read('MISP.redis_port') ?: 6379;
+        $database = Configure::read('MISP.redis_database') ?: 13;
         $pass = Configure::read('MISP.redis_password');
+
+        $redis = new Redis();
         if (!$redis->connect($host, $port)) {
             return false;
         }

--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -190,10 +190,9 @@ class Warninglist extends AppModel
     {
         $redis = $this->setupRedis();
         if ($redis !== false) {
-            $redis->del('misp:warninglist_entries_cache:');
-            foreach ($warninglistEntries as $entry) {
-                $redis->sAdd('misp:warninglist_entries_cache:' . $id, $entry);
-            }
+            $key = 'misp:warninglist_entries_cache:' . $id;
+            $redis->del($key);
+            $redis->sAddArray($key, $warninglistEntries);
             return true;
         }
         return false;

--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -203,7 +203,7 @@ class Warninglist extends AppModel
     {
         $redis = $this->setupRedis();
         if ($redis !== false) {
-            if (!$redis->exists('misp:warninglist_cache') || $redis->sCard('misp:warninglist_cache') == 0) {
+            if ($redis->sCard('misp:warninglist_cache') === 0) {
                 if (!empty($conditions)) {
                     $warninglists = $this->find('all', array('contain' => array('WarninglistType'), 'conditions' => $conditions));
                 } else {
@@ -237,7 +237,7 @@ class Warninglist extends AppModel
     {
         $redis = $this->setupRedis();
         if ($redis !== false) {
-            if (!$redis->exists('misp:warninglist_entries_cache:' . $id) || $redis->sCard('misp:warninglist_entries_cache:' . $id) == 0) {
+            if ($redis->sCard('misp:warninglist_entries_cache:' . $id) === 0) {
                 $entries = $this->WarninglistEntry->find('list', array(
                         'recursive' => -1,
                         'conditions' => array('warninglist_id' => $id),


### PR DESCRIPTION
This pull requests provides:
* small speed optimisations, because `class_exists('Redis')` is called just when Redis connection is created and not all the time.
* fix bug that prevent warning list cache deletion (when deleting cache `cacheWarninglistEntries` method was missing `$id` variable)
*  small speed optimisation, bacause we don't need to check if key in Redis exists and also if it is not empty – `sCard` returns zero for not exists keys.
* code cleanup, code with `?:` operator is shorter and less error prone 

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
