### PR TITLE
fix: [ui] Show proper error message for ForbiddenException again

### DIFF
--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -1619,10 +1619,14 @@ function getPopup(id, context, target, admin, popupType) {
             $(popupType).html(data);
             openPopup(popupType, false);
         },
-        error:function() {
+        error:function(xhr) {
             $(".loading").hide();
             $("#gray_out").fadeOut();
-            showMessage('fail', 'Something went wrong - the queried function returned an exception. Contact your administrator for further details (the exception has been logged).');
+            if (xhr.status === 403) {
+                showMessage('fail', 'Not allowed.');
+            } else {
+                showMessage('fail', 'Something went wrong - the queried function returned an exception. Contact your administrator for further details (the exception has been logged).');
+            }
         },
         url: url
     });


### PR DESCRIPTION
This was already fixed in https://github.com/MISP/MISP/pull/5043, but then removed in probably by mistake in https://github.com/MISP/MISP/commit/e4708c0b6c9f45578a29104bb9b7b4562b2fe84e :/