### PR TITLE
fix: [pubsub] Do not fetch setting for every push

### DIFF
--- a/app/Lib/Tools/PubSubTool.php
+++ b/app/Lib/Tools/PubSubTool.php
@@ -142,9 +142,7 @@ class PubSubTool
 
     private function __pushToRedis($ns, $data)
     {
-        $settings = $this->__getSetSettings();
-        $this->__redis->select($settings['redis_database']);
-        $this->__redis->rPush($settings['redis_namespace'] . $ns, $data);
+        $this->__redis->rPush($this->__settings['redis_namespace'] . $ns, $data);
         return true;
     }
 


### PR DESCRIPTION
#### What does it do?

Before this change, for every push to Redis in PubSub tool, settings are loaded again and again and also Redis database is changed for every push, even when settings is already in `$this->__settings` variable and Redis database is selected when connecting.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
