### PR TITLE
Modify the default parsing settings of Phishtank feed

### DIFF
--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -232,7 +232,7 @@
       "event_id": "5655",
       "publish": false,
       "override_ids": false,
-      "settings": "{\"csv\":{\"value\":\"\",\"delimiter\":\"\"},\"common\":{\"excluderegex\":\"\\/^http:\\\\\\/\\\\\\/www.phishtank.com\\/i\"}}",
+      "settings": "{\"csv\":{\"value\":\"2\",\"delimiter\":\",\"},\"common\":{\"excluderegex\":\"\\/^http:\\\\\\/\\\\\\/www.phishtank.com\\/i\"}}",
       "input_source": "network",
       "delete_local_file": false,
       "lookup_visible": false,


### PR DESCRIPTION
#### What does it do?
Modify the default parsing settings of the Phishtank feed to avoid data parsing target columns, which may contain Alexa top 1K domains.

Example of Phishtank feed format:
```
phish_id,url,phish_detail_url,submission_time,verified,verification_time,online,target
6525211,https://amazon.co.jp.account-update.checkjpid1.mixh.jp/go/amazon/,http://www.phishtank.com/phish_detail.php?phish_id=6525211,2020-04-24T00:56:58+00:00,yes,2020-04-24T11:30:30+00:00,yes,Amazon.com
6525539,http://cashwix.com,http://www.phishtank.com/phish_detail.php?phish_id=6525539,2020-04-24T03:28:29+00:00,yes,2020-04-24T03:30:59+00:00,yes,Alibaba.com
6525689,http://atlantabasecamp.com/closingdocs/onedrive/VdPCnDwL/,http://www.phishtank.com/phish_detail.php?phish_id=6525689,2020-04-24T06:31:23+00:00,yes,2020-04-24T12:24:47+00:00,yes,Microsoft
```
The current default configuration resolves domains like amazon.com in the Feed data and appears in the attributes.
https://github.com/MISP/MISP/blob/6bc82e89902fa6c4ddc63fbf27574265bf64ec2a/app/files/feed-metadata/defaults.json#L235
This will lead to an alarm, as shown:
![Phishtank_settings](https://user-images.githubusercontent.com/30207614/80224418-416dc100-867c-11ea-8344-c7d6c85d2fdb.png)
In fact, the 2nd column URL data is what we need, so it was changed to separate it with "," to get the 2nd column data

#### Questions

- [X] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [X] Minor
- [ ] Patch
