### PR TITLE
fix: [UI] Two times logout link

### DIFF
--- a/app/View/Elements/global_menu.ctp
+++ b/app/View/Elements/global_menu.ctp
@@ -420,15 +420,10 @@
                 )
             ),
             array(
-                'url' => h(Configure::read('Plugin.CustomAuth_custom_logout')),
+                'url' => h(Configure::read('Plugin.CustomAuth_custom_logout')) ?: '/users/logout',
                 'text' => __('Log out'),
-                'requirement' => (Configure::read('Plugin.CustomAuth_custom_logout') && empty(Configure::read('Plugin.CustomAuth_disable_logout')))
+                'requirement' => empty(Configure::read('Plugin.CustomAuth_disable_logout'))
             ),
-            array(
-                'url' => '/users/logout',
-                'text' => __('Log out'),
-                'requirement' => (!$externalAuthUser && empty(Configure::read('Plugin.CustomAuth_disable_logout')))
-            )
         );
     }
 ?>


### PR DESCRIPTION
Currently, when user log in using `ShibbAuth.ApacheShibb` plugin and `Plugin.CustomAuth_custom_logout` is set, two logout links are displayed. 

This fixes the issue.

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
