### PR TITLE
new: [security] HTTP headers hardening

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -139,6 +139,9 @@ class AppController extends Controller
                 $this->_stop();
             }
         }
+        if (Configure::read('Security.disable_browser_cache')) {
+            $this->response->disableCache();
+        }
         $this->response->header('X-XSS-Protection', '1; mode=block');
 
         if (!empty($this->params['named']['sql'])) {

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -139,6 +139,12 @@ class AppController extends Controller
                 $this->_stop();
             }
         }
+        if (Configure::read('Security.check_sec_fetch_site_header')) {
+            $secFetchSite = $this->request->header('Sec-Fetch-Site');
+            if ($secFetchSite !== false && $secFetchSite !== 'same-origin' && ($this->request->is('post') || $this->request->is('put') || $this->request->is('ajax'))) {
+                throw new MethodNotAllowedException("POST, PUT and AJAX requests are allowed just from same origin.");
+            }
+        }
         if (Configure::read('Security.disable_browser_cache')) {
             $this->response->disableCache();
         }

--- a/app/Controller/Component/RestResponseComponent.php
+++ b/app/Controller/Component/RestResponseComponent.php
@@ -513,6 +513,9 @@ class RestResponseComponent extends Component
             $headers["Access-Control-Allow-Origin"] = explode(',', Configure::read('Security.cors_origins'));
             $headers["Access-Control-Expose-Headers"] = ["X-Result-Count"];
         }
+        if (Configure::read('Security.disable_browser_cache')) {
+            $cakeResponse->disableCache();
+        }
         if (!empty($this->headers)) {
             $cakeResponse->header($this->headers);
         }

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1297,6 +1297,15 @@ class Server extends AppModel
                             'type' => 'boolean',
                             'null' => true
                         ),
+                        'disable_browser_cache' => array(
+                            'level' => 0,
+                            'description' => __('If enabled, HTTP headers that block browser cache will be send. Static files (like images or JavaScripts) will still be cached, but not generated pages.'),
+                            'value' => false,
+                            'errorMessage' => '',
+                            'test' => 'testBool',
+                            'type' => 'boolean',
+                            'null' => true,
+                        ),
                         'email_otp_enabled' => array(
                                 'level'=> 2,
                                 'description' => __('Enable two step authentication with a OTP sent by email. Requires e-mailing to be enabled. Warning: You cannot use it in combination with external authentication plugins.'),

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1306,6 +1306,15 @@ class Server extends AppModel
                             'type' => 'boolean',
                             'null' => true,
                         ),
+                        'check_sec_fetch_site_header' => [
+                            'level' => 0,
+                            'description' => __('If enabled, any POST, PUT or AJAX request will be allow just when Sec-Fetch-Site header is not defined or contains "same-origin".'),
+                            'value' => false,
+                            'errorMessage' => '',
+                            'test' => 'testBool',
+                            'type' => 'boolean',
+                            'null' => true,
+                        ],
                         'email_otp_enabled' => array(
                                 'level'=> 2,
                                 'description' => __('Enable two step authentication with a OTP sent by email. Requires e-mailing to be enabled. Warning: You cannot use it in combination with external authentication plugins.'),


### PR DESCRIPTION
#### What does it do?

Adds two new options:

* `Security.disable_browser_cache` - If enabled, HTTP headers that block browser cache will be send. Static files (like images or JavaScripts) will still be cached, but not generated pages. Warning: currently, some responses (that use deprecated `JsonResponse` class will still be cached. 
* `Security.check_sec_fetch_site_header` - If enabled, any POST, PUT or AJAX request will be allow just when `Sec-Fetch-Site` header is not defined or contains "same-origin". This is protection agains cross site request, but currently supported just in Chrome based browsers. See https://caniuse.com/mdn-http_headers_sec-fetch-site. More tuning can follow.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
