### PR TITLE
fix: [internal] Load Regexp just when they are requested

### DIFF
--- a/app/Model/Behavior/RegexpBehavior.php
+++ b/app/Model/Behavior/RegexpBehavior.php
@@ -4,37 +4,40 @@ App::uses('Regexp', 'Model');
 
 /**
  * Behavior to regexp all string fields in a model
- *
  */
 class RegexpBehavior extends ModelBehavior
 {
-    private $__allRegexp = array();
+    private $__allRegexp = null;
 
     public $excluded_types = array('sigma', 'float');
-
-    public function setup(Model $model, $config = null)
-    {
-        $regexp = new Regexp();
-        $this->__allRegexp = $regexp->find('all', array('order' => 'id ASC'));
-    }
 
     /**
      * replace the current value according to the regexp rules, or block blacklisted regular expressions
      *
      * @param Model $Model
-     * @param unknown_type $array
+     * @param string $type
+     * @param string $value
+     * @return string
      */
     public function runRegexp(Model $Model, $type, $value)
     {
         if (in_array($type, $this->excluded_types)) {
             return $value;
         }
+
+        if ($this->__allRegexp === null) {
+            $regexp = new Regexp();
+            $this->__allRegexp = $regexp->find('all', array('order' => 'id ASC'));
+        }
+
         foreach ($this->__allRegexp as $regexp) {
-            if (!empty($regexp['Regexp']['replacement']) && !empty($regexp['Regexp']['regexp']) && ($regexp['Regexp']['type'] === 'ALL' || $regexp['Regexp']['type'] === $type)) {
-                $value = preg_replace($regexp['Regexp']['regexp'], $regexp['Regexp']['replacement'], $value);
-            }
-            if (empty($regexp['Regexp']['replacement']) && preg_match($regexp['Regexp']['regexp'], $value) && ($regexp['Regexp']['type'] === 'ALL' || $regexp['Regexp']['type'] === $type)) {
-                return false;
+            if ($regexp['Regexp']['type'] === 'ALL' || $regexp['Regexp']['type'] === $type) {
+                if (!empty($regexp['Regexp']['replacement']) && !empty($regexp['Regexp']['regexp'])) {
+                    $value = preg_replace($regexp['Regexp']['regexp'], $regexp['Regexp']['replacement'], $value);
+                }
+                if (empty($regexp['Regexp']['replacement']) && preg_match($regexp['Regexp']['regexp'], $value)) {
+                    return false;
+                }
             }
         }
         return $value;


### PR DESCRIPTION
## What does it do?

Without this, Regexp are loaded twice for every request, even when they are never used. So this is small performance improvement. 

It also check if Regexp type is relevant for given type before regexp executing. 

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
