### PR TITLE
chg: [internal] Drop correlations indexes

### DIFF
--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -1396,7 +1396,12 @@ class AppModel extends Model
                 $sqlArray[] = "ALTER TABLE `sightingdbs` MODIFY `timestamp` int(11) NOT NULL DEFAULT 0;";
                 break;
             case 55:
-                $this->__dropIndex('correlations', 'value'); // index is not used in any SQL query
+                // index is not used in any SQL query
+                $this->__dropIndex('correlations', 'value');
+                // these index can be theoretically used, but probably just in very rare occasion
+                $this->__dropIndex('correlations', 'org_id');
+                $this->__dropIndex('correlations', 'sharing_group_id');
+                $this->__dropIndex('correlations', 'a_sharing_group_id');
                 break;
             case 'fixNonEmptySharingGroupID':
                 $sqlArray[] = 'UPDATE `events` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -81,7 +81,7 @@ class AppModel extends Model
         33 => false, 34 => false, 35 => false, 36 => false, 37 => false, 38 => false,
         39 => false, 40 => false, 41 => false, 42 => false, 43 => false, 44 => false,
         45 => false, 46 => false, 47 => false, 48 => false, 49 => false, 50 => false,
-        51 => false, 52 => false, 53 => false, 54 => false
+        51 => false, 52 => false, 53 => false, 54 => false, 55 => false,
     );
 
     public $advanced_updates_description = array(
@@ -1394,6 +1394,9 @@ class AppModel extends Model
                 break;
             case 54:
                 $sqlArray[] = "ALTER TABLE `sightingdbs` MODIFY `timestamp` int(11) NOT NULL DEFAULT 0;";
+                break;
+            case 55:
+                $this->__dropIndex('correlations', 'value'); // index is not used in any SQL query
                 break;
             case 'fixNonEmptySharingGroupID':
                 $sqlArray[] = 'UPDATE `events` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';

--- a/db_schema.json
+++ b/db_schema.json
@@ -6809,10 +6809,7 @@
             "event_id",
             "1_event_id",
             "attribute_id",
-            "1_attribute_id",
-            "org_id",
-            "sharing_group_id",
-            "a_sharing_group_id"
+            "1_attribute_id"
         ],
         "dashboards": [
             "id",

--- a/db_schema.json
+++ b/db_schema.json
@@ -6806,7 +6806,6 @@
         ],
         "correlations": [
             "id",
-            "value",
             "event_id",
             "1_event_id",
             "attribute_id",
@@ -7170,5 +7169,5 @@
             "id"
         ]
     },
-    "db_version": "54"
+    "db_version": "55"
 }


### PR DESCRIPTION
#### What does it do?

Removes `value` index from correlations table. This index is not used in any SQL query, it just takes database space (it can be around 20 % of table size) and computation time when inserting new correlation.

Also removes `org_id`, `sharing_group_id` and `a_sharing_group_id` indexes. These indexes are smaller, but still big and can be used just theoretically.

Removing index is in place operation, but to returning space to operation system, it is necessary to optimise correlations table, that must be run manually.

#### Questions

- [x] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
