### PR TITLE
fix: undefined variable when no feed was enable

### DIFF
--- a/app/Controller/FeedsController.php
+++ b/app/Controller/FeedsController.php
@@ -505,6 +505,9 @@ class FeedsController extends AppController
                 }
             }
         }
+        if (!isset($message)) {
+            $message = __('No feed enabled.');
+        }
         $this->Flash->success($message);
         $this->redirect(array('action' => 'index'));
     }


### PR DESCRIPTION
Just set the variable in case no feed is enable and we don't enter the loop.