### PR TITLE
fix: [internal] Remove closing PHP tags

### DIFF
--- a/app/Model/DecayingModelsFormulas/Base.php
+++ b/app/Model/DecayingModelsFormulas/Base.php
@@ -124,5 +124,3 @@ abstract class DecayingModelBase
     // Return a True if the attribute should be marked as decayed
     abstract public function isDecayed($model, $attribute, $score);
 }
-
-?>

--- a/app/Model/DecayingModelsFormulas/Polynomial.php
+++ b/app/Model/DecayingModelsFormulas/Polynomial.php
@@ -24,4 +24,3 @@ class Polynomial extends DecayingModelBase
         return $threshold > $score;
     }
 }
-?>

--- a/app/Model/DecayingModelsFormulas/PolynomialExtended.php
+++ b/app/Model/DecayingModelsFormulas/PolynomialExtended.php
@@ -51,4 +51,3 @@ class PolynomialExtended extends Polynomial
         return parent::isDecayed($model, $attribute, $score);
     }
 }
-?>

--- a/app/View/Helper/FontAwesomeHelper.php
+++ b/app/View/Helper/FontAwesomeHelper.php
@@ -446,4 +446,3 @@ App::uses('AppHelper', 'View/Helper');
             }
         }
     }
-?>

--- a/app/View/Helper/GenericPickerHelper.php
+++ b/app/View/Helper/GenericPickerHelper.php
@@ -113,4 +113,3 @@ class GenericPickerHelper extends AppHelper {
         return $template;
     }
 }
-?>

--- a/app/View/Helper/HighlightHelper.php
+++ b/app/View/Helper/HighlightHelper.php
@@ -40,4 +40,3 @@ App::uses('AppHelper', 'View/Helper');
 
         }
     }
-?>

--- a/app/View/Helper/OrgImgHelper.php
+++ b/app/View/Helper/OrgImgHelper.php
@@ -58,4 +58,3 @@ App::uses('AppHelper', 'View/Helper');
             }
         }
     }
-?>

--- a/app/View/Helper/PivotHelper.php
+++ b/app/View/Helper/PivotHelper.php
@@ -80,5 +80,3 @@ App::uses('AppHelper', 'View/Helper');
             return $height + $heightToAdd;
         }
     }
-
-?>

--- a/app/View/Helper/TextColourHelper.php
+++ b/app/View/Helper/TextColourHelper.php
@@ -17,4 +17,3 @@ App::uses('AppHelper', 'View/Helper');
             }
         }
     }
-?>

--- a/app/View/Helper/UserNameHelper.php
+++ b/app/View/Helper/UserNameHelper.php
@@ -21,4 +21,3 @@ App::uses('AppHelper', 'View/Helper');
             return '';
         }
     }
-?>

--- a/app/View/Helper/UtilityHelper.php
+++ b/app/View/Helper/UtilityHelper.php
@@ -9,4 +9,4 @@ App::uses('AppHelper', 'View/Helper');
             return $string;
         }
     }
-?>
+

--- a/app/View/Helper/XmlOutputHelper.php
+++ b/app/View/Helper/XmlOutputHelper.php
@@ -22,4 +22,3 @@ App::uses('AppHelper', 'View/Helper');
             }
         }
     }
-?>


### PR DESCRIPTION
## What does it do?

Removes closing PHP tag `?>` from end of files. It is bad practice and it can lead to empty lines in output.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
