### PR TITLE
fix: Default to 0 when no distribution is specified

### DIFF
--- a/app/Controller/EventDelegationsController.php
+++ b/app/Controller/EventDelegationsController.php
@@ -53,6 +53,9 @@ class EventDelegationsController extends AppController
             if (empty($this->request->data['EventDelegation'])) {
                 $this->request->data = array('EventDelegation' => $this->request->data);
             }
+            if (empty($this->request->data['EventDelegation']['distribution'])) {
+                $this->request->data['EventDelegation']['distribution'] = 0;
+            }
             if ($this->request->data['EventDelegation']['distribution'] != 4) {
                 $this->request->data['EventDelegation']['sharing_group_id'] = '0';
             }


### PR DESCRIPTION
The current behavior conducted to set distribution to -1 in the returned json, and raise an 'Undefined index' notice