### PR TITLE
chg: [mispzmq] Save PID and settings to scripts tmp folder

### DIFF
--- a/app/Lib/Tools/PubSubTool.php
+++ b/app/Lib/Tools/PubSubTool.php
@@ -21,7 +21,7 @@ class PubSubTool
                 $settings[$key] = $temp;
             }
         }
-        $settingsFile = new File(APP . 'files' . DS . 'scripts' . DS . 'mispzmq' . DS . 'settings.json', true, 0644);
+        $settingsFile = new File(APP . 'files' . DS . 'scripts' . DS . 'tmp' . DS . 'mispzmq_settings.json', true, 0644);
         $settingsFile->write(json_encode($settings, true));
         $settingsFile->close();
         return $settings;
@@ -51,7 +51,7 @@ class PubSubTool
     // otherwise return the pid
     public function checkIfRunning()
     {
-        $pidFile = new File(APP . 'files' . DS . 'scripts' . DS . 'mispzmq' . DS . 'mispzmq.pid');
+        $pidFile = new File(APP . 'files' . DS . 'scripts' . DS . 'tmp' . DS . 'mispzmq.pid');
         $pid = $pidFile->read(true, 'r');
         if ($pid === false || $pid === '') {
             return false;

--- a/app/files/scripts/mispzmq/mispzmq.py
+++ b/app/files/scripts/mispzmq/mispzmq.py
@@ -26,8 +26,8 @@ def check_pid(pid):
 
 class MISPZMQ:
     def __init__(self):
-        self.current_location = Path(__file__).parent
-        self.pidfile = self.current_location / "mispzmq.pid"
+        self.tmp_location = Path(__file__).parent.parent / "tmp"
+        self.pidfile = self.tmp_location / "mispzmq.pid"
         self.publishCount = 0
         if self.pidfile.exists():
             with open(self.pidfile.as_posix()) as f:
@@ -37,13 +37,13 @@ class MISPZMQ:
             else:
                 # Cleanup
                 self.pidfile.unlink()
-        if (self.current_location / 'settings.json').exists():
+        if (self.tmp_location / 'mispzmq_settings.json').exists():
             self.setup()
         else:
             raise Exception("The settings file is missing.")
 
     def setup(self):
-        with open((self.current_location / 'settings.json').as_posix()) as settings_file:
+        with open((self.tmp_location / 'mispzmq_settings.json').as_posix()) as settings_file:
             self.settings = json.load(settings_file)
         self.namespace = self.settings["redis_namespace"]
         self.r = redis.StrictRedis(host=self.settings["redis_host"], db=self.settings["redis_database"],


### PR DESCRIPTION
## What does it do?

Before this change, PID and setting file are stored at the same folder as python scripts. Then it is necessary to add write permission to the `mispzmq` folder, that can be dangerous. 

After this change, files are moved to scripts tmp folder.

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
