### PR TITLE
Clean up errors when trying to update warning lists

### DIFF
--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -49,7 +49,7 @@ class Warninglist extends AppModel
     public function update()
     {
         $directories = glob(APP . 'files' . DS . 'warninglists' . DS . 'lists' . DS . '*', GLOB_ONLYDIR);
-        $updated = array();
+        $updated = array('success' => [], 'fails' => []);
         foreach ($directories as $dir) {
             $file = new File($dir . DS . 'list.json');
             $list = json_decode($file->read(), true);


### PR DESCRIPTION
#### What does it do?

Pre-setups the array so that in the case of a full failure you don't get a bunch of PHP errors. 

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
