### PR TITLE
Do not log authkeys

### DIFF
--- a/app/Console/Command/AuthkeyShell.php
+++ b/app/Console/Command/AuthkeyShell.php
@@ -25,16 +25,8 @@ class AuthkeyShell extends AppShell {
             $this->User->id = $user['User']['id'];
             $newkey = $this->User->generateAuthKey();
             if ($this->User->saveField('authkey', $newkey)) {
-                $this->Log->create();
-                $this->Log->save(array(
-                    'org' => $user['Organisation']['name'],
-                    'model' => 'User',
-                    'model_id' => $user['User']['id'],
-                    'email' => 'SYSTEM',
-                    'action' => 'reset_auth_key',
-                    'title' => 'Authentication key for user ' . $user['User']['id'] . ' (' . $user['User']['email'] . ')',
-                    'change' => 'authkey(' . $user['User']['authkey'] . ') => (' . $newkey . ')'
-                ));
+                $logTitle = 'Authentication key for user ' . $user['User']['id'] . ' (' . $user['User']['email'] . ')';
+                $this->Log->createLogEntry('SYSTEM', 'reset_auth_key', 'User', $user['User']['id'], $logTitle, array('authkey' => array($user['User']['authkey'], $newkey)));
                 echo $newkey . PHP_EOL;
             } else {
                 echo 'Could not update account for User.id = ', $user['User']['id'], PHP_EOL;

--- a/app/Model/Log.php
+++ b/app/Model/Log.php
@@ -207,7 +207,8 @@ class Log extends AppModel
         if (is_array($change)) {
             $output = array();
             foreach ($change as $field => $values) {
-                if (strpos($field, 'password') !== false) { // if field name contains password, replace value with asterisk
+                $isSecret = strpos($field, 'password') !== false || ($field === 'authkey' && Configure::read('Security.do_not_log_authkeys'));
+                if ($isSecret) {
                     $oldValue = $newValue = "*****";
                 } else {
                     list($oldValue, $newValue) = $values;

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1261,6 +1261,15 @@ class Server extends AppModel
                             'type' => 'boolean',
                             'null' => true
                         ),
+                        'do_not_log_authkeys' => array(
+                            'level' => 0,
+                            'description' => __('If enabled, any authkey will be replaced by asterisks in Audit log.'),
+                            'value' => false,
+                            'errorMessage' => '',
+                            'test' => 'testBool',
+                            'type' => 'boolean',
+                            'null' => true
+                        ),
                         'allow_self_registration' => array(
                             'level' => 1,
                             'description' => __('Enabling this setting will allow users to have access to the pre-auth registration form. This will create an inbox entry for administrators to review.'),

--- a/app/Plugin/Assets/models/behaviors/LogableBehavior.php
+++ b/app/Plugin/Assets/models/behaviors/LogableBehavior.php
@@ -433,6 +433,10 @@ class LogableBehavior extends ModelBehavior {
 					$old = '';
 				}
 				if ($key != 'modified' && !in_array($key, $this->settings[$Model->alias]['ignore']) && $value != $old && in_array($key, $db_fields)) {
+				    if ($key === 'authkey' && Configure::read('Security.do_not_log_authkeys')) {
+				        $old = $value = '*****';
+                    }
+
 					if ($this->settings[$Model->alias]['change'] == 'full') {
 						$changed_fields[] = $key . ' (' . $old . ') => (' . $value . ')';
 					} else if ($this->settings[$Model->alias]['change'] == 'serialize') {

--- a/app/Plugin/SysLogLogable/Model/Behavior/SysLogLogableBehavior.php
+++ b/app/Plugin/SysLogLogable/Model/Behavior/SysLogLogableBehavior.php
@@ -66,14 +66,18 @@ class SysLogLogableBehavior extends LogableBehavior {
 				if (isset($Model->data[$Model->alias][$Model->primaryKey]) && !empty($this->old) && isset($this->old[$Model->alias][$key])) {
 					$old = $this->old[$Model->alias][$key];
 					if (is_array($old)) {
-						$old = json_encode($old, true);
+						$old = json_encode($old);
 					}
 				} else {
 					$old = '';
 				}
 				// TODO Audit, removed 'revision' as well
 				if ($key != 'lastpushedid' && $key!= 'timestamp' && $key != 'revision' && $key != 'modified' && !in_array($key, $this->settings[$Model->alias]['ignore']) && $value != $old && in_array($key, $db_fields)) {
-					if ($this->settings[$Model->alias]['change'] == 'full') {
+                    if ($key === 'authkey' && Configure::read('Security.do_not_log_authkeys')) {
+                        $old = $value = '*****';
+                    }
+
+				    if ($this->settings[$Model->alias]['change'] == 'full') {
 						if (($key != 'published') || (($key == 'published') && ($value == '1'))) { // remove (un-)published from edit
 							$changed_fields[] = $key . ' (' . $old . ') => (' . $value . ')';
 						}

--- a/app/View/Events/show_i_o_c_results.ctp
+++ b/app/View/Events/show_i_o_c_results.ctp
@@ -7,7 +7,7 @@ if (0 != count($attributes)): ?>
     <h4><?php echo __('Successfully added attributes');?>:</h4>
     <table class="table table-striped table-hover table-condensed">
     <tr>
-            <th><?php echo __('Uuid');?></th>
+            <th><?php echo __('UUID');?></th>
             <th><?php echo __('Category');?></th>
             <th><?php echo __('Type');?></th>
             <th><?php echo __('Value');?></th>
@@ -29,7 +29,7 @@ if (isset($fails)):?>
     <h4><?php echo __('Failed indicators');?>:</h4>
     <table class="table table-striped table-hover table-condensed">
     <tr>
-            <th><?php echo __('Uuid');?></th>
+            <th><?php echo __('UUID');?></th>
             <th><?php echo __('Search term');?></th>
             <th><?php echo __('Content');?></th>
     </tr><?php

--- a/app/View/Feeds/preview_event.ctp
+++ b/app/View/Feeds/preview_event.ctp
@@ -8,7 +8,7 @@
         <div class="span8">
             <h2><?php echo nl2br(h($title)); ?></h2>
             <dl>
-                <dt><?php echo __('Uuid');?></dt>
+                <dt><?php echo __('UUID');?></dt>
                 <dd><?php echo h($event['Event']['uuid']); ?></dd>
                 <dt><?php echo Configure::read('MISP.showorgalternate') ? __('Source Organisation') : __('Org')?></dt>
                 <dd><?php echo h($event['Orgc']['name']); ?></dd>

--- a/app/View/Organisations/index.ctp
+++ b/app/View/Organisations/index.ctp
@@ -86,7 +86,7 @@
             <th><?php echo __('Logo');?></th>
             <th><?php echo $this->Paginator->sort('name');?></th>
             <?php if ($isSiteAdmin): ?>
-                <th><?php echo $this->Paginator->sort('uuid');?></th>
+                <th><?php echo $this->Paginator->sort('uuid', 'UUID');?></th>
             <?php endif; ?>
             <th><?php echo $this->Paginator->sort('description');?></th>
             <th><?php echo $this->Paginator->sort('nationality');?></th>

--- a/app/View/Pages/doc/using_the_system.ctp
+++ b/app/View/Pages/doc/using_the_system.ctp
@@ -201,7 +201,7 @@ Templates are devided into sections, with each section having a title and a desc
 <b><?php echo __('General Event Information');?></b>
 <ul>
     <li><b><?php echo __('ID');?>:</b> <?php echo __('The ID of the event.');?></li>
-    <li><b><?php echo __('Uuid');?>:</b> <?php echo __('In order to avoid collisions between events and attributes (during for example a sync) a Uuid is assigned that uniquely identifies each of them.');?></li>
+    <li><b><?php echo __('UUID');?>:</b> <?php echo __('In order to avoid collisions between events and attributes (during for example a sync) a Uuid is assigned that uniquely identifies each of them.');?></li>
     <li><b><?php echo __('Org');?></b> <?php echo __('The organisation that has originally created the event. The logo (if it exists on the server, alternatively a string) representing the organisation is also shown int he right upper corner.');?></li>
     <li><b><?php echo __('Contributors');?>:</b> <?php echo __('Shows a list of the organisations that have contributed to the event via proposals. If you click any of the logos listed here, you\'ll get redirected to a filtered event history view, including only the changes made by the organisation.');?></li>
     <li><b><?php echo __('Tags');?>:</b> <?php echo __('A list of tags associated with the event. Clicking a tag will show a list of events with the same tag attached. The little cross next to each tag allows you to remove the tag from the event, whilst the \'+\' button allows you to assign a tag. For the latter two options to be visible, you have to have tagging permission.');?></li>

--- a/app/View/Servers/add.ctp
+++ b/app/View/Servers/add.ctp
@@ -64,7 +64,7 @@
             <input type="text" id="ServerExternalName" <?php if (isset($this->request->data['Server']['external_name'])) echo 'value="' . $this->request->data['Server']['external_name'] . '"';?>>
         </div>
         <div id="ServerExternalUuidContainer" class="input select hiddenField" style="display:none;">
-            <label for="ServerExternalUuid"><?php echo __('Remote Organisation\'s Uuid');?></label>
+            <label for="ServerExternalUuid"><?php echo __('Remote Organisation\'s UUID');?></label>
             <input type="text" id="ServerExternalUuid" <?php if (isset($this->request->data['Server']['external_uuid'])) echo 'value="' . $this->request->data['Server']['external_uuid'] . '"';?>>
         </div>
         <div class = "input clear"></div>

--- a/app/View/Servers/edit.ctp
+++ b/app/View/Servers/edit.ctp
@@ -71,7 +71,7 @@
             <input type="text" id="ServerExternalName" <?php if (isset($this->request->data['Server']['external_name'])) echo 'value="' . $this->request->data['Server']['external_name'] . '"';?>>
         </div>
         <div id="ServerExternalUuidContainer" class="input select hiddenField" style="display:none;">
-            <label for="ServerExternalUuid"><?php echo __('Remote Organisation\'s Uuid');?></label>
+            <label for="ServerExternalUuid"><?php echo __('Remote Organisation\'s UUID');?></label>
             <input type="text" id="ServerExternalUuid" <?php if (isset($this->request->data['Server']['external_uuid'])) echo 'value="' . $this->request->data['Server']['external_uuid'] . '"';?>>
         </div>
     <?php

--- a/app/View/Servers/preview_event.ctp
+++ b/app/View/Servers/preview_event.ctp
@@ -14,7 +14,7 @@
                     <?php echo h($event['Event']['id']); ?>
                     &nbsp;
                 </dd>
-                <dt><?php echo __('Uuid');?></dt>
+                <dt><?php echo __('UUID');?></dt>
                 <dd>
                     <?php echo h($event['Event']['uuid']); ?>
                     &nbsp;


### PR DESCRIPTION
## What does it do?

Add new option `Security.do_not_log_authkeys` for disabling autkeys logging in Audit logs.

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

## Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
