### PR TITLE
Removing mentioned stable support for Debian 9

### DIFF
--- a/INSTALL/README.md
+++ b/INSTALL/README.md
@@ -6,7 +6,6 @@ The text files in this folder are symlink to ../docs - Which is the actual sourc
 
 Currently the following install guides are being tested on a regular basis:
 ```
-INSTALL.debian9.txt
 INSTALL.kali.txt
 INSTALL.ubuntu1804.txt
 ```


### PR DESCRIPTION
As there is no file `INSTALL.debian9.txt` and we only have a file with the name `xINSTALL.debian9.txt`. The Debian 9 support seems to be experimental.
