### PR TITLE
fix: [UI] Fetching from not enabled feed should be error

### DIFF
--- a/app/Controller/FeedsController.php
+++ b/app/Controller/FeedsController.php
@@ -456,7 +456,7 @@ class FeedsController extends AppController
             $this->Feed->data['Feed']['settings'] = json_decode($this->Feed->data['Feed']['settings'], true);
         }
         if (!$this->Feed->data['Feed']['enabled']) {
-            $this->Flash->info(__('Feed is currently not enabled. Make sure you enable it.'));
+            $this->Flash->error(__('Feed is currently not enabled. Make sure you enable it.'));
             $this->redirect(array('action' => 'index'));
         }
         if (Configure::read('MISP.background_jobs')) {
@@ -582,7 +582,7 @@ class FeedsController extends AppController
         }
         $this->Feed->read();
         if (!$this->Feed->data['Feed']['enabled']) {
-            $this->Flash->info(__('Feed is currently not enabled. Make sure you enable it.'));
+            $this->Flash->error(__('Feed is currently not enabled. Make sure you enable it.'));
             $this->redirect(array('action' => 'previewIndex', $feedId));
         }
         try {


### PR DESCRIPTION
#### What does it do?

Info looks like it runs in background.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
