### PR TITLE
fix: Remove unusued config option

### DIFF
--- a/app/Config/config.default.php
+++ b/app/Config/config.default.php
@@ -110,7 +110,6 @@ $config = array(
 	'ApacheShibbAuth'  =>                      // Configuration for shibboleth authentication
 		array(
 			'apacheEnv'         => 'REMOTE_USER',        // If proxy variable = HTTP_REMOTE_USER
-			'ssoAuth'           => 'AUTH_TYPE',
 			'MailTag'           => 'EMAIL_TAG',
 			'OrgTag'            => 'FEDERATION_TAG',
 			'GroupTag'          => 'GROUP_TAG',


### PR DESCRIPTION
## What does it do?

Removes config option `ApacheShibbAuth. ssoAuth` from example config, because it is never used.

```
$ rg ssoAuth
app/Config/config.default.php
113:                    'ssoAuth'           => 'AUTH_TYPE',
```

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
