### PR TITLE
[add] malsilo.domain feed

### DIFF
--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -1397,6 +1397,32 @@
   },
   {
     "Feed": {
+      "id": "79",
+      "name": "malsilo.domain",
+      "provider": "MalSilo",
+      "url": "https://malsilo.gitlab.io/feeds/dumps/domain_list.txt",
+      "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]}}",
+      "enabled": false,
+      "distribution": "3",
+      "sharing_group_id": "0",
+      "tag_id": "0",
+      "default": false,
+      "source_format": "csv",
+      "fixed_event": true,
+      "delta_merge": false,
+      "event_id": "0",
+      "publish": false,
+      "override_ids": false,
+      "settings": "{\"csv\":{\"value\":\"3\",\"delimiter\":\",\"},\"common\":{\"excluderegex\":\"\"}}",
+      "input_source": "network",
+      "delete_local_file": false,
+      "lookup_visible": true,
+      "headers": "",
+      "caching_enabled": true
+    }
+  },
+  {
+    "Feed": {
       "id": "87",
       "name": "malshare.com - current all",
       "provider": "malshare.com",


### PR DESCRIPTION
#### What does it do?

Add MalSilo 2.0 new export - malsilo.domain - to the defaults.json MISP feeds.

#### Questions

- [ ] Does it require a DB change? _No_
- [ ] Are you using it in production? _Yes_
- [ ] Does it require a change in the API (PyMISP for example)? _No_

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
