### PR TITLE
Fix Declaration of RestResponseComponent warning

### DIFF
--- a/app/Controller/Component/RestResponseComponent.php
+++ b/app/Controller/Component/RestResponseComponent.php
@@ -279,7 +279,7 @@ class RestResponseComponent extends Component
 
     private $__scopedFieldsConstraint = array();
 
-    public function initialize($controller) {
+    public function initialize(Controller $controller) {
         $this->__configureFieldConstraints();
     }
 


### PR DESCRIPTION
FTFY:
```
Warning (2): Declaration of RestResponseComponent::initialize($controller) should be compatible with Component::initialize(Controller $controller) [APP/Controller/Component/RestResponseComponent.php, line 1645]
```
