### PR TITLE
fix: [audit] Correct title in audit log when admin edit user

### DIFF
--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -871,14 +871,10 @@ class UsersController extends AppController
                     $fieldsResultStr = substr($fieldsResultStr, 2);
                     $user = $this->User->find('first', array(
                         'recursive' => -1,
-                        'conditions' => array('User.id' => $this->id)
+                        'conditions' => array('User.id' => $this->User->id)
                     ));
                     $this->User->extralog($this->Auth->user(), "edit", "user", $fieldsResultStr, $user);
                     if ($this->_isRest()) {
-                        $user = $this->User->find('first', array(
-                                'conditions' => array('User.id' => $this->User->id),
-                                'recursive' => -1
-                        ));
                         $user['User']['password'] = '******';
                         return $this->RestResponse->viewData($user, $this->response->type());
                     } else {


### PR DESCRIPTION
## What does it do?

Fixes warning when admin edit user and also audit log title, that was just `User ():`

```
2019-09-09 17:34:25 Notice: Notice (8): Undefined index: User in [/var/www/MISP/app/Model/User.php, line 1400]
Trace:
ErrorHandler::handleError() - APP/Lib/cakephp/lib/Cake/Error/ErrorHandler.php, line 230
User::extralog() - APP/Model/User.php, line 1400
UsersController::admin_edit() - APP/Controller/UsersController.php, line 892
ReflectionMethod::invokeArgs() - [internal], line ??
Controller::invokeAction() - APP/Lib/cakephp/lib/Cake/Controller/Controller.php, line 499
Dispatcher::_invoke() - APP/Lib/cakephp/lib/Cake/Routing/Dispatcher.php, line 193
Dispatcher::dispatch() - APP/Lib/cakephp/lib/Cake/Routing/Dispatcher.php, line 167
[main] - APP/webroot/index.php, line 92
```

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch