### PR TITLE
Using json parser to parse json configuration output from cake

### DIFF
--- a/tools/misp-config
+++ b/tools/misp-config
@@ -28,6 +28,8 @@ use strict;
 use warnings;
 use File::Path qw(make_path);
 
+use JSON;
+
 my $misp_user="www-data";
 my $misp_path="/usr/share/misp";
 my $misp_config_path="/etc/misp/";
@@ -106,68 +108,55 @@ if ($create) {
 	close $internalfh;
     }
 
-    die "foo";
-    my $settings = `sudo -u $misp_user $misp_path/app/Console/cake admin getSetting all`;
-    my @lines = split("\n",$settings);
-    my $value = 0;
-    my $setting = 0;
-    foreach(@lines) {	
-	if ($_ =~ m/\"value\": (.*)/) {
-	    $value = substr $1, 0, -1;
-	}
-	if ($_ =~ m/\"setting\": \"(.*)\"/) {
-	    $setting = $1;
-	}
-	if ($value && $setting) {
-	    #print "$setting -> $value\n";
-	    my $category = "";
-	    my $key = "";
-	    my $section = "";
+    my $settings = `sudo -u $misp_user $misp_path/app/Console/cake admin getSetting all | tail -n +7`;
+    my $jsonconfig = decode_json($settings);
 
-	    # Plugin.S3_aws_secret_key -> false
-	    # ^      ^
-	    # |      |- Section (S3)
-	    # |      |- Key (S3_aws_secret_key)
-	    # |-- Category 
-	    #
-	    # We also have:
-	    # Proxy.host -> ""
-	    # Which won't create a section because of the missing _	    
-	    if ($setting =~ m/(\w+)\.(\w+)/) {
-		$category = $1;
-		$key = $2;
-		# print "Setting category: $1 and key: $2\n";
-		if ($key =~ m/(.*?)_/) {
-		    $section = $1
-		    # print "Section: $1\n";
-		} else { # There is no _, so the section is the key
-		    $section = $key;
-		}
-	    } else {
-		# Orphan settings are debug settings:
-		$category = "Debug";
-		$key = $setting;
-#		print "Orphan setting:$setting\n";
+    foreach my $item (@$jsonconfig) {
+	my $setting = $item->{'setting'};
+	my $value = $item->{'value'};
+	
+	my $category = "";
+	my $key = "";
+	my $section = "";	
+	# Plugin.S3_aws_secret_key -> false
+	# ^      ^
+	# |      |- Section (S3)
+	# |      |- Key (S3_aws_secret_key)
+	# |-- Category 
+	#
+	# We also have:
+	# Proxy.host -> ""
+	# Which won't create a section because of the missing _	    
+	if ($setting =~ m/(\w+)\.(\w+)/) {
+	    $category = $1;
+	    $key = $2;
+	    # print "Setting category: $1 and key: $2\n";
+	    if ($key =~ m/(.*?)_/) {
+		$section = $1
+		# print "Section: $1\n";
+	    } else { # There is no _, so the section is the key
+		$section = $key;
 	    }
-
-	    #
-	    # We have all we needed, we can write the files
-	    #
-	    my $conf_to_write = "$misp_config_path/$category.conf";
-	    unless($CATEGORIES_CREATED{"$category"}) {
-		if (-e $conf_to_write) {
-		    die "We cannot overwrite $conf_to_write, it already exists. Remove it manually.\n";
-		}
-	    }
-	    $CATEGORIES_CREATED{"$category"} = 1;
-	    open(my $fh, ">>", "$conf_to_write");
-	    print $fh "#$key $value\n";
-	    close $fh;
-	    
-	    # Unset those two variables to be filled again!
-	    $value = 0;
-	    $setting = 0;
+	} else {
+	    # Orphan settings are debug settings:
+	    $category = "Debug";
+	    $key = $setting;
+	    #		print "Orphan setting:$setting\n";
 	}
+
+	#
+	# We have all we needed, we can write the files
+	#
+	my $conf_to_write = "$misp_config_path/$category.conf";
+	unless($CATEGORIES_CREATED{"$category"}) {
+	    if (-e $conf_to_write) {
+		die "We cannot overwrite $conf_to_write, it already exists. Remove it manually.\n";
+	    }
+	}
+	$CATEGORIES_CREATED{"$category"} = 1;
+	open(my $fh, ">>", "$conf_to_write");
+	print $fh "#$key $value\n";
+	close $fh;
     }
 }
 


### PR DESCRIPTION
This PR improves misp-config to use the json parser from Perl instead of reading line by line with a regex. This improves accuracy and avoid to have to decode json encoded string.