### PR TITLE
fix: [correlations] Purge ssdeep table after attribute delete

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -820,6 +820,10 @@ class Attribute extends AppModel
                 ),
                 false
             );
+            if ($this->data['Attribute']['type'] === 'ssdeep') {
+                $this->FuzzyCorrelateSsdeep = ClassRegistry::init('FuzzyCorrelateSsdeep');
+                $this->FuzzyCorrelateSsdeep->purge(null, $this->data['Attribute']['id']);
+            }
         }
     }
 
@@ -1907,11 +1911,9 @@ class Attribute extends AppModel
                     'Correlation.attribute_id' => $a['id']))
             );
         }
-        if ($a['type'] == 'ssdeep') {
+        if ($a['type'] === 'ssdeep') {
             $this->FuzzyCorrelateSsdeep = ClassRegistry::init('FuzzyCorrelateSsdeep');
-            $this->FuzzyCorrelateSsdeep->deleteAll(
-                array('FuzzyCorrelateSsdeep.attribute_id' => $a['id'])
-            );
+            $this->FuzzyCorrelateSsdeep->purge(null, $a['id']);
         }
     }
 
@@ -2751,6 +2753,10 @@ class Attribute extends AppModel
     {
         $this->Correlation = ClassRegistry::init('Correlation');
         $this->purgeCorrelations($eventId);
+
+        $this->FuzzyCorrelateSsdeep = ClassRegistry::init('FuzzyCorrelateSsdeep');
+        $this->FuzzyCorrelateSsdeep->purge($eventId, $attributeId);
+
         // get all attributes..
         if (!$eventId) {
             $eventIds = $this->Event->find('list', array('recursive' => -1, 'fields' => array('Event.id')));

--- a/app/Model/FuzzyCorrelateSsdeep.php
+++ b/app/Model/FuzzyCorrelateSsdeep.php
@@ -89,4 +89,27 @@ class FuzzyCorrelateSsdeep extends AppModel
         $this->saveAll($to_save);
         return $result;
     }
+
+    /**
+     * @param int|null $eventId
+     * @param int|null $attributeId
+     * @return bool True on success, false on failure
+     */
+    public function purge($eventId = null, $attributeId = null)
+    {
+        if (!$eventId && !$attributeId) {
+            $this->query('TRUNCATE TABLE fuzzy_correlate_ssdeep;');
+        } elseif (!$attributeId) {
+            $this->Attribute = ClassRegistry::init('Attribute');
+            $attributeId = $this->Attribute->find('list', array(
+                'conditions' => array(
+                    'Attribute.event_id' => $eventId,
+                    'Attribute.type' => 'ssdeep',
+                ),
+                'fields' => 'Attribute.id',
+            ));
+        }
+
+        return $this->deleteAll(array('FuzzyCorrelateSsdeep.attribute_id' => $attributeId));
+    }
 }


### PR DESCRIPTION
#### What does it do?

And also before regenerating correlations. Without this change, `fuzzy_correlate_ssdeep` will grow and grow.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
