### PR TITLE
Schema diagnostic improvement

### DIFF
--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -2227,6 +2227,7 @@ misp.direct_call(relative_path, body)
             $this->set('remainingLockTime', $dbSchemaDiagnostics['remaining_lock_time']);
             $this->set('updateFailNumberReached', $dbSchemaDiagnostics['update_fail_number_reached']);
             $this->set('updateLocked', $dbSchemaDiagnostics['update_locked']);
+            $this->set('dataSource', $dbSchemaDiagnostics['dataSource']);
             $this->render('/Elements/healthElements/db_schema_diagnostic');
         }
 

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -4285,7 +4285,7 @@ class Server extends AppModel
         $dataSource = $this->getDataSource()->config['datasource'];
         if ($dataSource == 'Database/Mysql') {
             $sql = sprintf(
-                'select table_name as table_name, sum((data_length+index_length)/1024/1024) AS used, sum(data_free)/1024/1024 reclaimable from information_schema.tables where table_schema = %s group by table_name;',
+                'select TABLE_NAME, sum((DATA_LENGTH+INDEX_LENGTH)/1024/1024) AS used, sum(DATA_FREE)/1024/1024 AS reclaimable from information_schema.tables where table_schema = %s group by TABLE_NAME;',
                 "'" . $this->getDataSource()->config['database'] . "'"
             );
             $sqlResult = $this->query($sql);
@@ -4294,14 +4294,14 @@ class Server extends AppModel
                 foreach ($temp[0] as $k => $v) {
                     $temp[0][$k] = round($v, 2) . 'MB';
                 }
-                $temp[0]['table'] = $temp['tables']['table_name'];
+                $temp[0]['table'] = $temp['tables']['TABLE_NAME'];
                 $result[] = $temp[0];
             }
             return $result;
         }
         else if ($dataSource == 'Database/Postgres') {
             $sql = sprintf(
-                'select table_name as table, pg_total_relation_size(%s||%s||table_name) as used from information_schema.tables where table_schema = %s group by table_name;',
+                'select TABLE_NAME as table, pg_total_relation_size(%s||%s||TABLE_NAME) as used from information_schema.tables where table_schema = %s group by TABLE_NAME;',
                 "'" . $this->getDataSource()->config['database'] . "'",
                 "'.'",
                 "'" . $this->getDataSource()->config['database'] . "'"
@@ -4503,14 +4503,14 @@ class Server extends AppModel
         $dbActualSchema = array();
         $dataSource = $this->getDataSource()->config['datasource'];
         if ($dataSource == 'Database/Mysql') {
-            $sqlGetTable = sprintf('SELECT table_name as table_name FROM information_schema.tables WHERE table_schema = %s;', "'" . $this->getDataSource()->config['database'] . "'");
+            $sqlGetTable = sprintf('SELECT TABLE_NAME FROM information_schema.tables WHERE table_schema = %s;', "'" . $this->getDataSource()->config['database'] . "'");
             $sqlResult = $this->query($sqlGetTable);
-            $tables = HASH::extract($sqlResult, '{n}.tables.table_name');
+            $tables = HASH::extract($sqlResult, '{n}.tables.TABLE_NAME');
             foreach ($tables as $table) {
                 $sqlSchema = sprintf(
                     "SELECT %s
                     FROM information_schema.columns
-                    WHERE table_schema = '%s' AND table_name = '%s'", implode(',', $tableColumnNames), $this->getDataSource()->config['database'], $table);
+                    WHERE table_schema = '%s' AND TABLE_NAME = '%s'", implode(',', $tableColumnNames), $this->getDataSource()->config['database'], $table);
                 $sqlResult = $this->query($sqlSchema);
                 foreach ($sqlResult as $column_schema) {
                     $dbActualSchema[$table][] = $column_schema['columns'];

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -4285,7 +4285,7 @@ class Server extends AppModel
         $dataSource = $this->getDataSource()->config['datasource'];
         if ($dataSource == 'Database/Mysql') {
             $sql = sprintf(
-                'select table_name, sum((data_length+index_length)/1024/1024) AS used, sum(data_free)/1024/1024 reclaimable from information_schema.tables where table_schema = %s group by table_name;',
+                'select table_name as table_name, sum((data_length+index_length)/1024/1024) AS used, sum(data_free)/1024/1024 reclaimable from information_schema.tables where table_schema = %s group by table_name;',
                 "'" . $this->getDataSource()->config['database'] . "'"
             );
             $sqlResult = $this->query($sql);
@@ -4503,7 +4503,7 @@ class Server extends AppModel
         $dbActualSchema = array();
         $dataSource = $this->getDataSource()->config['datasource'];
         if ($dataSource == 'Database/Mysql') {
-            $sqlGetTable = sprintf('SELECT table_name FROM information_schema.tables WHERE table_schema = %s;', "'" . $this->getDataSource()->config['database'] . "'");
+            $sqlGetTable = sprintf('SELECT table_name as table_name FROM information_schema.tables WHERE table_schema = %s;', "'" . $this->getDataSource()->config['database'] . "'");
             $sqlResult = $this->query($sqlGetTable);
             $tables = HASH::extract($sqlResult, '{n}.tables.table_name');
             foreach ($tables as $table) {

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -4579,8 +4579,19 @@ class Server extends AppModel
                             $isCritical = false;
                             foreach($colElementDiffs as $colElementDiff) {
                                 if(!in_array($colElementDiff, $nonCriticalColumnElements)) {
-                                    $isCritical = true;
-                                    break;
+                                    if ($colElementDiff == 'column_default') {
+                                        $expectedValue = $column['column_default'];
+                                        $actualValue = $keyedActualColumn[$columnName]['column_default'];
+                                        if (preg_match(sprintf('/(\'|")+%s(\1)+/', $expectedValue), $actualValue)) { // some version of mysql quote the default value
+                                            continue;
+                                        } else {
+                                            $isCritical = true;
+                                            break;
+                                        }
+                                    } else {
+                                        $isCritical = true;
+                                        break;
+                                    }
                                 }
                             }
                             $dbDiff[$tableName][] = array(

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -4347,6 +4347,7 @@ class Server extends AppModel
         ))['AdminSetting']['value'];
         $dataSource = $this->getDataSource()->config['datasource'];
         $schemaDiagnostic = array(
+            'dataSource' => $dataSource,
             'actual_db_version' => $actualDbVersion,
             'checked_table_column' => array(),
             'diagnostic' => array(),

--- a/app/View/Elements/healthElements/db_schema_diagnostic.ctp
+++ b/app/View/Elements/healthElements/db_schema_diagnostic.ctp
@@ -159,6 +159,12 @@
                 __('Update are locked due to to many update fails') : sprintf(__('Update unlocked in %s'), h($humanReadableTime)))
             : __('Updates are not locked'),
         $updateLocked ? 'times' : 'check'
+        );
+    echo sprintf('<span class="label label-%s" title="%s" style="margin-left: 5px;">%s <i class="fas fa-%s"></i></span>',
+        $dataSource != 'Database/Mysql' ? 'important' : 'success',
+        $dataSource,
+        $dataSource,
+        $dataSource != 'Database/Mysql' ? 'times' : 'check'
     )
 ?>
 <script>

--- a/app/View/Elements/healthElements/db_schema_diagnostic.ctp
+++ b/app/View/Elements/healthElements/db_schema_diagnostic.ctp
@@ -165,8 +165,8 @@
         );
     echo sprintf('<span class="label label-%s" title="%s" style="margin-left: 5px;">%s <i class="fas fa-%s"></i></span>',
         $dataSource != 'Database/Mysql' ? 'important' : 'success',
-        $dataSource,
-        $dataSource,
+        __('DataSource: ') . h($dataSource),
+        __('DataSource: ') . h($dataSource),
         $dataSource != 'Database/Mysql' ? 'times' : 'check'
     )
 ?>

--- a/app/View/Elements/healthElements/diagnostics.ctp
+++ b/app/View/Elements/healthElements/diagnostics.ctp
@@ -236,7 +236,8 @@
                 'error' => $dbSchemaDiagnostics['error'],
                 'remainingLockTime' => $dbSchemaDiagnostics['remaining_lock_time'],
                 'updateFailNumberReached' => $dbSchemaDiagnostics['update_fail_number_reached'],
-                'updateLocked' => $dbSchemaDiagnostics['update_locked']
+                'updateLocked' => $dbSchemaDiagnostics['update_locked'],
+                'dataSource' => $dbSchemaDiagnostics['dataSource']
             )); ?>
         </div>
     <h3><?= __("Redis info") ?></h3>


### PR DESCRIPTION
- Improved UI: show ``datasource`` and hide non-critical warnings
- Consider quoted ``default_value`` equal to non-quoted one.
    - e.g.: ``network === 'network'`` (see #5441)

If you have additional whitelist requests or ideas, feel free to say

# Should mitigate/Fix
- #5441
- #5457
- #5455 