### PR TITLE
chg: [UI] Check if ssdeep PHP extension is installed

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -5266,15 +5266,15 @@ class Server extends AppModel
     public function extensionDiagnostics()
     {
         $results = array();
-        $extensions = array('redis', 'gd');
+        $extensions = array('redis', 'gd', 'ssdeep');
         foreach ($extensions as $extension) {
             $results['web']['extensions'][$extension] = extension_loaded($extension);
         }
         if (!is_readable(APP . '/files/scripts/selftest.php')) {
             $results['cli'] = false;
         } else {
-            $results['cli'] = exec('php ' . APP . '/files/scripts/selftest.php');
-            $results['cli'] = json_decode($results['cli'], true);
+            $execResult = exec('php ' . APP . '/files/scripts/selftest.php');
+            $results['cli'] = json_decode($execResult, true);
         }
         return $results;
     }

--- a/app/files/scripts/selftest.php
+++ b/app/files/scripts/selftest.php
@@ -1,10 +1,8 @@
 <?php
-	$extensions = array('redis', 'gd');
-	$results = array();
-	$results['phpversion'] = phpversion();
-	foreach ($extensions as $extension) {
-		$results['extensions'][$extension] = extension_loaded($extension);
-	}
-	echo json_encode($results);
-
-?>
+$extensions = array('redis', 'gd', 'ssdeep');
+$results = array();
+$results['phpversion'] = phpversion();
+foreach ($extensions as $extension) {
+    $results['extensions'][$extension] = extension_loaded($extension);
+}
+echo json_encode($results);


### PR DESCRIPTION
## What does it do?

This extensions is necessary for ssdeep correlations, so this change provide info about status of this extension in Diagnostic page.

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
