### PR TITLE
fix: Fix 'contain' param in app/Model/Attribute.php:fetchAttributes()

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -3077,6 +3077,14 @@ class Attribute extends AppModel
             );
         }
         if (isset($options['contain'])) {
+            // We may use a string instead of an array to ask for everything
+            // instead of some specific attributes. If so, remove the array from
+            // params, as we will later add the string.
+            foreach($options['contain'] as $contain) {
+                if (gettype($contain) == "string" && isset($params['contain'][$contain])) {
+                    unset($params['contain'][$contain]);
+                }
+            }
             $params['contain'] = array_merge_recursive($params['contain'], $options['contain']);
         }
         if (isset($options['page'])) {


### PR DESCRIPTION
Should also fix #5060, as we were looking for the `'locked'` key in method `deleteAttribute()`, which was not returned by `fetchAttributes()` (it triggered a notice which somehow seemed to prevent from starting session, and so destroying it too).