### PR TITLE
fix: [internal] Load MISP version just once in AppController

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -164,10 +164,10 @@ class AppController extends Controller
         } else {
             $this->Auth->authenticate['Form']['userFields'] = $auth_user_fields;
         }
-        $versionArray = $this->{$this->modelClass}->checkMISPVersion();
         if (!empty($this->params['named']['disable_background_processing'])) {
             Configure::write('MISP.background_jobs', 0);
         }
+        $versionArray = $this->{$this->modelClass}->checkMISPVersion();
         $this->mispVersion = implode('.', array_values($versionArray));
         $this->Security->blackHoleCallback = 'blackHole';
         $this->_setupBaseurl();
@@ -394,10 +394,8 @@ class AppController extends Controller
         // instead of using checkAction(), like we normally do from controllers when trying to find out about a permission flag, we can use getActions()
         // getActions returns all the flags in a single SQL query
         if ($this->Auth->user()) {
-            $versionArray = $this->{$this->modelClass}->checkMISPVersion();
-            $this->mispVersionFull = implode('.', array_values($versionArray));
             $this->set('mispVersion', implode('.', array($versionArray['major'], $versionArray['minor'], 0)));
-            $this->set('mispVersionFull', $this->mispVersionFull);
+            $this->set('mispVersionFull', $this->mispVersion);
             $role = $this->getActions();
             $this->set('me', $this->Auth->user());
             $this->set('isAdmin', $role['perm_admin']);

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -1497,7 +1497,6 @@ class AppModel extends Model
 
     public function checkMISPVersion()
     {
-        App::uses('Folder', 'Utility');
         $file = new File(ROOT . DS . 'VERSION.json', true);
         $version_array = json_decode($file->read(), true);
         $file->close();


### PR DESCRIPTION
## What does it do?

Small code cleanup and small speedup.

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
