### PR TITLE
fix: [feed] Incorrect call in Feed::__saveEvent

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -3419,7 +3419,7 @@ class Event extends AppModel
     }
 
     // Low level function to add an Event based on an Event $data array
-    public function _add(&$data, $fromXml, $user, $org_id = 0, $passAlong = null, $fromPull = false, $jobId = null, &$created_id = 0, &$validationErrors = array())
+    public function _add(array &$data, $fromXml, array $user, $org_id = 0, $passAlong = null, $fromPull = false, $jobId = null, &$created_id = 0, &$validationErrors = array())
     {
         if ($jobId) {
             App::uses('AuthComponent', 'Controller/Component');
@@ -3731,7 +3731,7 @@ class Event extends AppModel
         }
     }
 
-    public function _edit(&$data, $user, $id, $jobId = null, $passAlong = null, $force = false)
+    public function _edit(array &$data, array $user, $id = null, $jobId = null, $passAlong = null, $force = false)
     {
         $data = $this->cleanupEventArrayFromXML($data);
         unset($this->Attribute->validate['event_id']);
@@ -3740,8 +3740,10 @@ class Event extends AppModel
         // reposition to get the event.id with given uuid
         if (isset($data['Event']['uuid'])) {
             $existingEvent = $this->findByUuid($data['Event']['uuid']);
-        } else {
+        } elseif ($id) {
             $existingEvent = $this->findById($id);
+        } else {
+            throw new InvalidArgumentException("No event UUID or ID provided.");
         }
         if ($passAlong) {
             $this->Server = ClassRegistry::init('Server');

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -637,13 +637,13 @@ class Feed extends AppModel
     /**
      * @param array $feed
      * @param string $uuid
-     * @param $user Not used
+     * @param array $user
      * @return array|bool
      * @throws Exception
      */
-    public function downloadAndSaveEventFromFeed($feed, $uuid, $user)
+    public function downloadAndSaveEventFromFeed(array $feed, $uuid, array $user)
     {
-        $event = $this->downloadEventFromFeed($feed, $uuid, $user);
+        $event = $this->downloadEventFromFeed($feed, $uuid);
         if (!is_array($event) || isset($event['code'])) {
             return false;
         }
@@ -653,11 +653,10 @@ class Feed extends AppModel
     /**
      * @param array $feed
      * @param string $uuid
-     * @param $user Not used
      * @return bool|string|array
      * @throws Exception
      */
-    public function downloadEventFromFeed($feed, $uuid, $user)
+    public function downloadEventFromFeed(array $feed, $uuid)
     {
         $filerRules = $this->__prepareFilterRules($feed);
         $HttpSocket = $this->isFeedLocal($feed) ? false : $this->__setupHttpSocket($feed);
@@ -665,7 +664,12 @@ class Feed extends AppModel
         return $this->__prepareEvent($event, $feed, $filerRules);
     }
 
-    private function __saveEvent($event, $user)
+    /**
+     * @param array $event
+     * @param array $user
+     * @return array
+     */
+    private function __saveEvent(array $event, array $user)
     {
         $this->Event = ClassRegistry::init('Event');
         $existingEvent = $this->Event->find('first', array(
@@ -677,7 +681,7 @@ class Feed extends AppModel
         if (!empty($existingEvent)) {
             $result['action'] = 'edit';
             if ($existingEvent['Event']['timestamp'] < $event['Event']['timestamp']) {
-                $result['result'] = $this->Event->_edit($event, true, $user);
+                $result['result'] = $this->Event->_edit($event, $user);
             } else {
                 $result['result'] = 'No change';
             }


### PR DESCRIPTION
#### What does it do?

Second parameter for `Event::_edit` method should be user array, but boolean value was given.

It also set more typehints to check incorrect function calls.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
