### PR TITLE
fix: [galaxy] Fetch all events for galaxy cluster

### DIFF
--- a/app/Controller/GalaxyClustersController.php
+++ b/app/Controller/GalaxyClustersController.php
@@ -138,15 +138,14 @@ class GalaxyClustersController extends AppController
             'conditions' => $conditions
         ));
         if (!empty($cluster)) {
-            $galaxyType = $cluster['GalaxyCluster']['type'];
             $this->loadModel('Tag');
             $tag = $this->Tag->find('first', array(
-                    'conditions' => array(
-                            'name' => $cluster['GalaxyCluster']['tag_name']
-                    ),
-                    'fields' => array('id'),
-                    'recursive' => -1,
-                    'contain' => array('EventTag.tag_id')
+                'conditions' => array(
+                    'LOWER(name)' => strtolower($cluster['GalaxyCluster']['tag_name']),
+                ),
+                'fields' => array('id'),
+                'recursive' => -1,
+                'contain' => array('EventTag.tag_id')
             ));
             if (!empty($tag)) {
                 $cluster['GalaxyCluster']['tag_count'] = count($tag['EventTag']);


### PR DESCRIPTION
#### What does it do?

Without this change, just tags with same case are loaded.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
