### PR TITLE
chg: [feed] Use precomputed hashes to speedup attaching correlation

### DIFF
--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -365,19 +365,12 @@ class Feed extends AppModel
                     if ($scope === 'Server' || $source[$scope]['source_format'] == 'misp') {
                         $pipe = $redis->multi(Redis::PIPELINE);
                         $eventUuidHitPosition = array();
-                        $i = 0;
                         foreach ($objects as $k => $object) {
                             if (isset($object[$scope])) {
                                 foreach ($object[$scope] as $currentFeed) {
                                     if ($source[$scope]['id'] == $currentFeed['id']) {
-                                        $eventUuidHitPosition[$i] = $k;
-                                        $i++;
-                                        if (in_array($object['type'], $compositeTypes)) {
-                                            $value = explode('|', $object['value']);
-                                            $redis->smembers($cachePrefix . 'event_uuid_lookup:' . md5($value[0]));
-                                        } else {
-                                            $redis->smembers($cachePrefix . 'event_uuid_lookup:' . md5($object['value']));
-                                        }
+                                        $eventUuidHitPosition[] = $k;
+                                        $redis->smembers($cachePrefix . 'event_uuid_lookup:' . $hashTable[$k]);
                                     }
                                 }
                             }


### PR DESCRIPTION
## What does it do?

We don't need to compute `md5` hash again.

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
