### PR TITLE
Fixes #5244.

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -3067,6 +3067,7 @@ class AttributesController extends AppController
                     $this->Auth->user(),
                     array(
                         'conditions' => array('Attribute.id' => $id, 'Attribute.deleted' => 0),
+                        'flatten' => 1,
                         'contain' => array('Event.orgc_id')
                     )
                 );


### PR DESCRIPTION
AttributeController->addTag was searching for attribute id without flattening.

#### What does it do?

If it fixes an existing issue, see #5244.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
