### PR TITLE
fix: [internal] Missing field for server model when editing event

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -3756,7 +3756,8 @@ class Event extends AppModel
                     'Server.name',
                     'Server.id',
                     'Server.unpublish_event',
-                    'Server.publish_without_email'
+                    'Server.publish_without_email',
+                    'Server.internal',
                 )
             ));
         } else {


### PR DESCRIPTION
#### What does it do?

Field is provided for `_add` method, but missing for `_edit` method.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
