### PR TITLE
fix: [internal] Clear also cake core and model caches

### DIFF
--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -1460,13 +1460,15 @@ class AppModel extends Model
     public function cleanCacheFiles()
     {
         Cache::clear();
+        Cache::clear(false, '_cake_core_');
+        Cache::clear(false, '_cake_model_');
         clearCache();
-        $files = array();
-        $files = array_merge($files, glob(CACHE . 'models' . DS . 'myapp*'));
+
+        $files = glob(CACHE . 'models' . DS . 'myapp*');
         $files = array_merge($files, glob(CACHE . 'persistent' . DS . 'myapp*'));
-        foreach ($files as $f) {
-            if (is_file($f)) {
-                unlink($f);
+        foreach ($files as $file) {
+            if (is_file($file)) {
+                unlink($file);
             }
         }
     }


### PR DESCRIPTION
## What does it do?

By default, `Cache::clear` method clears just `default` cache type, but we need to clear also at least `_cake_model_` cache too.

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
