### PR TITLE
chg: [correlation] Allow to drop Correlation.{date,info} columns

### DIFF
--- a/INSTALL/MYSQL.sql
+++ b/INSTALL/MYSQL.sql
@@ -150,8 +150,6 @@ CREATE TABLE IF NOT EXISTS `correlations` (
   `a_distribution` tinyint(4) NOT NULL,
   `sharing_group_id` int(11) NOT NULL,
   `a_sharing_group_id` int(11) NOT NULL,
-  `date` date NOT NULL,
-  `info` text COLLATE utf8_bin NOT NULL,
   PRIMARY KEY (`id`),
   INDEX `event_id` (`event_id`),
   INDEX `1_event_id` (`1_event_id`),

--- a/db_schema.json
+++ b/db_schema.json
@@ -1010,28 +1010,6 @@
                 "column_type": "int(11)",
                 "column_default": null,
                 "extra": ""
-            },
-            {
-                "column_name": "date",
-                "is_nullable": "NO",
-                "data_type": "date",
-                "character_maximum_length": null,
-                "numeric_precision": null,
-                "collation_name": null,
-                "column_type": "date",
-                "column_default": null,
-                "extra": ""
-            },
-            {
-                "column_name": "info",
-                "is_nullable": "NO",
-                "data_type": "text",
-                "character_maximum_length": "65535",
-                "numeric_precision": null,
-                "collation_name": "utf8_bin",
-                "column_type": "text",
-                "column_default": null,
-                "extra": ""
             }
         ],
         "correlation_exclusions": [


### PR DESCRIPTION
#### What does it do?

Until we will remove info and date columns from correlations table, we will just save dummy values to that columns (they cannot be empty). This will at least little bit reduce correlations table size (for our usage it is 10 %).

This can be merged after #5954.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
