### PR TITLE
fix: [internal] Allow to use GPG when it is installed by composer

### DIFF
--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -901,9 +901,8 @@ class User extends AppModel
     {
         $failed = false;
         // Sign the body
-        require_once 'Crypt/GPG.php';
         try {
-            $gpg = new Crypt_GPG(array('homedir' => Configure::read('GnuPG.homedir'), 'gpgconf' => Configure::read('GnuPG.gpgconf'), 'binary' => (Configure::read('GnuPG.binary') ? Configure::read('GnuPG.binary') : '/usr/bin/gpg'), 'debug'));   // , 'debug' => true
+            $gpg = $this->initializeGpg();
             if (Configure::read('GnuPG.sign')) {
                 $gpg->addSignKey(Configure::read('GnuPG.email'), Configure::read('GnuPG.password'));
                 $body = $gpg->sign($body, Crypt_GPG::SIGN_MODE_CLEAR);


### PR DESCRIPTION
## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
