### PR TITLE
fix: Require exact monolog version 1.24

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -3,7 +3,8 @@
     "minimum-stability": "dev",
     "require": {
         "kamisama/cake-resque": "4.1.2",
-        "pear/crypt_gpg": "1.6.3"
+        "pear/crypt_gpg": "1.6.3",
+        "monolog/monolog": "1.24.0"
     },
     "suggest": {
         "elasticsearch/elasticsearch": "For logging to elasticsearch",


### PR DESCRIPTION
## What does it do?

Fixes https://github.com/MISP/MISP/issues/5085 by requiring exact version of monolog package.

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch