### PR TITLE
fix: [UI] Show proper menu when editing event info

### DIFF
--- a/app/View/Events/add.ctp
+++ b/app/View/Events/add.ctp
@@ -65,7 +65,11 @@
             )
         )
     ));
-    echo $this->element('/genericElements/SideMenu/side_menu', array('menuList' => 'event-collection', 'menuItem' => $action === 'add' ? 'add' : 'editEvent'));
+    echo $this->element('/genericElements/SideMenu/side_menu', array(
+        'menuList' => $action === 'add' ? 'event-collection' : 'event',
+        'menuItem' => $action === 'add' ? 'add' : 'editEvent',
+        'event' => isset($event) ? $event : null,
+    ));
 ?>
 
 <script type="text/javascript">


### PR DESCRIPTION
#### What does it do?

Do not show different menu when clicking on Edit Event.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
