### PR TITLE
fix: [API] make param 'tag' alias of 'tags' for /events/restSearch

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -6590,6 +6590,10 @@ class Event extends AppModel
             }
         }
 
+        if (isset($filters['tag']) and !isset($filters['tags'])) {
+            $filters['tags'] = $filters['tag'];
+        }
+
         $subqueryElements = $this->harvestSubqueryElements($filters);
         $filters = $this->addFiltersFromSubqueryElements($filters, $subqueryElements);
 


### PR DESCRIPTION
#### What does it do?

Fixes `#5577`
Considering what I added, if both tags and tag parameter were set, only 'tags' will be used though. Don't think that's an issue since tag was only there for historical purposes as per discussion on gitter.

#### Questions

- [ ] Does it require a DB change? no
- [ ] Are you using it in production? I will
- [ ] Does it require a change in the API (PyMISP for example)? It shouldn't

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
