### PR TITLE
chg: [feed] Use https when fetching DGAs feed

### DIFF
--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -907,7 +907,7 @@
       "id": "46",
       "name": "All current domains belonging to known malicious DGAs",
       "provider": "osint.bambenekconsulting.com",
-      "url": "http://osint.bambenekconsulting.com/feeds/dga-feed-high.csv",
+      "url": "https://osint.bambenekconsulting.com/feeds/dga-feed-high.csv",
       "rules": "",
       "enabled": true,
       "distribution": "3",


### PR DESCRIPTION
## What does it do?

Make DGAs feed little bit safer. 

## Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
