### PR TITLE
fix: [UI] Proposal attachment downloading

### DIFF
--- a/app/View/Elements/Events/View/value_field.ctp
+++ b/app/View/Elements/Events/View/value_field.ctp
@@ -24,7 +24,8 @@ switch ($object['type']) {
                 $filename = $filenameHash[0];
             }
 
-            $url = array('controller' => 'attributes', 'action' => 'download', $object['id']);
+            $controller = isset($object['objectType']) && $object['objectType'] === 'proposal' ? 'shadow_attributes' : 'attributes';
+            $url = array('controller' => $controller, 'action' => 'download', $object['id']);
             echo $this->Html->link($filename, $url, array('class' => $linkClass));
             if (isset($filenameHash[1])) {
                 echo '<br />' . $filenameHash[1];


### PR DESCRIPTION
## What does it do?

Before this patch, instead of proposal attachment, real attachment with the same ID was downloaded.

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
