### PR TITLE
fix: [UI] Automatic logout

### DIFF
--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -4268,13 +4268,16 @@ function queryEventLock(event_id, user_org_id) {
 
 function checkIfLoggedIn() {
     if (tabIsActive) {
-        $.get("/users/checkIfLoggedIn.json", function(data) {
-            if (data.slice(-2) !== 'OK') {
-                window.location.replace(baseurl + "/users/login");
-            }
-        });
+        $.get("/users/checkIfLoggedIn.json")
+            .fail(function (xhr) {
+                if (xhr.status === 403) {
+                    window.location.replace(baseurl + "/users/login");
+                }
+            });
     }
-    setTimeout(function() { checkIfLoggedIn(); }, 5000);
+    setTimeout(function () {
+        checkIfLoggedIn();
+    }, 5000);
 }
 
 function insertRawRestResponse() {


### PR DESCRIPTION
## What does it do?

Automatic logout was broken, because for not logged user the call `/users/checkIfLoggedIn.json` returns status code 403, that is considered as fail in jQuery and the code inside was not handled.

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
