### PR TITLE
fix: [stix export] Bump minimum CybOX version to 2.1.0.21

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -4976,7 +4976,7 @@ class Server extends AppModel
     public function stixDiagnostics(&$diagnostic_errors, &$stixVersion, &$cyboxVersion, &$mixboxVersion, &$maecVersion, &$stix2Version, &$pymispVersion)
     {
         $result = array();
-        $expected = array('stix' => '>1.2.0.6', 'cybox' => '>2.1.0.18.dev0', 'mixbox' => '1.0.3', 'maec' => '>4.1.0.14', 'stix2' => '>1.2.0', 'pymisp' => '>2.4.120');
+        $expected = array('stix' => '>1.2.0.6', 'cybox' => '>2.1.0.21', 'mixbox' => '1.0.3', 'maec' => '>4.1.0.14', 'stix2' => '>1.2.0', 'pymisp' => '>2.4.120');
         // check if the STIX and Cybox libraries are working using the test script stixtest.py
         $scriptResult = shell_exec($this->getPythonVersion() . ' ' . APP . 'files' . DS . 'scripts' . DS . 'stixtest.py');
         $scriptResult = json_decode($scriptResult, true);


### PR DESCRIPTION
Because of 65048be032378a6a43bda2b8883f27aef1707545 the old minimal CybOX version 2.1.0.18 will throw an error. All is fine when 2.1.0.21 is used though.