### PR TITLE
chg: [feed] Modify value when checking if value exists in current event

### DIFF
--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -963,6 +963,15 @@ class Feed extends AppModel
                 if (isset($existsAttributesValueToId[$dataPoint['value']])) {
                     unset($data[$k]);
                     unset($existsAttributesValueToId[$dataPoint['value']]);
+                    continue;
+                }
+
+                // Because some types can be saved in modified version (for example, IPv6 address is convert to compressed
+                // format, we should also check if current event contains modified value.
+                $modifiedValue = $this->Event->Attribute->modifyBeforeValidation($dataPoint['type'], $dataPoint['value']);
+                if (isset($existsAttributesValueToId[$modifiedValue])) {
+                    unset($data[$k]);
+                    unset($existsAttributesValueToId[$modifiedValue]);
                 }
             }
             if ($feed['Feed']['delta_merge'] && !empty($existsAttributesValueToId)) {


### PR DESCRIPTION
## What does it do?

Because for example when fetching Tor exit nodes list and enabled 'delta_merge', for IPv6 addresses MISP delete old addresses (because they are converted to compressed format) and then inserted again.

This takes time and also generates a lot of audit log messages.

## Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
