### PR TITLE
chg: [internal] Removed unused function

### DIFF
--- a/app/Model/Log.php
+++ b/app/Model/Log.php
@@ -96,18 +96,6 @@ class Log extends AppModel
         'email' => array('values' => array('admin_email'))
     );
 
-    public function beforeValidete()
-    {
-        parent::beforeValidate();
-        if (!isset($this->data['Log']['org']) || empty($this->data['Log']['org'])) {
-            $this->data['Log']['org'] = 'SYSTEM';
-        }
-        // truncate the description if it would exceed the allowed size in mysql
-        if (!empty($this->data['Log']['description'] && strlen($this->data['Log']['description']) > 65536)) {
-            $this->data['Log']['description'] = substr($this->data['Log']['description'], 0, 65535);
-        }
-    }
-
     public function beforeSave($options = array())
     {
         if (!empty(Configure::read('MISP.log_skip_db_logs_completely'))) {


### PR DESCRIPTION
## What does it do?

This function has typo in name `beforeValid*e*te`, so its never called. And because everything works, I think it is safe to remove it.

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
