### PR TITLE
fix: [internal] user_count variable is already number

### DIFF
--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -1322,7 +1322,7 @@ class User extends AppModel
             if ($jobId) {
                 if ($k % 100 == 0) {
                     $job->id =  $jobId;
-                    $job->saveField('progress', 100 * (($k + 1) / count($user_count)));
+                    $job->saveField('progress', 100 * (($k + 1) / $user_count));
                     $job->saveField('message', __('Reset in progress - %s/%s.', $k, $user_count));
                 }
             }


### PR DESCRIPTION
## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
