### PR TITLE
fix: [UI] Remove unused code from Communities view template

### DIFF
--- a/app/View/Communities/view.ctp
+++ b/app/View/Communities/view.ctp
@@ -56,12 +56,3 @@
 <?php
     echo $this->element('/genericElements/SideMenu/side_menu', array('menuList' => 'sync', 'menuItem' => 'view_community'));
 ?>
-<script type="text/javascript">
-    <?php
-        $startingTab = 'description';
-        if (!$local) $startingTab = 'events';
-    ?>
-    $(document).ready(function () {
-        organisationViewContent('<?php echo $startingTab; ?>', '<?php echo h($id);?>');
-    });
-</script>


### PR DESCRIPTION
## What does it do?

This code was probably copied from Organisation view template, but doesn't make sense for Communities.

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
