### PR TITLE
chg: Show descriptions in import modules

### DIFF
--- a/app/View/Events/import_module.ctp
+++ b/app/View/Events/import_module.ctp
@@ -3,7 +3,7 @@
     <fieldset>
         <legend><?php echo h(Inflector::humanize($module['name']));?></legend>
         <?php if (isset($module['meta']['description'])) {
-            echo '<p>'.$module['meta']['description'].'</p>';
+            echo '<p>'.h($module['meta']['description']).'</p>';
         } ?>
         <?php
             if (isset($module['mispattributes']['userConfig']) && !empty($module['mispattributes']['userConfig'])) {

--- a/app/View/Events/import_module.ctp
+++ b/app/View/Events/import_module.ctp
@@ -2,6 +2,9 @@
 <?php echo $this->Form->create('', array('type' => 'file'));?>
     <fieldset>
         <legend><?php echo h(Inflector::humanize($module['name']));?></legend>
+        <?php if (isset($module['meta']['description'])) {
+            echo '<p>'.$module['meta']['description'].'</p>';
+        } ?>
         <?php
             if (isset($module['mispattributes']['userConfig']) && !empty($module['mispattributes']['userConfig'])) {
                 foreach ($module['mispattributes']['userConfig'] as $configName => $config) {


### PR DESCRIPTION
The description already present in all the import modules was lost, while it could help the user to know what kind of file he's expected to upload.