### PR TITLE
Minor visual bug in event view

### DIFF
--- a/app/View/Events/view.ctp
+++ b/app/View/Events/view.ctp
@@ -197,7 +197,7 @@
         );
         $table_data[] = array(
             'key' => __('First recorded change'),
-            'value' => date('Y-m-d H:i:s', $oldest_timestamp)
+            'value' => (!$oldest_timestamp) ? '' : date('Y-m-d H:i:s', $oldest_timestamp)
         );
         $table_data[] = array(
             'key' => __('Last change'),


### PR DESCRIPTION
Creating a new event with no attributes the "First recorded change" value displayed is "1970-01-01 01:00:00".

![MISP_Event](https://raw.githubusercontent.com/davidonzo/host/master/misp_loves_70s_me_too.png)

This is quite normal looking at the php code in "app/Controller/EventsController.php" from line 1277 to 1289
```
$oldest_timestamp = false;
        if (!empty($event['Object'])) {
            foreach ($event['Object'] as $k => $object) {
                if (!empty($object['Attribute'])) {
                    foreach ($object['Attribute'] as $attribute) {
                        if ($oldest_timestamp == false || $oldest_timestamp < $attribute['timestamp']) {
                            $oldest_timestamp = $attribute['timestamp'];
                        }
                    }
                    $attributeCount += count($object['Attribute']);
                }
            }
        }
```
As long as no attributes/objects are added to the event $oldest_timestamp will always be false.
It's just a little visual bug. So my pragmatic solution was change line 200 in "app/view/Events/view.ctp from 

```'value' => date('Y-m-d H:i:s', $oldest_timestamp)```

to

```'value' => (!$oldest_timestamp) ? '' : date('Y-m-d H:i:s', $oldest_timestamp)```

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
