### PR TITLE
fix: [security] Check event ACL before allowing user to send event contact form

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -2,6 +2,9 @@
 App::uses('AppController', 'Controller');
 App::uses('Xml', 'Utility');
 
+/**
+ * @property Event $Event
+ */
 class EventsController extends AppController
 {
     public $components = array(
@@ -2792,9 +2795,8 @@ class EventsController extends AppController
     // Users with a GnuPG key will get the mail encrypted, other users will get the mail unencrypted
     public function contact($id = null)
     {
-        $id = $this->Toolbox->findIdByUuid($this->Event, $id);
-        $this->Event->id = $id;
-        if (!$this->Event->exists()) {
+        $events = $this->Event->fetchEvent($this->Auth->user(), array('eventid' => $id));
+        if (empty($events)) {
             throw new NotFoundException(__('Invalid event'));
         }
         // User has filled in his contact form, send out the email.
@@ -2844,7 +2846,7 @@ class EventsController extends AppController
         }
         // User didn't see the contact form yet. Present it to him.
         if (empty($this->data)) {
-            $this->data = $this->Event->read(null, $id);
+            $this->data = $events[0];
         }
     }
 


### PR DESCRIPTION
#### What does it do?

User could send contact form to event creator even if he don't have permission to access event.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
