### PR TITLE
Feed correlations optimisations

### DIFF
--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -426,13 +426,13 @@ class Feed extends AppModel
                         $mispFeedHits = $pipe->exec();
                         foreach ($mispFeedHits as $sourcehitPos => $f) {
                             foreach ($f as $url) {
-                                $urlParts = explode('/', $url);
-                                if (empty($event[$scope][$urlParts[0]]['event_uuids']) || !in_array($urlParts[1], $event[$scope][$urlParts[0]]['event_uuids'])) {
-                                    $event[$scope][$urlParts[0]]['event_uuids'][] = $urlParts[1];
+                                list($feedId, $eventUuid) = explode('/', $url);
+                                if (empty($event[$scope][$feedId]['event_uuids']) || !in_array($eventUuid, $event[$scope][$feedId]['event_uuids'])) {
+                                    $event[$scope][$feedId]['event_uuids'][] = $eventUuid;
                                 }
                                 foreach ($objects[$eventUuidHitPosition[$sourcehitPos]][$scope] as $tempKey => $tempFeed) {
-                                    if ($tempFeed['id'] == $urlParts[0]) {
-                                        $objects[$eventUuidHitPosition[$sourcehitPos]][$scope][$tempKey]['event_uuids'][] = $urlParts[1];
+                                    if ($tempFeed['id'] == $feedId) {
+                                        $objects[$eventUuidHitPosition[$sourcehitPos]][$scope][$tempKey]['event_uuids'][] = $eventUuid;
                                     }
                                 }
                             }

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -353,8 +353,10 @@ class Feed extends AppModel
             $hashTable = array();
             $hitIds = array();
             $this->Event = ClassRegistry::init('Event');
+            $compositeTypes = $this->Event->Attribute->getCompositeTypes();
+
             foreach ($objects as $k => $object) {
-                if (in_array($object['type'], $this->Event->Attribute->getCompositeTypes())) {
+                if (in_array($object['type'], $compositeTypes)) {
                     $value = explode('|', $object['value']);
                     $hashTable[$k] = md5($value[0]);
                 } else {
@@ -407,7 +409,7 @@ class Feed extends AppModel
                                     if ($source[$scope]['id'] == $currentFeed['id']) {
                                         $eventUuidHitPosition[$i] = $k;
                                         $i++;
-                                        if (in_array($object['type'], $this->Event->Attribute->getCompositeTypes())) {
+                                        if (in_array($object['type'], $compositeTypes)) {
                                             $value = explode('|', $object['value']);
                                             $redis->smembers('misp:' . strtolower($scope) . '_cache:event_uuid_lookup:' . md5($value[0]));
                                         } else {

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -349,27 +349,19 @@ class Feed extends AppModel
                 $sources = $this->Server->find('all', $params);
             }
 
-            $counter = 0;
-            $hashTable = array();
-            $sourceList = array();
             $pipe = $redis->multi(Redis::PIPELINE);
-            $objectsWithFeedHits = array();
             $hashTable = array();
             $hitIds = array();
             $this->Event = ClassRegistry::init('Event');
-            $objectKeys = array();
             foreach ($objects as $k => $object) {
                 if (in_array($object['type'], $this->Event->Attribute->getCompositeTypes())) {
                     $value = explode('|', $object['value']);
                     $hashTable[$k] = md5($value[0]);
-                    $objectKeys[] = $k;
                 } else {
                     $hashTable[$k] = md5($object['value']);
                 }
                 $redis->sismember('misp:' . strtolower($scope) . '_cache:combined', $hashTable[$k]);
-                $objectKeys[] = $k;
             }
-            $results = array();
             $results = $pipe->exec();
             if (!$overrideLimit && count($objects) > 10000) {
                 foreach ($results as $k => $result) {


### PR DESCRIPTION
## What does it do?

* Remove unused variables that are never and array `$objectKeys`, that is only append, but never read
* `getCompositeTypes` is call just once, not again and again for every attribute in event
* Sources from DB are fetched just when correlation is found
* Cache key prefix string is computed just once

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
