### PR TITLE
chg: [internal] Better error handling for JSON decoding

### DIFF
--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -2890,4 +2890,31 @@ class AppModel extends Model
     {
         return Configure::read('MISP.tmpdir') ?: sys_get_temp_dir();
     }
+
+    /**
+     * Decodes JSON string and throws exception if string is not valid JSON or if is not array.
+     *
+     * @param string $json
+     * @return array
+     * @throws JsonException
+     * @throws UnexpectedValueException
+     */
+    protected function jsonDecode($json)
+    {
+        if (defined('JSON_THROW_ON_ERROR')) {
+            // JSON_THROW_ON_ERROR is supported since PHP 7.3
+            $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        } else {
+            $decoded = json_decode($json, true);
+            if ($decoded === null) {
+                throw new UnexpectedValueException('Could not parse JSON: ' . json_last_error_msg(), json_last_error());
+            }
+        }
+
+        if (!is_array($decoded)) {
+            throw new UnexpectedValueException('JSON must be array type, get ' . gettype($decoded));
+        }
+
+        return $decoded;
+    }
 }

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1116,13 +1116,10 @@ class Event extends AppModel
                 return $result;
             }
         }
-        $uploadFailed = false;
         try {
-            $json = json_decode($newTextBody, true);
+            $this->jsonDecode($newTextBody);
         } catch (Exception $e) {
-            $uploadFailed = true;
-        }
-        if (!is_array($json) || $uploadFailed) {
+            $this->logException("Invalid JSON returned when pushing to remote server {$server['Server']['id']}", $e);
             return $this->__logUploadResult($server, $event, $newTextBody);
         }
         return 'Success';
@@ -1172,18 +1169,8 @@ class Event extends AppModel
     {
         switch ($response->code) {
             case '200': // 200 (OK) + entity-action-result
-                if ($response->isOk()) {
-                    $newTextBody = $response->body();
-                    return true;
-                } else {
-                    try {
-                        $jsonArray = json_decode($response->body, true);
-                    } catch (Exception $e) {
-                        return true;
-                    }
-                    return $jsonArray['name'];
-                }
-                // no break
+                $newTextBody = $response->body();
+                return true;
             case '302': // Found
                 $newLocation = $response->headers['Location'];
                 $newTextBody = $response->body();
@@ -6079,7 +6066,7 @@ class Event extends AppModel
                 'action' => 'warning',
                 'user_id' => 0,
                 'title' => 'Uploading Event (' . $event['Event']['id'] . ') to Server (' . $server['Server']['id'] . ')',
-                'change' => 'Returned message: ', $newTextBody,
+                'change' => 'Returned message: ' . $newTextBody,
         ));
         return false;
     }

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -2709,12 +2709,12 @@ class Server extends AppModel
         if (empty($filter_rules)) {
             return $final;
         }
-        $filter_rules = json_decode($filter_rules, true);
+        $filter_rules = $this->jsonDecode($filter_rules);
         $url_params = array();
         foreach ($filter_rules as $field => $rules) {
             $temp = array();
             if ($field === 'url_params') {
-                $url_params = json_decode($rules, true);
+                $url_params = $this->jsonDecode($rules);
             } else {
                 foreach ($rules as $operator => $elements) {
                     foreach ($elements as $k => $element) {
@@ -4255,7 +4255,7 @@ class Server extends AppModel
             }
             if ($response->code == '405') {
                 try {
-                    $responseText = json_decode($response->body, true)['message'];
+                    $responseText = $this->jsonDecode($response->body)['message'];
                 } catch (Exception $e) {
                     return array('status' => 3);
                 }
@@ -4458,7 +4458,12 @@ class Server extends AppModel
 
     public function isJson($string)
     {
-        return (json_last_error() == JSON_ERROR_NONE);
+        try {
+            $this->jsonDecode($string);
+            return true;
+        } catch (Exception $e) {
+            return false;
+        }
     }
 
     public function captureServer($server, $user)
@@ -5001,9 +5006,19 @@ class Server extends AppModel
         $expected = array('stix' => '>1.2.0.9', 'cybox' => '>2.1.0.21', 'mixbox' => '1.0.3', 'maec' => '>4.1.0.14', 'stix2' => '>1.2.0', 'pymisp' => '>2.4.120');
         // check if the STIX and Cybox libraries are working using the test script stixtest.py
         $scriptResult = shell_exec($this->getPythonVersion() . ' ' . APP . 'files' . DS . 'scripts' . DS . 'stixtest.py');
-        $scriptResult = json_decode($scriptResult, true);
-        if ($scriptResult == null) {
-            return array('operational' => 0, 'stix' => array('expected' => $expected['stix']), 'cybox' => array('expected' => $expected['cybox']), 'mixbox' => array('expected' => $expected['mixbox']), 'maec' => array('expected' => $expected['maec']), 'stix2' => array('expected' => $expected['stix2']), 'pymisp' => array('expected' => $expected['pymisp']));
+        try {
+            $scriptResult = $this->jsonDecode($scriptResult);
+        } catch (Exception $e) {
+            $this->logException('Invalid JSON returned from stixtest', $e);
+            return array(
+                'operational' => 0,
+                'stix' => array('expected' => $expected['stix']),
+                'cybox' => array('expected' => $expected['cybox']),
+                'mixbox' => array('expected' => $expected['mixbox']),
+                'maec' => array('expected' => $expected['maec']),
+                'stix2' => array('expected' => $expected['stix2']),
+                'pymisp' => array('expected' => $expected['pymisp'])
+            );
         }
         $scriptResult['operational'] = $scriptResult['success'];
         if ($scriptResult['operational'] == 0) {
@@ -5950,11 +5965,14 @@ class Server extends AppModel
         }
         if ($response->isOk()) {
             try {
-                $response = json_decode($response->body, true);
+                $response = $this->jsonDecode($response->body);
             } catch (Exception $e) {
+                $message = 'Invalid response received from the remote instance.';
+
+                $this->logException($message, $e);
+
                 $this->Log = ClassRegistry::init('Log');
                 $this->Log->create();
-                $message = 'Invalid response received from the remote instance.';
                 $this->Log->save(array(
                         'org' => 'SYSTEM',
                         'model' => 'Server',


### PR DESCRIPTION
#### What does it do?

Many times in MISP, if string is not valid JSON, no error is showed to user or written to log. This pull changes at least some of them.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
