### PR TITLE
fix: [UI] Do not show Good-Bye when using custom logout

### DIFF
--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -1265,7 +1265,9 @@ class UsersController extends AppController
         if ($this->Session->check('Auth.User')) {
             $this->User->extralog($this->Auth->user(), "logout");
         }
-        $this->Flash->info(__('Good-Bye'));
+        if (!Configure::read('Plugin.CustomAuth_custom_logout')) {
+            $this->Flash->info(__('Good-Bye'));
+        }
         $user = $this->User->find('first', array(
             'conditions' => array(
                 'User.id' => $this->Auth->user('id')


### PR DESCRIPTION
#### What does it do?

Because without this patch, Good-Bye is show when user successfully log in.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
