### PR TITLE
Add SAML (Shibboleth) login button

### DIFF
--- a/app/View/Users/login.ctp
+++ b/app/View/Users/login.ctp
@@ -43,6 +43,12 @@
         <?php
             echo $this->Form->button(__('Login'), array('class' => 'btn btn-primary'));
             echo $this->Form->end();
+            if (true == Configure::read('ApacheShibbAuth')):
+        ?>
+            <div class="clear"></div>
+             <a class="btn btn-info" href="/Shibboleth.sso/Login">Login with SAML</a>
+        <?php
+            endif;
         ?>
     </td>
     <td style="width:250px;padding-left:50px">


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2020-01-21: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

Doesn't fix an issue, just adds additional options.

With Shibboleth and SAML you have 2 options, for SAML login and don't allow local login or allow both.  The example in the documentation forces (requires) SAML authentication and thus doesn't allow you to use local credentials if needed.  This adds a button below the login form to redirect to the Shibboleth login page if using passive Shibboleth auth.  To use passive auth set "ShibRequestSetting requireSession 0/false" instead of "ShibRequestSetting requireSession 1/true"

#### Questions

- [ ] Does it require a DB change? No
- [ ] Are you using it in production? Not yet, but might.
- [ ] Does it require a change in the API (PyMISP for example)? No

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
