### PR TITLE
fix: [internal] syslog shouldn't end with new line

### DIFF
--- a/app/Plugin/SysLog/Lib/SysLog.php
+++ b/app/Plugin/SysLog/Lib/SysLog.php
@@ -68,10 +68,10 @@ class SysLog {
 		} else if (in_array($type, $debugTypes)) {
 			$priority = LOG_DEBUG;
 		}
-		$output = date('Y-m-d H:i:s') . ' ' . ucfirst($type) . ': ' . $message . "\n";
 		if (!openlog($this->_ident, LOG_PID | LOG_PERROR, $this->_facility)) {
 			return false;
 		}
+		$output = date('Y-m-d H:i:s') . ' ' . ucfirst($type) . ': ' . $message;
 		$result = syslog($priority, $output);
 		closelog();
 		return $result;


### PR DESCRIPTION
Because then two lines are logged

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
