### PR TITLE
fix: [UI] Show feed caching just for site admins

### DIFF
--- a/app/View/Feeds/index.ctp
+++ b/app/View/Feeds/index.ctp
@@ -205,7 +205,8 @@
                     'data_path' => 'Feed.cache_timestamp',
                     'enabled_path' => 'Feed.caching_enabled',
                     'element' => 'caching',
-                    'sort' => 'Feed.cache_timestamp'
+                    'sort' => 'Feed.cache_timestamp',
+                    'requirement' => $isSiteAdmin,
                 )
             ),
             'title' => __('Feeds'),


### PR DESCRIPTION
#### What does it do?

Without this patch, when user is not site admin, for all feeds is showed 'Not cached', that is not true. And it also generates a lot of warnings to debug log.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
