### PR TITLE
Enforce iso datetime

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -1594,6 +1594,13 @@ class Attribute extends AppModel
                 }
                 $value = ($value) ? '1' : '0';
                 break;
+            case 'datetime':
+                try {
+                    $value = (new DateTime($value))->setTimezone(new DateTimeZone('GMT'))->format('Y-m-d\TH:i:s.uO'); // ISO8601 formating with microseconds
+                } catch (Exception $e) {
+                    // silently skip. Rejection will be done in runValidation()
+                }
+                break;
         }
         return $value;
     }

--- a/app/View/Attributes/add.ctp
+++ b/app/View/Attributes/add.ctp
@@ -141,6 +141,31 @@
             endif;
         ?>
         checkSharingGroup('Attribute');
+
+        var $form = $('#AttributeType').closest('form').submit(function( event ) {
+            if ($('#AttributeType').val() === 'datetime') {
+                // add timezone of the browser if not set
+                var allowLocalTZ = true;
+                var $valueInput = $('#AttributeValue')
+                var dateValue = moment($valueInput.val())
+                if (dateValue.isValid()) {
+                    if (dateValue.creationData().format !== "YYYY-MM-DDTHH:mm:ssZ" && dateValue.creationData().format !== "YYYY-MM-DDTHH:mm:ss.SSSSZ") {
+                        // Missing timezone data
+                        var confirm_message = '<?php echo __('As no timezone has been entered, it has been auto-detected as: ') ?>' + dateValue.format('Z')
+                        confirm_message += '<?php echo '\r\n' . __('This value will be submited instead: '); ?>' + dateValue.toISOString(allowLocalTZ)
+                        if (confirm(confirm_message)) {
+                            $valueInput.val(dateValue.toISOString(allowLocalTZ));
+                        } else {
+                            return false;
+                        }
+                    }
+                } else {
+                    textStatus = '<?php echo __('Value is not a valid datetime. Excpected format YYYY-MM-DDTHH:mm:ssZ') ?>'
+                    showMessage('fail',  + ": " + '???');
+                    return false;
+                }
+            }
+        });
     });
 </script>
 <?php echo $this->element('form_seen_input'); ?>

--- a/app/View/Attributes/add.ctp
+++ b/app/View/Attributes/add.ctp
@@ -151,8 +151,8 @@
                 if (dateValue.isValid()) {
                     if (dateValue.creationData().format !== "YYYY-MM-DDTHH:mm:ssZ" && dateValue.creationData().format !== "YYYY-MM-DDTHH:mm:ss.SSSSZ") {
                         // Missing timezone data
-                        var confirm_message = '<?php echo __('As no timezone has been entered, it has been auto-detected as: ') ?>' + dateValue.format('Z')
-                        confirm_message += '<?php echo '\r\n' . __('This value will be submited instead: '); ?>' + dateValue.toISOString(allowLocalTZ)
+                        var confirm_message = '<?php echo __('Timezone missing, auto-detected as: ') ?>' + dateValue.format('Z')
+                        confirm_message += '<?php echo '\r\n' . __('The following value will be submited instead: '); ?>' + dateValue.toISOString(allowLocalTZ)
                         if (confirm(confirm_message)) {
                             $valueInput.val(dateValue.toISOString(allowLocalTZ));
                         } else {

--- a/app/View/Attributes/add.ctp
+++ b/app/View/Attributes/add.ctp
@@ -161,7 +161,7 @@
                     }
                 } else {
                     textStatus = '<?php echo __('Value is not a valid datetime. Excpected format YYYY-MM-DDTHH:mm:ssZ') ?>'
-                    showMessage('fail',  + ": " + '???');
+                    showMessage('fail', textStatus);
                     return false;
                 }
             }


### PR DESCRIPTION
This PR change the way datetime is saved.
Valid ISO8601 format is enforced with timezone sets to UTC and support of microseconds.
Note that any datetime format supported by the PHP ``DateTimeInterface`` will be transformed. Meaning that a RFC:2822 format will be transformed into ISO8601.
```
Mon, 15 Aug 2005 15:52:01 → 2005-08-15T13:52:01.000000+0000
(Server is timezone +02:00)
```

If timezone is missing:
- UI: Notification message informing users that the local timezone of the browser is assume and has been applied to the datetime value
- API: Timezone of the server is assume. We can't do much at this point

### Example
![ezgif-7-326f2f3cf28c](https://user-images.githubusercontent.com/6977223/73272422-a2533d80-41e2-11ea-86f5-2f02d110ffa9.gif)

