### PR TITLE
Mark NULL vs "" as not critical

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -4594,7 +4594,7 @@ class Server extends AppModel
                                     if ($colElementDiff == 'column_default') {
                                         $expectedValue = $column['column_default'];
                                         $actualValue = $keyedActualColumn[$columnName]['column_default'];
-                                        if (preg_match(sprintf('/(\'|")+%s(\1)+/', $expectedValue), $actualValue)) { // some version of mysql quote the default value
+                                        if (preg_match(sprintf('@(\'|")+%s(\1)+@', $expectedValue), $actualValue) || (empty($expectedValue) && $actualValue === 'NULL')) { // some version of mysql quote the default value
                                             continue;
                                         } else {
                                             $isCritical = true;


### PR DESCRIPTION
This is a simple fix for #5457 as it marks the differences of a default NULL value when there is none expected as a non-critical difference. 

It also uses @ as a regex divider instead of / so it does not collide with 'http://localhost' which is the default value for sightingdbs.host