### PR TITLE
fix: check Misp time fields exist before using them

### DIFF
--- a/app/files/scripts/stix2/misp2stix2.py
+++ b/app/files/scripts/stix2/misp2stix2.py
@@ -1790,7 +1790,8 @@ class StixBuilder():
     def handle_time_fields(attribute, timestamp, stix_type):
         to_return = {'created': timestamp, 'modified': timestamp}
         for misp_field, stix_field in zip(('first_seen', 'last_seen'), _time_fields[stix_type]):
-            to_return[stix_field] = datetime.strptime(attribute[misp_field].split('+')[0], '%Y-%m-%dT%H:%M:%S.%f') if attribute[misp_field] else timestamp
+            if attribute.get(misp_field):
+                to_return[stix_field] = datetime.strptime(attribute[misp_field].split('+')[0], '%Y-%m-%dT%H:%M:%S.%f') if attribute[misp_field] else timestamp
         return to_return
 
     @staticmethod


### PR DESCRIPTION
#### What does it do?
According to [MISP RFC](https://github.com/MISP/misp-rfc/blob/master/misp-core-format/raw.md), first_seen & last_seen fields' requirement levels are **MAY**, while `handle_time_fields(attribute, timestamp, stix_type)` function in app/files/scripts/stix2/misp2stix2.py does not check if first_seen, last_seen exist and will cause exception if those keys don't exist.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
