### PR TITLE
fix: [log] Proper format log message for reset auth key

### DIFF
--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -1373,7 +1373,7 @@ class User extends AppModel
                     $updatedUser['User']['id'],
                     $updatedUser['User']['email']
                 ),
-                $fieldsResult = 'authkey(' . $oldKey . ') => (' . $newkey . ')',
+                $fieldsResult = ['authkey' =>  [$oldKey, $newkey]],
                 $updatedUser
         );
         if ($alert) {


### PR DESCRIPTION
In future, it will be also possible to filter auth keys in logs.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
