### PR TITLE
fix: Fix messages when we try to delete an attribute

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -4033,24 +4033,26 @@ class Attribute extends AppModel
         if (!$this->exists()) {
             return false;
         }
-        $result = $this->find('first', array(
+        $result = $this->fetchAttributes($user, array(
             'conditions' => array('Attribute.id' => $id),
+            'flatten' => 1,
             'recursive' => -1,
             'contain' => array('Event')
         ));
         if (empty($result)) {
-            throw new ForbiddenException(__('Attribute not found or not authorised.'));
+            throw new ForbiddenException(__('Invalid attribute'));
         }
+        result = $result[0];
 
         // check for permissions
         if (!$user['Role']['perm_site_admin']) {
             if ($result['Event']['locked']) {
                 if ($user['org_id'] != $result['Event']['org_id'] || !$user['Role']['perm_sync']) {
-                    throw new ForbiddenException(__('Attribute not found or not authorised.'));
+                    throw new ForbiddenException(__('You do not have permission to do that.'));
                 }
             } else {
                 if ($user['org_id'] != $result['Event']['orgc_id']) {
-                    throw new ForbiddenException(__('Attribute not found or not authorised.'));
+                    throw new ForbiddenException(__('You do not have permission to do that.'));
                 }
             }
         }


### PR DESCRIPTION
Better error messages when deleting an attribute, should fix [this issue in PyMISP](https://github.com/MISP/PyMISP/blob/e95948bcf6a5a14a67a00361a2d96065f143fd8b/pymisp/aping.py#L425). When the user can't see the attribute or the attribute doesn't exist, return "Invalid attribute". When the user can see the attribute but is not allowed to delete it, return "You do not have permission to do that.".