### PR TITLE
chg: [feed] Compute md5 value just once

### DIFF
--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -1043,8 +1043,9 @@ class Feed extends AppModel
         }
 
         foreach ($values as $k => $value) {
-            $redis->sAdd('misp:feed_cache:' . $feedId, md5($value['value']));
-            $redis->sAdd('misp:feed_cache:combined', md5($value['value']));
+            $md5Value = md5($value['value']);
+            $redis->sAdd('misp:feed_cache:' . $feedId, $md5Value);
+            $redis->sAdd('misp:feed_cache:combined', $md5Value);
             if ($k % 1000 == 0) {
                 $this->jobProgress($jobId, "Feed $feedId: $k/" . count($values) . " values cached.");
             }


### PR DESCRIPTION
## What does it do?

Just little speedup of feeds caching.

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
