### PR TITLE
chg: [correlations] Big speedup when correlating CIDR

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -1965,7 +1965,7 @@ class Attribute extends AppModel
             $ip_version = filter_var($networkIp, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ? 4 : 6;
 
             $conditions = array(
-                'type' => array('ip-src', 'ip-dst'),
+                'type' => array('ip-src', 'ip-dst', 'ip-src|port', 'ip-dst|port'),
                 'value1 NOT LIKE' => '%/%', // do not return CIDR, just plain IPs
                 'disable_correlation' => 0,
                 'deleted' => 0,
@@ -2074,7 +2074,7 @@ class Attribute extends AppModel
             return true;
         }
 
-        if (Configure::read('MISP.enable_advanced_correlations') && in_array($a['type'], array('ip-src', 'ip-dst'))) {
+        if (Configure::read('MISP.enable_advanced_correlations') && in_array($a['type'], array('ip-src', 'ip-dst', 'ip-src|port', 'ip-dst|port'))) {
             $extraConditions = $this->__cidrCorrelation($a);
         } else if ($a['type'] === 'ssdeep' && function_exists('ssdeep_fuzzy_compare')) {
             $this->FuzzyCorrelateSsdeep = ClassRegistry::init('FuzzyCorrelateSsdeep');

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -1981,6 +1981,11 @@ class Attribute extends AppModel
                     $conditions['INET_ATON(value1) BETWEEN ? AND ?'] = array($startIp, $endIp);
                 } else {
                     $conditions[] = 'IS_IPV6(value1)';
+                    // Just fetch IPv6 address that starts with given prefix. This is fast, because value1 is indexed.
+                    $ipv6Parts = explode(':', rtrim($ip_array[0], ':'));
+                    $ipv6Parts = array_slice($ipv6Parts, 0, intval($ip_array[1] / 16));
+                    $prefix = implode(':', $ipv6Parts);
+                    $conditions['value1 LIKE'] = $prefix . '%';
                 }
             }
 


### PR DESCRIPTION
#### What does it do?

This change provides massive speed-up when saving CIDR.

For example, when creating correlations for event with 30 IPv4 CIDR IP addresses (and with 200 000 IPv4 addresses in DB), with current version it takes almost 25 to 30 minutes. After this change, it take just 30 seconds.

The main magic is to move comparison logic to database, that is much faster than PHP. The only problem, that used functions are available just in MySQL database, so old logic is still included for PostgreSQL. Also this speedup is not available for IPv6 addresses (it is probably possible to implement it, but IPv6 addresses are still not that usual).

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
