### PR TITLE
fix: [internal] Deleting multiple Redis keys

### DIFF
--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -986,14 +986,14 @@ class Feed extends AppModel
             } elseif ($scope == 'freetext' || $scope == 'csv') {
                 $params['conditions']['source_format'] = array('csv', 'freetext');
             } elseif ($scope == 'misp') {
-                $redis->del('misp:feed_cache:event_uuid_lookup:');
+                $redis->del($redis->keys('misp:feed_cache:event_uuid_lookup:*'));
                 $params['conditions']['source_format'] = 'misp';
             } else {
                 throw new InvalidArgumentException("Invalid value for scope, it must be integer or 'freetext', 'csv', 'misp' or 'all' string.");
             }
         } else {
             $redis->del('misp:feed_cache:combined');
-            $redis->del('misp:feed_cache:event_uuid_lookup:');
+            $redis->del($redis->keys('misp:feed_cache:event_uuid_lookup:*'));
         }
         $feeds = $this->find('all', $params);
         $atLeastOneSuccess = false;

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -5141,7 +5141,7 @@ class Server extends AppModel
             $params['conditions']['Server.id'] = $id;
         } else {
             $redis->del('misp:server_cache:combined');
-            $redis->del('misp:server_cache:event_uuid_lookup:');
+            $redis->del($redis->keys('misp:server_cache:event_uuid_lookup:*'));
         }
         $servers = $this->find('all', $params);
         if ($jobId) {


### PR DESCRIPTION
## What does it do?

Deleting keys by prefix doesn't work, first keys must be loaded from Redis and then deleted.

Example:

```
php > $redis = new Redis();
php > $redis->connect('redis');
php > $redis->select(1);
php > $redis->sAdd('test:1', 'value');
php > $redis->sAdd('test:2', 'value');
php > $redis->keys('*');
php > var_dump($redis->keys('*'));
array(2) {
  [0] =>
  string(6) "test:1"
  [1] =>
  string(6) "test:2"
}
php > $redis->del('test:');
php > var_dump($redis->keys('*'));
array(2) {
  [0] =>
  string(6) "test:1"
  [1] =>
  string(6) "test:2"
}
php > $redis->del($redis->keys('test:*'));
php > var_dump($redis->keys('*'));
array(0) {
}
```

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch