### PR TITLE
chg: [UI] Collapse S/MIME or GPG key

### DIFF
--- a/app/View/Communities/view.ctp
+++ b/app/View/Communities/view.ctp
@@ -14,12 +14,19 @@
             )
         );
         $optional_fields = array(
-            'type', 'description', 'rules', 'email', 'sector', 'nationality', 'eligibility', 'pgp_key'
+            'type', 'description', 'rules', 'email', 'sector', 'nationality', 'eligibility',
         );
         foreach ($optional_fields as $field) {
             if (!empty($community[$field])) {
                 $table_data[] = array('key' => Inflector::humanize($field), 'value' => $community[$field]);
             }
+        }
+        if (!empty($community['pgp_key'])) {
+            $table_data[] = array(
+                'key' => __('GnuPG key'),
+                'element' => 'genericElements/key',
+                'element_params' => array('key' => $community['pgp_key']),
+            );
         }
         //misp-project.org/org-logos/uuid.png
         echo sprintf(

--- a/app/View/Elements/genericElements/key.ctp
+++ b/app/View/Elements/genericElements/key.ctp
@@ -1,0 +1,10 @@
+<?php if (empty($key)): ?>
+    <span class="bold red"><?= __('N/A') ?></span>
+<?php else: ?>
+    <details>
+        <?php if (!empty($description)): ?>
+        <summary style="cursor: pointer"><?= h($description) ?></summary>
+        <?php endif; ?>
+        <pre class="quickSelect" style="line-height: 1.44"><?= h($key) ?></pre>
+    </details>
+<?php endif; ?>

--- a/app/View/Users/admin_view.ctp
+++ b/app/View/Users/admin_view.ctp
@@ -59,8 +59,8 @@ $buttonModifyStatus = $mayModify ? 'button_on':'button_off';
     $table_data[] = array('key' => __('Password change'), 'boolean' => $user['User']['change_pw']);
     $table_data[] = array(
         'key' => __('GnuPG key'),
-        'class_value' => "quickSelect " . $user['User']['gpgkey'] ? 'green' : 'bold red',
-        'html' => $user['User']['gpgkey'] ? nl2br(h($user['User']['gpgkey'])) : __("N/A")
+        'element' => 'genericElements/key',
+        'element_params' => array('key' => $user['User']['gpgkey']),
     );
     if (!empty($user['User']['gpgkey'])) {
         $table_data[] = array(
@@ -76,9 +76,9 @@ $buttonModifyStatus = $mayModify ? 'button_on':'button_off';
     }
     if (Configure::read('SMIME.enabled')) {
         $table_data[] = array(
-            'key' => __('SMIME Public certificate'),
-            'class_value' => "red quickSelect",
-            'html' => (h($user['User']['certif_public'])) ? $this->Utility->space2nbsp(nl2br(h($user['User']['certif_public']))) : "N/A"
+            'key' => __('S/MIME Public certificate'),
+            'element' => 'genericElements/key',
+            'element_params' => array('key' => $user['User']['certif_public']),
         );
     }
     $table_data[] = array('key' => __('Newsread'), 'html' => $user['User']['newsread'] ? date('Y/m/d H:i:s', h($user['User']['newsread'])) : __('N/A'));

--- a/app/View/Users/view.ctp
+++ b/app/View/Users/view.ctp
@@ -29,8 +29,8 @@
     $table_data[] = array('key' => __('Terms accepted'), 'boolean' => $user['User']['termsaccepted']);
     $table_data[] = array(
         'key' => __('GnuPG key'),
-        'class_value' => "quickSelect " . $user['User']['gpgkey'] ? 'green' : 'bold red',
-        'html' => $user['User']['gpgkey'] ? nl2br(h($user['User']['gpgkey'])) : __("N/A")
+        'element' => 'genericElements/key',
+        'element_params' => array('key' => $user['User']['gpgkey']),
     );
     if (!empty($user['User']['gpgkey'])) {
         $table_data[] = array(
@@ -46,9 +46,9 @@
     }
     if (Configure::read('SMIME.enabled')) {
         $table_data[] = array(
-            'key' => __('SMIME Public certificate'),
-            'class_value' => "red quickSelect",
-            'html' => (h($user['User']['certif_public'])) ? $this->Utility->space2nbsp(nl2br(h($user['User']['certif_public']))) : "N/A"
+            'key' => __('S/MIME Public certificate'),
+            'element' => 'genericElements/key',
+            'element_params' => array('key' => $user['User']['certif_public']),
         );
     }
     echo sprintf(


### PR DESCRIPTION
## What does it do?

Nicer view of GPG or S/MIME keys in UI.

After change:

<img width="980" alt="Snímek obrazovky 2019-10-02 v 19 11 03" src="https://user-images.githubusercontent.com/163343/66065768-7253a080-e548-11e9-92db-e0719321ae55.png">

Note: The term 'Podrobnosti' is provided by browser according to browser language. 

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
