### PR TITLE
fix: Saving attribute with same value remove correlation

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -653,10 +653,6 @@ class Attribute extends AppModel
 
         $this->data = $this->ISODatetimeToUTC($this->data, $this->alias);
 
-        // update correlation... (only needed here if there's an update)
-        if ($this->id || !empty($this->data['Attribute']['id'])) {
-            $this->__beforeSaveCorrelation($this->data['Attribute']);
-        }
         // always return true after a beforeSave()
         return true;
     }


### PR DESCRIPTION
## What does it do?

Before this patch, when user save attribute with correlation and keep the value of it, the correlations are missing.

The problem is, that correlations are not regenerated when value is not changed (makes sense), but all correlations are automatically deleted in `beforeSave` when editing existing attribute.

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
