### PR TITLE
fix: [UI] Removed unused JS from galaxy view

### DIFF
--- a/app/View/Elements/galaxyQuickView.ctp
+++ b/app/View/Elements/galaxyQuickView.ctp
@@ -151,9 +151,5 @@
                 $(this).parent().children('.collapse-status-container').children('.collapse-status').html('+');
             }
         });
-        $('.delete-cluster').click(function() {
-            var tagName = $(this).data('tag-name');
-            removeTag($id = false, $tag_id = false, $galaxy = false);
-        });
     });
 </script>

--- a/app/View/Elements/galaxyQuickViewMini.ctp
+++ b/app/View/Elements/galaxyQuickViewMini.ctp
@@ -146,9 +146,5 @@ $(document).ready(function () {
             $(this).children('span').html('+');
         }
     });
-    $('.delete-cluster').click(function() {
-        var tagName = $(this).data('tag-name');
-        removeTag($id = false, $tag_id = false, $galaxy = false);
-    });
 });
 </script>


### PR DESCRIPTION
## What does it do?

In the code, there is no:
* HTML element with class `delete-cluster` and
* JS method `removeTag`.

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
