### PR TITLE
fix: [stix export] log stack trace on error, support 'AMBER NATO ALLI…

### DIFF
--- a/app/Lib/Export/StixExport.php
+++ b/app/Lib/Export/StixExport.php
@@ -131,7 +131,11 @@ class StixExport
     {
         foreach ($this->__filenames as $f => $filename) {
             if ($index >= $f) {
-                unlink($this->__tmp_dir . $filename);
+                try {
+                    unlink($this->__tmp_dir . $filename);
+                } catch (Exception $e) {
+                    unset($e);
+                }
             }
         }
         $this->__stix_file->close();

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -7,6 +7,7 @@ import datetime
 import re
 import ntpath
 import socket
+import traceback
 from misp2stix_mapping import *
 from collections import defaultdict
 from copy import deepcopy
@@ -156,6 +157,7 @@ class StixBuilder(object):
             print(json.dumps({'success': 1}))
         except Exception as e:
             print(json.dumps({'error': e.__str__()}))
+            traceback.print_tb()
 
     def generate_package(self, event):
         self.objects_to_parse = defaultdict(dict)

--- a/app/files/scripts/misp2stix_mapping.py
+++ b/app/files/scripts/misp2stix_mapping.py
@@ -1,7 +1,7 @@
 # mappings
 status_mapping = {'0' : 'New', '1' : 'Open', '2' : 'Closed'}
 threat_level_mapping = {'1' : 'High', '2' : 'Medium', '3' : 'Low', '4' : 'Undefined'}
-TLP_order = {'RED' : 4, 'AMBER' : 3, 'GREEN' : 2, 'WHITE' : 1}
+TLP_order = {'RED' : 4, 'AMBER' : 3, 'AMBER NATO ALLIANCE': 3, 'GREEN' : 2, 'WHITE' : 1}
 confidence_mapping = {False : 'None', True : 'High'}
 
 not_implemented_attributes = ('yara', 'snort', 'pattern-in-traffic', 'pattern-in-memory')


### PR DESCRIPTION
This patch does 3 things:

1. Silently ignore missing temp files during delete phase
1. Log a python stack trace in exec-errors.log when misp2stix.py breaks
1. Map 'AMBER NATO ALLIANCE' to AMBER in Stix export

I needed 1 and 2 to fix 3 on our server..