### PR TITLE
Pull event info from first stix2 report.

### DIFF
--- a/app/files/scripts/stix2/stix2misp.py
+++ b/app/files/scripts/stix2/stix2misp.py
@@ -24,7 +24,7 @@ import io
 import re
 import stix2
 from stix2misp_mapping import *
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 
 _MISP_dir = "/".join([p for p in os.path.dirname(os.path.realpath(__file__)).split('/')[:-4]])
 _PyMISP_dir = '{_MISP_dir}/PyMISP'.format(_MISP_dir=_MISP_dir)
@@ -107,7 +107,7 @@ class StixParser():
         try:
             self.report[parsed_object['id'].split('--')[1]] = parsed_object
         except AttributeError:
-            self.report = {parsed_object['id'].split('--')[1]: parsed_object}
+            self.report = OrderedDict({parsed_object['id'].split('--')[1]: parsed_object})
 
     def _load_usual_object(self, parsed_object):
         self.event[parsed_object._type][parsed_object['id'].split('--')[1]] = parsed_object
@@ -128,14 +128,25 @@ class StixParser():
                     except PyMISPInvalidFormat:
                         continue
 
+    def _event_info_from_report(self, report_attributes):
+        if report_attributes['name'] is None:
+            self.misp_event.info = "Imported with MISP import script for {} from {}.".format(self.stix_version, os.path.basename(self.filename))
+        else:
+            self.misp_event.info = report_attributes['name']
+
     def build_from_STIX_with_report(self):
         report_attributes = defaultdict(set)
+        report_attributes['name'] = None
+
         for ruuid, report in self.report.items():
             try:
                 report_attributes['orgs'].add(report.created_by_ref.split('--')[1])
             except AttributeError:
                 pass
-            report_attributes['name'].add(report.name)
+
+            if report_attributes['name'] is None:
+                report_attributes['name'] = report.name
+
             if report.get('published'):
                 report_attributes['published'].add(report.published)
             if 'labels' in report:
@@ -155,10 +166,9 @@ class StixParser():
             self.misp_event['Org'] = {'name': identity['name']}
         if len(report_attributes['published']) == 1:
             self.misp_event.publish_timestamp = self.getTimestampfromDate(report_attributes['published'].pop())
-        if len(report_attributes['name']) == 1:
-            self.misp_event.info = report_attributes['name'].pop()
-        else:
-            self.misp_event.info = "Imported with MISP import script for {}.".format(self.stix_version)
+
+        self._event_info_from_report(report_attributes)
+
         for l in report_attributes['labels']:
             self.misp_event.add_tag(l)
 


### PR DESCRIPTION
In the original Stix 2 to MISP converter, it would only set the event info if there was only one report object in the bundle. Otherwise, a generic title is used. This change updates the code to use the name of the first report encountered in the bundle. The report attribute has be changed from a dict to an OrderedDict to preserve order. If no report is encountered, the generic title is still used but it has been updated to include the file name.

Originally https://github.com/MISP/MISP/pull/5835.