### PR TITLE
IPv6 CIDR correlations

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -760,7 +760,7 @@ class Attribute extends AppModel
                 }
             }
         }
-        if (Configure::read('MISP.enable_advanced_correlations') && in_array($this->data['Attribute']['type'], array('ip-src', 'ip-dst', 'domain-ip')) && strpos($this->data['Attribute']['value'], '/')) {
+        if (Configure::read('MISP.enable_advanced_correlations') && in_array($this->data['Attribute']['type'], array('ip-src', 'ip-dst')) && strpos($this->data['Attribute']['value'], '/')) {
             $this->setCIDRList();
         }
         if ($created && isset($this->data['Attribute']['event_id']) && empty($this->data['Attribute']['skip_auto_increment'])) {
@@ -813,7 +813,7 @@ class Attribute extends AppModel
 
     public function afterDelete()
     {
-        if (Configure::read('MISP.enable_advanced_correlations') && in_array($this->data['Attribute']['type'], array('ip-src', 'ip-dst', 'domain-ip')) && strpos($this->data['Attribute']['value'], '/')) {
+        if (Configure::read('MISP.enable_advanced_correlations') && in_array($this->data['Attribute']['type'], array('ip-src', 'ip-dst')) && strpos($this->data['Attribute']['value'], '/')) {
             $this->setCIDRList();
         }
         if (isset($this->data['Attribute']['event_id'])) {
@@ -1958,23 +1958,17 @@ class Attribute extends AppModel
     private function __cidrCorrelation($a)
     {
         $ipValues = array();
-        $ip = $a['type'] == 'domain-ip' ? $a['value2'] : $a['value1'];
+        $ip = $a['value1'];
         if (strpos($ip, '/') !== false) {
             $ip_array = explode('/', $ip);
             $ip_version = filter_var($ip_array[0], FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ? 4 : 6;
             $ipList = $this->find('list', array(
                 'conditions' => array(
-                    'type' => array('ip-src', 'ip-dst', 'domain_ip'),
+                    'type' => array('ip-src', 'ip-dst'),
                 ),
-                'fields' => array('value1', 'value2'),
+                'fields' => array('value1'),
                 'order' => false
             ));
-            $ipList = array_merge(array_keys($ipList), array_values($ipList));
-            foreach ($ipList as $key => $value) {
-                if ($value == '') {
-                    unset($ipList[$key]);
-                }
-            }
             foreach ($ipList as $ipToCheck) {
                 if (filter_var($ipToCheck, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) && $ip_version == 4) {
                     if ($ip_version == 4) {
@@ -2037,7 +2031,7 @@ class Attribute extends AppModel
             if (!empty($event['Event']['disable_correlation']) && $event['Event']['disable_correlation']) {
                 return true;
             }
-            if (Configure::read('MISP.enable_advanced_correlations') && in_array($a['type'], array('ip-src', 'ip-dst', 'domain-ip'))) {
+            if (Configure::read('MISP.enable_advanced_correlations') && in_array($a['type'], array('ip-src', 'ip-dst'))) {
                 $extraConditions = $this->__cidrCorrelation($a);
             }
             if ($a['type'] == 'ssdeep') {

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -1500,8 +1500,8 @@ class Attribute extends AppModel
                 if (filter_var($parts[1], FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
                     // convert IPv6 address to compressed format
                     $parts[1] = inet_ntop(inet_pton($value));
-                    $value = implode('|', $parts);
                 }
+                $value = implode('|', $parts);
                 break;
             case 'filename|md5':
             case 'filename|sha1':

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -3837,7 +3837,6 @@ class Attribute extends AppModel
                 $pipeline->sadd('misp:cidr_cache_list', $cidr);
             }
             $pipeline->exec();
-            $redis->smembers('misp:cidr_cache_list');
         }
         return $cidrList;
     }
@@ -3846,8 +3845,8 @@ class Attribute extends AppModel
     {
         $redis = $this->setupRedis();
         if ($redis) {
-            if (!$redis->exists('misp:cidr_cache_list') || $redis->sCard('misp:cidr_cache_list') == 0) {
-                $cidrList = $this->setCIDRList($redis);
+            if ($redis->sCard('misp:cidr_cache_list') === 0) {
+                $cidrList = $this->setCIDRList();
             } else {
                 $cidrList = $redis->smembers('misp:cidr_cache_list');
             }

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -1959,20 +1959,22 @@ class Attribute extends AppModel
     {
         $ipValues = array();
         $ip = $a['value1'];
-        if (strpos($ip, '/') !== false) {
+        if (strpos($ip, '/') !== false) { // IP is CIDR
             $ip_array = explode('/', $ip);
             $ip_version = filter_var($ip_array[0], FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ? 4 : 6;
             $ipList = $this->find('list', array(
                 'conditions' => array(
                     'type' => array('ip-src', 'ip-dst'),
+                    'value1 NOT LIKE' => '%/%', // do not return CIDR, just plain IPs
                 ),
+                'group' => 'value1', // return just unique values
                 'fields' => array('value1'),
                 'order' => false
             ));
             foreach ($ipList as $ipToCheck) {
                 $ipToCheckVersion = filter_var($ipToCheck, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ? 4 : 6;
                 if ($ipToCheckVersion === $ip_version) {
-                    if ($ip_version == 4) {
+                    if ($ip_version === 4) {
                         if ($this->__ipv4InCidr($ipToCheck, $ip)) {
                             $ipValues[] = $ipToCheck;
                         }
@@ -1984,19 +1986,18 @@ class Attribute extends AppModel
                 }
             }
         } else {
-            $ip = $a['value1'];
             $ip_version = filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ? 4 : 6;
             $cidrList = $this->getSetCIDRList();
             foreach ($cidrList as $cidr) {
                 $cidr_ip = explode('/', $cidr)[0];
                 if (filter_var($cidr_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
-                    if ($ip_version == 4) {
+                    if ($ip_version === 4) {
                         if ($this->__ipv4InCidr($ip, $cidr)) {
                             $ipValues[] = $cidr;
                         }
                     }
                 } else {
-                    if ($ip_version == 6) {
+                    if ($ip_version === 6) {
                         if ($this->__ipv6InCidr($ip, $cidr)) {
                             $ipValues[] = $cidr;
                         }

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -3822,6 +3822,7 @@ class Attribute extends AppModel
                 'value1 LIKE' => '%/%'
             ),
             'fields' => array('value1'),
+            'group' => 'value1', // return just unique value
             'order' => false
         ));
     }

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -1970,7 +1970,8 @@ class Attribute extends AppModel
                 'order' => false
             ));
             foreach ($ipList as $ipToCheck) {
-                if (filter_var($ipToCheck, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) && $ip_version == 4) {
+                $ipToCheckVersion = filter_var($ipToCheck, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ? 4 : 6;
+                if ($ipToCheckVersion === $ip_version) {
                     if ($ip_version == 4) {
                         if ($this->__ipv4InCidr($ipToCheck, $ip)) {
                             $ipValues[] = $ipToCheck;

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -3833,11 +3833,15 @@ class Attribute extends AppModel
         if ($redis) {
             $redis->del('misp:cidr_cache_list');
             $cidrList = $this->__getCIDRList();
-            $pipeline = $redis->multi(Redis::PIPELINE);
-            foreach ($cidrList as $cidr) {
-                $pipeline->sadd('misp:cidr_cache_list', $cidr);
+            if (method_exists($redis, 'saddArray')) {
+                $redis->sAddArray('misp:cidr_cache_list', $cidrList);
+            } else {
+                $pipeline = $redis->multi(Redis::PIPELINE);
+                foreach ($cidrList as $cidr) {
+                    $pipeline->sadd('misp:cidr_cache_list', $cidr);
+                }
+                $pipeline->exec();
             }
-            $pipeline->exec();
         }
         return $cidrList;
     }


### PR DESCRIPTION
## What does it do?

* Fixes #5877
* Removed support for `domain-ip` attribute (probably outdated?)
* Fixed removing dot from domain for `domain|ip` type.
* Use faster algorithm for IPv6 CIDR correlations.
* Faster correlation when inserting CIDR attribute (removed duplicated values).
* Some optimisations when creating Redis `misp:cidr_cache_list`.

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
