### PR TITLE
fix: [feed] When fetching feeds, accept also text/plain in HTTP

### DIFF
--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -461,7 +461,7 @@ class Feed extends AppModel
 
         $result = array(
             'header' => array(
-                    'Accept' => 'application/json',
+                    'Accept' => array('application/json', 'text/plain'),
                     'Content-Type' => 'application/json',
                     'MISP-version' => $version,
                     'MISP-uuid' => Configure::read('MISP.uuid')


### PR DESCRIPTION
## What does it do?

Fixes #5131

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
