### PR TITLE
chg: [users] Remove unused method UsersController::arrayCopy

### DIFF
--- a/app/Controller/Component/ACLComponent.php
+++ b/app/Controller/Component/ACLComponent.php
@@ -503,7 +503,6 @@ class ACLComponent extends Component
                     'admin_index' => array('perm_admin'),
                     'admin_quickEmail' => array('perm_admin'),
                     'admin_view' => array('perm_admin'),
-                    'arrayCopy' => array(),
                     'attributehistogram' => array('*'),
                     'change_pw' => array('*'),
                     'checkAndCorrectPgps' => array(),

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -1308,22 +1308,6 @@ class UsersController extends AppController
         return $this->response;
     }
 
-    // Used for fields_before and fields for audit
-    public function arrayCopy(array $array)
-    {
-        $result = array();
-        foreach ($array as $key => $val) {
-            if (is_array($val)) {
-                $result[$key] = arrayCopy($val);
-            } elseif (is_object($val)) {
-                $result[$key] = clone $val;
-            } else {
-                $result[$key] = $val;
-            }
-        }
-        return $result;
-    }
-
     public function checkAndCorrectPgps()
     {
         if (!self::_isAdmin()) {


### PR DESCRIPTION
## What does it do?

Just small code cleanup, that removes public method from controller that is never used and even doesn't look like it should be controller action.

Usage search before commit:
```
MISP$ rg arrayCopy
app/Controller/UsersController.php
1331:    public function arrayCopy(array $array)
1336:                $result[$key] = arrayCopy($val);

app/Controller/Component/ACLComponent.php
506:                    'arrayCopy' => array(),
```

Usage search after commit:
```
MISP$ rg -i arrayCopy
MISP$
```

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
