### PR TITLE
new: [internal] Use UUID V4 where possible

### DIFF
--- a/app/Console/Command/UserInitShell.php
+++ b/app/Console/Command/UserInitShell.php
@@ -1,4 +1,6 @@
 <?php
+App::uses('UuidTool', 'Tools');
+
 class UserInitShell extends AppShell {
 	public $uses = array('User', 'Role', 'Organisation', 'Server', 'ConnectionManager');
 	public function main() {
@@ -46,7 +48,7 @@ class UserInitShell extends AppShell {
 					'description' => 'Automatically generated admin organisation',
 					'type' => 'ADMIN',
 					'date_created' => $date,
-					'uuid' => CakeText::uuid(),
+					'uuid' => UuidTool::v4(),
 					'local' => 1
 			));
 			$this->Organisation->save($org);

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -26,6 +26,7 @@ App::uses('ConnectionManager', 'Model');
 App::uses('Controller', 'Controller');
 App::uses('File', 'Utility');
 App::uses('RequestRearrangeTool', 'Tools');
+App::uses('UuidTool', 'Tools');
 
 /**
  * Application Controller
@@ -165,7 +166,7 @@ class AppController extends Controller
         // Check if the instance has a UUID, if not assign one.
         if (!Configure::read('MISP.uuid')) {
             $this->loadModel('Server');
-            $this->Server->serverSettingsSaveValue('MISP.uuid', CakeText::uuid());
+            $this->Server->serverSettingsSaveValue('MISP.uuid', UuidTool::v4());
         }
         // check if Apache provides kerberos authentication data
         $envvar = Configure::read('ApacheSecureAuth.apacheEnv');

--- a/app/Controller/Component/IOCImportComponent.php
+++ b/app/Controller/Component/IOCImportComponent.php
@@ -1,4 +1,5 @@
 <?php
+App::uses('UuidTool', 'Tools');
 
 class IOCImportComponent extends Component
 {
@@ -196,7 +197,7 @@ class IOCImportComponent extends Component
                 if (!in_array($condensed, $duplicateFilter)) {
                     $this->saved_uuids[] = $attribute['uuid'];
                     $duplicateFilter[] = $condensed;
-                    $event['Attribute'][$k]['uuid'] = CakeText::uuid();
+                    $event['Attribute'][$k]['uuid'] = UuidTool::v4();
                 } else {
                     unset($event['Attribute'][$k]);
                 }
@@ -211,7 +212,7 @@ class IOCImportComponent extends Component
         // Define the fields used in the global iocinfo variable.
         foreach ($this->iocinfo as $k => $v) {
             if (isset($event[$v])) {
-                $event['Attribute'][] = array('uuid' => CakeText::uuid(), 'category' => 'Other', 'type' => 'comment', 'event_id' => $id, 'value' => $v . ': ' . $event[$v], 'to_ids' => $this->typeToIdsSettings['comment'], 'distribution' => $this->distribution, 'comment' => 'OpenIOC import from file ' . $filename);
+                $event['Attribute'][] = array('uuid' => UuidTool::v4(), 'category' => 'Other', 'type' => 'comment', 'event_id' => $id, 'value' => $v . ': ' . $event[$v], 'to_ids' => $this->typeToIdsSettings['comment'], 'distribution' => $this->distribution, 'comment' => 'OpenIOC import from file ' . $filename);
             }
         }
 

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -1,6 +1,7 @@
 <?php
 App::uses('AppController', 'Controller');
 App::uses('Xml', 'Utility');
+App::uses('UuidTool', 'Tools');
 
 class EventsController extends AppController
 {
@@ -3177,7 +3178,7 @@ class EventsController extends AppController
             // add the original openIOC file as an attachment
             $saveEvent['Attribute'][] = array(
                 'category' => 'External analysis',
-                'uuid' =>  CakeText::uuid(),
+                'uuid' =>  UuidTool::v4(),
                 'type' => 'attachment',
                 'value' => $this->data['Event']['submittedioc']['name'],
                 'to_ids' => false,

--- a/app/Controller/ObjectReferencesController.php
+++ b/app/Controller/ObjectReferencesController.php
@@ -1,6 +1,6 @@
 <?php
-
 App::uses('AppController', 'Controller');
+App::uses('UuidTool', 'Tools');
 
 class ObjectReferencesController extends AppController
 {
@@ -68,8 +68,7 @@ class ObjectReferencesController extends AppController
                 'event_id' => $object['Event']['id'],
                 'object_uuid' => $object['Object']['uuid'],
                 'object_id' => $objectId,
-                'referenced_type' => $referenced_type,
-                'uuid' => CakeText::uuid()
+                'uuid' => UuidTool::v4()
             );
             $object_uuid = $object['Object']['uuid'];
             $this->ObjectReference->create();

--- a/app/Controller/OrganisationsController.php
+++ b/app/Controller/OrganisationsController.php
@@ -1,5 +1,6 @@
 <?php
 App::uses('AppController', 'Controller');
+App::uses('UuidTool', 'Tools');
 
 class OrganisationsController extends AppController
 {
@@ -284,7 +285,7 @@ class OrganisationsController extends AppController
 
     public function admin_generateuuid()
     {
-        $this->set('uuid', CakeText::uuid());
+        $this->set('uuid', UuidTool::v4());
         $this->set('_serialize', array('uuid'));
     }
 

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -1,5 +1,6 @@
 <?php
 App::uses('AppController', 'Controller');
+App::uses('UuidTool', 'Tools');
 
 class UsersController extends AppController
 {
@@ -1178,7 +1179,7 @@ class UsersController extends AppController
                         'name' => !empty(Configure::read('MISP.org')) ? Configure::read('MISP.org') : 'ADMIN',
                         'description' => 'Automatically generated admin organisation',
                         'type' => 'ADMIN',
-                        'uuid' => CakeText::uuid(),
+                        'uuid' => UuidTool::v4(),
                         'local' => 1,
                         'date_created' => $date,
                         'sector' => '',

--- a/app/Lib/Export/OpeniocExport.php
+++ b/app/Lib/Export/OpeniocExport.php
@@ -1,4 +1,5 @@
 <?php
+App::uses('UuidTool', 'Tools');
 
 class OpeniocExport
 {
@@ -168,7 +169,7 @@ class OpeniocExport
 		// We will start adding all the components that will be in the xml file here
 		$date = date("Y-m-d\Th:i:s");
 		$temp .= '<?xml version="1.0" encoding="utf-8"?>' . PHP_EOL;
-		$temp .= '<ioc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" id="' . CakeText::uuid() . '" last-modified="' . $date . '" xmlns="http://schemas.mandiant.com/2010/ioc">' . PHP_EOL;
+		$temp .= '<ioc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" id="' . UuidTool::v4() . '" last-modified="' . $date . '" xmlns="http://schemas.mandiant.com/2010/ioc">' . PHP_EOL;
 		$temp .= '  <short_description>Filtered indicator list</short_description>' . PHP_EOL;
 		$temp .= '  <description>Filtered indicator list</description>' . PHP_EOL;
 		$temp .= '  <keywords />' . PHP_EOL;
@@ -176,7 +177,7 @@ class OpeniocExport
 		$temp .= '  <authored_date>' . $date . '</authored_date>' . PHP_EOL;
 		$temp .= '  <links />' . PHP_EOL;
 		$temp .= '  <definition>' . PHP_EOL;
-		$temp .= '    <Indicator operator="OR" id="' . CakeText::uuid() . '">' . PHP_EOL;
+		$temp .= '    <Indicator operator="OR" id="' . UuidTool::v4() . '">' . PHP_EOL;
 		return $temp;
 
     }

--- a/app/Lib/Export/Stix2Export.php
+++ b/app/Lib/Export/Stix2Export.php
@@ -1,6 +1,6 @@
 <?php
-
 App::uses('StixExport', 'Export');
+App::uses('UuidTool', 'Tools');
 
 class Stix2Export extends StixExport
 {
@@ -11,7 +11,7 @@ class Stix2Export extends StixExport
     {
         $framing_file = $this->__scripts_dir . 'misp_framing.py ';
         $my_server = ClassRegistry::init('Server');
-        return $my_server->getPythonVersion() . ' ' . $framing_file . $this->__return_type . ' ' . escapeshellarg(CakeText::uuid()) . $this->__end_of_cmd;
+        return $my_server->getPythonVersion() . ' ' . $framing_file . $this->__return_type . ' ' . escapeshellarg(UuidTool::v4()) . $this->__end_of_cmd;
     }
 
     protected function __parse_misp_events($filename)

--- a/app/Lib/Tools/IOCExportTool.php
+++ b/app/Lib/Tools/IOCExportTool.php
@@ -1,4 +1,5 @@
 <?php
+App::uses('UuidTool', 'Tools');
 
 class IOCExportTool
 {
@@ -47,7 +48,7 @@ class IOCExportTool
         $temp .= '  <authored_date>' . h($event['Event']['date']) . 'T00:00:00</authored_date>' . PHP_EOL;
         $temp .= '  <links />' . PHP_EOL;
         $temp .= '  <definition>' . PHP_EOL;
-        $temp .= '    <Indicator operator="OR" id="' . CakeText::uuid() . '">' . PHP_EOL;
+        $temp .= '    <Indicator operator="OR" id="' . UuidTool::v4() . '">' . PHP_EOL;
         return $temp;
     }
 
@@ -57,7 +58,7 @@ class IOCExportTool
         // We will start adding all the components that will be in the xml file here
         $date = date("Y-m-d\TH:i:s");
         $temp .= '<?xml version="1.0" encoding="utf-8"?>' . PHP_EOL;
-        $temp .= '<ioc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" id="' . CakeText::uuid() . '" last-modified="' . $date . '" xmlns="http://schemas.mandiant.com/2010/ioc">' . PHP_EOL;
+        $temp .= '<ioc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" id="' . UuidTool::v4() . '" last-modified="' . $date . '" xmlns="http://schemas.mandiant.com/2010/ioc">' . PHP_EOL;
         $temp .= '  <short_description>Filtered indicator list</short_description>' . PHP_EOL;
         $temp .= '  <description>Filtered indicator list</description>' . PHP_EOL;
         $temp .= '  <keywords />' . PHP_EOL;
@@ -65,7 +66,7 @@ class IOCExportTool
         $temp .= '  <authored_date>' . $date . '</authored_date>' . PHP_EOL;
         $temp .= '  <links />' . PHP_EOL;
         $temp .= '  <definition>' . PHP_EOL;
-        $temp .= '    <Indicator operator="OR" id="' . CakeText::uuid() . '">' . PHP_EOL;
+        $temp .= '    <Indicator operator="OR" id="' . UuidTool::v4() . '">' . PHP_EOL;
         return $temp;
     }
 

--- a/app/Lib/Tools/UuidTool.php
+++ b/app/Lib/Tools/UuidTool.php
@@ -1,0 +1,46 @@
+<?php
+
+// import compatibility library for PHP < 7.0
+if (!function_exists('random_bytes')) {
+    if (file_exists(APP . 'Lib' . DS . 'random_compat' . DS . 'lib' . DS . 'random.php')) {
+        require_once(APP . 'Lib' . DS . 'random_compat' . DS . 'lib' . DS . 'random.php');
+    }
+}
+
+// Code inspired from https://github.com/jchook/uuid-v4
+class UuidTool
+{
+    // Buffering random_bytes() speeds up generation of many uuids at once
+    const BUFFER_SIZE = 512;
+
+    protected static $buf;
+    protected static $bufIdx = self::BUFFER_SIZE;
+
+    /**
+     * @return string
+     * @throws Exception
+     */
+    public static function v4()
+    {
+        $b = self::randomBytes(16);
+        $b[6] = chr((ord($b[6]) & 0x0f) | 0x40);
+        $b[8] = chr((ord($b[8]) & 0x3f) | 0x80);
+        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($b), 4));
+    }
+
+    /**
+     * @param int $n
+     * @return string
+     * @throws Exception
+     */
+    protected static function randomBytes($n)
+    {
+        if (self::$bufIdx + $n >= self::BUFFER_SIZE) {
+            self::$buf = random_bytes(self::BUFFER_SIZE);
+            self::$bufIdx = 0;
+        }
+        $idx = self::$bufIdx;
+        self::$bufIdx += $n;
+        return substr(self::$buf, $idx, $n);
+    }
+}

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -1,11 +1,11 @@
 <?php
-
 App::uses('AppModel', 'Model');
 App::uses('Folder', 'Utility');
 App::uses('File', 'Utility');
 App::uses('FinancialTool', 'Tools');
 App::uses('RandomTool', 'Tools');
 App::uses('MalwareTool', 'Tools');
+App::uses('UuidTool', 'Tools');
 
 class Attribute extends AppModel
 {
@@ -857,7 +857,7 @@ class Attribute extends AppModel
         }
         // generate UUID if it doesn't exist
         if (empty($this->data['Attribute']['uuid'])) {
-            $this->data['Attribute']['uuid'] = CakeText::uuid();
+            $this->data['Attribute']['uuid'] = UuidTool::v4();
         }
         // generate timestamp if it doesn't exist
         if (empty($this->data['Attribute']['timestamp'])) {

--- a/app/Model/Dashboard.php
+++ b/app/Model/Dashboard.php
@@ -1,5 +1,7 @@
 <?php
 App::uses('AppModel', 'Model');
+App::uses('UuidTool', 'Tools');
+
 class Dashboard extends AppModel
 {
     public $recursive = -1;
@@ -244,7 +246,7 @@ class Dashboard extends AppModel
             $this->create();
             $data = array(
                 'user_id' => $user['id'],
-                'uuid' => CakeText::uuid()
+                'uuid' => UuidTool::v4(),
             );
             if (empty($user['role']['perm_site_admin'])) {
                 $data['restrict_to_org_id'] = $user['org_id'];

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -2,6 +2,7 @@
 App::uses('AppModel', 'Model');
 App::uses('CakeEmail', 'Network/Email');
 App::uses('RandomTool', 'Tools');
+App::uses('UuidTool', 'Tools');
 
 class Event extends AppModel
 {
@@ -599,7 +600,7 @@ class Event extends AppModel
 
         // generate UUID if it doesn't exist
         if (empty($this->data['Event']['uuid'])) {
-            $this->data['Event']['uuid'] = CakeText::uuid();
+            $this->data['Event']['uuid'] = UuidTool::v4();
         }
 
         // Convert event ID to uuid if needed

--- a/app/Model/Inbox.php
+++ b/app/Model/Inbox.php
@@ -1,5 +1,7 @@
 <?php
 App::uses('AppModel', 'Model');
+App::uses('UuidTool', 'Tools');
+
 class Inbox extends AppModel
 {
     public $useTable = 'inbox';
@@ -16,13 +18,11 @@ class Inbox extends AppModel
     public function beforeValidate($options = array())
     {
         parent::beforeValidate();
-        $this->data['Inbox']['uuid'] = CakeText::uuid();
+        $this->data['Inbox']['uuid'] = UuidTool::v4();
         $this->data['Inbox']['timestamp'] = time();
         $this->data['Inbox']['ip'] = $_SERVER['REMOTE_ADDR'];
         $this->data['Inbox']['user_agent'] = $_SERVER['HTTP_USER_AGENT'];
         $this->data['Inbox']['user_agent_sha256'] = hash('sha256', $_SERVER['HTTP_USER_AGENT']);
         return true;
     }
-
-
 }

--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -1,6 +1,6 @@
 <?php
-
 App::uses('AppModel', 'Model');
+App::uses('UuidTool', 'Tools');
 
 class MispObject extends AppModel
 {
@@ -185,7 +185,7 @@ class MispObject extends AppModel
         }
         // generate UUID if it doesn't exist
         if (empty($this->data[$this->alias]['uuid'])) {
-            $this->data[$this->alias]['uuid'] = CakeText::uuid();
+            $this->data[$this->alias]['uuid'] = UuidTool::v4();
         }
         // generate timestamp if it doesn't exist
         if (empty($this->data[$this->alias]['timestamp'])) {

--- a/app/Model/ObjectReference.php
+++ b/app/Model/ObjectReference.php
@@ -1,6 +1,6 @@
 <?php
-
 App::uses('AppModel', 'Model');
+App::uses('UuidTool', 'Tools');
 
 class ObjectReference extends AppModel
 {
@@ -43,7 +43,7 @@ class ObjectReference extends AppModel
     {
         parent::beforeValidate();
         if (empty($this->data['ObjectReference']['uuid'])) {
-            $this->data['ObjectReference']['uuid'] = CakeText::uuid();
+            $this->data['ObjectReference']['uuid'] = UuidTool::v4();
         }
         $date = new DateTime();
         $this->data['ObjectReference']['timestamp'] = $date->getTimestamp();

--- a/app/Model/Organisation.php
+++ b/app/Model/Organisation.php
@@ -1,6 +1,8 @@
 <?php
 App::uses('AppModel', 'Model');
 App::uses('ConnectionManager', 'Model');
+App::uses('UuidTool', 'Tools');
+
 class Organisation extends AppModel
 {
     public $useTable = 'organisations';
@@ -86,7 +88,7 @@ class Organisation extends AppModel
     {
         parent::beforeValidate();
         if (empty($this->data['Organisation']['uuid'])) {
-            $this->data['Organisation']['uuid'] = CakeText::uuid();
+            $this->data['Organisation']['uuid'] = UuidTool::v4();
         } else {
             $this->data['Organisation']['uuid'] = trim($this->data['Organisation']['uuid']);
         }
@@ -227,7 +229,7 @@ class Organisation extends AppModel
         if (empty($existingOrg)) {
             $this->create();
             $organisation = array(
-                    'uuid' =>CakeText::uuid(),
+                    'uuid' => UuidTool::v4(),
                     'name' => $name,
                     'local' => $local,
                     'created_by' => $user_id

--- a/app/Model/ShadowAttribute.php
+++ b/app/Model/ShadowAttribute.php
@@ -1,8 +1,8 @@
 <?php
-
 App::uses('AppModel', 'Model');
 App::uses('Folder', 'Utility');
 App::uses('File', 'Utility');
+App::uses('UuidTool', 'Tools');
 
 class ShadowAttribute extends AppModel
 {
@@ -360,7 +360,7 @@ class ShadowAttribute extends AppModel
 
         // generate UUID if it doesn't exist
         if (empty($this->data['ShadowAttribute']['uuid'])) {
-            $this->data['ShadowAttribute']['uuid'] = CakeText::uuid();
+            $this->data['ShadowAttribute']['uuid'] = UuidTool::v4();
         }
 
         if (!empty($this->data['ShadowAttribute']['type']) && empty($this->data['ShadowAttribute']['category'])) {

--- a/app/Model/SharingGroup.php
+++ b/app/Model/SharingGroup.php
@@ -1,5 +1,6 @@
 <?php
 App::uses('AppModel', 'Model');
+App::uses('UuidTool', 'Tools');
 
 class SharingGroup extends AppModel
 {
@@ -64,7 +65,7 @@ class SharingGroup extends AppModel
     {
         parent::beforeValidate();
         if (empty($this->data['SharingGroup']['uuid'])) {
-            $this->data['SharingGroup']['uuid'] = CakeText::uuid();
+            $this->data['SharingGroup']['uuid'] = UuidTool::v4();
         }
         $date = date('Y-m-d H:i:s');
         if (empty($this->data['SharingGroup']['created'])) {
@@ -544,7 +545,7 @@ class SharingGroup extends AppModel
                 'name' => array(),
                 'releasability' => array(),
                 'description' => array('default' => ''),
-                'uuid' => array('default' => CakeText::uuid()),
+                'uuid' => array('default' => UuidTool::v4()),
                 'organisation_uuid' => array('default' => $user['Organisation']['uuid']),
                 'created' => array('default' => $date = date('Y-m-d H:i:s')),
                 'modified' => array('default' => $date = date('Y-m-d H:i:s')),

--- a/app/Model/Sighting.php
+++ b/app/Model/Sighting.php
@@ -1,6 +1,7 @@
 <?php
 App::uses('AppModel', 'Model');
 App::uses('RandomTool', 'Tools');
+App::uses('UuidTool', 'Tools');
 
 class Sighting extends AppModel
 {
@@ -52,7 +53,7 @@ class Sighting extends AppModel
             $this->data['Sighting']['date_sighting'] = $date;
         }
         if (empty($this->data['Sighting']['uuid'])) {
-            $this->data['Sighting']['uuid'] = CakeText::uuid();
+            $this->data['Sighting']['uuid'] = UuidTool::v4();
         }
         return true;
     }

--- a/app/Model/TagCollection.php
+++ b/app/Model/TagCollection.php
@@ -1,6 +1,6 @@
 <?php
-
 App::uses('AppModel', 'Model');
+App::uses('UuidTool', 'Tools');
 
 class TagCollection extends AppModel
 {
@@ -50,7 +50,7 @@ class TagCollection extends AppModel
         parent::beforeValidate();
         // generate UUID if it doesn't exist
         if (empty($this->data['TagCollection']['uuid'])) {
-            $this->data['TagCollection']['uuid'] = CakeText::uuid();
+            $this->data['TagCollection']['uuid'] = UuidTool::v4();
         }
         return true;
     }


### PR DESCRIPTION
#### What does it do?

UUID v4 is all random (so with lower probability of collision than v1), faster and do not leak MISP instance IP address.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
