### PR TITLE
fix: [UI] Show image attachment for previewing event

### DIFF
--- a/app/View/Elements/Events/View/value_field.ctp
+++ b/app/View/Elements/Events/View/value_field.ctp
@@ -5,7 +5,7 @@ switch ($object['type']) {
     case 'attachment':
     case 'malware-sample':
         if ($object['type'] === 'attachment' && isset($object['image'])) {
-            if (extension_loaded('gd')) {
+            if ($object['image'] === true) {
                 $img = '<it class="fa fa-spin fa-spinner" style="font-size: large; left: 50%; top: 50%;"></it>';
                 $img .= '<img class="screenshot screenshot-collapsed useCursorPointer img-rounded hidden" src="' . $baseurl . '/attributes/viewPicture/' . h($object['id']) . '/1' . '" title="' . h($object['value']) . '" onload="$(this).show(200); $(this).parent().find(\'.fa-spinner\').remove();"/>';
                 echo $img;


### PR DESCRIPTION
## What does it do?

Show image attachment for previewing event. Previously, it just shows "loading" image.

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
