### PR TITLE
Add support to add local tags to an event using the API.

### DIFF
--- a/app/Controller/TagsController.php
+++ b/app/Controller/TagsController.php
@@ -894,7 +894,7 @@ class TagsController extends AppController
         return $object;
     }
 
-    public function attachTagToObject($uuid = false, $tag = false)
+    public function attachTagToObject($uuid = false, $tag = false, $local = false)
     {
         if (!$this->request->is('post')) {
             throw new MethodNotAllowedException('This method is only accessible via POST requests.');
@@ -920,6 +920,14 @@ class TagsController extends AppController
             $conditions = array('Tag.id' => $tag);
         } else {
             $conditions = array('LOWER(Tag.name) LIKE' => strtolower(trim($tag)));
+        }
+        if (empty($local)) {
+            if (!empty($this->request->data['local'])) {
+                $local = $this->request->data['local'];
+            }
+        }
+        if (!is_bool($local)) {
+            throw new InvalidArgumentException('Invalid local flag');
         }
         $objectType = '';
         $object = $this->__findObjectByUuid($uuid, $objectType);
@@ -948,23 +956,18 @@ class TagsController extends AppController
         $connectorObject = $objectType . 'Tag';
         $conditions = array(
             strtolower($objectType) . '_id' => $object[$objectType]['id'],
-            'tag_id' => $existingTag['Tag']['id']
+            'tag_id' => $existingTag['Tag']['id'],
+            'local' => ($local ? 1 : 0)
         );
         $existingAssociation = $this->$objectType->$connectorObject->find('first', array(
-            'conditions' => array(
-                strtolower($objectType) . '_id' => $object[$objectType]['id'],
-                'tag_id' => $existingTag['Tag']['id']
-            )
+            'conditions' => $conditions
         ));
         if (!empty($existingAssociation)) {
             return $this->RestResponse->saveSuccessResponse('Tags', 'attachTagToObject', false, $this->response->type(), $objectType . ' already has the requested tag attached, no changes had to be made.');
         }
         $this->$objectType->$connectorObject->create();
         $data = array(
-            $connectorObject => array(
-                strtolower($objectType) . '_id' => $object[$objectType]['id'],
-                'tag_id' => $existingTag['Tag']['id']
-            )
+            $connectorObject => $conditions
         );
         if ($objectType == 'Attribute') {
             $data[$connectorObject]['event_id'] = $object['Event']['id'];
@@ -983,7 +986,11 @@ class TagsController extends AppController
             } else if ($objectType === 'Event') {
                 $this->Event->unpublishEvent($object['Event']['id']);
             }
-            $message = 'Tag ' . $existingTag['Tag']['name'] . '(' . $existingTag['Tag']['id'] . ') successfully attached to ' . $objectType . '(' . $object[$objectType]['id'] . ').';
+            if($local) {
+                $message = 'Local tag ' . $existingTag['Tag']['name'] . '(' . $existingTag['Tag']['id'] . ') successfully attached to ' . $objectType . '(' . $object[$objectType]['id'] . ').';
+            } else {
+                $message = 'Global tag ' . $existingTag['Tag']['name'] . '(' . $existingTag['Tag']['id'] . ') successfully attached to ' . $objectType . '(' . $object[$objectType]['id'] . ').';
+            }
             return $this->RestResponse->saveSuccessResponse('Tags', 'attachTagToObject', false, $this->response->type(), $message);
         } else {
             return $this->RestResponse->saveFailResponse('Tags', 'attachTagToObject', false, 'Failed to attach tag to object.', $this->response->type());


### PR DESCRIPTION
#### What does it do?

The current API does not allow users to add local tags to an event. 

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [X] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
