### PR TITLE
fix: [shell] Update updateWarningLists from CLI

### DIFF
--- a/app/Console/Command/AdminShell.php
+++ b/app/Console/Command/AdminShell.php
@@ -159,13 +159,12 @@ class AdminShell extends AppShell
         }
     }
 
-    public function updateWarningLists() {
-        $result = $this->Galaxy->update();
-        if ($result) {
-            echo 'Warning lists updated' . PHP_EOL;
-        } else {
-            echo 'Could not update warning lists' . PHP_EOL;
-        }
+    public function updateWarningLists() 
+    {
+        $result = $this->Warninglist->update();
+        $success = count($result['success']);
+        $fails = count($result['fails']);
+        echo "$success warninglists updated, $fails fails" . PHP_EOL;
     }
 
     public function updateNoticeLists() {


### PR DESCRIPTION
## What does it do?

Currently, the command `cake Admin updateWarningLists` updates Galaxy. After this pull, it will really update Warninglists :D

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
