### PR TITLE
Decaying v2

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -552,7 +552,6 @@ class AppController extends Controller
         if (!empty($homepage)) {
             $this->set('homepage', $homepage['UserSetting']['value']);
         }
-        Configure::write('user_id', $this->Auth->user('id'));
     }
 
     private function __rateLimitCheck()

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -552,6 +552,7 @@ class AppController extends Controller
         if (!empty($homepage)) {
             $this->set('homepage', $homepage['UserSetting']['value']);
         }
+        Configure::write('user_id', $this->Auth->user('id'));
     }
 
     private function __rateLimitCheck()

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -4477,6 +4477,7 @@ class Attribute extends AppModel
 
         $subqueryElements = $this->Event->harvestSubqueryElements($filters);
         $filters = $this->Event->addFiltersFromSubqueryElements($filters, $subqueryElements);
+        $filters = $this->Event->addFiltersFromUserSettings($user, $filters);
         $conditions = $this->buildFilterConditions($user, $filters);
         $params = array(
                 'conditions' => $conditions,

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -3477,8 +3477,8 @@ class Attribute extends AppModel
                     $this->DecayingModel = ClassRegistry::init('DecayingModel');
                     $include_full_model = isset($options['includeFullModel']) && $options['includeFullModel'] ? 1 : 0;
                     if (empty($results[$key]['Attribute']['AttributeTag'])) {
-                        $results[$key]['Attribute']['AttributeTag'] = $results[$key]['AttributeTag'];
-                        $results[$key]['Attribute']['EventTag'] = $results[$key]['EventTag'];
+                        $results[$key]['Attribute']['AttributeTag'] = isset($results[$key]['AttributeTag']) ? $results[$key]['AttributeTag'] : array();
+                        $results[$key]['Attribute']['EventTag'] = isset($results[$key]['EventTag']) ? $results[$key]['EventTag'] : array();
                     }
                     $results[$key]['Attribute'] = $this->DecayingModel->attachScoresToAttribute($user, $results[$key]['Attribute'], $options['decayingModel'], $options['modelOverrides'], $include_full_model);
                     unset($results[$key]['Attribute']['AttributeTag']);

--- a/app/Model/DecayingModel.php
+++ b/app/Model/DecayingModel.php
@@ -309,8 +309,9 @@ class DecayingModel extends AppModel
                                 unset($taxonomies[$namespace]['TaxonomyPredicate'][$p]['TaxonomyEntry'][$e]);
                             } else {
                                 $tag_name = sprintf('%s:%s="%s"', $taxonomy['namespace'], $predicate['value'], $entry['value']);
-                                if (isset($tags[strtoupper($tag_name)])) {
-                                    $taxonomies[$namespace]['TaxonomyPredicate'][$p]['TaxonomyEntry'][$e]['Tag'] = $tags[strtoupper($tag_name)]['Tag'];
+                                $upperTagName = strtoupper($tag_name);
+                                if (isset($tags[$upperTagName])) {
+                                    $taxonomies[$namespace]['TaxonomyPredicate'][$p]['TaxonomyEntry'][$e]['Tag'] = $tags[$upperTagName]['Tag'];
                                 } else { // tag is not created yet. Create a false one.
                                     $taxonomies[$namespace]['TaxonomyPredicate'][$p]['TaxonomyEntry'][$e]['Tag'] = array(
                                         'id' => 0,
@@ -318,11 +319,10 @@ class DecayingModel extends AppModel
                                         'colour' => 'grey',
                                     );
                                 }
-                                $taxonomies[$namespace]['TaxonomyPredicate'][$p]['TaxonomyEntry'][$e]['Tag'] = $tags[strtoupper($tag_name)]['Tag'];
                                 // Take care of numerical_value override
-                                if (isset($tags[strtoupper($tag_name)]['Tag']['original_numerical_value']) && is_numeric($tags[strtoupper($tag_name)]['Tag']['original_numerical_value'])) {
-                                    $taxonomies[$namespace]['TaxonomyPredicate'][$p]['TaxonomyEntry'][$e]['original_numerical_value'] = $tags[strtoupper($tag_name)]['Tag']['original_numerical_value'];
-                                    $taxonomies[$namespace]['TaxonomyPredicate'][$p]['TaxonomyEntry'][$e]['numerical_value'] = $tags[strtoupper($tag_name)]['Tag']['numerical_value'];
+                                if (isset($tags[$upperTagName]['Tag']['original_numerical_value']) && is_numeric($tags[$upperTagName]['Tag']['original_numerical_value'])) {
+                                    $taxonomies[$namespace]['TaxonomyPredicate'][$p]['TaxonomyEntry'][$e]['original_numerical_value'] = $tags[$upperTagName]['Tag']['original_numerical_value'];
+                                    $taxonomies[$namespace]['TaxonomyPredicate'][$p]['TaxonomyEntry'][$e]['numerical_value'] = $tags[$upperTagName]['Tag']['numerical_value'];
                                 }
                                 // In some cases, tags may not have a numerical_value. Make sure it has one.
                                 if (empty($taxonomies[$namespace]['TaxonomyPredicate'][$p]['TaxonomyEntry'][$e]['Tag']['numerical_value']) && !empty($entry['numerical_value'])) {
@@ -340,8 +340,8 @@ class DecayingModel extends AppModel
                             unset($taxonomies[$namespace]['TaxonomyPredicate'][$p]);
                         } else {
                             $tag_name = sprintf('%s:%s', $taxonomy['namespace'], $predicate['value']);
-                            if (isset($tags[strtoupper($tag_name)])) {
-                                $taxonomies[$namespace]['TaxonomyPredicate'][$p]['Tag'] = $tags[strtoupper($tag_name)]['Tag'];
+                            if (isset($tags[$upperTagName])) {
+                                $taxonomies[$namespace]['TaxonomyPredicate'][$p]['Tag'] = $tags[$upperTagName]['Tag'];
                             } else { // tag is not created yet. Create a false one.
                                 $taxonomies[$namespace]['TaxonomyPredicate'][$p]['Tag'] = array(
                                     'id' => 0,
@@ -352,9 +352,9 @@ class DecayingModel extends AppModel
                             $taxonomies[$namespace]['TaxonomyPredicate'][$p]['numerical_predicate'] = true;
                             $taxonomies[$namespace]['TaxonomyPredicate'][$p]['Tag']['numerical_value'] = $predicate['numerical_value'];
                             // Take care of numerical_value override
-                            if (isset($tags[strtoupper($tag_name)]['Tag']['original_numerical_value']) && is_numeric($tags[strtoupper($tag_name)]['Tag']['original_numerical_value'])) {
-                                $taxonomies[$namespace]['TaxonomyPredicate'][$p]['original_numerical_value'] = $tags[strtoupper($tag_name)]['Tag']['original_numerical_value'];
-                                $taxonomies[$namespace]['TaxonomyPredicate'][$p]['numerical_value'] = $tags[strtoupper($tag_name)]['Tag']['numerical_value'];
+                            if (isset($tags[$upperTagName]['Tag']['original_numerical_value']) && is_numeric($tags[$upperTagName]['Tag']['original_numerical_value'])) {
+                                $taxonomies[$namespace]['TaxonomyPredicate'][$p]['original_numerical_value'] = $tags[$upperTagName]['Tag']['original_numerical_value'];
+                                $taxonomies[$namespace]['TaxonomyPredicate'][$p]['numerical_value'] = $tags[$upperTagName]['Tag']['numerical_value'];
                             }
                             // In some cases, tags may not have a numerical_value. Make sure it has one.
                             if (empty($taxonomies[$namespace]['TaxonomyPredicate'][$p]['Tag']['numerical_value']) && !empty($predicate['numerical_value'])) {

--- a/app/Model/DecayingModel.php
+++ b/app/Model/DecayingModel.php
@@ -319,7 +319,15 @@ class DecayingModel extends AppModel
                                     );
                                 }
                                 $taxonomies[$namespace]['TaxonomyPredicate'][$p]['TaxonomyEntry'][$e]['Tag'] = $tags[strtoupper($tag_name)]['Tag'];
-                                $taxonomies[$namespace]['TaxonomyPredicate'][$p]['TaxonomyEntry'][$e]['Tag']['numerical_value'] = $entry['numerical_value'];
+                                // Take care of numerical_value override
+                                if (isset($tags[strtoupper($tag_name)]['Tag']['original_numerical_value']) && is_numeric($tags[strtoupper($tag_name)]['Tag']['original_numerical_value'])) {
+                                    $taxonomies[$namespace]['TaxonomyPredicate'][$p]['TaxonomyEntry'][$e]['original_numerical_value'] = $tags[strtoupper($tag_name)]['Tag']['original_numerical_value'];
+                                    $taxonomies[$namespace]['TaxonomyPredicate'][$p]['TaxonomyEntry'][$e]['numerical_value'] = $tags[strtoupper($tag_name)]['Tag']['numerical_value'];
+                                }
+                                // In some cases, tags may not have a numerical_value. Make sure it has one.
+                                if (empty($taxonomies[$namespace]['TaxonomyPredicate'][$p]['TaxonomyEntry'][$e]['Tag']['numerical_value']) && !empty($entry['numerical_value'])) {
+                                    $taxonomies[$namespace]['TaxonomyPredicate'][$p]['TaxonomyEntry'][$e]['Tag']['numerical_value'] = $entry['numerical_value'];
+                                }
                             }
                         }
                         if (empty($taxonomies[$namespace]['TaxonomyPredicate'][$p]['TaxonomyEntry'])) {
@@ -341,8 +349,17 @@ class DecayingModel extends AppModel
                                     'colour' => 'grey',
                                 );
                             }
-                            $taxonomies[$namespace]['TaxonomyPredicate'][$p]['Tag']['numerical_value'] = $predicate['numerical_value'];
                             $taxonomies[$namespace]['TaxonomyPredicate'][$p]['numerical_predicate'] = true;
+                            $taxonomies[$namespace]['TaxonomyPredicate'][$p]['Tag']['numerical_value'] = $predicate['numerical_value'];
+                            // Take care of numerical_value override
+                            if (isset($tags[strtoupper($tag_name)]['Tag']['original_numerical_value']) && is_numeric($tags[strtoupper($tag_name)]['Tag']['original_numerical_value'])) {
+                                $taxonomies[$namespace]['TaxonomyPredicate'][$p]['original_numerical_value'] = $tags[strtoupper($tag_name)]['Tag']['original_numerical_value'];
+                                $taxonomies[$namespace]['TaxonomyPredicate'][$p]['numerical_value'] = $tags[strtoupper($tag_name)]['Tag']['numerical_value'];
+                            }
+                            // In some cases, tags may not have a numerical_value. Make sure it has one.
+                            if (empty($taxonomies[$namespace]['TaxonomyPredicate'][$p]['Tag']['numerical_value']) && !empty($predicate['numerical_value'])) {
+                                $taxonomies[$namespace]['TaxonomyPredicate'][$p]['Tag']['numerical_value'] = $predicate['numerical_value'];
+                            }
                         }
                     }
                     
@@ -358,7 +375,6 @@ class DecayingModel extends AppModel
                 $excluded_taxonomies[$namespace] = array('taxonomy' => $taxonomies[$namespace], 'reason' => __('No predicate'));
             }
         }
-
         return array(
             'taxonomies' => $taxonomies,
             'excluded_taxonomies' => $excluded_taxonomies,

--- a/app/Model/DecayingModelsFormulas/Base.php
+++ b/app/Model/DecayingModelsFormulas/Base.php
@@ -136,12 +136,18 @@ abstract class DecayingModelBase
             $all_sightings = $this->Sighting->listSightings($user, $attribute['id'], 'attribute', false, 0, true);
             if (!empty($all_sightings)) {
                 $last_sighting_timestamp = $all_sightings[0]['Sighting']['date_sighting'];
+            } elseif (!is_null($attribute['last_seen'])) {
+                $last_sighting_timestamp = (new DateTime($attribute['last_seen']))->format('U');
             } else {
-                $last_sighting_timestamp = $attribute['timestamp']; // if no sighting, take the last update time
+                $last_sighting_timestamp = $attribute['timestamp']; // if no sighting nor valid last_seen, take the last update time
             }
         }
         if ($attribute['timestamp'] > $last_sighting_timestamp) { // The attribute was modified after the last sighting
-            $last_sighting_timestamp = $attribute['timestamp'];
+            if (!is_null($attribute['last_seen'])) {
+                $last_sighting_timestamp = (new DateTime($attribute['last_seen']))->format('U');
+            } else {
+                $last_sighting_timestamp = $attribute['timestamp'];
+            }
         }
         $timestamp = time();
         $scores = array(

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -6690,6 +6690,7 @@ class Event extends AppModel
 
         $subqueryElements = $this->harvestSubqueryElements($filters);
         $filters = $this->addFiltersFromSubqueryElements($filters, $subqueryElements);
+        $filters = $this->addFiltersFromUserSettings($user, $filters);
 
         if (empty($exportTool->mock_query_only)) {
             $filters['include_attribute_count'] = 1;
@@ -6966,6 +6967,14 @@ class Event extends AppModel
                 $filters['org'] = $orgcIdsFromMeta;
             }
         }
+        return $filters;
+    }
+
+    public function addFiltersFromUserSettings($user, $filters)
+    {
+        $this->UserSetting = ClassRegistry::init('UserSetting');
+        $defaultParameters = $this->UserSetting->getDefaulRestSearchParameters($user);
+        $filters = array_replace_recursive($defaultParameters, $filters);
         return $filters;
     }
 

--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -1337,6 +1337,7 @@ class MispObject extends AppModel
         }
         $subqueryElements = $this->Event->harvestSubqueryElements($filters);
         $filters = $this->Event->addFiltersFromSubqueryElements($filters, $subqueryElements);
+        $filters = $this->Event->addFiltersFromUserSettings($user, $filters);
         $conditions = $this->buildFilterConditions($user, $filters);
         $params = array(
                 'conditions' => $conditions,

--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -426,7 +426,7 @@ class Tag extends AppModel
     */
     public function checkForOverride($tags)
     {
-        $userId = Configure::read('user_id');
+        $userId = Configure::read('CurrentUserId');
         $this->UserSetting = ClassRegistry::init('UserSetting');
         if ($this->tagOverrides === false && $userId > 0) {
             $this->tagOverrides = $this->UserSetting->getTagNumericalValueOverride($userId);

--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -69,6 +69,8 @@ class Tag extends AppModel
         )
     );
 
+    private $tagOverrides = false;
+
     public function beforeValidate($options = array())
     {
         parent::beforeValidate();
@@ -131,6 +133,12 @@ class Tag extends AppModel
                 }
             }
         }
+    }
+
+    public function afterFind($results, $primary = false)
+    {
+        $results = $this->checkForOverride($results);
+        return $results;
     }
 
     public function validateColour($fields)
@@ -411,6 +419,28 @@ class Tag extends AppModel
             $tags[$k]['Tag']['hide_tag'] = 1;
         }
         return ($this->saveAll($tags));
+    }
+
+    /**
+    * Recover user_id from the session and override numerical_values from userSetting
+    */
+    public function checkForOverride($tags)
+    {
+        $userId = Configure::read('user_id');
+        $this->UserSetting = ClassRegistry::init('UserSetting');
+        if ($this->tagOverrides === false && $userId > 0) {
+            $this->tagOverrides = $this->UserSetting->getTagNumericalValueOverride($userId);
+        }
+        foreach ($tags as $k => $tag) {
+            if (isset($tag['Tag']['name'])) {
+                $tagName = $tag['Tag']['name'];
+                if (isset($this->tagOverrides[$tagName]) && is_numeric($this->tagOverrides[$tagName])) {
+                    $tags[$k]['Tag']['original_numerical_value'] = $tags[$k]['Tag']['numerical_value'];
+                    $tags[$k]['Tag']['numerical_value'] = $this->tagOverrides[$tagName];
+                }
+            }
+        }
+        return $tags;
     }
 
     public function getTagsByName($tag_names, $containTagConnectors = true)

--- a/app/Model/Taxonomy.php
+++ b/app/Model/Taxonomy.php
@@ -290,7 +290,7 @@ class Taxonomy extends AppModel
                     if (isset($tags[strtoupper($temp['tag'])])) {
                         $existingTag = $tags[strtoupper($temp['tag'])];
                         $taxonomy['entries'][$key]['existing_tag'] = $existingTag;
-                        // numerical_value is overriden at tag level. Propagate the override further up
+                        // numerical_value is overridden at tag level. Propagate the override further up
                         if (isset($existingTag['Tag']['original_numerical_value'])) {
                             $taxonomy['entries'][$key]['original_numerical_value'] = $existingTag['Tag']['original_numerical_value'];
                             $taxonomy['entries'][$key]['numerical_value'] = $existingTag['Tag']['numerical_value'];

--- a/app/Model/Taxonomy.php
+++ b/app/Model/Taxonomy.php
@@ -287,7 +287,17 @@ class Taxonomy extends AppModel
             $tags = $this->Tag->getTagsByName($tag_names, false);
             if (isset($taxonomy['entries'])) {
                 foreach ($taxonomy['entries'] as $key => $temp) {
-                    $taxonomy['entries'][$key]['existing_tag'] = isset($tags[strtoupper($temp['tag'])]) ? $tags[strtoupper($temp['tag'])] : false;
+                    if (isset($tags[strtoupper($temp['tag'])])) {
+                        $existingTag = $tags[strtoupper($temp['tag'])];
+                        $taxonomy['entries'][$key]['existing_tag'] = $existingTag;
+                        // numerical_value is overriden at tag level. Propagate the override further up
+                        if (isset($existingTag['Tag']['original_numerical_value'])) {
+                            $taxonomy['entries'][$key]['original_numerical_value'] = $existingTag['Tag']['original_numerical_value'];
+                            $taxonomy['entries'][$key]['numerical_value'] = $existingTag['Tag']['numerical_value'];
+                        }
+                    } else {
+                        $taxonomy['entries'][$key]['existing_tag'] = false;
+                    }
                 }
             }
         }

--- a/app/Model/UserSetting.php
+++ b/app/Model/UserSetting.php
@@ -87,6 +87,11 @@ class UserSetting extends AppModel
                 )
             )
         ),
+        'tag_numerical_value_override' => array(
+            'placeholder' => array(
+                'false-positive:risk="medium"' => 99
+            )
+        ),
     );
 
     // massage the data before we send it off for validation before saving anything
@@ -201,6 +206,22 @@ class UserSetting extends AppModel
             'conditions' => array(
                 'UserSetting.user_id' => $user['id'],
                 'UserSetting.setting' => 'default_restsearch_parameters'
+            )
+        ));
+        $parameters = array();
+        if (!empty($setting)) {
+            $parameters = $setting['UserSetting']['value'];
+        }
+        return $parameters;
+     }
+
+     public function getTagNumericalValueOverride($userId)
+     {
+        $setting = $this->find('first', array(
+            'recursive' => -1,
+            'conditions' => array(
+                'UserSetting.user_id' => $userId,
+                'UserSetting.setting' => 'tag_numerical_value_override'
             )
         ));
         $parameters = array();

--- a/app/Model/UserSetting.php
+++ b/app/Model/UserSetting.php
@@ -67,7 +67,26 @@ class UserSetting extends AppModel
         ),
         'homepage' => array(
             'path' => '/events/index'
-        )
+        ),
+        'default_restsearch_parameters' => array(
+            'placeholder' => array(
+                'AND' => array(
+                    'NOT' => array(
+                        'EventTag.name' => array(
+                            '%osint%'
+                        )
+                    ),
+                    'OR' => array(
+                        'Tag.name' => array(
+                            'tlp:green',
+                            'tlp:amber',
+                            'tlp:red',
+                            '%privint%'
+                        )
+                    )
+                )
+            )
+        ),
     );
 
     // massage the data before we send it off for validation before saving anything
@@ -173,6 +192,22 @@ class UserSetting extends AppModel
              }
          }
          return false;
+     }
+
+     public function getDefaulRestSearchParameters($user)
+     {
+        $setting = $this->find('first', array(
+            'recursive' => -1,
+            'conditions' => array(
+                'UserSetting.user_id' => $user['id'],
+                'UserSetting.setting' => 'default_restsearch_parameters'
+            )
+        ));
+        $parameters = array();
+        if (!empty($setting)) {
+            $parameters = $setting['UserSetting']['value'];
+        }
+        return $parameters;
      }
 
     /*

--- a/app/View/DecayingModel/decaying_tool_basescore.ctp
+++ b/app/View/DecayingModel/decaying_tool_basescore.ctp
@@ -38,10 +38,19 @@
                                                 <li>
                                                     <a style="position: relative; padding: 3px 5px;">
                                                         <span class="tagComplete"
-                                                        style="margin-right: 35px;background-color: <?php echo h($entry['Tag']['colour']); ?>;color:<?php echo h($this->TextColour->getTextColour($entry['Tag']['colour']));?>"
+                                                        style="margin-right:50px;background-color: <?php echo h($entry['Tag']['colour']); ?>;color:<?php echo h($this->TextColour->getTextColour($entry['Tag']['colour']));?>"
                                                         title="<?php echo sprintf('%s: %s', h($entry['expanded']), h($entry['description'])) ?>"><?php echo h($entry['Tag']['name']); ?>
                                                         </span>
-                                                        <span class="label label-inverse numerical-value-label"><?php echo h($entry['numerical_value']) ?></span>
+                                                        <span class="label label-inverse numerical-value-label">
+                                                            <?php echo h($entry['numerical_value']) ?>
+                                                            <?php if(isset($entry['original_numerical_value'])): ?>
+                                                                <i
+                                                                    class="<?= $this->FontAwesome->getClass('exclamation-triangle') ?> fa-exclamation-triangle"
+                                                                    title="<?= __('Numerical value overriden by userSetting.&#10;Original numerical_value = %s', h($entry['original_numerical_value'])) ?>"
+                                                                    data-value-overriden="1"
+                                                                ></i>
+                                                            <?php endif; ?>
+                                                        </span>
                                                     </a>
                                                 </li>
                                             <?php endforeach; ?>

--- a/app/View/Taxonomies/view.ctp
+++ b/app/View/Taxonomies/view.ctp
@@ -97,7 +97,16 @@
             <?php endif; ?>
                 <td id="tag_<?php echo h($k); ?>" class="short"><?php echo h($item['tag']); ?></td>
                 <td><?php echo h($item['expanded']); ?>&nbsp;</td>
-                <td class="short"><?php echo isset($item['numerical_value']) ? h($item['numerical_value']) : ''; ?>&nbsp;</td>
+                <td class="short">
+                    <?php echo isset($item['numerical_value']) ? h($item['numerical_value']) : ''; ?>&nbsp;
+                    <?php if(isset($item['original_numerical_value'])): ?>
+                        <i
+                            class="<?= $this->FontAwesome->getClass('exclamation-triangle') ?> fa-exclamation-triangle"
+                            title="<?= __('Numerical value overriden by userSetting.&#10;Original numerical_value = %s', h($item['original_numerical_value'])) ?>"
+                            data-value-overriden="1"
+                        ></i>
+                    <?php endif; ?>
+                </td>
                 <td class="short">
                 <?php
                     if ($item['existing_tag']) {
@@ -193,6 +202,7 @@
         $('.select_taxonomy, .select_all').click(function(){
             taxonomyListAnyCheckBoxesChecked();
         });
+        $('[data-value-overriden="1"]').tooltip();
     });
 </script>
 <?php


### PR DESCRIPTION
## New features
#### UserSetting
- New setting `default_restsearch_parameters` allowing users to supply restSearch parameters that will automatically be passed during API fetch. The main purpose of this new setting is to enable users to inject filters when integrating with third-party tools not offering the possibility to control the query performed against MISP.
![image](https://user-images.githubusercontent.com/6977223/83493800-9b507a80-a4b5-11ea-8a34-7b3f3fa0eb7e.png)
- New setting `tag_numerical_value_override` allowing users to override the `numerical_value` of tags. The main purpose of this new setting is to let user have their own numerical value for tags. It does not constrain site-admin to diverge from the official misp-taxonomy repository and let them define new values for entries not possessing having one.
![image](https://user-images.githubusercontent.com/6977223/83495357-dce22500-a4b7-11ea-8b66-5bfa47d63001.png)
![image](https://user-images.githubusercontent.com/6977223/83495640-406c5280-a4b8-11ea-8549-10c158ee4a7c.png)

## Major changes in decay computation
#### Attribute's `last_seen` will now takes precedence over the Attribute's `timestamp` if the former is set
In the decaying implementation prior to this pull request, if no sightings were recorded, the simulated last sighting was set on the `timestamp` value. However, once this pull request will be merged, the `last_seen` value will be used instead. Users will be able to alter Attributes (attach tags, modify `last_seen`, ...) without refreshing the decaying score to its maximum value.
