### PR TITLE
Added DigitalSide OSINT Feed

### DIFF
--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -1941,5 +1941,33 @@
       "org_id": "0",
       "hide_tag": false
     }
-  }
+  },
+  {
+        "Feed": {
+            "id": "114",
+            "name": "DigitalSide Threat-Intel OSINT Feed",
+            "provider": "osint.digitalside.it",
+            "url": "https:\/\/osint.digitalside.it\/Threat-Intel\/digitalside-misp-feed\/",
+            "rules": "",
+            "enabled": false,
+            "distribution": "0",
+            "sharing_group_id": "0",
+            "tag_id": "0",
+            "default": false,
+            "source_format": "misp",
+            "fixed_event": true,
+            "delta_merge": false,
+            "event_id": "0",
+            "publish": false,
+            "override_ids": false,
+            "settings": "{\"csv\":{\"value\":\"\",\"delimiter\":\",\"},\"common\":{\"excluderegex\":\"\"}}",
+            "input_source": "network",
+            "delete_local_file": false,
+            "lookup_visible": false,
+            "headers": "",
+            "caching_enabled": false,
+            "force_to_ids": false,
+            "cache_timestamp": false
+        }
+    }
 ]


### PR DESCRIPTION
Added DigitalSide OSINT Feed to the list of available OSINT sources.
Here is the home page of the project: https://osint.digitalside.it/

As reported in the project home page the MISP feed cointains a set of Open Source Cyber Threat Intellegence information, monstly based on malware analysis and compromised URLs, IPs and domains. The purpose is to develop new wayes to hunt, analyze, collect and share relevants sets of IoCs to be used by SOC/CSIRT/CERT with minimun effort.

Hope this help the community.
Hope the community will help me to share relevant infos and IoCs as well as possible.

Regards

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [X] Minor
- [ ] Patch
