### PR TITLE
Fixing BasicAuth using ldap or AD

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -152,7 +152,8 @@ class AppController extends Controller
         }
         // check if Apache provides kerberos authentication data
         $envvar = Configure::read('ApacheSecureAuth.apacheEnv');
-        if (isset($_SERVER[$envvar])) {
+        if  (isset($_SERVER['PHP_AUTH_USER']))  {
+            $_SERVER[$envvar]=$_SERVER['PHP_AUTH_USER'];
             $this->Auth->className = 'ApacheSecureAuth';
             $this->Auth->authenticate = array(
                 'Apache' => array(


### PR DESCRIPTION

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2016-06-03: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

The  $_SERVER[$envvar] was previously never set, this is effectively $_SERVER['REMOTE_USER']. 
Its the easiest to fix that here, as the  $_SERVER['PHP_AUTH_USER'] only is set if the user is authenticated by BasicAuth at this stage. It is also possible to fix this in the misp-ssl.config with the virtualhost, but it was simply easier to just fix it here, and at the same time a bit tricky to actually set the variable in the virtualhost section, its easier in PHP.

#### Questions

- [NO] Does it require a DB change?
- [ YES] Are you using it in production?
- [NO] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
