### PR TITLE
chg: [internal] Faster loading sightings if the same attribute is req…

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -5480,18 +5480,14 @@ class Event extends AppModel
         );
     }
 
-    public function getSightingData($event)
+    public function getSightingData(array $event)
     {
         $this->Sighting = ClassRegistry::init('Sighting');
         if (!empty($event['Sighting'])) {
-            $attributeSightings = array();
-            $attributeOwnSightings = array();
-            $attributeSightingsPopover = array();
             $sightingsData = array();
             $sparklineData = array();
             $startDates = array();
-            $range = (!empty(Configure::read('MISP.Sightings_range')) && is_numeric(Configure::read('MISP.Sightings_range'))) ? Configure::read('MISP.Sightings_range') : 365;
-            $range = strtotime("-" . $range . " days", time());
+            $range = $this->Sighting->getMaximumRange();
             foreach ($event['Sighting'] as $sighting) {
                 $type = $this->Sighting->type[$sighting['type']];
                 if (!isset($sightingsData[$sighting['attribute_id']][$type])) {
@@ -5533,22 +5529,21 @@ class Event extends AppModel
                 }
             }
             $csv = array();
+            $today = strtotime(date('Y-m-d', time()));
             foreach ($startDates as $k => $v) {
                 $startDates[$k] = date('Y-m-d', $v);
             }
-            $range = (!empty(Configure::read('MISP.Sightings_range')) && is_numeric(Configure::read('MISP.Sightings_range'))) ? Configure::read('MISP.Sightings_range') : 365;
             foreach ($sparklineData as $aid => $data) {
                 if (!isset($startDates[$aid])) {
                     continue;
                 }
                 $startDate = $startDates[$aid];
-                if (strtotime($startDate) < strtotime('-' . $range . ' days', time())) {
+                if (strtotime($startDate) < $range) {
                     $startDate = date('Y-m-d');
                 }
                 $startDate = date('Y-m-d', strtotime("-3 days", strtotime($startDate)));
-                $to = date('Y-m-d', time());
                 $sighting = $data;
-                for ($date = $startDate; strtotime($date) <= strtotime($to); $date = date('Y-m-d', strtotime("+1 day", strtotime($date)))) {
+                for ($date = $startDate; strtotime($date) <= $today; $date = date('Y-m-d', strtotime("+1 day", strtotime($date)))) {
                     if (!isset($csv[$aid])) {
                         $csv[$aid] = 'Date,Close\n';
                     }

--- a/app/Model/Sighting.php
+++ b/app/Model/Sighting.php
@@ -216,7 +216,8 @@ class Sighting extends AppModel
         }
         $conditions = array('Sighting.event_id' => $event['Event']['id']);
         if ($attribute_id) {
-            $conditions[] = array('Sighting.attribute_id' => $attribute_id);
+            $attribute = $this->Attribute->fetchAttribute($attribute_id);
+            $conditions['Sighting.attribute_id'] = $attribute_id;
         }
         if (!$ownEvent && (!Configure::read('Plugin.Sightings_policy') || Configure::read('Plugin.Sightings_policy') == 0)) {
             $conditions['Sighting.org_id'] = $user['org_id'];
@@ -263,7 +264,9 @@ class Sighting extends AppModel
                 $sightings[$k]['Sighting']['Organisation'] = $sightings[$k]['Organisation'];
             }
             // zeroq: add attribute UUID to sighting to make synchronization easier
-            $attribute = $this->Attribute->fetchAttribute($sighting['Sighting']['attribute_id']);
+            if (!isset($attribute)) {
+                $attribute = $this->Attribute->fetchAttribute($sighting['Sighting']['attribute_id']);
+            }
             $sightings[$k]['Sighting']['attribute_uuid'] = $attribute['Attribute']['uuid'];
 
             $sightings[$k] = $sightings[$k]['Sighting'] ;

--- a/app/Model/Sighting.php
+++ b/app/Model/Sighting.php
@@ -472,9 +472,8 @@ class Sighting extends AppModel
 
     public function getSightingsForTag($user, $tag_id, $sgids = array(), $type = false)
     {
-        $range = (!empty(Configure::read('MISP.Sightings_range')) && is_numeric(Configure::read('MISP.Sightings_range'))) ? Configure::read('MISP.Sightings_range') : 365;
         $conditions = array(
-            'Sighting.date_sighting >' => strtotime("-" . $range . " days"),
+            'Sighting.date_sighting >' => $this->getMaximumRange(),
             'EventTag.tag_id' => $tag_id
         );
         if ($type !== false) {
@@ -511,9 +510,8 @@ class Sighting extends AppModel
 
     public function getSightingsForObjectIds($user, $tagList, $context = 'event', $type = '0')
     {
-        $range = (!empty(Configure::read('MISP.Sightings_range')) && is_numeric(Configure::read('MISP.Sightings_range'))) ? Configure::read('MISP.Sightings_range') : 365;
         $conditions = array(
-            'Sighting.date_sighting >' => strtotime("-" . $range . " days"),
+            'Sighting.date_sighting >' => $this->getMaximumRange(),
             ucfirst($context) . 'Tag.tag_id' => $tagList
 
         );
@@ -844,5 +842,15 @@ class Sighting extends AppModel
             }
         }
         return $saved;
+    }
+
+    /**
+     * @return int Timestamp
+     */
+    public function getMaximumRange()
+    {
+        $rangeInDays = Configure::read('MISP.Sightings_range');
+        $rangeInDays = (!empty($rangeInDays) && is_numeric($rangeInDays)) ? $rangeInDays : 365;
+        return strtotime("-$rangeInDays days");
     }
 }


### PR DESCRIPTION
#### What does it do?

In our case, it speed us loading attribute sighting graph from 1 minute to 478 ms.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
