### PR TITLE
fix: [UI] GnuPG diagnostic message

### DIFF
--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -907,7 +907,7 @@ class ServersController extends AppController
             );
             $writeableErrors = array(0 => __('OK'), 1 => __('not found'), 2 => __('is not writeable'));
             $readableErrors = array(0 => __('OK'), 1 => __('not readable'));
-            $gpgErrors = array(0 => __('OK'), 1 => __('FAIL: settings not set'), 2 => __('FAIL: Failed to load GnuPG'), 3 => __('FAIL: Issues with the key/passphrase'), 4 => __('FAIL: encrypt failed'));
+            $gpgErrors = array(0 => __('OK'), 1 => __('FAIL: settings not set'), 2 => __('FAIL: Failed to load GnuPG'), 3 => __('FAIL: Issues with the key/passphrase'), 4 => __('FAIL: sign failed'));
             $proxyErrors = array(0 => __('OK'), 1 => __('not configured (so not tested)'), 2 => __('Getting URL via proxy failed'));
             $zmqErrors = array(0 => __('OK'), 1 => __('not enabled (so not tested)'), 2 => __('Python ZeroMQ library not installed correctly.'), 3 => __('ZeroMQ script not running.'));
             $stixOperational = array(0 => __('Some of the libraries related to STIX are not installed. Make sure that all libraries listed below are correctly installed.'), 1 => __('OK'));


### PR DESCRIPTION
## What does it do?

As you can see, error code 4 is returned when sign failed, not encrypt:

https://github.com/MISP/MISP/blob/1ebf403ee88a7c24551da42b4955b57a14910ff4/app/Model/Server.php#L4366-L4370

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
