### PR TITLE
fix: [UI] MISP logo is in center at login page

### DIFF
--- a/app/View/Users/login.ctp
+++ b/app/View/Users/login.ctp
@@ -2,12 +2,12 @@
     <?php
         echo $this->Session->flash('auth');
     ?>
-<table style="width:1200px;margin-left:auto;margin-right:auto;">
+<table style="margin-left:auto;margin-right:auto;">
     <tr>
     <td style="text-align:right;width:250px;padding-right:50px">
         <?php if (Configure::read('MISP.welcome_logo')) echo $this->Html->image('custom/' . h(Configure::read('MISP.welcome_logo')), array('alt' => __('Logo'), 'onerror' => "this.style.display='none';")); ?>
     </td>
-    <td style="width:450px">
+    <td style="width:460px">
         <span style="font-size:18px;">
             <?php
                 if (Configure::read('MISP.welcome_text_top')) {
@@ -15,7 +15,7 @@
                 }
             ?>
         </span><br /><br />
-        <div style="width:100%;">
+        <div>
         <?php if (Configure::read('MISP.main_logo') && file_exists(APP . '/webroot/img/custom/' . Configure::read('MISP.main_logo'))): ?>
             <img src="<?php echo $baseurl?>/img/custom/<?php echo h(Configure::read('MISP.main_logo'));?>" style=" display:block; margin-left: auto; margin-right: auto;" />
         <?php else: ?>
@@ -34,7 +34,7 @@
             endif;
             echo $this->Form->create('User');
         ?>
-        <legend style="width:450px;"><?php echo __('Login');?></legend>
+        <legend><?php echo __('Login');?></legend>
         <?php
             echo $this->Form->input('email', array('autocomplete' => 'off', 'autofocus'));
             echo $this->Form->input('password', array('autocomplete' => 'off'));


### PR DESCRIPTION
## What does it do?

Put MISP logo in the middle of login page. Tested in Firefox, but I must also test in Chrome.

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
