### PR TITLE
fix: `DefaultRoleId` is not implemented for ApacheShibbAuth

### DIFF
--- a/app/Config/config.default.php
+++ b/app/Config/config.default.php
@@ -119,7 +119,6 @@ $config = array(
 				'group_two'   => 2,
 				'group_one'   => 1,
 			),
-			'DefaultRoleId'     => 3,
 			'DefaultOrg'        => 'DEFAULT_ORG',
 		),
 	*/


### PR DESCRIPTION
#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
