### PR TITLE
fix: Proper logout when `CustomAuth_custom_logout` is set

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -112,7 +112,14 @@ class AppController extends Controller
     public function beforeFilter()
     {
         $this->Auth->loginRedirect = Configure::read('MISP.baseurl') . '/users/routeafterlogin';
-        $this->Auth->logoutRedirect = Configure::read('MISP.baseurl') . '/users/login';
+
+        $customLogout = Configure::read('Plugin.CustomAuth_custom_logout');
+        if ($customLogout) {
+            $this->Auth->logoutRedirect = $customLogout;
+        } else {
+            $this->Auth->logoutRedirect = Configure::read('MISP.baseurl') . '/users/login';
+        }
+
         $this->__sessionMassage();
         if (Configure::read('Security.allow_cors')) {
             // Add CORS headers

--- a/app/View/Elements/global_menu.ctp
+++ b/app/View/Elements/global_menu.ctp
@@ -420,14 +420,9 @@
                 )
             ),
             array(
-                'url' => h(Configure::read('Plugin.CustomAuth_custom_logout')),
-                'text' => __('Log out'),
-                'requirement' => (Configure::read('Plugin.CustomAuth_custom_logout') && empty(Configure::read('Plugin.CustomAuth_disable_logout')))
-            ),
-            array(
                 'url' => '/users/logout',
                 'text' => __('Log out'),
-                'requirement' => (!$externalAuthUser && empty(Configure::read('Plugin.CustomAuth_disable_logout')))
+                'requirement' => empty(Configure::read('Plugin.CustomAuth_disable_logout'))
             )
         );
     }


### PR DESCRIPTION
#### What does it do?

Currently, when `Plugin.CustomAuth_disable_logout` config variable is set and user click on logout link, MISP cookie will still be preserved. 

After this change, MISP cookie will be deleted first and then redirected to external logout path.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
