### PR TITLE
Force refresh for proxy settings

### DIFF
--- a/app/Lib/Tools/SyncTool.php
+++ b/app/Lib/Tools/SyncTool.php
@@ -40,6 +40,8 @@ class SyncTool
      */
     public function createHttpSocket($params = array())
     {
+        // Refresh config
+        Configure::load('config');
         // Use own CA PEM file
         $caPath = Configure::read('MISP.ca_path');
         if (!isset($params['ssl_cafile']) && $caPath) {


### PR DESCRIPTION
Observed that proxy settings were not getting read properly, unless issued Configure::load('config').
On a side note shouldn't every Configure::read without a load be treated as stale?

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2016-06-03: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

Fixes the issue of proxy address not getting utilized while fetching feeds even when set through UI.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
