### PR TITLE
fix: [UI] Correct title for '+' button

### DIFF
--- a/app/View/Elements/eventattributetoolbar.ctp
+++ b/app/View/Elements/eventattributetoolbar.ctp
@@ -49,7 +49,7 @@
                 'children' => array(
                     array(
                         'id' => 'create-button',
-                        'title' => $possibleAction === 'attribute' ? __('Add attribute') : __('Add proposal'),
+                        'title' => $possibleAction === 'Attribute' ? __('Add attribute') : __('Add proposal'),
                         'fa-icon' => 'plus',
                         //'onClick' => 'clickCreateButton',
                         'onClick' => 'openGenericModal',


### PR DESCRIPTION
#### What does it do?

`$possibleAction` variable contains value with first uppercase letter.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
