### PR TITLE
Debian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,16 @@
-misp (2.4.221-1) UNRELEASED; urgency=low
+misp (2.4.122-1) UNRELEASED; urgency=low
 
-  * Bump to release 2.4.221
+  * Bump to release 2.4.122
 
--- Sebastien Tricaud <sebastien.tricaud@devo.com>  Wed, 12 Feb 2020 14:44:35 -0800
+ -- Sebastien Tricaud <sebastien.tricaud@devo.com>  Mon, 02 Mar 2020 15:50:40 -0800
 
-misp (2.4.220-1) UNRELEASED; urgency=low
+misp (2.4.121-1) UNRELEASED; urgency=low
+
+  * Bump to release 2.4.121
+
+ -- Sebastien Tricaud <sebastien.tricaud@devo.com>  Wed, 12 Feb 2020 14:44:35 -0800
+
+misp (2.4.120-1) UNRELEASED; urgency=low
 
   * First package of MISP
 

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,10 @@ Package: misp
 Architecture: all
 Pre-Depends: ${misc:Pre-Depends}
 Depends: libapache2-mod-php | php-cgi | php,
+	 ca-certificates,
 	 python3,
+	 python3-setuptools,
+	 python3-wheel,
 	 composer,
 	 mariadb-client,
 	 openssl,
@@ -20,6 +23,7 @@ Depends: libapache2-mod-php | php-cgi | php,
 	 unzip,
 	 moreutils,
 	 php-mysql,
+	 php-pear,
 	 php-redis,
 	 php-gd,
 	 php-gnupg,
@@ -28,6 +32,7 @@ Depends: libapache2-mod-php | php-cgi | php,
 	 php-readline,
 	 php-mbstring,
 	 php7.3-opcache,
+	 libfuzzy-dev,
 	 ${misc:Depends}
 Recommends: ${misc:Recommends}, redis-server, mariadb-server
 Description: Threat Intelligence Platform

--- a/debian/install
+++ b/debian/install
@@ -1,6 +1,8 @@
+VERSION.json usr/share/misp
 app usr/share/misp
 Plugin usr/share/misp
 tools usr/share/misp
 cti-python-stix2 usr/share/misp
 PyMISP usr/share/misp
 INSTALL/MYSQL.sql usr/share/doc/misp
+INSTALL/misp-workers.service usr/share/doc/misp

--- a/debian/postinst
+++ b/debian/postinst
@@ -29,7 +29,8 @@ if [ "$1" = "configure" ] ; then
 
    cd /usr/share/misp/app
    sudo -u www-data composer dump-autoload
-
+   sudo -u www-data composer install --ignore-platform-reqs
+   
    phpenmod redis
    phpenmod gnupg   
 
@@ -55,11 +56,9 @@ if [ "$1" = "configure" ] ; then
    mysql -h$HOST -uroot -p$ROOTPWD -e "CREATE USER IF NOT EXISTS '$MISPDBUSER'@'localhost' IDENTIFIED BY '$MISPDBUSERPWD';"
    mysql -h$HOST -uroot -p$ROOTPWD -e "GRANT ALL PRIVILEGES ON misp.* TO '$MISPDBUSER'@'localhost';"
    mysql -h$HOST -uroot -p$ROOTPWD -e "FLUSH PRIVILEGES;"
-   mysql -h$HOST -uroot -p$ROOTPWD -e "CREATE DATABASE $MISPDB;"
    echo "Creating MISP Database..."
-   gunzip < /usr/share/doc/misp/MYSQL.sql.gz | mysql -h$HOST -u$MISPDBUSER -p$MISPDBUSERPWD $MISPDB   
+   mysql -h$HOST -uroot -p$ROOTPWD -e "CREATE DATABASE $MISPDB;" && gunzip < /usr/share/doc/misp/MYSQL.sql.gz | mysql -h$HOST -u$MISPDBUSER -p$MISPDBUSERPWD $MISPDB || true
 
-   #   /usr/share/misp/app/Config/database.php
    echo "Updating salt..."
    sed -i -E "s/'salt'\s=>\s'(\S+)'/'salt' => '`openssl rand -base64 32|tr "/" "-"`'/" /usr/share/misp/app/Config/config.php
 
@@ -69,11 +68,15 @@ if [ "$1" = "configure" ] ; then
    sed -i -E "s/'password'\s=>\s'db password'/'password' => '$MISPDBUSERPWD'/" /usr/share/misp/app/Config/database.php
    sed -i -E "s/'database'\s=>\s'misp'/'database' => '$MISPDB'/" /usr/share/misp/app/Config/database.php
 
-   composer require resque/php-resque || true
-   # No composer.json in current directory, do you want to use the one at /usr/share/misp/app? [Y,n]? Y
-
-   
    sudo -u www-data /usr/share/misp/app/Console/cake admin setSetting MISP.baseurl "$BASEURL"
-   
-   echo "{\"major\":2, \"minor\":4, \"hotfix\":221}" > /usr/share/misp/VERSION.json    
+
+   #
+   # Starting MISP Workers at every boot
+   #
+   chmod +x /usr/share/misp/app/Console/worker/start.sh
+   cat /usr/share/doc/misp/misp-workers.service > /etc/systemd/system/misp-workers.service
+   sed -i -E "s/\/var\/www\/MISP/\/usr\/share\/misp/" /etc/systemd/system/misp-workers.service
+   sed -i -E "s/%h/\/usr\/share\/misp/" /etc/systemd/system/misp-workers.service
+   systemctl daemon-reload
+   systemctl enable --now misp-workers   
 fi


### PR DESCRIPTION
This updates the MISP debian package to the new version.

There was also an mistake with the version number from the debian changelog, I fixed it to reflect the upstream release.

The biggest change it that it now installs workers via systemd.
