### PR TITLE
Return STIX in JSON format when Accept header asks for it

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -1188,6 +1188,9 @@ class AppController extends Controller
         if ($returnFormat === 'download') {
             $returnFormat = 'json';
         }
+        if ($returnFormat === 'stix' && $this->_isJson()) {
+            $returnFormat = 'stix-json';
+        }
         $elementCounter = 0;
         $renderView = false;
         $final = $this->$scope->restSearch($user, $returnFormat, $filters, false, false, $elementCounter, $renderView);


### PR DESCRIPTION
According to https://www.circl.lu/doc/misp/automation/ MISP will return JSON when `Accept: application/json` is set. This was not working for /events/stix/download which always returned XML. This patch fixes that.