### PR TITLE
Set rate_limit_count to 0 when not defined

### DIFF
--- a/app/Model/Role.php
+++ b/app/Model/Role.php
@@ -220,6 +220,9 @@ class Role extends AppModel
                 $this->data['Role']['memory_limit'] = '';
             }
         }
+        if (empty($this->data['Role']['rate_limit_count'])) {
+            $this->data['Role']['rate_limit_count'] = 0;
+        }
         return true;
     }
 


### PR DESCRIPTION
This patch fixes this error when creating a role:
```
2019-12-04 08:38:35 Error: [PDOException] SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect integer value: '' for column `misp`.`roles`.`rate_limit_count` at row 1
Request URL: /admin/roles/add
Stack Trace:
#0 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Datasource/DboSource.php(502): PDOStatement->execute(Array)
#1 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Datasource/DboSource.php(468): DboSource->_execute('INSERT INTO `mi...', Array)
#2 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Datasource/DboSource.php(1132): DboSource->execute('INSERT INTO `mi...')
#3 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Model.php(1942): DboSource->create(Object(Role), Array, Array)
#4 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Model.php(1760): Model->_doSave(Array, Array)
#5 /var/www/MISP/app/Controller/RolesController.php(51): Model->save(Array)
#6 [internal function]: RolesController->admin_add()
#7 /var/www/MISP/app/Lib/cakephp/lib/Cake/Controller/Controller.php(499): ReflectionMethod->invokeArgs(Object(RolesController), Array)
#8 /var/www/MISP/app/Lib/cakephp/lib/Cake/Routing/Dispatcher.php(193): Controller->invokeAction(Object(CakeRequest))
#9 /var/www/MISP/app/Lib/cakephp/lib/Cake/Routing/Dispatcher.php(167): Dispatcher->_invoke(Object(RolesController), Object(CakeRequest))
#10 /var/www/MISP/app/webroot/index.php(92): Dispatcher->dispatch(Object(CakeRequest), Object(CakeResponse))
#11 {main}
```