### PR TITLE
fix: [events:export-csv] Default to_ids to be 1

### DIFF
--- a/app/Controller/Component/RestSearchComponent.php
+++ b/app/Controller/Component/RestSearchComponent.php
@@ -15,7 +15,7 @@ class RestSearchComponent extends Component
         'Event' => array(
             'returnFormat', 'value', 'type', 'category', 'org', 'tags', 'searchall', 'from', 'to', 'last', 'eventid', 'withAttachments',
             'metadata', 'uuid', 'publish_timestamp', 'timestamp', 'published', 'enforceWarninglist', 'sgReferenceOnly',
-            'limit', 'page', 'requested_attributes', 'includeContext', 'headerless', 'includeWarninglistHits', 'attackGalaxy', 'deleted',
+            'limit', 'page', 'requested_attributes', 'includeContext', 'headerless', 'includeWarninglistHits', 'attackGalaxy', 'to_ids', 'deleted',
             'excludeLocalTags', 'date', 'includeSightingdb', 'tag', 'object_relation'
         ),
         'Object' => array(

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -3088,7 +3088,8 @@ class EventsController extends AppController
             'ordered_url_params' => func_get_args(),
             'injectedParams' => array(
                 'returnFormat' => 'csv',
-                'to_ids' => '1'
+                'to_ids' => '1',
+                'published' => '1'
             )
         ));
         return $this->restSearch();
@@ -3996,26 +3997,26 @@ class EventsController extends AppController
                     'checkbox_default' => true
             ),
             'openIOC' => array(
-                    'url' => '/events/downloadOpenIOCEvent/download/' . $id,
+                    'url' => '/events/restSearch/openioc/to_ids:1/published:1/eventid:' . $id . '.json',
                     'text' => 'OpenIOC (all indicators marked to IDS)',
                     'requiresPublished' => false,
                     'checkbox' => false,
             ),
             'csv' => array(
-                    'url' => '/events/csv/download/' . $id,
+                    'url' => '/events/restSearch/returnFormat:csv/to_ids:1/published:1/includeContext:0/eventid:' . $id,
                     'text' => 'CSV',
                     'requiresPublished' => false,
                     'checkbox' => true,
                     'checkbox_text' => 'Include non-IDS marked attributes',
-                    'checkbox_set' => '/events/csv/download/' . $id . '/1'
+                    'checkbox_set' => '/events/restSearch/returnFormat:csv/to_ids:1||0/published:1||0/includeContext:0/eventid:' . $id
             ),
             'csv_with_context' => array(
-                    'url' => '/events/restSearch/returnFormat:csv/eventid:' . $id,
+                    'url' => '/events/restSearch/returnFormat:csv/to_ids:1/published:1/includeContext:1/eventid:' . $id,
                     'text' => 'CSV with additional context',
                     'requiresPublished' => false,
                     'checkbox' => true,
                     'checkbox_text' => 'Include non-IDS marked attributes',
-                    'checkbox_set' => '/events/restSearch/returnFormat:csv/to_ids:1||0/published:1||0/eventid:' . $id
+                    'checkbox_set' => '/events/restSearch/returnFormat:csv/to_ids:1||0/published:1||0/includeContext:1/eventid:' . $id
             ),
             'stix_xml' => array(
                     'url' => '/events/restSearch/stix/eventid:' . $id,
@@ -4061,6 +4062,7 @@ class EventsController extends AppController
             ),
             'bro' => array(
                     'url' => '/attributes/bro/download/all/false/' . $id,
+                    // 'url' => '/attributes/restSearch/returnFormat:bro/published:1||0/eventid:' . $id,
                     'text' => 'Download Bro rules',
                     'requiresPublished' => false,
                     'checkbox' => false
@@ -4081,7 +4083,7 @@ class EventsController extends AppController
                 }
             }
             $exports['csv'] = array(
-                'url' => '/events/csv/download/' . $id . '/1',
+                'url' => '/events/restSearch/returnFormat:csv/includeContext:0/eventid:' . $id,
                 'text' => 'CSV (event not published, IDS flag ignored)',
                 'requiresPublished' => false,
                 'checkbox' => false

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -3087,7 +3087,8 @@ class EventsController extends AppController
             'named_params' => $this->params['named'],
             'ordered_url_params' => func_get_args(),
             'injectedParams' => array(
-                'returnFormat' => 'csv'
+                'returnFormat' => 'csv',
+                'to_ids' => '1'
             )
         ));
         return $this->restSearch();


### PR DESCRIPTION
Even though the recommended way is to use `restSearch`, it lets users use the web interface to download CSVs.
Should fix
- #5704
- #5765