### PR TITLE
fix: [UI] Bootstrap 2 doesn't support auto position for popover

### DIFF
--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -1834,7 +1834,6 @@ function popoverConfirm(clicked, message, placement) {
         popoverContent += '<button id="popoverConfirmOK" class="btn btn-primary" style="margin-right: 5px;" onclick=submitPopover(this)>Yes</button>';
         popoverContent += '<button class="btn btn-inverse" style="float: right;" onclick=cancelPrompt()>Cancel</button>';
     popoverContent += '</div>';
-    placement = placement === undefined ? 'auto' : placement;
     openPopover($clicked, popoverContent, undefined, placement);
     $("#popoverConfirmOK")
     .focus()


### PR DESCRIPTION
## What does it do?

Without this change, popover is position to upper top corner of page, thats annoying. 

For supported positions see https://getbootstrap.com/2.3.2/javascript.html#popovers

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
