### PR TITLE
fix: [stix] Store synonymsToTagNames.json file in tmp folder

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -5827,7 +5827,7 @@ class Event extends AppModel
 
     private function __getTagNamesFromSynonyms($scriptDir)
     {
-        $synonymsToTagNames = $scriptDir . DS . 'synonymsToTagNames.json';
+        $synonymsToTagNames = $scriptDir . DS . 'tmp' . DS . 'synonymsToTagNames.json';
         if (!file_exists($synonymsToTagNames) || (time() - filemtime($synonymsToTagNames)) > 600) {
             if (empty($this->GalaxyCluster)) {
                 $this->GalaxyCluster = ClassRegistry::init('GalaxyCluster');


### PR DESCRIPTION
#### What does it do?

`script` folder is not required to be writeable, so storing in that location can silently fail.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
