### PR TITLE
Adding the apache modules enablement in preinst

### DIFF
--- a/debian/preinst
+++ b/debian/preinst
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+#DEBHELPER#
+
+. /usr/share/debconf/confmodule
+
+a2enmod rewrite || true
+a2enmod headers || true


### PR DESCRIPTION
This adds the preinst script which enables the two modules required by MISP: headera and rewrite.

