### PR TITLE
fix: [UI] Module diagnostic colors

### DIFF
--- a/app/View/Elements/healthElements/diagnostics.ctp
+++ b/app/View/Elements/healthElements/diagnostics.ctp
@@ -385,14 +385,14 @@
     ?>
         <div style="background-color:#f7f7f9;width:400px;">
             <?php
-                $colour = 'green';
+                $colour = 'red';
                 if (isset($moduleErrors[$moduleStatus[$type]])) {
                     $message = $moduleErrors[$moduleStatus[$type]];
                 } else {
                     $message = h($moduleStatus[$type]);
                 }
-                if ($moduleStatus[$type] > 0) {
-                    $colour = 'red';
+                if ($moduleStatus[$type] === 0) {
+                    $colour = 'green';
                 }
                 echo $type . __(' module system') . '…<span style="color:' . $colour . ';">' . $message . '</span>';
             ?>


### PR DESCRIPTION
#### What does it do?

Fixes super confusion module diagnostic, when „Connection refused” status is green.

<img width="585" alt="Snímek obrazovky 2020-05-29 v 10 05 26" src="https://user-images.githubusercontent.com/163343/83236666-2965f180-a194-11ea-8b5a-de1ff1c21e73.png">


#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
