### PR TITLE
fix: Force schema columns lowercase to match expected

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -4550,6 +4550,7 @@ class Server extends AppModel
                     WHERE table_schema = '%s' AND TABLE_NAME = '%s'", implode(',', $tableColumnNames), $this->getDataSource()->config['database'], $table);
                 $sqlResult = $this->query($sqlSchema);
                 foreach ($sqlResult as $column_schema) {
+                    $column_schema['columns'] = array_change_key_case($column_schema['columns'],CASE_LOWER);
                     $dbActualSchema[$table][] = $column_schema['columns'];
                 }
                 $dbActualIndexes[$table] = $this->getDatabaseIndexes($this->getDataSource()->config['database'], $table);


### PR DESCRIPTION
#### What does it do?

If it fixes an existing issue, please use github syntax: #5653 

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch

NOTE: It might be possible for `array_change_key_case` to return false if `$column_schema['columns']` is not an array. However, I don't believe it could ever NOT be an array. 