### PR TITLE
chg: [internal] Faster generating correlations when enabling

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -5217,10 +5217,6 @@ class EventsController extends AppController
         if (!$this->_isSiteAdmin() && !Configure::read('MISP.allow_disabling_correlation')) {
             throw new MethodNotAllowedException(__('Disabling the correlation is not permitted on this instance.'));
         }
-        $this->Event->id = $id;
-        if (!$this->Event->exists()) {
-            throw new NotFoundException(__('Invalid Event.'));
-        }
         if (!$this->Auth->user('Role')['perm_modify']) {
             throw new MethodNotAllowedException(__('You don\'t have permission to do that.'));
         }
@@ -5242,13 +5238,7 @@ class EventsController extends AppController
             if ($event['Event']['disable_correlation']) {
                 $event['Event']['disable_correlation'] = 0;
                 $this->Event->save($event);
-                $attributes = $this->Event->Attribute->find('all', array(
-                    'conditions' => array('Attribute.event_id' => $id),
-                    'recursive' => -1
-                ));
-                foreach ($attributes as $attribute) {
-                    $this->Event->Attribute->__afterSaveCorrelation($attribute['Attribute'], false, $event);
-                }
+                $this->Event->Attribute->generateCorrelation(false, 0, $id);
             } else {
                 $event['Event']['disable_correlation'] = 1;
                 $this->Event->save($event);

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -2825,8 +2825,10 @@ class Attribute extends AppModel
         // get all attributes..
         if (!$eventId) {
             $eventIds = $this->Event->find('list', array('recursive' => -1, 'fields' => array('Event.id')));
+            $full = true;
         } else {
             $eventIds = array($eventId);
+            $full = false;
         }
         $attributeCount = 0;
         if (Configure::read('MISP.background_jobs') && $jobId) {
@@ -2862,7 +2864,7 @@ class Attribute extends AppModel
             }
             $attributes = $this->find('all', array('recursive' => -1, 'conditions' => $attributeConditions, 'order' => array()));
             foreach ($attributes as $k => $attribute) {
-                $this->__afterSaveCorrelation($attribute['Attribute'], true, $event);
+                $this->__afterSaveCorrelation($attribute['Attribute'], $full, $event);
                 $attributeCount++;
             }
         }


### PR DESCRIPTION
#### What does it do?

Use `Attribute->generateCorrelation` that is faster and takes less memory than manually calling `__afterSaveCorrelation` method for each attribute.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
