### PR TITLE
chg: [internal] Speed up of loading attributes and events

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -1775,25 +1775,21 @@ class AttributesController extends AppController
     private function __searchUI($attributes)
     {
         $sightingsData = array();
-        $sgids = $this->Attribute->Event->cacheSgids($this->Auth->user(), true);
         $this->Feed = ClassRegistry::init('Feed');
         if (!empty($options['overrideLimit'])) {
             $overrideLimit = true;
         } else {
             $overrideLimit = false;
         }
-        $this->loadModel('GalaxyCluster');
-        $cluster_names = $this->GalaxyCluster->find('list', array('fields' => array('GalaxyCluster.tag_name'), 'group' => array('GalaxyCluster.tag_name', 'GalaxyCluster.id')));
+
         $this->loadModel('Sighting');
         foreach ($attributes as $k => $attribute) {
             $attributes[$k]['Attribute']['AttributeTag'] = $attributes[$k]['AttributeTag'];
             $attributes[$k]['Attribute'] = $this->Attribute->Event->massageTags($attributes[$k]['Attribute'], 'Attribute');
             unset($attributes[$k]['AttributeTag']);
-            foreach ($attributes[$k]['Attribute']['AttributeTag'] as $k2 => $attributeTag) {
-                if (in_array($attributeTag['Tag']['name'], $cluster_names)) {
-                    unset($attributes[$k]['Attribute']['AttributeTag'][$k2]);
-                }
-            }
+
+            $this->Attribute->removeGalaxyClusterTags($attributes[$k]['Attribute']);
+
             $sightingsData = array_merge(
                 $sightingsData,
                 $this->Sighting->attachToEvent($attribute, $this->Auth->user(), $attributes[$k]['Attribute']['id'], $extraConditions = false)

--- a/app/Controller/DecayingModelController.php
+++ b/app/Controller/DecayingModelController.php
@@ -639,24 +639,14 @@ class DecayingModelController extends AppController
 
             // attach sightings and massage tags
             $sightingsData = array();
-            if (!empty($options['overrideLimit'])) {
-                $overrideLimit = true;
-            } else {
-                $overrideLimit = false;
-            }
-            $this->loadModel('GalaxyCluster');
-            $cluster_names = $this->GalaxyCluster->find('list', array('fields' => array('GalaxyCluster.tag_name'), 'group' => array('GalaxyCluster.tag_name', 'GalaxyCluster.id')));
             $this->loadModel('Sighting');
-            $eventTags = array();
             foreach ($attributes as $k => $attribute) {
                 $attributes[$k]['Attribute']['AttributeTag'] = $attributes[$k]['AttributeTag'];
                 $attributes[$k]['Attribute'] = $this->User->Event->massageTags($attributes[$k]['Attribute'], 'Attribute');
                 unset($attributes[$k]['AttributeTag']);
-                foreach ($attributes[$k]['Attribute']['AttributeTag'] as $k2 => $attributeTag) {
-                    if (in_array($attributeTag['Tag']['name'], $cluster_names)) {
-                        unset($attributes[$k]['Attribute']['AttributeTag'][$k2]);
-                    }
-                }
+
+                $this->User->Event->Attribute->removeGalaxyClusterTags($attributes[$k]['Attribute']);
+
                 $sightingsData = array_merge(
                     $sightingsData,
                     $this->Sighting->attachToEvent($attribute, $this->Auth->user(), $attributes[$k]['Attribute']['id'], $extraConditions = false)

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -1149,25 +1149,15 @@ class EventsController extends AppController
         $this->set('emptyEvent', $emptyEvent);
 
         // remove galaxies tags
-        $this->loadModel('GalaxyCluster');
-        $cluster_names = $this->GalaxyCluster->find('list', array('fields' => array('GalaxyCluster.tag_name'), 'group' => array('GalaxyCluster.tag_name', 'GalaxyCluster.id')));
         foreach ($event['Object'] as $k => $object) {
             if (isset($object['Attribute'])) {
                 foreach ($object['Attribute'] as $k2 => $attribute) {
-                    foreach ($attribute['AttributeTag'] as $k3 => $attributeTag) {
-                        if (in_array($attributeTag['Tag']['name'], $cluster_names)) {
-                            unset($event['Object'][$k]['Attribute'][$k2]['AttributeTag'][$k3]);
-                        }
-                    }
+                    $this->Event->Attribute->removeGalaxyClusterTags($event['Object'][$k]['Attribute'][$k2]);
                 }
             }
         }
         foreach ($event['Attribute'] as $k => $attribute) {
-            foreach ($attribute['AttributeTag'] as $k2 => $attributeTag) {
-                if (in_array($attributeTag['Tag']['name'], $cluster_names)) {
-                    unset($event['Attribute'][$k]['AttributeTag'][$k2]);
-                }
-            }
+            $this->Event->Attribute->removeGalaxyClusterTags($event['Attribute'][$k]);
         }
         if (empty($this->passedArgs['sort'])) {
             $filters['sort'] = 'timestamp';
@@ -1358,12 +1348,9 @@ class EventsController extends AppController
                 $this->set($alias, $currentModel->{$variable});
             }
         }
-        $cluster_names = $this->GalaxyCluster->find('list', array('fields' => array('GalaxyCluster.tag_name'), 'group' => array('GalaxyCluster.tag_name', 'GalaxyCluster.id')));
-        foreach ($event['EventTag'] as $k => $eventTag) {
-            if (in_array($eventTag['Tag']['name'], $cluster_names)) {
-                unset($event['EventTag'][$k]);
-            }
-        }
+
+        $this->Event->removeGalaxyClusterTags($event);
+
         $startDate = null;
         $modificationMap = array();
         foreach ($event['Attribute'] as $k => $attribute) {
@@ -1375,11 +1362,8 @@ class EventsController extends AppController
             }
             $modDate = date("Y-m-d", $attribute['timestamp']);
             $modificationMap[$modDate] = empty($modificationMap[$modDate])? 1 : $modificationMap[date("Y-m-d", $attribute['timestamp'])] + 1;
-            foreach ($attribute['AttributeTag'] as $k2 => $attributeTag) {
-                if (in_array($attributeTag['Tag']['name'], $cluster_names)) {
-                    unset($event['Attribute'][$k]['AttributeTag'][$k2]);
-                }
-            }
+
+            $this->Event->Attribute->removeGalaxyClusterTags($event['Attribute'][$k]);
         }
         $attributeTagsName = $this->Event->Attribute->AttributeTag->extractAttributeTagsNameFromEvent($event, 'both');
         $this->set('attributeTags', array_values($attributeTagsName['tags']));
@@ -1400,11 +1384,8 @@ class EventsController extends AppController
                     }
                     $modDate = date("Y-m-d", $attribute['timestamp']);
                     $modificationMap[$modDate] = empty($modificationMap[$modDate])? 1 : $modificationMap[date("Y-m-d", $attribute['timestamp'])] + 1;
-                    foreach ($attribute['AttributeTag'] as $k3 => $attributeTag) {
-                        if (in_array($attributeTag['Tag']['name'], $cluster_names)) {
-                            unset($event['Object'][$k]['Attribute'][$k2]['AttributeTag'][$k3]);
-                        }
-                    }
+
+                    $this->Event->Attribute->removeGalaxyClusterTags($event['Object'][$k]['Attribute'][$k2]);
                 }
             }
         }

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -4403,4 +4403,27 @@ class Attribute extends AppModel
         }
         return true;
     }
+
+    /**
+     * @param array $attribute
+     */
+    public function removeGalaxyClusterTags(array &$attribute)
+    {
+        $tagIds = array();
+        foreach ($attribute['Galaxy'] as $galaxy) {
+            foreach ($galaxy['GalaxyCluster'] as $galaxyCluster) {
+                $tagIds[] = $galaxyCluster['tag_id'];
+            }
+        }
+
+        if (empty($tagIds)) {
+            return;
+        }
+
+        foreach ($attribute['AttributeTag'] as $k => $attributeTag) {
+            if (in_array($attributeTag['Tag']['id'], $tagIds)) {
+                unset($attribute['AttributeTag'][$k]);
+            }
+        }
+    }
 }

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -6935,4 +6935,27 @@ class Event extends AppModel
         }
         return true;
     }
+
+    /**
+     * @param array $event
+     */
+    public function removeGalaxyClusterTags(array &$event)
+    {
+        $tagIds = array();
+        foreach ($event['Galaxy'] as $galaxy) {
+            foreach ($galaxy['GalaxyCluster'] as $galaxyCluster) {
+                $tagIds[] = $galaxyCluster['tag_id'];
+            }
+        }
+
+        if (empty($tagIds)) {
+            return;
+        }
+
+        foreach ($event['EventTag'] as $k => $eventTag) {
+            if (in_array($eventTag['tag_id'], $tagIds)) {
+                unset($event['EventTag'][$k]);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## What does it do?

This patch changes the way how Galaxy Cluster tags are remove from attributes and events. In previous behaviour, all GalaxyCluster tags was loaded from DB (thousands now) and then compared according to tag name. 

Now, because Galaxies are already part of attribute or event data, just tags that are part of that already loaded galaxies are removed.

### Speedup

(all values are in ms)

| Action.         | Before | After |
|-----------------|--------|-------|
| List attributes | 5319   | 4453  |
| View event      | 3128   | 2150  |
| View all attrs. | 2185   | 1380  |

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
