### PR TITLE
Additionnal protection against XSS

### DIFF
--- a/app/Controller/UserSettingsController.php
+++ b/app/Controller/UserSettingsController.php
@@ -342,7 +342,7 @@ class UserSettingsController extends AppController
                 )
             );
             $result = $this->UserSetting->setSetting($this->Auth->user(), $setting);
-            return $this->RestResponse->saveSuccessResponse('UserSettings', 'setHomePage', false, $this->response->type(), 'Homepage set to ' . $this->request->data['path']);
+            return $this->RestResponse->saveSuccessResponse('UserSettings', 'setHomePage', false, 'json', 'Homepage set to ' . $this->request->data['path']);
         } else {
             $this->layout = false;
         }


### PR DESCRIPTION
The response type defaults to html while it should be JSON. This avoids any HTML reflected input to be interpreted by the browser.
