### PR TITLE
fix: [UI] Allow to skip pagination in IndexTable

### DIFF
--- a/app/View/Elements/genericElements/IndexTable/index_table.ctp
+++ b/app/View/Elements/genericElements/IndexTable/index_table.ctp
@@ -24,20 +24,22 @@
     if (!empty($data['html'])) {
         echo sprintf('<p>%s</p>', $data['html']);
     }
-    $paginationData = array();
-    if (!empty($data['paginationBaseurl'])) {
-        $paginationData['paginationBaseurl'] = $data['paginationBaseurl'];
+    $skipPagination = isset($data['skip_pagination']) && $data['skip_pagination'];
+    if (!$skipPagination) {
+        $paginationData = array();
+        if (!empty($data['paginationBaseurl'])) {
+            $paginationData['paginationBaseurl'] = $data['paginationBaseurl'];
+        }
+        echo $this->element('/genericElements/IndexTable/pagination', $paginationData);
     }
-    echo $this->element('/genericElements/IndexTable/pagination', $paginationData);
     if (!empty($data['top_bar'])) {
         echo $this->element('/genericElements/ListTopBar/scaffold', array('data' => $data['top_bar']));
     }
     $rows = '';
+    $row_element = $data['row_element'] ?: 'row';
+    $options = isset($data['options']) ? $data['options'] : array();
+    $actions = isset($data['actions']) ? $data['actions'] : array();
     foreach ($data['data'] as $k => $data_row) {
-        $row_element = 'row';
-        if (!empty($data['row_element'])) {
-            $row_element = $data['row_element'];
-        }
         $rows .= sprintf(
             '<tr data-row-id="%s">%s</tr>',
             h($k),
@@ -47,17 +49,20 @@
                     'k' => $k,
                     'row' => $data_row,
                     'fields' => $data['fields'],
-                    'options' => empty($data['options']) ? array() : $data['options'],
-                    'actions' => empty($data['actions']) ? array() : $data['actions']
+                    'options' => $options,
+                    'actions' => $actions,
                 )
             )
         );
     }
+
     echo sprintf(
         '<table class="table table-striped table-hover table-condensed">%s%s</table>',
         $this->element('/genericElements/IndexTable/headers', array('fields' => $data['fields'], 'paginator' => $this->Paginator, 'actions' => empty($data['actions']) ? false : true)),
         $rows
     );
-    echo $this->element('/genericElements/IndexTable/pagination_counter', $paginationData);
-    echo $this->element('/genericElements/IndexTable/pagination', $paginationData);
-?>
+
+    if (!$skipPagination) {
+        echo $this->element('/genericElements/IndexTable/pagination_counter', $paginationData);
+        echo $this->element('/genericElements/IndexTable/pagination', $paginationData);
+    }


### PR DESCRIPTION
## What does it do?

`skip_pagination` parameter is used in 
https://github.com/MISP/MISP/blob/3e3318c4192513d3b1a08b64590654e321b6fe8c/app/View/Elements/healthElements/diagnostics.ctp#L202
but not used in View.


## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch