### PR TITLE
fix: [UI] Remove double escaping

### DIFF
--- a/app/View/Elements/genericElements/SideMenu/side_menu.ctp
+++ b/app/View/Elements/genericElements/SideMenu/side_menu.ctp
@@ -447,7 +447,7 @@
                     } else if((Configure::read('Plugin.CustomAuth_custom_password_reset'))) {
                         echo $this->element('/genericElements/SideMenu/side_menu_link', array(
                             'element_id' => 'custom_pw_reset',
-                            'url' => h(Configure::read('Plugin.CustomAuth_custom_password_reset')),
+                            'url' => Configure::read('Plugin.CustomAuth_custom_password_reset'),
                             'text' => __('Reset Password')
                         ));
                     }


### PR DESCRIPTION
#### What does it do?

URL is already escaped in https://github.com/MISP/MISP/blob/7d9600c81d8e106e004c9278953e5227a5287e00/app/View/Elements/genericElements/SideMenu/side_menu_link.ctp#L16

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
