### PR TITLE
new: [UI] Download GPG public key from GPG homedir

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -373,7 +373,7 @@ class AppController extends Controller
                 }
             }
         } else {
-            $pre_auth_actions = array('login', 'register');
+            $pre_auth_actions = array('login', 'register', 'getGpgPublicKey');
             if (!empty(Configure::read('Security.email_otp_enabled'))) {
                 $pre_auth_actions[] = 'email_otp';
             }

--- a/app/Controller/Component/ACLComponent.php
+++ b/app/Controller/Component/ACLComponent.php
@@ -685,6 +685,7 @@ class ACLComponent extends Component
                     'verifyCertificate' => array(),
                     'verifyGPG' => array(),
                     'view' => array('*'),
+                    'getGpgPublicKey' => array('*'),
             ),
             'userSettings' => array(
                     'index' => array('*'),

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -1212,6 +1212,27 @@ class User extends AppModel
         $syslog->write('notice', "$description -- $action" . (empty($fieldResult) ? '' : ' -- ' . $result['Log']['change']));
     }
 
+    /**
+     * @return array|null
+     * @throws Exception
+     */
+    public function getGpgPublicKey()
+    {
+        $email = Configure::read('GnuPG.email');
+        if (!$email) {
+            throw new Exception("Configuration option 'GnuPG.email' is not set, public key cannot be exported.");
+        }
+
+        $cryptGpg = $this->initializeGpg();
+        $fingerprint = $cryptGpg->getFingerprint($email);
+        if (!$fingerprint) {
+            return null;
+        }
+
+        $publicKey = $cryptGpg->exportPublicKey($fingerprint);
+        return array($fingerprint, $publicKey);
+    }
+
     public function getOrgActivity($orgId, $params=array())
     {
         $conditions = array();

--- a/app/View/Elements/footer.ctp
+++ b/app/View/Elements/footer.ctp
@@ -11,7 +11,9 @@
             <div class="pull-left footerText" style="float:left;position:absolute;padding-top:12px;z-index:2;">
                 <?php
                 $gpgpath = ROOT.DS.APP_DIR.DS.WEBROOT_DIR.DS.'gpg.asc';
-                if (file_exists($gpgpath) && (is_file($gpgpath) || is_link($gpgpath))){ ?>
+                if (Configure::read("MISP.download_gpg_from_homedir")) { ?>
+                    <span>Download: <?= $this->Html->link(__('GnuPG key'), array('controller' => 'users', 'action' => 'getGpgPublicKey')) ?></span>
+                <?php } else if (file_exists($gpgpath) && (is_file($gpgpath) || is_link($gpgpath))){ ?>
                     <span>Download: <?php echo $this->Html->link(__('GnuPG key'), $this->webroot.'gpg.asc');?></span>
                 <?php } else { ?>
                     <span><?php echo __('Could not locate the GnuPG public key.');?></span>


### PR DESCRIPTION
## What does it do?

Currently the GPG public key is stored in two locations: GPG homedir and `app/webroot/gpg.asc`. So for example if admin update key just in GPG homedir, users will still download old/expired key. 

This pull request introduce new config `MISP.download_gpg_from_homedir` and when this config is set to `true`, public key will be extracted and downloaded from GPG homedir.

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
