### PR TITLE
Fix the CoinBlockerLists

### DIFF
--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -1112,7 +1112,7 @@
     "Feed": {
       "id": "64",
       "name": "This list contains all domains - A list for administrators to prevent mining in networks",
-      "provider": "CoinBlockerLists",
+      "provider": "ZeroDot1 - CoinBlockerLists",
       "url": "https://gitlab.com/ZeroDot1/CoinBlockerLists/raw/master/list.txt?inline=false",
       "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]}}",
       "enabled": true,
@@ -1137,7 +1137,7 @@
     "Feed": {
       "id": "65",
       "name": "This list contains all optional domains - An additional list for administrators",
-      "provider": "CoinBlockerLists",
+      "provider": "ZeroDot1 - CoinBlockerLists",
       "url": "https://gitlab.com/ZeroDot1/CoinBlockerLists/raw/master/list_optional.txt?inline=false",
       "rules": "",
       "enabled": true,
@@ -1162,33 +1162,8 @@
     "Feed": {
       "id": "66",
       "name": "This list contains all browser mining domains - A list to prevent browser mining only",
-      "provider": "CoinBlockerLists",
+      "provider": "ZeroDot1 - CoinBlockerLists",
       "url": "https://gitlab.com/ZeroDot1/CoinBlockerLists/raw/master/list_browser.txt?inline=false",
-      "rules": "",
-      "enabled": true,
-      "distribution": "3",
-      "sharing_group_id": "0",
-      "tag_id": "0",
-      "default": false,
-      "source_format": "freetext",
-      "fixed_event": false,
-      "delta_merge": false,
-      "event_id": "0",
-      "publish": false,
-      "override_ids": false,
-      "settings": "{\"csv\":{\"value\":\"\",\"delimiter\":\",\"},\"common\":{\"excluderegex\":\"\"}}",
-      "input_source": "network",
-      "delete_local_file": false,
-      "lookup_visible": true,
-      "headers": ""
-    }
-  },
-  {
-    "Feed": {
-      "id": "68",
-      "name": "This list contains all IPs - A additional list for administrators to prevent mining in networks",
-      "provider": "CoinBlockerLists",
-      "url": "https://gitlab.com/ZeroDot1/CoinBlockerLists/raw/master/MiningServerIPList.txt?inline=false",
       "rules": "",
       "enabled": true,
       "distribution": "3",


### PR DESCRIPTION
Delete the MiningServerIPList.txt feed because the feed is no longer available. 

All current downloads can be found via the CoinBlockerLists homepage.
https://zerodot1.gitlab.io/CoinBlockerListsWeb/downloads.html

Thanks to everyone for using the CoinBlockerLists, I appreciate it very much.

```json
{
    "Feed": {
      "id": "68",
      "name": "This list contains all IPs - A additional list for administrators to prevent mining in networks",
      "provider": "CoinBlockerLists",
      "url": "https://gitlab.com/ZeroDot1/CoinBlockerLists/raw/master/MiningServerIPList.txt?inline=false",
      "rules": "",
      "enabled": true,
      "distribution": "3",
      "sharing_group_id": "0",
      "tag_id": "0",
      "default": false,
      "source_format": "freetext",
      "fixed_event": false,
      "delta_merge": false,
      "event_id": "0",
      "publish": false,
      "override_ids": false,
      "settings": "{\"csv\":{\"value\":\"\",\"delimiter\":\",\"},\"common\":{\"excluderegex\":\"\"}}",
      "input_source": "network",
      "delete_local_file": false,
      "lookup_visible": true,
      "headers": ""
    }
  },
```


#### What does it do?
This fix corrects bugs and removes a feed that is no longer available.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

I don't know, I hope the fix is helpful.

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
