### PR TITLE
fix: [sharingGroup:captureSharingGroup] Fix failing capture in case of roaming mode

### DIFF
--- a/app/Model/SharingGroup.php
+++ b/app/Model/SharingGroup.php
@@ -269,7 +269,7 @@ class SharingGroup extends AppModel
                     }
                 }
             }
-            if (isset($sg['SharingGroupServer'])) {
+            if (!empty($sg['SharingGroupServer'])) {
                 foreach ($sg['SharingGroupServer'] as $server) {
                     if (isset($server['Server'][0])) {
                         $server['Server'] = $server['Server'][0];
@@ -496,6 +496,7 @@ class SharingGroup extends AppModel
 
     public function captureSG($sg, $user, $syncLocal=false)
     {
+        $this->Log = ClassRegistry::init('Log');
         $existingSG = !isset($sg['uuid']) ? null : $this->find('first', array(
                 'recursive' => -1,
                 'conditions' => array('SharingGroup.uuid' => $sg['uuid']),
@@ -548,7 +549,8 @@ class SharingGroup extends AppModel
                 'organisation_uuid' => array('default' => $user['Organisation']['uuid']),
                 'created' => array('default' => $date = date('Y-m-d H:i:s')),
                 'modified' => array('default' => $date = date('Y-m-d H:i:s')),
-                'active' => array('default' => 1)
+                'active' => array('default' => 1),
+                'roaming' => array('default' => false),
             );
             foreach (array_keys($attributes) as $a) {
                 if (isset($sg[$a])) {


### PR DESCRIPTION
:warning: Not entirely sure if some of the points modified here are intentional..

Fix failing capture in case of enabled roaming mode.
- The concerned element to be saved wasn't as the Log class wasn't initialized
- Then, due to a wrong check against the server list, the distribution level was defaulted to `org only`
- Finally, the `roaming mode` property was always saved as `false` regardless of the actual value of the sharing group

<details>
<summary>Sharing group configuration that was failing</summary>
<br>
<pre>
{
    "SharingGroup": {
        "id": "1",
        "name": "SG - All",
        "releasability": "All",
        "description": "",
        "uuid": "5efd8682-a634-4bd9-80d8-01700a00020f",
        "organisation_uuid": "5ec28ec1-8d7c-4859-9068-5041f331dc3b",
        "org_id": "1",
        "sync_user_id": "0",
        "active": true,
        "created": "2020-07-02 09:02:26",
        "modified": "2020-07-02 15:00:02",
        "local": true,
        "roaming": true
    },
    "Organisation": {
        "id": "1",
        "name": "original.org",
        "date_created": "2020-05-18 15:33:53",
        "date_modified": "2020-06-05 11:18:00",
        "description": "Automatically generated admin organisation",
        "type": "ADMIN",
        "nationality": "Not specified",
        "sector": "",
        "created_by": "0",
        "uuid": "5ec28ec1-8d7c-4859-9068-5041f331dc3b",
        "contacts": "",
        "local": true,
        "restricted_to_domain": [],
        "landingpage": null
    },
    "SharingGroupOrg": [
        {
            "id": "1",
            "sharing_group_id": "1",
            "org_id": "1",
            "extend": true,
            "Organisation": {
                "id": "1",
                "name": "original.org",
                "uuid": "5ec28ec1-8d7c-4859-9068-5041f331dc3b",
                "local": true
            }
        },
        {
            "id": "2",
            "sharing_group_id": "1",
            "org_id": "4",
            "extend": false,
            "Organisation": {
                "id": "4",
                "name": "ORGNAME-misp2",
                "uuid": "5ef459ed-8138-4422-8582-28900a00020f",
                "local": false
            }
        }
    ],
    "SharingGroupServer": []
}
</pre>
</details>