### PR TITLE
chg: [correlations] Refactored correlation saving

### DIFF
--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -81,7 +81,7 @@ class AppModel extends Model
         33 => false, 34 => false, 35 => false, 36 => false, 37 => false, 38 => false,
         39 => false, 40 => false, 41 => false, 42 => false, 43 => false, 44 => false,
         45 => false, 46 => false, 47 => false, 48 => false, 49 => false, 50 => false,
-        51 => false, 52 => false, 53 => false, 54 => false
+        51 => false, 52 => false, 53 => false, 54 => false, 55 => false,
     );
 
     public $advanced_updates_description = array(
@@ -1394,6 +1394,9 @@ class AppModel extends Model
                 break;
             case 54:
                 $sqlArray[] = "ALTER TABLE `sightingdbs` MODIFY `timestamp` int(11) NOT NULL DEFAULT 0;";
+                break;
+            case 55:
+                $sqlArray[] = "ALTER TABLE `correlations` DROP `info`, DROP `date`, DROP INDEX `value`;";
                 break;
             case 'fixNonEmptySharingGroupID':
                 $sqlArray[] = 'UPDATE `events` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -2010,183 +2010,190 @@ class Attribute extends AppModel
         if (!empty($a['disable_correlation']) || Configure::read('MISP.completely_disable_correlation')) {
             return true;
         }
+
         // Don't do any correlation if the type is a non correlating type
-        if (!in_array($a['type'], $this->nonCorrelatingTypes)) {
-            if (!$event) {
-                $event = $this->Event->find('first', array(
-                        'recursive' => -1,
-                        'fields' => array('Event.distribution', 'Event.id', 'Event.info', 'Event.org_id', 'Event.date', 'Event.sharing_group_id', 'Event.disable_correlation'),
-                        'conditions' => array('id' => $a['event_id']),
-                        'order' => array(),
-                ));
-            }
-            if (!empty($event['Event']['disable_correlation']) && $event['Event']['disable_correlation']) {
-                return true;
-            }
-            if (Configure::read('MISP.enable_advanced_correlations') && in_array($a['type'], array('ip-src', 'ip-dst'))) {
-                $extraConditions = $this->__cidrCorrelation($a);
-            }
-            if ($a['type'] == 'ssdeep') {
-                if (function_exists('ssdeep_fuzzy_compare')) {
-                    $this->FuzzyCorrelateSsdeep = ClassRegistry::init('FuzzyCorrelateSsdeep');
-                    $fuzzyIds = $this->FuzzyCorrelateSsdeep->query_ssdeep_chunks($a['value'], $a['id']);
-                    if (!empty($fuzzyIds)) {
-                        $ssdeepIds = $this->find('list', array(
-                            'recursive' => -1,
-                            'conditions' => array(
-                                'Attribute.type' => 'ssdeep',
-                                'Attribute.id' => $fuzzyIds
-                            ),
-                            'fields' => array('Attribute.id', 'Attribute.value1')
-                        ));
-                        $extraConditions = array('Attribute.id' => array());
-                        $threshold = !empty(Configure::read('MISP.ssdeep_correlation_threshold')) ? Configure::read('MISP.ssdeep_correlation_threshold') : 40;
-                        foreach ($ssdeepIds as $k => $v) {
-                            $ssdeep_value = ssdeep_fuzzy_compare($a['value'], $v);
-                            if ($ssdeep_value >= $threshold) {
-                                $extraConditions['Attribute.id'][] = $k;
-                            }
-                        }
-                    }
-                }
-            }
-            $this->Correlation = ClassRegistry::init('Correlation');
-            $correlatingValues = array($a['value1']);
-            if (!empty($a['value2']) && !isset($this->primaryOnlyCorrelatingTypes[$a['type']])) {
-                $correlatingValues[] = $a['value2'];
-            }
-            foreach ($correlatingValues as $k => $cV) {
-                $conditions = array(
-                    'OR' => array(
-                            'Attribute.value1' => $cV,
-                            'AND' => array(
-                                    'Attribute.value2' => $cV,
-                                    'NOT' => array('Attribute.type' => $this->primaryOnlyCorrelatingTypes)
-                            )
+        if (in_array($a['type'], $this->nonCorrelatingTypes)) {
+            return true;
+        }
+
+        if (!$event) {
+            $event = $this->Event->find('first', array(
+                'recursive' => -1,
+                'fields' => array('Event.distribution', 'Event.id', 'Event.info', 'Event.org_id', 'Event.date', 'Event.sharing_group_id', 'Event.disable_correlation'),
+                'conditions' => array('id' => $a['event_id']),
+                'order' => array(),
+            ));
+        }
+
+        if (!empty($event['Event']['disable_correlation']) && $event['Event']['disable_correlation']) {
+            return true;
+        }
+
+        if (Configure::read('MISP.enable_advanced_correlations') && in_array($a['type'], array('ip-src', 'ip-dst'))) {
+            $extraConditions = $this->__cidrCorrelation($a);
+        } else if ($a['type'] === 'ssdeep' && function_exists('ssdeep_fuzzy_compare')) {
+            $this->FuzzyCorrelateSsdeep = ClassRegistry::init('FuzzyCorrelateSsdeep');
+            $fuzzyIds = $this->FuzzyCorrelateSsdeep->query_ssdeep_chunks($a['value'], $a['id']);
+            if (!empty($fuzzyIds)) {
+                $ssdeepIds = $this->find('list', array(
+                    'recursive' => -1,
+                    'conditions' => array(
+                        'Attribute.type' => 'ssdeep',
+                        'Attribute.id' => $fuzzyIds
                     ),
-                    'Attribute.disable_correlation' => 0,
-                    'Event.disable_correlation' => 0,
-                    '(Attribute.deleted + 0)' => 0
-                );
-                if (!empty($extraConditions)) {
-                    $conditions['OR'][] = $extraConditions;
-                }
-                $correlatingAttributes[$k] = $this->find('all', array(
-                        'conditions' => $conditions,
-                        'recursive => -1',
-                        'fields' => array('Attribute.event_id', 'Attribute.id', 'Attribute.distribution', 'Attribute.sharing_group_id', 'Attribute.deleted', 'Attribute.type'),
-                        'contain' => array('Event' => array('fields' => array('Event.id', 'Event.date', 'Event.info', 'Event.org_id', 'Event.distribution', 'Event.sharing_group_id'))),
-                        'order' => array(),
+                    'fields' => array('Attribute.id', 'Attribute.value1')
                 ));
-                foreach ($correlatingAttributes[$k] as $key => &$correlatingAttribute) {
-                    if ($correlatingAttribute['Attribute']['id'] == $a['id']) {
-                        unset($correlatingAttributes[$k][$key]);
-                    } elseif ($correlatingAttribute['Attribute']['event_id'] == $a['event_id']) {
-                        unset($correlatingAttributes[$k][$key]);
-                    } elseif ($full && $correlatingAttribute['Attribute']['id'] <= $a['id']) {
-                        unset($correlatingAttributes[$k][$key]);
-                    } elseif (in_array($correlatingAttribute['Attribute']['type'], $this->nonCorrelatingTypes)) {
-                        unset($correlatingAttributes[$k][$key]);
-                    } elseif (isset($this->primaryOnlyCorrelatingTypes[$a['type']]) && $correlatingAttribute['value1'] !== $a['value1']) {
-                        unset($correlatingAttribute[$k][$key]);
+                $threshold = Configure::read('MISP.ssdeep_correlation_threshold') ?: 40;
+                $attributeIds = array();
+                foreach ($ssdeepIds as $attributeId => $v) {
+                    $ssdeep_value = ssdeep_fuzzy_compare($a['value'], $v);
+                    if ($ssdeep_value >= $threshold) {
+                        $attributeIds[] = $attributeId;
                     }
                 }
+                $extraConditions = array('Attribute.id' => $attributeIds);
             }
-            $correlations = array();
-            $testCorrelations = array();
-            foreach ($correlatingAttributes as $k => $cA) {
-                foreach ($cA as $corr) {
-                    if (Configure::read('MISP.deadlock_avoidance')) {
-                        $correlations[] = array(
-                            'value' => $correlatingValues[$k],
-                            '1_event_id' => $event['Event']['id'],
-                            '1_attribute_id' => $a['id'],
-                            'event_id' => $corr['Attribute']['event_id'],
-                            'attribute_id' => $corr['Attribute']['id'],
-                            'org_id' => $corr['Event']['org_id'],
-                            'distribution' => $corr['Event']['distribution'],
-                            'a_distribution' => $corr['Attribute']['distribution'],
-                            'sharing_group_id' => $corr['Event']['sharing_group_id'],
-                            'a_sharing_group_id' => $corr['Attribute']['sharing_group_id'],
-                            'date' => $corr['Event']['date'],
-                            'info' => $corr['Event']['info']
-                        );
-                        $correlations[] = array(
-                            'value' => $correlatingValues[$k],
-                            '1_event_id' => $corr['Event']['id'],
-                            '1_attribute_id' => $corr['Attribute']['id'],
-                            'event_id' => $a['event_id'],
-                            'attribute_id' => $a['id'],
-                            'org_id' => $event['Event']['org_id'],
-                            'distribution' => $event['Event']['distribution'],
-                            'a_distribution' => $a['distribution'],
-                            'sharing_group_id' => $event['Event']['sharing_group_id'],
-                            'a_sharing_group_id' => $a['sharing_group_id'],
-                            'date' => $event['Event']['date'],
-                            'info' => $event['Event']['info']
-                        );
-                    } else {
-                        $correlations[] = array(
-                                $correlatingValues[$k],
-                                $event['Event']['id'],
-                                $a['id'],
-                                $corr['Attribute']['event_id'],
-                                $corr['Attribute']['id'],
-                                $corr['Event']['org_id'],
-                                $corr['Event']['distribution'],
-                                $corr['Attribute']['distribution'],
-                                $corr['Event']['sharing_group_id'],
-                                $corr['Attribute']['sharing_group_id'],
-                                $corr['Event']['date'],
-                                $corr['Event']['info']
-                        );
-                        $correlations[] = array(
-                                $correlatingValues[$k],
-                                $corr['Event']['id'],
-                                $corr['Attribute']['id'],
-                                $a['event_id'],
-                                $a['id'],
-                                $event['Event']['org_id'],
-                                $event['Event']['distribution'],
-                                $a['distribution'],
-                                $event['Event']['sharing_group_id'],
-                                $a['sharing_group_id'],
-                                $event['Event']['date'],
-                                $event['Event']['info']
-                        );
-                    }
-                }
-            }
-            $fields = array(
-                    'value',
-                    '1_event_id',
-                    '1_attribute_id',
-                    'event_id',
-                    'attribute_id',
-                    'org_id',
-                    'distribution',
-                    'a_distribution',
-                    'sharing_group_id',
-                    'a_sharing_group_id',
-                    'date',
-                    'info'
+        }
+
+        $correlatingValues = array($a['value1']);
+        if (!empty($a['value2']) && !in_array($a['type'], $this->primaryOnlyCorrelatingTypes)) {
+            $correlatingValues[] = $a['value2'];
+        }
+
+        $correlatingAttributes = array();
+        foreach ($correlatingValues as $k => $cV) {
+            $conditions = array(
+                'OR' => array(
+                    'Attribute.value1' => $cV,
+                    'AND' => array(
+                        'Attribute.value2' => $cV,
+                        'NOT' => array('Attribute.type' => $this->primaryOnlyCorrelatingTypes)
+                    )
+                ),
+                'NOT' => array(
+                    'Attribute.event_id' => $a['event_id'],
+                    'Attribute.type' => $this->nonCorrelatingTypes,
+                ),
+                'Attribute.disable_correlation' => 0,
+                'Event.disable_correlation' => 0,
+                '(Attribute.deleted + 0)' => 0
             );
-            if (Configure::read('MISP.deadlock_avoidance')) {
-                if (!empty($correlations)) {
-                    $this->Correlation->saveMany($correlations, array(
-                        'atomic' => false,
-                        'callbacks' => false,
-                        'deep' => false,
-                        'validate' => false,
-                        'fieldList' => $fields
-                    ));
-                }
-            } else {
-                if (!empty($correlations)) {
-                    $db = $this->getDataSource();
-                    $db->insertMulti('correlations', $fields, $correlations);
+            if (!empty($extraConditions)) {
+                $conditions['OR'][] = $extraConditions;
+            }
+            if ($full) {
+                $conditions['Attribute.id > '] = $a['id'];
+            }
+            $correlatingAttributes[$k] = $this->find('all', array(
+                'conditions' => $conditions,
+                'recursive' => -1,
+                'fields' => array(
+                    'Attribute.event_id',
+                    'Attribute.id',
+                    'Attribute.distribution',
+                    'Attribute.sharing_group_id',
+                    'Attribute.value1',
+                    'Attribute.value2',
+                ),
+                'contain' => array('Event' => array('fields' => array('Event.id', 'Event.date', 'Event.info', 'Event.org_id', 'Event.distribution', 'Event.sharing_group_id'))),
+                'order' => array(),
+            ));
+        }
+        $correlations = array();
+        foreach ($correlatingAttributes as $k => $cA) {
+            foreach ($cA as $corr) {
+                if (Configure::read('MISP.deadlock_avoidance')) {
+                    $correlations[] = array(
+                        'value' => $k === 0 ? $corr['Attribute']['value1'] : $corr['Attribute']['value2'],
+                        '1_event_id' => $event['Event']['id'],
+                        '1_attribute_id' => $a['id'],
+                        'event_id' => $corr['Attribute']['event_id'],
+                        'attribute_id' => $corr['Attribute']['id'],
+                        'org_id' => $corr['Event']['org_id'],
+                        'distribution' => $corr['Event']['distribution'],
+                        'a_distribution' => $corr['Attribute']['distribution'],
+                        'sharing_group_id' => $corr['Event']['sharing_group_id'],
+                        'a_sharing_group_id' => $corr['Attribute']['sharing_group_id'],
+                        'date' => $corr['Event']['date'],
+                        'info' => $corr['Event']['info']
+                    );
+                    $correlations[] = array(
+                        'value' => $correlatingValues[$k],
+                        '1_event_id' => $corr['Event']['id'],
+                        '1_attribute_id' => $corr['Attribute']['id'],
+                        'event_id' => $a['event_id'],
+                        'attribute_id' => $a['id'],
+                        'org_id' => $event['Event']['org_id'],
+                        'distribution' => $event['Event']['distribution'],
+                        'a_distribution' => $a['distribution'],
+                        'sharing_group_id' => $event['Event']['sharing_group_id'],
+                        'a_sharing_group_id' => $a['sharing_group_id'],
+                        'date' => $event['Event']['date'],
+                        'info' => $event['Event']['info']
+                    );
+                } else {
+                    $correlations[] = array(
+                        $k === 0 ? $corr['Attribute']['value1'] : $corr['Attribute']['value2'],
+                        $event['Event']['id'],
+                        $a['id'],
+                        $corr['Attribute']['event_id'],
+                        $corr['Attribute']['id'],
+                        $corr['Event']['org_id'],
+                        $corr['Event']['distribution'],
+                        $corr['Attribute']['distribution'],
+                        $corr['Event']['sharing_group_id'],
+                        $corr['Attribute']['sharing_group_id'],
+                        $corr['Event']['date'],
+                        $corr['Event']['info']
+                    );
+                    $correlations[] = array(
+                        $correlatingValues[$k],
+                        $corr['Event']['id'],
+                        $corr['Attribute']['id'],
+                        $a['event_id'],
+                        $a['id'],
+                        $event['Event']['org_id'],
+                        $event['Event']['distribution'],
+                        $a['distribution'],
+                        $event['Event']['sharing_group_id'],
+                        $a['sharing_group_id'],
+                        $event['Event']['date'],
+                        $event['Event']['info']
+                    );
                 }
             }
+        }
+
+        if (empty($correlations)) {
+            return true;
+        }
+
+        $fields = array(
+            'value',
+            '1_event_id',
+            '1_attribute_id',
+            'event_id',
+            'attribute_id',
+            'org_id',
+            'distribution',
+            'a_distribution',
+            'sharing_group_id',
+            'a_sharing_group_id',
+            'date',
+            'info'
+        );
+        if (Configure::read('MISP.deadlock_avoidance')) {
+            $this->Correlation = ClassRegistry::init('Correlation');
+            return $this->Correlation->saveMany($correlations, array(
+                'atomic' => false,
+                'callbacks' => false,
+                'deep' => false,
+                'validate' => false,
+                'fieldList' => $fields,
+            ));
+        } else {
+            $db = $this->getDataSource();
+            return $db->insertMulti('correlations', $fields, $correlations);
         }
     }
 

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -2784,7 +2784,14 @@ class Attribute extends AppModel
                     'conditions' => array('id' => $id),
                     'order' => array()
             ));
-            $attributeConditions = array('Attribute.event_id' => $id, 'Attribute.deleted' => 0);
+            $attributeConditions = array(
+                'Attribute.event_id' => $id,
+                'Attribute.deleted' => 0,
+                'Attribute.disable_correlation' => 0,
+                'NOT' => array(
+                    'Attribute.type' => $this->nonCorrelatingTypes,
+                ),
+            );
             if ($attributeId) {
                 $attributeConditions['Attribute.id'] = $attributeId;
             }

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -2095,7 +2095,7 @@ class Attribute extends AppModel
                     'Attribute.value1',
                     'Attribute.value2',
                 ),
-                'contain' => array('Event' => array('fields' => array('Event.id', 'Event.date', 'Event.info', 'Event.org_id', 'Event.distribution', 'Event.sharing_group_id'))),
+                'contain' => array('Event' => array('fields' => array('Event.id', 'Event.org_id', 'Event.distribution', 'Event.sharing_group_id'))),
                 'order' => array(),
             ));
         }
@@ -2114,8 +2114,6 @@ class Attribute extends AppModel
                         'a_distribution' => $corr['Attribute']['distribution'],
                         'sharing_group_id' => $corr['Event']['sharing_group_id'],
                         'a_sharing_group_id' => $corr['Attribute']['sharing_group_id'],
-                        'date' => $corr['Event']['date'],
-                        'info' => $corr['Event']['info']
                     );
                     $correlations[] = array(
                         'value' => $correlatingValues[$k],
@@ -2128,8 +2126,6 @@ class Attribute extends AppModel
                         'a_distribution' => $a['distribution'],
                         'sharing_group_id' => $event['Event']['sharing_group_id'],
                         'a_sharing_group_id' => $a['sharing_group_id'],
-                        'date' => $event['Event']['date'],
-                        'info' => $event['Event']['info']
                     );
                 } else {
                     $correlations[] = array(
@@ -2143,8 +2139,6 @@ class Attribute extends AppModel
                         $corr['Attribute']['distribution'],
                         $corr['Event']['sharing_group_id'],
                         $corr['Attribute']['sharing_group_id'],
-                        $corr['Event']['date'],
-                        $corr['Event']['info']
                     );
                     $correlations[] = array(
                         $correlatingValues[$k],
@@ -2157,8 +2151,6 @@ class Attribute extends AppModel
                         $a['distribution'],
                         $event['Event']['sharing_group_id'],
                         $a['sharing_group_id'],
-                        $event['Event']['date'],
-                        $event['Event']['info']
                     );
                 }
             }
@@ -2179,8 +2171,6 @@ class Attribute extends AppModel
             'a_distribution',
             'sharing_group_id',
             'a_sharing_group_id',
-            'date',
-            'info'
         );
         if (Configure::read('MISP.deadlock_avoidance')) {
             $this->Correlation = ClassRegistry::init('Correlation');
@@ -2780,7 +2770,7 @@ class Attribute extends AppModel
             }
             $event = $this->Event->find('first', array(
                     'recursive' => -1,
-                    'fields' => array('Event.distribution', 'Event.id', 'Event.info', 'Event.org_id', 'Event.date', 'Event.sharing_group_id', 'Event.disable_correlation'),
+                    'fields' => array('Event.distribution', 'Event.id', 'Event.org_id', 'Event.sharing_group_id', 'Event.disable_correlation'),
                     'conditions' => array('id' => $id),
                     'order' => array()
             ));

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -635,12 +635,6 @@ class Event extends AppModel
         if (!Configure::read('MISP.completely_disable_correlation') && !$created) {
             $this->Correlation = ClassRegistry::init('Correlation');
             $db = $this->getDataSource();
-            if (isset($this->data['Event']['date'])) {
-                $this->Correlation->updateAll(array('Correlation.date' => $db->value($this->data['Event']['date'])), array('Correlation.event_id' => intval($this->data['Event']['id'])));
-            }
-            if (isset($this->data['Event']['info'])) {
-                $this->Correlation->updateAll(array('Correlation.info' => $db->value($this->data['Event']['info'])), array('Correlation.event_id' => intval($this->data['Event']['id'])));
-            }
             if (isset($this->data['Event']['distribution'])) {
                 $this->Correlation->updateAll(array('Correlation.distribution' => $db->value($this->data['Event']['distribution'])), array('Correlation.event_id' => intval($this->data['Event']['id'])));
             }

--- a/db_schema.json
+++ b/db_schema.json
@@ -483,28 +483,6 @@
                 "column_type": "int(11)",
                 "column_default": null,
                 "extra": ""
-            },
-            {
-                "column_name": "date",
-                "is_nullable": "NO",
-                "data_type": "date",
-                "character_maximum_length": null,
-                "numeric_precision": null,
-                "collation_name": null,
-                "column_type": "date",
-                "column_default": null,
-                "extra": ""
-            },
-            {
-                "column_name": "info",
-                "is_nullable": "NO",
-                "data_type": "text",
-                "character_maximum_length": "65535",
-                "numeric_precision": null,
-                "collation_name": "utf8_bin",
-                "column_type": "text",
-                "column_default": null,
-                "extra": ""
             }
         ],
         "dashboards": [
@@ -6806,7 +6784,6 @@
         ],
         "correlations": [
             "id",
-            "value",
             "event_id",
             "1_event_id",
             "attribute_id",
@@ -7170,5 +7147,5 @@
             "id"
         ]
     },
-    "db_version": "54"
+    "db_version": "55"
 }


### PR DESCRIPTION
## What does it do?

* Always show other correlating value (useful for CIDR and ssdeep correlations)
* Make correlation saving faster (move more work to database, do not fetch not necessary fields) 
* Fix a bug, that `ip-src|port` also correlate port number
* Remove `info` and `date` columns from `correlations` table and also index for `value` column to make table smaller (fixes #5299)
* Loading correlations is 2x-5x faster (depends on number of related events)
* Should help for #5379 and #481

## Questions

- [x] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
