### PR TITLE
Fixed event freetext feed speedup

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -659,20 +659,10 @@ class Attribute extends AppModel
 
     private function __alterAttributeCount($event_id, $increment = true)
     {
-        $event = $this->Event->find('first', array(
-            'recursive' => -1,
-            'conditions' => array('Event.id' => $event_id)
-        ));
-        if (!empty($event)) {
-            if ($increment) {
-                $event['Event']['attribute_count'] = $event['Event']['attribute_count'] + 1;
-            } else {
-                $event['Event']['attribute_count'] = $event['Event']['attribute_count'] - 1;
-            }
-            if ($event['Event']['attribute_count'] >= 0) {
-                $this->Event->save($event, array('callbacks' => false));
-            }
-        }
+        return $this->Event->updateAll(
+            array('Event.attribute_count' => $increment ? 'Event.attribute_count+1' : 'GREATEST(Event.attribute_count-1, 0)'),
+            array('Event.id' => $event_id)
+        );
     }
 
     public function afterSave($created, $options = array())
@@ -692,7 +682,7 @@ class Attribute extends AppModel
         if (isset($this->data['Attribute']['deleted']) && $this->data['Attribute']['deleted']) {
             $this->__beforeSaveCorrelation($this->data['Attribute']);
             if (isset($this->data['Attribute']['event_id'])) {
-                $this->__alterAttributeCount($this->data['Attribute']['event_id'], false, $passedEvent);
+                $this->__alterAttributeCount($this->data['Attribute']['event_id'], false);
             }
         } else {
             /*

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -991,8 +991,8 @@ class Feed extends AppModel
         foreach ($data as $k => $chunk) {
             $this->Event->Attribute->create();
             $this->Event->Attribute->save($chunk);
-            if ($k % 100 == 0) {
-                $this->jobProgress($jobId, null, 50 + round((50 * ((($k + 1) * 100) / count($data)))));
+            if ($k % 100 === 0) {
+                $this->jobProgress($jobId, null, 50 + round(($k + 1) / count($data) * 50));
             }
         }
         if (!empty($data)) {


### PR DESCRIPTION
## What does it do?

Optimisations of freetext import with a lot of attributes.  Previously, fetching big feeds with a lot of attributes (for example `alienvault reputation generic feed`), could take tens of minutes even when attributes are the same. After this change, it take just tens of seconds. 

It also fixes progressbar for job when fetching just one event and speedups attribute save (when incrementing attributes count, instead of two database queries, just one atomic query is used).

## Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
