### PR TITLE
Various fixes on Sharinggroups, Events and correlations

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -858,6 +858,12 @@ class AttributesController extends AppController
             if (!isset($this->request->data['Attribute'])) {
                 $this->request->data = array('Attribute' => $this->request->data);
             }
+            if ($this->request->data['Attribute']['distribution'] == 4) {
+                $sg = $this->Attribute->Event->SharingGroup->fetchAllAuthorised($this->Auth->user(), 'name', 1, $this->request->data['Attribute']['sharing_group_id']);
+                if (empty($sg)) {
+                    throw new MethodNotAllowedException(__('Invalid Sharing Group or not authorised.'));
+                }
+            }
             $existingAttribute = $this->Attribute->findByUuid($this->Attribute->data['Attribute']['uuid']);
             // check if the attribute has a timestamp already set (from a previous instance that is trying to edit via synchronisation)
             // check which attribute is newer

--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -148,6 +148,12 @@ class AttributesController extends AppController
             if (!isset($this->request->data['Attribute'])) {
                 $this->request->data = array('Attribute' => $this->request->data);
             }
+            if ($this->request->data['Attribute']['distribution'] == 4) {
+                $sg = $this->Event->SharingGroup->fetchAllAuthorised($this->Auth->user(), 'name', 1, $this->request->data['Attribute']['sharing_group_id']);
+                if (empty($sg)) {
+                    throw new MethodNotAllowedException(__('Invalid Sharing Group or not authorised.'));
+                }
+            }
             //
             // multiple attributes in batch import
             //

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -698,7 +698,7 @@ class Attribute extends AppModel
              * Only recorrelate if:
              * - We are dealing with a new attribute OR
              * - The existing attribute's previous state is known AND
-             *   value, type or disable correlation have changed
+             *   value, type, disable correlation or distribution have changed
              * This will avoid recorrelations when it's not really needed, such as adding a tag
              */
             if (!$created) {
@@ -706,7 +706,9 @@ class Attribute extends AppModel
                     empty($this->old) ||
                     $this->data['Attribute']['value'] != $this->old['Attribute']['value'] ||
                     $this->data['Attribute']['disable_correlation'] != $this->old['Attribute']['disable_correlation'] ||
-                    $this->data['Attribute']['type'] != $this->old['Attribute']['type']
+                    $this->data['Attribute']['type'] != $this->old['Attribute']['type'] ||
+                    $this->data['Attribute']['distribution'] != $this->old['Attribute']['distribution'] ||
+                    $this->data['Attribute']['sharing_group_id'] != $this->old['Attribute']['sharing_group_id']
                 ) {
                     $this->__beforeSaveCorrelation($this->data['Attribute']);
                     $this->__afterSaveCorrelation($this->data['Attribute'], false, $passedEvent);

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -2464,7 +2464,11 @@ class Event extends AppModel
         }
         foreach ($data as $k => $v) {
             if ($v['distribution'] == 4) {
-                $data[$k]['SharingGroup'] = $sharingGroupData[$v['sharing_group_id']]['SharingGroup'];
+                if (isset($sharingGroupData[$v['sharing_group_id']])) {
+                    $data[$k]['SharingGroup'] = $sharingGroupData[$v['sharing_group_id']]['SharingGroup'];
+                } else {
+                    unset($data[$k]); // current user could not fetch the sharing_group
+                }
             }
         }
         return $data;

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -641,6 +641,12 @@ class Event extends AppModel
             if (isset($this->data['Event']['info'])) {
                 $this->Correlation->updateAll(array('Correlation.info' => $db->value($this->data['Event']['info'])), array('Correlation.event_id' => intval($this->data['Event']['id'])));
             }
+            if (isset($this->data['Event']['distribution'])) {
+                $this->Correlation->updateAll(array('Correlation.distribution' => $db->value($this->data['Event']['distribution'])), array('Correlation.event_id' => intval($this->data['Event']['id'])));
+            }
+            if (isset($this->data['Event']['sharing_group_id'])) {
+                $this->Correlation->updateAll(array('Correlation.sharing_group_id' => $db->value($this->data['Event']['sharing_group_id'])), array('Correlation.event_id' => intval($this->data['Event']['id'])));
+            }
         }
         if (empty($this->data['Event']['unpublishAction']) && empty($this->data['Event']['skip_zmq']) && Configure::read('Plugin.ZeroMQ_enable') && Configure::read('Plugin.ZeroMQ_event_notifications_enable')) {
             $pubSubTool = $this->getPubSubTool();

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -2150,6 +2150,22 @@ class Event extends AppModel
             'Object' => array('name', 'meta-category')
         );
         foreach ($results as $eventKey => &$event) {
+            if ($event['Event']['distribution'] == 4 && !in_array($event['Event']['sharing_group_id'], $sgids)) {
+                $this->Log = ClassRegistry::init('Log');
+                $this->Log->create();
+                $this->Log->save(array(
+                    'org' => $user['Organisation']['name'],
+                    'model' => 'Event',
+                    'model_id' => $event['Event']['id'],
+                    'email' => $user['email'],
+                    'action' => 'fetchEvent',
+                    'user_id' => $user['id'],
+                    'title' => 'User was able to fetch the event but not the sharing_group it belongs to',
+                    'change' => ''
+                ));
+                unset($results[$eventKey]); // Current user cannot access sharing_group associated to this event
+                continue;
+            }
             $this->__attachReferences($user, $event, $sgids, $fields);
             $event = $this->Orgc->attachOrgsToEvent($event, $fieldsOrg);
             if (!$options['sgReferenceOnly'] && $event['Event']['sharing_group_id']) {

--- a/app/View/Events/view.ctp
+++ b/app/View/Events/view.ctp
@@ -301,27 +301,27 @@
                     )
                 )
             );
-            if (!Configure::read('MISP.completely_disable_correlation') && Configure::read('MISP.allow_disabling_correlation')) {
-                $table_data[] = array(
-                    'key' => __('Correlation'),
-                    'class' => $event['Event']['disable_correlation'] ? 'background-red bold' : '',
-                    'html' => sprintf(
-                        '%s%s',
-                        $event['Event']['disable_correlation'] ? __('Disabled') : __('Enabled'),
-                        (!$mayModify && !$isSiteAdmin) ? '' : sprintf(
+        }
+        if (!Configure::read('MISP.completely_disable_correlation') && Configure::read('MISP.allow_disabling_correlation')) {
+            $table_data[] = array(
+                'key' => __('Correlation'),
+                'class' => $event['Event']['disable_correlation'] ? 'background-red bold' : '',
+                'html' => sprintf(
+                    '%s%s',
+                    $event['Event']['disable_correlation'] ? __('Disabled') : __('Enabled'),
+                    (!$mayModify && !$isSiteAdmin) ? '' : sprintf(
+                        sprintf(
+                            ' (<a onClick="getPopup(%s);" style="%scursor:pointer;font-weight:normal;">%s</a>)',
                             sprintf(
-                                ' (<a onClick="getPopup(%s);" style="%scursor:pointer;font-weight:normal;">%s</a>)',
-                                sprintf(
-                                    "'%s', 'events', 'toggleCorrelation', '', '#confirmation_box'",
-                                    h($event['Event']['id'])
-                                ),
-                                $event['Event']['disable_correlation'] ? 'color:white;' : '',
-                                $event['Event']['disable_correlation'] ? __('enable') : __('disable')
-                            )
+                                "'%s', 'events', 'toggleCorrelation', '', '#confirmation_box'",
+                                h($event['Event']['id'])
+                            ),
+                            $event['Event']['disable_correlation'] ? 'color:white;' : '',
+                            $event['Event']['disable_correlation'] ? __('enable') : __('disable')
                         )
                     )
-                );
-            }
+                )
+            );
         }
 
     ?>


### PR DESCRIPTION
This PR fixes multiples related bugs on Sharing groups, Events and Correlations.

1. Prevent user not being part of a Sharing group to be able to view the Event, even if they are the owner. This can happen on pulled Events from improperly configured sync setup where the remote user can see the Events (if he/she is site_admin) but is not part of the sharing group.
   - Log entry is created, just in case
2. Similar to 1, Attributes and Objects are virtually removed from the Event if they are distributed with a sharing group where the user does not belong to it
3. Viewing correlation of related event is unaffected, meaning that it's still possible to view correlations (at Event level only) for Attributes that are not displayed. This is intrinsic to the design of the correlations and is meant to be changed upon correlation system revamp
4. Prevent user to save Sharing group if they are not part of it. Closely linked to 1, it is still possible to create the Sharing group if we are in a `local`/`internal` sync setup
5. Trigger re-correlation whenever an Event or Attribute get edited
6. Prevent save of Attribute if an invalid `sharing_group_id` is provided

:warning: Draft Pull Request! More testing need to be done