### PR TITLE
Better error handling for fetching feeds

### DIFF
--- a/app/Console/Command/ServerShell.php
+++ b/app/Console/Command/ServerShell.php
@@ -407,12 +407,26 @@ class ServerShell extends AppShell
         );
         $this->Job->save($data);
         $jobId = $this->Job->id;
-        $result = $this->Feed->cacheFeedInitiator($user, $jobId, 'all');
-        $this->Job->save(array(
-            'message' => 'Job done.',
-            'progress' => 100,
-            'status' => 4
-        ));
+        try {
+            $result = $this->Feed->cacheFeedInitiator($user, $jobId, 'all');
+        } catch (Exception $e) {
+            CakeLog::error($e->getMessage());
+            $result = false;
+        }
+        if ($result) {
+            $this->Job->save(array(
+                'message' => 'Job done.',
+                'progress' => 100,
+                'status' => 4
+            ));
+        } else {
+            $this->Job->save(array(
+                'message' => 'Job failed. See logs for more details.',
+                'progress' => 100,
+                'status' => 3,
+            ));
+        }
+
         $this->Task->id = $task['Task']['id'];
         $this->Task->saveField('message', 'Job completed at ' . date('d/m/Y - H:i:s'));
     }

--- a/app/Console/Command/ServerShell.php
+++ b/app/Console/Command/ServerShell.php
@@ -253,13 +253,19 @@ class ServerShell extends AppShell
             $jobId = $this->Job->id;
         }
         $this->Job->read(null, $jobId);
-        $result = $this->Feed->cacheFeedInitiator($user, $jobId, $scope);
+        try {
+            $result = $this->Feed->cacheFeedInitiator($user, $jobId, $scope);
+        } catch (Exception $e) {
+            CakeLog::error($e->getMessage());
+            $result = false;
+        }
+
         $this->Job->id = $jobId;
         if ($result !== true) {
-            $message = 'Job Failed. Reason: ';
+            $message = 'Job failed. See logs for more details.';
             $this->Job->save(array(
                     'id' => $jobId,
-                    'message' => $message . $result,
+                    'message' => $message,
                     'progress' => 0,
                     'status' => 3
             ));

--- a/app/Controller/FeedsController.php
+++ b/app/Controller/FeedsController.php
@@ -520,7 +520,13 @@ class FeedsController extends AppController
             $this->Flash->info(__('Feed is currently not enabled. Make sure you enable it.'));
             $this->redirect(array('action' => 'previewIndex', $feedId));
         }
-        $result = $this->Feed->downloadAndSaveEventFromFeed($this->Feed->data, $eventUuid, $this->Auth->user());
+        try {
+            $result = $this->Feed->downloadAndSaveEventFromFeed($this->Feed->data, $eventUuid, $this->Auth->user());
+        } catch (Exception $e) {
+            $this->Flash->error(__('Download failed.') . ' ' . $e->getMessage());
+            $this->redirect(array('action' => 'previewIndex', $feedId));
+        }
+
         if (isset($result['action'])) {
             if ($result['result']) {
                 if ($result['action'] == 'add') {
@@ -762,7 +768,11 @@ class FeedsController extends AppController
             throw new NotFoundException(__('Invalid feed.'));
         }
         $this->Feed->read();
-        $event = $this->Feed->downloadEventFromFeed($this->Feed->data, $eventUuid, $this->Auth->user());
+        try {
+            $event = $this->Feed->downloadEventFromFeed($this->Feed->data, $eventUuid, $this->Auth->user());
+        } catch (Exception $e) {
+            throw new Exception(__('Could not download the selected Event'), 0, $e);
+        }
         if ($this->_isRest()) {
             return $this->RestResponse->viewData($event, $this->response->type());
         }

--- a/app/Controller/FeedsController.php
+++ b/app/Controller/FeedsController.php
@@ -674,10 +674,10 @@ class FeedsController extends AppController
         $HttpSocket = $syncTool->setupHttpSocketFeed($feed);
         $params = array();
         // params is passed as reference here, the pagination happens in the method, which isn't ideal but considering the performance gains here it's worth it
-        $resultArray = $this->Feed->getFreetextFeed($feed, $HttpSocket, $feed['Feed']['source_format'], $currentPage, 60, $params);
-        // we want false as a valid option for the split fetch, but we don't want it for the preview
-        if (!is_array($resultArray)) {
-            $this->Flash->info($resultArray);
+        try {
+            $resultArray = $this->Feed->getFreetextFeed($feed, $HttpSocket, $feed['Feed']['source_format'], $currentPage, 60, $params);
+        } catch (Exception $e) {
+            $this->Flash->error("Could not fetch feed: {$e->getMessage()}");
             $this->redirect(array('controller' => 'feeds', 'action' => 'index'));
         }
         $this->params->params['paging'] = array($this->modelClass => $params);
@@ -723,7 +723,12 @@ class FeedsController extends AppController
             throw new MethodNotAllowedException(__('Invalid feed type.'));
         }
         $HttpSocket = $syncTool->setupHttpSocketFeed($feed);
-        $resultArray = $this->Feed->getFreetextFeed($feed, $HttpSocket, $feed['Feed']['source_format'], $currentPage);
+        try {
+            $resultArray = $this->Feed->getFreetextFeed($feed, $HttpSocket, $feed['Feed']['source_format'], $currentPage);
+        } catch (Exception $e) {
+            $this->Flash->error("Could not fetch feed: {$e->getMessage()}");
+            $this->redirect(array('controller' => 'feeds', 'action' => 'index'));
+        }
         // we want false as a valid option for the split fetch, but we don't want it for the preview
         if ($resultArray == false) {
             $resultArray = array();

--- a/app/Controller/FeedsController.php
+++ b/app/Controller/FeedsController.php
@@ -875,11 +875,11 @@ class FeedsController extends AppController
             $feed['Feed']['settings'] = json_decode($feed['Feed']['settings'], true);
         }
         $data = json_decode($this->request->data['Feed']['data'], true);
-        $result = $this->Feed->saveFreetextFeedData($feed, $data, $this->Auth->user());
-        if ($result === true) {
+        try {
+            $this->Feed->saveFreetextFeedData($feed, $data, $this->Auth->user());
             $this->Flash->success(__('Data pulled.'));
-        } else {
-            $this->Flash->error(__('Could not pull the selected data. Reason: %s', $result));
+        } catch (Exception $e) {
+            $this->Flash->error(__('Could not pull the selected data. Reason: %s', $e->getMessage()));
         }
         $this->redirect(array('controller' => 'feeds', 'action' => 'index'));
     }

--- a/app/Controller/FeedsController.php
+++ b/app/Controller/FeedsController.php
@@ -579,11 +579,13 @@ class FeedsController extends AppController
         App::uses('SyncTool', 'Tools');
         $syncTool = new SyncTool();
         $HttpSocket = $syncTool->setupHttpSocketFeed($feed);
-        $events = $this->Feed->getManifest($feed, $HttpSocket);
-        if (!is_array($events)) {
-            $this->Flash->info($events);
+        try {
+            $events = $this->Feed->getManifest($feed, $HttpSocket);
+        } catch (Exception $e) {
+            $this->Flash->error("Could not fetch manifest for feed: {$e->getMessage()}");
             $this->redirect(array('controller' => 'feeds', 'action' => 'index'));
         }
+
         if (!empty($this->params['named']['searchall'])) {
             foreach ($events as $uuid => $event) {
                 $found = false;

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -200,19 +200,6 @@ class Feed extends AppModel
         return $events;
     }
 
-    private function __getRecursive($url, $query, $request, $iterations = 0)
-    {
-        if ($iterations == 5) {
-            return false;
-        }
-        $HttpSocket = $this->__setupHttpSocket(false);
-        $response = $HttpSocket->get($url, $query, $request);
-        if ($response->code == 302 || $response->code == 301) {
-            $response = $this->__getRecursive($response['header']['Location'], $query, $request, $iterations + 1);
-        }
-        return $response;
-    }
-
     public function getFreetextFeed($feed, $HttpSocket, $type = 'freetext', $page = 1, $limit = 60, &$params = array())
     {
         $result = array();
@@ -235,8 +222,8 @@ class Feed extends AppModel
                 $fetchIssue = false;
                 try {
                     $request = $this->__createFeedRequest($feed['Feed']['headers']);
-                    $response = $this->__getRecursive($feed['Feed']['url'], '', $request);
-                    //$response = $HttpSocket->get($feed['Feed']['url'], '', array());
+                    $request['redirect'] = 5; // follow redirects
+                    $response = $HttpSocket->get($feed['Feed']['url'], '', $request);
                 } catch (Exception $e) {
                     return $e->getMessage();
                 }

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -471,10 +471,7 @@ class Feed extends AppModel
         $currentItem = 0;
         $this->Event = ClassRegistry::init('Event');
         $results = array();
-        $filterRules = false;
-        if (isset($feed['Feed']['rules']) && !empty($feed['Feed']['rules'])) {
-            $filterRules = json_decode($feed['Feed']['rules'], true);
-        }
+        $filterRules = $this->__prepareFilterRules($feed);
         if (isset($actions['add']) && !empty($actions['add'])) {
             foreach ($actions['add'] as $uuid) {
                 $result = $this->__addEventFromFeed($HttpSocket, $feed, $uuid, $user, $filterRules);
@@ -587,9 +584,9 @@ class Feed extends AppModel
 
     private function __filterEventsIndex($events, $feed)
     {
-        $filterRules = array();
-        if (isset($feed['Feed']['rules']) && !empty($feed['Feed']['rules'])) {
-            $filterRules = json_decode($feed['Feed']['rules'], true);
+        $filterRules = $this->__prepareFilterRules($feed);
+        if (!$filterRules) {
+            $filterRules = array();
         }
         foreach ($events as $k => $event) {
             if (isset($filterRules['orgs']['OR']) && !empty($filterRules['orgs']['OR']) && !in_array($event['Orgc']['name'], $filterRules['orgs']['OR'])) {

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -514,11 +514,8 @@ class Feed extends AppModel
     {
         $version = $this->checkMISPVersion();
         $version = implode('.', $version);
-        try {
-            $commit = trim(shell_exec('git log --pretty="%H" -n1 HEAD'));
-        } catch (Exception $e) {
-            $commit = false;
-        }
+        $commit = trim(shell_exec('git log --pretty="%H" -n1 HEAD'));
+
         $result = array(
             'header' => array(
                     'Accept' => 'application/json',

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -417,21 +417,16 @@ class Feed extends AppModel
         foreach ($actions['add'] as $uuid) {
             try {
                 $result = $this->__addEventFromFeed($HttpSocket, $feed, $uuid, $user, $filterRules);
+                if ($result !== 'blocked') {
+                    $results['add']['success'] = $uuid;
+                }
+
             } catch (Exception $e) {
                 CakeLog::error($this->exceptionAsMessage("Could not add event '$uuid' from feed {$feed['Feed']['id']}.", $e));
                 $results['add']['fail'] = array('uuid' => $uuid, 'reason' => $e->getMessage());
-                $currentItem++;
-                continue;
             }
+
             $this->__cleanupFile($feed, '/' . $uuid . '.json');
-            if ($result === 'blocked') {
-                continue;
-            }
-            if ($result === true) {
-                $results['add']['success'] = $uuid;
-            } else {
-                $results['add']['fail'] = array('uuid' => $uuid, 'reason' => $result);
-            }
             $this->jobProgress($jobId, null, 100 * (($currentItem + 1) / $total));
             $currentItem++;
         }
@@ -440,22 +435,15 @@ class Feed extends AppModel
             $uuid = $editTarget['uuid'];
             try {
                 $result = $this->__updateEventFromFeed($HttpSocket, $feed, $uuid, $editTarget['id'], $user, $filterRules);
+                if ($result !== 'blocked') {
+                    $results['edit']['success'] = $uuid;
+                }
             } catch (Exception $e) {
                 CakeLog::error($this->exceptionAsMessage("Could not edit event '$uuid' from feed {$feed['Feed']['id']}.", $e));
                 $results['edit']['fail'] = array('uuid' => $uuid, 'reason' => $e->getMessage());
-                $currentItem++;
-                continue;
             }
 
-            if ($result === 'blocked') {
-                continue;
-            }
             $this->__cleanupFile($feed, '/' . $uuid . '.json');
-            if ($result === true) {
-                $results['edit']['success'] = $uuid;
-            } else {
-                $results['edit']['fail'] = array('uuid' => $uuid, 'reason' => $result);
-            }
             if ($currentItem % 10 == 0) {
                 $this->jobProgress($jobId, null, 100 * (($currentItem + 1) / $total));
             }


### PR DESCRIPTION
## What does it do?

Currently, the error handling for fetching feeds is very bad and leads to error like in issue #5007. Sometimes methods return string as error message, but then return value of that methods are checked by `empty` method so they are considered as valid value. Some methods returns numbers as error code, but again, not properly checked. Some of error states are not checked at all (for example JSON parsing). 

This is the first step to fix that problem by using Exception and proper error handling and error logging when fetching feed manifest. Next steps (fetching feed events and free text feed) will follow in this branch. 

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch