### PR TITLE
Push sightings regardsless of distribution level

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -3997,8 +3997,10 @@ class Event extends AppModel
         $failedServers = array();
         App::uses('SyncTool', 'Tools');
         foreach ($servers as &$server) {
-            if (((!isset($server['Server']['internal']) || !$server['Server']['internal']) && $event['Event']['distribution'] < 2) ||
-                ((!isset($server['Server']['push_sightings']) || !$server['Server']['push_sightings'])) && $scope === 'sightings') {
+            if (($scope === 'events' &&
+                    (!isset($server['Server']['internal'] || !$server['Server']['internal']) && $event['Event']['distribution'] < 2)) ||
+                ($scope === 'sightings' &&
+                    (!isset($server['Server']['push_sightings'] || !$server['Server']['push_sightings'])))) {
                 continue;
             }
             $syncTool = new SyncTool();


### PR DESCRIPTION
Sightings can (and should) be pushed upstream. So they should not be held back by the distribution level of the event. Pushing sightings will not create an event if it doesn't already exist on the remote server, instead those sightings will be ignored. So there is no risk of leaking information outside of the MISP sharing model. Also, the "push sightings" bit on servers provides fine-grained control over which servers get sightings.