### PR TITLE
fix: [feed] Preview feed event don't have id

### DIFF
--- a/app/View/Feeds/preview_event.ctp
+++ b/app/View/Feeds/preview_event.ctp
@@ -102,7 +102,6 @@
 <script type="text/javascript">
 // tooltips
 $(document).ready(function () {
-    //loadEventTags("<?php echo $event['Event']['id']; ?>");
     $("th, td, dt, div, span, li").tooltip({
         'placement': 'top',
         'container' : 'body',


### PR DESCRIPTION
## What does it do?

Removes unnecessary notice from log. For preview event, ID is not defined.

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch