### PR TITLE
Soft-delete Attributes when performing a feed delta-merge

### DIFF
--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -996,8 +996,16 @@ class Feed extends AppModel
                 }
             }
             if ($feed['Feed']['delta_merge'] && !empty($existsAttributesValueToId)) {
-                $to_delete = array_values($existsAttributesValueToId);
-                $this->Event->Attribute->deleteAll(array('Attribute.id' => $to_delete, 'Attribute.deleted' => 0));
+                $attributesToDelete = $this->Event->Attribute->find('all', array(
+                    'conditions' => array(
+                        'Attribute.id' => array_values($existsAttributesValueToId)
+                    ),
+                    'recursive' => -1
+                ));
+                foreach ($attributesToDelete as $k => $attribute) {
+                    $attributesToDelete[$k]['Attribute']['deleted'] = 1;
+                }
+                $this->Event->Attribute->saveMany($attributesToDelete); // We need to trigger callback methods
             }
         }
         if (empty($data)) {


### PR DESCRIPTION
When performing a feed delta-merge save, Attribute where hard-deleted. This PR soft-delete them.
It introduces an overhead that seems to be needed:
- Fetching all the Attributes (so that we have a trace in the logs)
- Iterating to change the `deleted` value
- Saving them (We need to execute the callback methods - `updateAll()` doesn't do it)
If you see a cleaner/faster way to do it. Please tell me :)

Fix https://github.com/MISP/MISP/issues/5949.