### PR TITLE
fix: Don't show an empty error when there is no error

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -5160,8 +5160,9 @@ class EventsController extends AppController
                     $this->set('importComment', $importComment);
                     $this->render($render_name);
                 }
+            } else {
+                $this->Flash->error($fail);
             }
-            $this->Flash->error($fail);
         }
         $this->set('configTypes', $this->Module->configTypes);
         $this->set('module', $module);


### PR DESCRIPTION
When there was no error, an empty red panel still was shown on the top of the page.