### PR TITLE
Fix issue #6006 - sgsids is never set

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -6622,7 +6622,7 @@ class Event extends AppModel
                         ));
                         if (!empty($temp)) {
                             if (!$user['Role']['perm_site_admin'] && $user['org_id'] != $event['Event']['orgc_id']) {
-                                if ($temp[$type]['distribution'] == 0 || ($temp[$type]['distribution'] == 4 && !in_array($temp[$type]['sharing_group_id'], $sgsids))) {
+                                if ($temp[$type]['distribution'] == 0 || ($temp[$type]['distribution'] == 4 && !in_array($temp[$type]['sharing_group_id'], $sgids))) {
                                     unset($object['ObjectReference'][$k2]);
                                     continue;
                                 }


### PR DESCRIPTION
#### What does it do?
The value `$sgsids` is never set.  I expect it should be `$sgids` based on the function variable.  I believe this will fix the error described in #6006

#### Questions

- [ ] Does it require a DB change? **No**
- [ ] Are you using it in production?  **Not yet**
- [ ] Does it require a change in the API (PyMISP for example)?  **No**
