### PR TITLE
Allow python scripts to write to exec-errors.log

### DIFF
--- a/INSTALL/misplogrotate.te
+++ b/INSTALL/misplogrotate.te
@@ -1,8 +1,9 @@
-module misplogrotate 1.1;
+module misplogrotate 1.2;
 require {
 	type httpd_t;
 	type logrotate_t;
 	type httpd_log_t;
+	type httpd_sys_script_t;
 	type httpd_sys_content_t;
 	type httpd_sys_rw_content_t;
 	class dir { ioctl read getattr lock search open remove_name };
@@ -12,4 +13,4 @@ require {
 allow logrotate_t httpd_sys_content_t:dir { ioctl read getattr lock search open };
 allow logrotate_t httpd_sys_rw_content_t:dir { ioctl read getattr lock search open };
 allow httpd_t httpd_log_t:dir remove_name;
-allow httpd_t httpd_log_t:file { unlink write };
+allow { httpd_t httpd_sys_script_t } httpd_log_t:file { unlink write };


### PR DESCRIPTION
We were missing a crucial SELinux rule to allow the httpd_sys_script_t role to write to httpd_log_t files. This caused audit entries like this:
```
type=AVC msg=audit(1571825472.085:2697584): avc:  denied  { write } for  pid=10159 comm="python3" path="/var/www/MISP/app/tmp/logs/exec-errors.log" dev="dm-2" ino=657769 scontext=system_u:system_r:httpd_sys_script_t:s0 tcontext=unconfined_u:object_r:httpd_log_t:s0 tclass=file permissive=0
```