### PR TITLE
chg: [mail] Refactor email generating

### DIFF
--- a/app/Console/Command/EventShell.php
+++ b/app/Console/Command/EventShell.php
@@ -2,6 +2,11 @@
 App::uses('Folder', 'Utility');
 App::uses('File', 'Utility');
 require_once 'AppShell.php';
+
+/**
+ * @property User $User
+ * @property Event $Event
+ */
 class EventShell extends AppShell
 {
     public $uses = array('Event', 'Post', 'Attribute', 'Job', 'User', 'Task', 'Allowedlist', 'Server', 'Organisation');
@@ -135,7 +140,7 @@ class EventShell extends AppShell
         $job = $this->Job->read(null, $processId);
         $eventId = $this->args[2];
         $oldpublish = $this->args[3];
-        $user = $this->User->getAuthUser($userId);
+        $user = $this->User->getUserById($userId);
         if (empty($user)) {
             die("Invalid user ID '$userId' provided.");
         }
@@ -156,11 +161,11 @@ class EventShell extends AppShell
         $isSiteAdmin = $this->args[4];
         $processId = $this->args[5];
         $this->Job->id = $processId;
-        $user = $this->User->getAuthUser($userId);
+        $user = $this->User->getUserById($userId);
         if (empty($user)) {
             die("Invalid user ID '$userId' provided.");
         }
-        $result = $this->Event->sendContactEmail($id, $message, $all, array('User' => $user), $isSiteAdmin);
+        $result = $this->Event->sendContactEmail($id, $message, $all, $user, $isSiteAdmin);
         $this->Job->saveField('progress', '100');
         $this->Job->saveField('date_modified', date("Y-m-d H:i:s"));
         if ($result != true) $this->Job->saveField('message', 'Job done.');

--- a/app/Console/Command/EventShell.php
+++ b/app/Console/Command/EventShell.php
@@ -6,6 +6,7 @@ require_once 'AppShell.php';
 /**
  * @property User $User
  * @property Event $Event
+ * @property Job $Job
  */
 class EventShell extends AppShell
 {
@@ -136,19 +137,14 @@ class EventShell extends AppShell
     {
         $this->ConfigLoad->execute();
         $userId = $this->args[0];
-        $processId = $this->args[1];
-        $job = $this->Job->read(null, $processId);
+        $jobId = $this->args[1];
         $eventId = $this->args[2];
         $oldpublish = $this->args[3];
         $user = $this->User->getUserById($userId);
         if (empty($user)) {
             die("Invalid user ID '$userId' provided.");
         }
-        $result = $this->Event->sendAlertEmail($eventId, $user, $oldpublish, $processId);
-        $job['Job']['progress'] = 100;
-        $job['Job']['message'] = 'Emails sent.';
-        //$job['Job']['date_modified'] = date("Y-m-d H:i:s");
-        $this->Job->save($job);
+        $this->Event->sendAlertEmail($eventId, $user, $oldpublish, $jobId);
     }
 
     public function contactemail()
@@ -158,17 +154,14 @@ class EventShell extends AppShell
         $message = $this->args[1];
         $all = $this->args[2];
         $userId = $this->args[3];
-        $isSiteAdmin = $this->args[4];
-        $processId = $this->args[5];
-        $this->Job->id = $processId;
+        $processId = $this->args[4];
+
         $user = $this->User->getUserById($userId);
         if (empty($user)) {
             die("Invalid user ID '$userId' provided.");
         }
-        $result = $this->Event->sendContactEmail($id, $message, $all, $user, $isSiteAdmin);
-        $this->Job->saveField('progress', '100');
-        $this->Job->saveField('date_modified', date("Y-m-d H:i:s"));
-        if ($result != true) $this->Job->saveField('message', 'Job done.');
+        $result = $this->Event->sendContactEmail($id, $message, $all, $user);
+        $this->Job->saveStatus($processId, $result);
     }
 
     public function postsemail()

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -2756,7 +2756,7 @@ class EventsController extends AppController
             $user = $this->Auth->user();
             $user = $this->Event->User->fillKeysToUser($user);
 
-            $success = $this->Event->sendContactEmailRouter($id, $message, $creator_only, $user, $this->_isSiteAdmin());
+            $success = $this->Event->sendContactEmailRouter($id, $message, $creator_only, $user);
             if ($success) {
                 $return_message = __('Email sent to the reporter.');
                 if ($this->_isRest()) {

--- a/app/Lib/Tools/SendEmail.php
+++ b/app/Lib/Tools/SendEmail.php
@@ -516,6 +516,9 @@ class SendEmail
         // If the e-mail is sent on behalf of a user, then we want the target user to be able to respond to the sender.
         // For this reason we should also attach the public key of the sender along with the message (if applicable).
         if ($replyToUser) {
+            if (!isset($replyToUser['User']['email'])) {
+                throw new InvalidArgumentException("Invalid replyToUser model provided.");
+            }
             $email->replyTo($replyToUser['User']['email']);
             if (!empty($replyToUser['User']['gpgkey'])) {
                 $attachments['gpgkey.asc'] = $replyToUser['User']['gpgkey'];

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -3291,7 +3291,7 @@ class Event extends AppModel
             $body .= 'Reported by : ' . $event['Orgc']['name'] . "\n";
         }
         $bodyevent .= 'Risk        : ' . $event['ThreatLevel']['name'] . "\n";
-        $bodyevent .= 'Analysis    : ' . $event['Event']['analysis'] . "\n";
+        $bodyevent .= 'Analysis    : ' . $this->analysisLevels[$event['Event']['analysis']] . "\n";
 
         foreach ($event['RelatedEvent'] as $relatedEvent) {
             $bodyevent .= 'Related to  : ' . $this->__getAnnounceBaseurl() . '/events/view/' . $relatedEvent['Event']['id'] . ' (' . $relatedEvent['Event']['date'] . ')' . "\n";
@@ -3299,19 +3299,21 @@ class Event extends AppModel
 
         $bodyevent .= 'Info  : ' . "\n";
         $bodyevent .= $event['Event']['info'] . "\n";
-        $bodyevent .= "\n";
-        $bodyevent .= 'Attributes  :' . "\n";
+
         $bodyTempOther = "";
-        foreach ($event['Attribute'] as $attribute) {
-            $line = '- ' . $attribute['type'] . str_repeat(' ', $appendlen - 2 - strlen($attribute['type'])) . ': ' . $attribute['value'] . "\n";
-            if ('other' == $attribute['type']) { // append the 'other' attribute types to the bottom.
-                $bodyTempOther .= $line;
-            } else {
-                $bodyevent .= $line;
-            }
+        if (!empty($event['Attribute'])) {
+            $bodyevent .= 'Attributes:' . "\n";
+            $this->__buildAlertEmailAttribute($bodyevent, $bodyTempOther, $event['Attribute'], null);
         }
-        $bodyevent .= "\n";
-        $bodyevent .= $bodyTempOther;   // append the 'other' attribute types to the bottom.
+        if (!empty($event['Object'])) {
+            $bodyevent .= 'Objects:' . "\n";
+            $this->__buildAlertEmailObject($bodyevent, $bodyTempOther, $event['Object'], null);
+        }
+        if (!empty($bodyTempOther)) {
+            $bodyevent .= "\n";
+        }
+        $bodyevent .= $bodyTempOther;    // append the 'other' attribute types to the bottom.
+
         return array($bodyevent, $body);
     }
 

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -3058,7 +3058,10 @@ class Event extends AppModel
                 // Fetch event for exact user to respect ACLs
                 $eventForUser = $this->fetchEvent($user, ['eventid' => $id, 'includeAllTags' => true, 'includeEventCorrelations' => true])[0];
                 $body = $this->__buildAlertEmailBody($eventForUser, $user, $oldpublish);
-                $bodyNoEnc = "A new or modified event was just published on " . $this->__getAnnounceBaseurl() . "/events/view/" . $eventForUser['Event']['id'];
+
+                $eventUrl = $this->__getAnnounceBaseurl() . "/events/view/" . $eventForUser['Event']['id'];
+                $bodyNoEnc = __("A new or modified event was just published on %s", $eventUrl) . "\n\n";
+                $bodyNoEnc .= "If you would like to unsubscribe from receiving such alert e-mails, simply\ndisable publish alerts via " . $this->__getAnnounceBaseurl() . '/users/edit';
                 $this->User->sendEmail(array('User' => $user), $body, $bodyNoEnc, $subject);
             }
             if ($jobId) {

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -3027,11 +3027,11 @@ class Event extends AppModel
         } else {
             $subject = '';
         }
-        $subjMarkingString = !empty(Configure::read('MISP.email_subject_TLP_string')) ? Configure::read('MISP.email_subject_TLP_string') : "tlp:amber";
-        $subjTag = !empty(Configure::read('MISP.email_subject_tag')) ? Configure::read('MISP.email_subject_tag') : "tlp";
+        $subjMarkingString = Configure::read('MISP.email_subject_TLP_string') ?: "tlp:amber";
+        $subjTag = Configure::read('MISP.email_subject_tag') ?: "tlp";
         $tagLen = strlen($subjTag);
         foreach ($event[0]['EventTag'] as $k => $tag) {
-            $tagName=$tag['Tag']['name'];
+            $tagName = $tag['Tag']['name'];
             if (strncasecmp($subjTag, $tagName, $tagLen) == 0 && strlen($tagName) > $tagLen && ($tagName[$tagLen] == ':' || $tagName[$tagLen] == '=')) {
                 if (Configure::read('MISP.email_subject_include_tag_name') === false) {
                     $subjMarkingString = trim(substr($tagName, $tagLen+1), '"');
@@ -3045,7 +3045,7 @@ class Event extends AppModel
         if (Configure::read('MISP.threatlevel_in_email_subject') === false) {
             $threatLevel = '';
         }
-        $subject = "[" . Configure::read('MISP.org') . " MISP] Event " . $id . " - " . $subject . $threatLevel . $subjMarkingString;
+        $subject = "[" . Configure::read('MISP.org') . " MISP] Event " . $id . " - " . $subject . $threatLevel . strtoupper($subjMarkingString);
 
         // Initialise the Job class if we have a background process ID
         // This will keep updating the process's progress bar
@@ -3250,13 +3250,13 @@ class Event extends AppModel
         if (empty($orgMembers)) {
             return false;
         }
+        $tplColorString = Configure::read('MISP.email_subject_TLP_string') ?: "tlp:amber";
+        $subject = "[" . Configure::read('MISP.org') . " MISP] Need info about event " . $id . " - " . strtoupper($tplColorString);
+        $result = true;
         foreach ($orgMembers as $reporter) {
             $temp = $this->__buildContactEventEmailBody($user, $message, $event, $reporter, $id);
             $bodyevent = $temp[0];
             $body = $temp[1];
-            $result = true;
-            $tplColorString = !empty(Configure::read('MISP.email_subject_TLP_string')) ? Configure::read('MISP.email_subject_TLP_string') : "tlp:amber";
-            $subject = "[" . Configure::read('MISP.org') . " MISP] Need info about event " . $id . " - ".$tplColorString;
             $result = $this->User->sendEmail($reporter, $bodyevent, $body, $subject, $user) && $result;
         }
         return $result;

--- a/app/Model/Post.php
+++ b/app/Model/Post.php
@@ -118,8 +118,8 @@ class Post extends AppModel
         $bodyDetail .= "The following message was added: \n";
         $bodyDetail .= "\n";
         $bodyDetail .= $message . "\n";
-        $tplColorString = !empty(Configure::read('MISP.email_subject_TLP_string')) ? Configure::read('MISP.email_subject_TLP_string') : "tlp:amber";
-        $subject = "[" . Configure::read('MISP.org') . " MISP] New post in discussion " . $post['Post']['thread_id'] . " - ".$tplColorString;
+        $tplColorString = Configure::read('MISP.email_subject_TLP_string') ?: "tlp:amber";
+        $subject = "[" . Configure::read('MISP.org') . " MISP] New post in discussion " . $post['Post']['thread_id'] . " - " . strtoupper($tplColorString);
         foreach ($orgMembers as $recipient) {
             $this->User->sendEmail($recipient, $bodyDetail, $body, $subject);
         }

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -740,10 +740,21 @@ class User extends AppModel
         $sendEmail->sendExternal($params);
     }
 
-    // all e-mail sending is now handled by this method
-    // Just pass the user ID in an array that is the target of the e-mail along with the message body and the alternate message body if the message cannot be encrypted
-    // the remaining two parameters are the e-mail subject and a secondary user object which will be used as the replyto address if set. If it is set and an encryption key for the replyTo user exists, then his/her public key will also be attached
-    public function sendEmail($user, $body, $bodyNoEnc = false, $subject, $replyToUser = false)
+    /**
+     * All e-mail sending is now handled by this method
+     * Just pass the user array that is the target of the e-mail along with the message body and the alternate message body if the message cannot be encrypted
+     * the remaining two parameters are the e-mail subject and a secondary user object which will be used as the replyto address if set. If it is set and an encryption key for the replyTo user exists, then his/her public key will also be attached
+     *
+     * @param array $user
+     * @param string $body
+     * @param string|false $bodyNoEnc
+     * @param string $subject
+     * @param array|false $replyToUser
+     * @return bool
+     * @throws Crypt_GPG_BadPassphraseException
+     * @throws Crypt_GPG_Exception
+     */
+    public function sendEmail(array $user, $body, $bodyNoEnc = false, $subject, $replyToUser = false)
     {
         if ($user['User']['disabled']) {
             return true;

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -717,7 +717,7 @@ class User extends AppModel
             'conditions' => $conditions,
             'recursive' => -1,
             'fields' => array('id', 'email', 'gpgkey', 'certif_public', 'org_id', 'disabled'),
-            'contain' => ['Role' => ['fields' => ['perm_site_admin']], 'Organisation' => ['fields' => ['id']]],
+            'contain' => ['Role' => ['fields' => ['perm_site_admin', 'perm_audit']], 'Organisation' => ['fields' => ['id']]],
         ));
         foreach ($users as $k => $user) {
             $user = $user['User'];


### PR DESCRIPTION
#### What does it do?

* Change TLP in subject, because according to https://www.us-cert.gov/tlp, TLP in email subject must be uppercase.
* Use internal fetcher for every user to ensure that just visible attributes are send
* Defang attributes also in contact email (uses the same logic as for alert email)

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
