### PR TITLE
fix: Remove interoperability parameter from stix2.parse call

### DIFF
--- a/app/files/scripts/stix2/stix2misp.py
+++ b/app/files/scripts/stix2/stix2misp.py
@@ -2033,7 +2033,7 @@ def from_misp(stix_objects):
 def main(args):
     filename = Path(os.path.dirname(args[0]), args[1])
     with open(filename, 'rt', encoding='utf-8') as f:
-        event = stix2.parse(f.read(), allow_custom=True, interoperability=True)
+        event = stix2.parse(f.read(), allow_custom=True)
     stix_parser = StixFromMISPParser() if from_misp(event.objects) else ExternalStixParser()
     stix_parser.handler(event, filename, args[2:])
     stix_parser.save_file()

--- a/app/files/scripts/stixtest/stix2_check.py
+++ b/app/files/scripts/stixtest/stix2_check.py
@@ -22,11 +22,11 @@ def externalise_event(event):
 
 def get_external(event):
     externalise_event(event)
-    return ExternalStixParser(), stix2.parse(event, allow_custom=True, interoperability=True)
+    return ExternalStixParser(), stix2.parse(event, allow_custom=True)
 
 
 def get_internal(event):
-    return StixFromMISPParser(), stix2.parse(event, allow_custom=True, interoperability=True)
+    return StixFromMISPParser(), stix2.parse(event, allow_custom=True)
 
 
 def query_import(filename, externalise):


### PR DESCRIPTION
#### What does it do?

Remove unsupported parameter from stix2.parse API calls.

See: https://stix2.readthedocs.io/en/latest/api/stix2.parsing.html#stix2.parsing.parse

Interoperability parameter is not recognized by stix2 api and throws an error.

```
Traceback (most recent call last):
  File "/var/www/MISP/app/files/scripts/stix2/stix2misp.py", line 2037, in <module>
    main(sys.argv)
  File "/var/www/MISP/app/files/scripts/stix2/stix2misp.py", line 2029, in main
    event = stix2.parse(f.read(), allow_custom=True, interoperability=True)
TypeError: parse() got an unexpected keyword argument 'interoperability'
```

Stix2 JSON import starts to work after this fix.

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
