### PR TITLE
chg: No need to encapsulate data in API request

### DIFF
--- a/app/Controller/EventBlacklistsController.php
+++ b/app/Controller/EventBlacklistsController.php
@@ -67,6 +67,9 @@ class EventBlacklistsController extends AppController
     public function massDelete()
     {
         if ($this->request->is('post') || $this->request->is('put')) {
+            if (!isset($this->request->data['EventBlacklist'])) {
+                $this->request->data = array('EventBlacklist' => $this->request->data);
+            }
             $ids = $this->request->data['EventBlacklist']['ids'];
             $event_ids = json_decode($ids, true);
             if (empty($event_ids)) {


### PR DESCRIPTION
More coherent with other API calls (I quickly looked for similar cases, but that's the only "obvious"' one I found).