### PR TITLE
Event timeline sightings

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -4514,16 +4514,20 @@ class EventsController extends AppController
         if (!in_array($type, $validTools)) {
             throw new MethodNotAllowedException('Invalid type.');
         }
-
         App::uses('EventTimelineTool', 'Tools');
         $grapher = new EventTimelineTool();
         $data = $this->request->is('post') ? $this->request->data : array();
         $dataFiltering = array_key_exists('filtering', $data) ? $data['filtering'] : array();
+        $scope = isset($data['scope']) ? $data['scope'] : 'seen';
 
         $extended = isset($this->params['named']['extended']) ? 1 : 0;
 
         $grapher->construct($this->Event, $this->Auth->user(), $dataFiltering, $extended);
-        $json = $grapher->get_timeline($id);
+        if ($scope == 'seen') {
+            $json = $grapher->get_timeline($id);
+        } elseif ($scope == 'sightings') {
+            $json = $grapher->get_sighting_timeline($id);
+        }
 
         array_walk_recursive($json, function (&$item, $key) {
             if (!mb_detect_encoding($item, 'utf-8', true)) {

--- a/app/webroot/css/event-timeline.css
+++ b/app/webroot/css/event-timeline.css
@@ -59,6 +59,15 @@
 	box-shadow: 0 0 20px rgba(82, 168, 236, 1);`
 }
 
+.vis-item.sighting_positive {
+	background-color: green;
+	border-color: white;
+}
+.vis-item.sighting_negative {
+	background-color: red;
+	border-color: white;
+}
+
 .vis-item.object {
 	background-color: #3465a4;
 	border-color: black;

--- a/app/webroot/js/event-timeline.js
+++ b/app/webroot/js/event-timeline.js
@@ -472,7 +472,9 @@ function reload_timeline() {
                     return {id: id, content: itemIds[id]}
                 })
                 eventTimeline.setGroups(groups);
+                eventTimeline.setOptions({selectable: false});
             } else {
+                eventTimeline.setOptions({selectable: true});
                 eventTimeline.setGroups([]);
             }
         },

--- a/app/webroot/js/event-timeline.js
+++ b/app/webroot/js/event-timeline.js
@@ -29,10 +29,16 @@ var options = {
                 return build_object_template(item);
 
             case "object_attribute":
-                console.log('Error');
+                console.log('Error: Group not valid');
                 break;
 
             default:
+                if (item.className == "sighting_positive" || item.className == "sighting_negative") {
+                    return build_sighting_template(item);
+                } else {
+                    console.log(item)
+                    console.log('Error: Unkown group');
+                }
                 break;
         }
     },
@@ -196,6 +202,13 @@ function build_object_template(obj) {
         )
     }
     var html = table[0].outerHTML;
+    return html;
+}
+
+function build_sighting_template(attr){
+    var span = $('<span data-itemID="'+attr.id+'">');
+    span.text(attr.content);
+    var html = span[0].outerHTML;
     return html;
 }
 
@@ -372,6 +385,8 @@ function map_scope(val) {
             return 'seen';
         case 'Object relationship':
             return 'relationship';
+        case 'Sightings':
+            return 'sightings';
         default:
             return 'seen';
     }
@@ -400,7 +415,8 @@ function update_badge() {
 
 function reload_timeline() {
     update_badge();
-    var payload = {scope: map_scope($('#select_timeline_scope').val())};
+    var selectedScope = map_scope($('#select_timeline_scope').val());
+    var payload = {scope: selectedScope};
     $.ajax({
         url: "/events/"+"getEventTimeline"+"/"+scope_id+"/"+extended_text+"event.json",
         dataType: 'json',
@@ -413,6 +429,8 @@ function reload_timeline() {
         },
         success: function( data, textStatus, jQxhr ){
             items_timeline.clear();
+            mapping_text_to_id = new Map();
+            var itemIds = {};
             for (var item of data.items) {
                 item.className = item.group;
                 item.orig_id = item.id;
@@ -420,16 +438,43 @@ function reload_timeline() {
                 set_spanned_time(item);
                 if (item.group == 'object') {
                     for (var attr of item.Attribute) {
-                        mapping_text_to_id.set(attr.contentType+': '+attr.content+' ('+item.orig_id+')', item.id);
+                        if (selectedScope == 'sightings') {
+                            var k = attr.contentType+': '+attr.content+' ('+item.orig_id.split('-')[0]+')'
+                            if (!mapping_text_to_id.get(k)) {
+                                mapping_text_to_id.set(k, item.id);
+                            }
+                        } else {
+                            mapping_text_to_id.set(attr.contentType+': '+attr.content+' ('+item.orig_id+')', item.id);
+                        }
                         adjust_text_length(attr);
                     }
                 } else {
-                    mapping_text_to_id.set(item.content+' ('+item.orig_id+')', item.id);
+                    if (selectedScope == 'sightings') {
+                        var k = item.content+' ('+item.orig_id.split('-')[0]+')'
+                        if (!mapping_text_to_id.get(k)) {
+                            mapping_text_to_id.set(k, item.id);
+                        }
+                    } else {
+                        mapping_text_to_id.set(item.content+' ('+item.orig_id+')', item.id);
+                    }
                     adjust_text_length(item);
+                }
+                itemIds[item.attribute_id] = item.content;
+                if (selectedScope == 'sightings') {
+                    item.group = item.attribute_id;
+                    item.content = '';
                 }
             }
             items_timeline.add(data.items);
             handle_not_seen_enabled($('#checkbox_timeline_display_hide_not_seen_enabled').prop('checked'), false)
+            if (selectedScope == 'sightings') {
+                var groups = Object.keys(itemIds).map(function(id) {
+                    return {id: id, content: itemIds[id]}
+                })
+                eventTimeline.setGroups(groups);
+            } else {
+                eventTimeline.setGroups([]);
+            }
         },
         error: function( jqXhr, textStatus, errorThrown ){
             console.log( errorThrown );
@@ -610,11 +655,11 @@ function init_popover() {
         label: "Scope",
         tooltip: "The time scope represented by the timeline",
         event: function(value) {
-            if (value == "First seen/Last seen") {
+            if (value == "First seen/Last seen" || value == "Sightings") {
                 reload_timeline();
             }
         },
-        options: ["First seen/Last seen"],
+        options: ["First seen/Last seen", "Sightings"],
         default: "First seen/Last seen"
     });
 


### PR DESCRIPTION
The event timeline now supports sightings visualisation.
If sightings are not pooled regularly at a same rate, we need to extrapolate the range. The strategy used is prioritisation of false positive. Suggestion are of course welcome!

![image](https://user-images.githubusercontent.com/6977223/80079200-40d80c00-8550-11ea-8524-525bb14e343f.png)


Extrapolation strategy:
- If only positive sightings: Will be from first to last sighting (including time.now())
- If both positive and false positive: False positive gets priority. The visual range will be marked as false positive between the two positive sightings.