### PR TITLE
new: [diag] Check if ZIP extension is installed

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -5482,7 +5482,7 @@ class Server extends AppModel
     public function extensionDiagnostics()
     {
         $results = array();
-        $extensions = array('redis', 'gd', 'ssdeep');
+        $extensions = array('redis', 'gd', 'ssdeep', 'zip');
         foreach ($extensions as $extension) {
             $results['web']['extensions'][$extension] = extension_loaded($extension);
         }

--- a/app/files/scripts/selftest.php
+++ b/app/files/scripts/selftest.php
@@ -1,5 +1,5 @@
 <?php
-$extensions = array('redis', 'gd', 'ssdeep');
+$extensions = array('redis', 'gd', 'ssdeep', 'zip');
 $results = array();
 $results['phpversion'] = phpversion();
 foreach ($extensions as $extension) {


### PR DESCRIPTION
#### What does it do?

Zip extension is required for fetching ZIP compressed feeds.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
