### PR TITLE
fix: [internal] Removing attributes from empty event

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -663,7 +663,7 @@ class Attribute extends AppModel
     private function __alterAttributeCount($event_id, $increment = true)
     {
         return $this->Event->updateAll(
-            array('Event.attribute_count' => $increment ? 'Event.attribute_count+1' : 'GREATEST(Event.attribute_count-1, 0)'),
+            array('Event.attribute_count' => $increment ? 'Event.attribute_count+1' : 'GREATEST(Event.attribute_count, 1) - 1'),
             array('Event.id' => $event_id)
         );
     }


### PR DESCRIPTION
## What does it do?

In rare occasion, number attributes in `attribute_count` field can be different than real state. If `attribute_count` is already zero and we try to decrement that value, database returns type error (it is not possible to decrement unsigned value). This fix the behaviour.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
