### PR TITLE
fix: [mail] Fix body of passwordReset/newUser emails

### DIFF
--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -1158,7 +1158,7 @@ class User extends AppModel
     public function initiatePasswordReset($user, $firstTime = false, $simpleReturn = false, $fixedPassword = false)
     {
         $org = Configure::read('MISP.org');
-        $options = array('passwordResetText', 'newUserText');
+        $options = array('newUserText', 'passwordResetText');
         $subjects = array('[' . $org . ' MISP] New user registration', '[' . $org .  ' MISP] Password reset');
         $textToFetch = $options[($firstTime ? 0 : 1)];
         $subject = $subjects[($firstTime ? 0 : 1)];


### PR DESCRIPTION
When MISP sends an email with new credentials, the body is generated from one of the configured templates - passwordResetText or newUserText. However, these two templates were swapped - the newUserText was used for password reset, while passwordResetText was used when new account is created.

This PR fixes it.

#### Release Type:

- [ ] Major
- [ ] Minor
- [x] Patch