### PR TITLE
Fix venv and ssdeep for RHEL 7

### DIFF
--- a/docs/INSTALL.rhel7.md
+++ b/docs/INSTALL.rhel7.md
@@ -332,6 +332,10 @@ installCake_RHEL ()
   sudo scl enable rh-php72 'yes no|pecl install redis'
   echo "extension=redis.so" |sudo tee /etc/opt/rh/rh-php72/php.d/99-redis.ini
 
+  sudo ln -s /usr/lib64/libfuzzy.so /usr/lib/libfuzzy.so
+  sudo scl enable rh-php72 'pecl install ssdeep'
+  echo "extension=ssdeep.so" |sudo tee /etc/opt/rh/rh-php72/php.d/99-ssdeep.ini
+
   # Install gnupg extension
   sudo yum install gpgme-devel -y
   sudo scl enable rh-php72 'pecl install gnupg'

--- a/docs/INSTALL.rhel7.md
+++ b/docs/INSTALL.rhel7.md
@@ -218,7 +218,7 @@ installCoreRHEL () {
 
   # Create a python3 virtualenv
   sudo pip3 install virtualenv
-  $SUDO_WWW python3 /usr/local/bin/virtualenv -p python3 $PATH_TO_MISP/venv
+  $SUDO_WWW python3 -m venv $PATH_TO_MISP/venv
   sudo mkdir /usr/share/httpd/.cache
   sudo chown $WWW_USER:$WWW_USER /usr/share/httpd/.cache
   $SUDO_WWW $PATH_TO_MISP/venv/bin/pip install -U pip setuptools

--- a/docs/INSTALL.rhel7.md
+++ b/docs/INSTALL.rhel7.md
@@ -218,7 +218,7 @@ installCoreRHEL () {
 
   # Create a python3 virtualenv
   sudo pip3 install virtualenv
-  $SUDO_WWW python3 -- virtualenv -p python3 $PATH_TO_MISP/venv
+  $SUDO_WWW python3 /usr/local/bin/virtualenv -p python3 $PATH_TO_MISP/venv
   sudo mkdir /usr/share/httpd/.cache
   sudo chown $WWW_USER:$WWW_USER /usr/share/httpd/.cache
   $SUDO_WWW $PATH_TO_MISP/venv/bin/pip install -U pip setuptools


### PR DESCRIPTION
Two fixed for the RHEL 7 / CentOS 7 installation documentation:

1. pip3 now installs virtualenv-20.0.12 which does not have a callable virtualenv.py anymore. /usr/local/bin/virtualenv should be used instead.
1. the ssdeep php modules was never installed. The braindead install script needs libfuzzy.so in /usr/lib/