### PR TITLE
fix: [security] Respect ACL when event edit

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -1290,6 +1290,10 @@ class AppController extends Controller
      */
     protected function __canModifyEvent(array $event)
     {
+        if (!isset($event['Event'])) {
+            throw new InvalidArgumentException('Passed object does not contains Event.');
+        }
+
         if ($this->userRole['perm_site_admin']) {
             return true;
         }

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -1301,4 +1301,30 @@ class AppController extends Controller
         }
         return false;
     }
+
+    /**
+     * Returns true if user can add or remove tags for given event.
+     *
+     * @param array $event
+     * @param bool $isTagLocal
+     * @return bool
+     */
+    protected function __canModifyTag(array $event, $isTagLocal = false)
+    {
+        // Site admin can add any tag
+        if ($this->userRole['perm_site_admin']) {
+            return true;
+        }
+        // User must have tagger or sync permission
+        if (!$this->userRole['perm_tagger'] && !$this->userRole['perm_sync']) {
+            return false;
+        }
+        if ($this->__canModifyEvent($event)) {
+            return true; // full access
+        }
+        if ($isTagLocal && Configure::read('MISP.host_org_id') == $this->Auth->user('org_id')) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -1281,4 +1281,24 @@ class AppController extends Controller
             return $this->RestResponse->viewData($final, $responseType, false, true, $filename, array('X-Result-Count' => $elementCounter, 'X-Export-Module-Used' => $returnFormat, 'X-Response-Format' => $responseType));
         }
     }
+
+    /**
+     * Returns true if user can modify given event.
+     *
+     * @param array $event
+     * @return bool
+     */
+    protected function __canModifyEvent(array $event)
+    {
+        if ($this->userRole['perm_site_admin']) {
+            return true;
+        }
+        if ($this->userRole['perm_modify_org'] && $event['Event']['orgc_id'] == $this->Auth->user('org_id')) {
+            return true;
+        }
+        if ($this->userRole['perm_modify'] && $event['Event']['user_id'] == $this->Auth->user('id')) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -2900,6 +2900,9 @@ class AttributesController extends AppController
 
     public function toggleCorrelation($id)
     {
+        if (!$this->_isSiteAdmin() && !Configure::read('MISP.allow_disabling_correlation')) {
+            throw new MethodNotAllowedException(__('Disabling the correlation is not permitted on this instance.'));
+        }
         $attribute = $this->Attribute->find('first', array(
             'conditions' => array('Attribute.id' => $id),
             'recursive' => -1,

--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -109,27 +109,15 @@ class AttributesController extends AppController
             throw new MethodNotAllowedException(__('You do not have permissions to create attributes'));
         }
         $this->loadModel('Event');
-        if (Validation::uuid($eventId)) {
-            $temp = $this->Event->find('first', array('recursive' => -1, 'fields' => array('Event.id'), 'conditions' => array('Event.uuid' => $eventId)));
-            if (empty($temp)) {
-                throw new NotFoundException(__('Invalid event'));
-            }
-            $eventId = $temp['Event']['id'];
-        } elseif (!is_numeric($eventId)) {
+        $event = $this->Event->fetchSimpleEvent($this->Auth->user(), $eventId);
+        if (!$event) {
             throw new NotFoundException(__('Invalid event'));
         }
-        $this->Event->id = $eventId;
-        if (!$this->Event->exists()) {
-            throw new NotFoundException(__('Invalid event'));
-        }
-        // remove the published flag from the event
-        $this->Event->recursive = -1;
-        $this->Event->read(null, $eventId);
-        if (!$this->_isSiteAdmin() && ($this->Event->data['Event']['orgc_id'] != $this->_checkOrg() || !$this->userRole['perm_modify'])) {
+        if (!$this->__canModifyEvent($event)) {
             throw new ForbiddenException(__('You do not have permission to do that.'));
         }
         if (!$this->_isRest()) {
-            $this->Event->insertLock($this->Auth->user(), $this->Event->data['Event']['id']);
+            $this->Event->insertLock($this->Auth->user(), $event['Event']['id']);
         }
         if ($this->request->is('ajax')) {
             $this->set('ajax', true);
@@ -141,7 +129,6 @@ class AttributesController extends AppController
             if ($this->request->is('ajax')) {
                 $this->autoRender = false;
             }
-            $date = new DateTime();
             if (!isset($this->request->data['Attribute'])) {
                 $this->request->data = array('Attribute' => $this->request->data);
             }
@@ -173,7 +160,6 @@ class AttributesController extends AppController
             if (!isset($attributes[0])) {
                 $attributes = array(0 => $attributes);
             }
-            $uuids = array();
             $this->Warninglist = ClassRegistry::init('Warninglist');
             $fails = array();
             $successes = 0;
@@ -181,7 +167,7 @@ class AttributesController extends AppController
             $inserted_ids = array();
             foreach ($attributes as $k => $attribute) {
                 $validationErrors = array();
-                $this->Attribute->captureAttribute($attribute, $eventId, $this->Auth->user(), false, false, false, $validationErrors, $this->params['named']);
+                $this->Attribute->captureAttribute($attribute, $event['Event']['id'], $this->Auth->user(), false, false, false, $validationErrors, $this->params['named']);
                 if (empty($validationErrors)) {
                     $inserted_ids[] = $this->Attribute->id;
                     $successes +=1;
@@ -190,7 +176,7 @@ class AttributesController extends AppController
                 }
             }
             if (!empty($successes)) {
-                $this->Event->unpublishEvent($eventId);
+                $this->Event->unpublishEvent($event['Event']['id']);
             }
             if ($this->_isRest()) {
                 if (!empty($successes)) {
@@ -228,8 +214,6 @@ class AttributesController extends AppController
                     }
                 }
             } else {
-                $message = '';
-                $redirect = '/events/view/' . $eventId;
                 if (empty($fails)) {
                     $message = 'Attributes saved.';
                 } else {
@@ -281,7 +265,7 @@ class AttributesController extends AppController
                     }
                 } else {
                     if ($successes > 0) {
-                        $this->redirect(array('controller' => 'events', 'action' => 'view', $eventId));
+                        $this->redirect(array('controller' => 'events', 'action' => 'view', $event['Event']['id']));
                     }
                 }
             }
@@ -300,11 +284,9 @@ class AttributesController extends AppController
         $categories = array_keys($this->Attribute->categoryDefinitions);
         $categories = $this->_arrayToValuesIndexArray($categories);
         $this->set('categories', $categories);
-        $this->loadModel('Event');
-        $events = $this->Event->findById($eventId);
-        $this->set('event_id', $events['Event']['id']);
+        $this->set('event_id', $event['Event']['id']);
         // combobox for distribution
-        $this->set('currentDist', $events['Event']['distribution']);
+        $this->set('currentDist', $event['Event']['distribution']);
         // tooltip for distribution
 
         $this->loadModel('SharingGroup');
@@ -337,19 +319,13 @@ class AttributesController extends AppController
         $this->set('fieldDesc', $fieldDesc);
         $this->set('typeDefinitions', $this->Attribute->typeDefinitions);
         $this->set('categoryDefinitions', $this->Attribute->categoryDefinitions);
-        $this->set('published', $events['Event']['published']);
+        $this->set('published', $event['Event']['published']);
         $this->set('action', $this->action);
     }
 
     public function download($id = null)
     {
-        if (is_numeric($id)) {
-            $conditions = array('Attribute.id' => $id);
-        } elseif (Validation::uuid($id)) {
-            $conditions = array('Attribute.uuid' => $id);
-        } else {
-            throw new NotFoundException(__('Invalid attribute id.'));
-        }
+        $conditions = $this->__idToConditions($id);
         $conditions['Attribute.type'] = array('attachment', 'malware-sample');
         $attributes = $this->Attribute->fetchAttributes($this->Auth->user(), array('conditions' => $conditions, 'flatten' => true));
         if (empty($attributes)) {
@@ -410,16 +386,15 @@ class AttributesController extends AppController
 
     public function add_attachment($eventId = null)
     {
+        $event = $this->Attribute->Event->fetchSimpleEvent($this->Auth->user(), $eventId);
+        if (empty($event)) {
+            throw new NotFoundException(__('Invalid Event.'));
+        }
+        if (!$this->__canModifyEvent($event)) {
+            throw new ForbiddenException(__('You do not have permission to do that.'));
+        }
+
         if ($this->request->is('post')) {
-            $this->Attribute->Event->id = $this->request->data['Attribute']['event_id'];
-            $this->Attribute->Event->recursive = -1;
-            $event = $this->Attribute->Event->read();
-            if (empty($event)) {
-                throw new NotFoundException(__('Invalid Event.'));
-            }
-            if (!$this->_isSiteAdmin() && ($this->Attribute->Event->data['Event']['orgc_id'] != $this->_checkOrg() || !$this->userRole['perm_modify'])) {
-                throw new UnauthorizedException(__('You do not have permission to do that.'));
-            }
             $fails = array();
             $success = 0;
 
@@ -442,14 +417,14 @@ class AttributesController extends AppController
                 if ($this->request->data['Attribute']['malware']) {
                     if ($this->request->data['Attribute']['advanced']) {
                         $result = $this->Attribute->advancedAddMalwareSample(
-                            $eventId,
+                            $event['Event']['id'],
                             $this->request->data['Attribute'],
                             $filename,
                             $tmpfile
                         );
                     } else {
                         $result = $this->Attribute->simpleAddMalwareSample(
-                            $eventId,
+                            $event['Event']['id'],
                             $this->request->data['Attribute'],
                             $filename,
                             $tmpfile
@@ -471,11 +446,11 @@ class AttributesController extends AppController
                             foreach ($object['Attribute'] as $ka => $attribute) {
                                 $object['Attribute'][$ka]['distribution'] = 5;
                             }
-                            $this->Attribute->Object->captureObject(array('Object' => $object), $eventId, $this->Auth->user());
+                            $this->Attribute->Object->captureObject(array('Object' => $object), $event['Event']['id'], $this->Auth->user());
                         }
                         if (!empty($result['ObjectReference'])) {
                             foreach ($result['ObjectReference'] as $reference) {
-                                $this->Attribute->Object->ObjectReference->smartSave($reference, $eventId);
+                                $this->Attribute->Object->ObjectReference->smartSave($reference, $event['Event']['id']);
                             }
                         }
                     }
@@ -485,7 +460,7 @@ class AttributesController extends AppController
                                 'value' => $filename,
                                 'category' => $this->request->data['Attribute']['category'],
                                 'type' => 'attachment',
-                                'event_id' => $this->request->data['Attribute']['event_id'],
+                                'event_id' => $event['Event']['id'],
                                 'data' => base64_encode($tmpfile->read()),
                                 'comment' => $this->request->data['Attribute']['comment'],
                                 'to_ids' => 0,
@@ -511,8 +486,7 @@ class AttributesController extends AppController
                     $message = __('The attachment(s) could not be saved. Please contact your administrator.');
                 }
             } else {
-                $this->Attribute->Event->id = $this->request->data['Attribute']['event_id'];
-                $this->Attribute->Event->saveField('published', 0);
+                $this->Attribute->Event->unpublishEvent($event['Event']['id']);
             }
             if (empty($success) && !empty($fails)) {
                 $this->Flash->error($message);
@@ -520,21 +494,16 @@ class AttributesController extends AppController
                 $this->Flash->success($message);
             }
             if (!$this->_isRest()) {
-                $this->Attribute->Event->insertLock($this->Auth->user(), $eventId);
+                $this->Attribute->Event->insertLock($this->Auth->user(), $event['Event']['id']);
             }
-            $this->redirect(array('controller' => 'events', 'action' => 'view', $eventId));
+            $this->redirect(array('controller' => 'events', 'action' => 'view', $event['Event']['id']));
         } else {
             // set the event_id in the form
-            $this->request->data['Attribute']['event_id'] = $eventId;
-        }
-
-        $event = $this->Attribute->Event->findById($eventId);
-        if (empty($event)) {
-            throw new NotFoundException(__('Invalid Event.'));
+            $this->request->data['Attribute']['event_id'] = $event['Event']['id'];
         }
 
         if (!$this->_isRest()) {
-            $this->Attribute->Event->insertLock($this->Auth->user(), $eventId);
+            $this->Attribute->Event->insertLock($this->Auth->user(), $event['Event']['id']);
         }
 
         // Filter categories that contains attachment type
@@ -575,8 +544,8 @@ class AttributesController extends AppController
             $this->Event->id = $eventId;
             $this->Event->recursive = -1;
             $this->Event->read();
-            if (!$this->_isSiteAdmin() && ($this->Event->data['Event']['orgc_id'] != $this->_checkOrg() || !$this->userRole['perm_modify'])) {
-                throw new UnauthorizedException(__('You do not have permission to do that.'));
+            if (!$this->__canModifyEvent($this->Event->data)) {
+                throw new ForbiddenException(__('You do not have permission to do that.'));
             }
             //
             // File upload
@@ -763,58 +732,25 @@ class AttributesController extends AppController
         if ($this->request->is('get') && $this->_isRest()) {
             return $this->RestResponse->describe('Attributes', 'edit', false, $this->response->type());
         }
-        if (Validation::uuid($id)) {
-            $temp = $this->Attribute->find('first', array(
-                'recursive' => -1,
-                'fields' => array('Attribute.id', 'Attribute.uuid'),
-                'conditions' => array('Attribute.uuid' => $id)
-            ));
-            if ($temp == null) {
-                throw new NotFoundException('Invalid attribute');
-            }
-            $id = $temp['Attribute']['id'];
-        } elseif (!is_numeric($id)) {
-            throw new NotFoundException(__('Invalid attribute'));
-        }
-        $this->Attribute->id = $id;
-        $date = new DateTime();
-        if (!$this->Attribute->exists()) {
-            throw new NotFoundException(__('Invalid attribute'));
-        }
-        $conditions = array('conditions' => array('Attribute.id' => $id), 'withAttachments' => true, 'flatten' => true);
-        $conditions['includeAllTags'] = false;
-        $conditions['includeAttributeUuid'] = true;
-        $attribute = $this->Attribute->fetchAttributes($this->Auth->user(), $conditions);
+        $attribute = $this->__fetchAttribute($id);
         if (empty($attribute)) {
             throw new MethodNotAllowedException('Invalid attribute');
         }
-        $this->Attribute->data = $attribute[0];
-        $event = $this->Attribute->Event->find('first', array(
-            'conditions' =>
-                array(
-                    'Event.id' => $attribute[0]['Attribute']['event_id']
-                ),
-            'recursive' => -1,
-            'fields' => array('Event.id', 'Event.user_id')
-        ));
+        $this->Attribute->data = $attribute;
         if ($this->Attribute->data['Attribute']['deleted']) {
             throw new NotFoundException(__('Invalid attribute'));
         }
-        if (!$this->_isSiteAdmin()) {
-            if ($this->Attribute->data['Event']['orgc_id'] == $this->Auth->user('org_id')
-                && (($this->userRole['perm_modify'] && $event['Event']['user_id'] != $this->Auth->user('id'))
-                    || $this->userRole['perm_modify_org'])) {
-                // Allow the edit
+        $this->Attribute->id = $attribute['Attribute']['id'];
+        if (!$this->__canModifyEvent($attribute)) {
+            $message = __('You do not have permission to do that.');
+            if ($this->_isRest()) {
+                throw new ForbiddenException($message);
             } else {
-                $message = __('You do not have permission to do that.');
-                if ($this->_isRest()) {
-                    throw new ForbiddenException($message);
-                } else {
-                    $this->Flash->error($message);
-                    $this->redirect(array('controller' => 'events', 'action' => 'index'));
-                }
+                $this->Flash->error($message);
+                $this->redirect(array('controller' => 'events', 'action' => 'index'));
             }
         }
+        $date = new DateTime();
         if (!$this->_isRest()) {
             $this->Attribute->Event->insertLock($this->Auth->user(), $this->Attribute->data['Attribute']['event_id']);
         }
@@ -866,14 +802,6 @@ class AttributesController extends AppController
                     $this->redirect(array('controller' => 'events', 'action' => 'index'));
                 }
             }
-            $this->loadModel('Event');
-            $event = $this->Attribute->Event->find('first', array(
-                'recursive' => -1,
-                'conditions' => array('Event.id' => $eventId)
-            ));
-            if (empty($event)) {
-                throw new NotFoundException(__('Invalid Event.'));
-            }
             if ($existingAttribute['Attribute']['object_id']) {
                 $result = $this->Attribute->save($this->request->data, array('fieldList' => $this->Attribute->editableFields));
                 if ($result) {
@@ -897,7 +825,7 @@ class AttributesController extends AppController
             if ($result) {
                 $this->Flash->success(__('The attribute has been saved'));
                 // remove the published flag from the event
-                $this->Event->unpublishEvent($eventId);
+                $this->Attribute->Event->unpublishEvent($eventId);
                 if (!empty($this->Attribute->data['Attribute']['object_id'])) {
                     $object = $this->Attribute->Object->find('first', array(
                         'recursive' => -1,
@@ -948,11 +876,8 @@ class AttributesController extends AppController
             $this->set('objectAttribute', false);
         }
         // enabling / disabling the distribution field in the edit view based on whether user's org == orgc in the event
-        $this->loadModel('Event');
-        $this->Event->id = $eventId;
-        $this->set('event_id', $eventId);
-        $this->Event->read();
-        $this->set('published', $this->Event->data['Event']['published']);
+        $this->set('event_id', $attribute['Event']['id']);
+        $this->set('published', $attribute['Event']['published']);
         // needed for RBAC
         // combobox for types
         $types = array_keys($this->Attribute->typeDefinitions);
@@ -964,7 +889,7 @@ class AttributesController extends AppController
         $types = $this->_arrayToValuesIndexArray($types);
         $this->set('types', $types);
         // combobox for categories
-        $this->set('currentDist', $this->Event->data['Event']['distribution']);
+        $this->set('currentDist', $attribute['Event']['distribution']);
 
         $this->loadModel('SharingGroup');
         $sgs = $this->SharingGroup->fetchAllAuthorised($this->Auth->user(), 'name', 1);
@@ -1016,44 +941,17 @@ class AttributesController extends AppController
     // ajax edit - post a single edited field and this method will attempt to save it and return a json with the validation errors if they occur.
     public function editField($id)
     {
-        if (Validation::uuid($id)) {
-            $this->Attribute->recursive = -1;
-            $temp = $this->Attribute->findByUuid($id);
-            if ($temp == null) {
-                throw new NotFoundException(__('Invalid attribute'));
-            }
-            $id = $temp['Attribute']['id'];
-        } elseif (!is_numeric($id)) {
-            throw new NotFoundException(__('Invalid event id.'));
-        }
-        if ((!$this->request->is('post') && !$this->request->is('put'))) {
-            throw new MethodNotAllowedException();
-        }
-        $this->Attribute->id = $id;
-        if (!$this->Attribute->exists()) {
-            return new CakeResponse(array('body'=> json_encode(array('fail' => false, 'errors' => 'Invalid attribute')), 'status'=>200, 'type' => 'json'));
-        }
-        $conditions = array('conditions' => array('Attribute.id' => $id), 'withAttachments' => true, 'flatten' => true);
-        $conditions['includeAllTags'] = false;
-        $conditions['includeAttributeUuid'] = true;
-        $attribute = $this->Attribute->fetchAttributes($this->Auth->user(), $conditions);
+        $attribute = $this->__fetchAttribute($id);
         if (empty($attribute)) {
-            throw new MethodNotAllowedException('Invalid attribute');
+            return new CakeResponse(array('body'=> json_encode(array('fail' => false, 'errors' => 'Invalid attribute')), 'status' => 200, 'type' => 'json'));
         }
-        $attribute = $attribute[0];
         $this->Attribute->data = $attribute;
-
-        if (!$this->_isSiteAdmin()) {
-            if ($this->Attribute->data['Event']['orgc_id'] == $this->Auth->user('org_id')
-            && (($this->userRole['perm_modify'] && $this->Attribute->data['Event']['user_id'] != $this->Auth->user('id'))
-            || $this->userRole['perm_modify_org'])) {
-                // Allow the edit
-            } else {
-                return new CakeResponse(array('body'=> json_encode(array('fail' => false, 'errors' => 'You do not have permission to do that')), 'status'=>200, 'type' => 'json'));
-            }
+        $this->Attribute->id = $attribute['Attribute']['id'];
+        if (!$this->__canModifyEvent($attribute)) {
+            return new CakeResponse(array('body' => json_encode(array('fail' => false, 'errors' => 'You do not have permission to do that')), 'status' => 200, 'type' => 'json'));
         }
         if (!$this->_isRest()) {
-            $this->Attribute->Event->insertLock($this->Auth->user(), $this->Attribute->data['Attribute']['event_id']);
+            $this->Attribute->Event->insertLock($this->Auth->user(), $attribute['Attribute']['event_id']);
         }
         $validFields = array('value', 'category', 'type', 'comment', 'to_ids', 'distribution', 'first_seen', 'last_seen');
         $changed = false;
@@ -1080,15 +978,8 @@ class AttributesController extends AppController
         $date = new DateTime();
         $attribute['Attribute']['timestamp'] = $date->getTimestamp();
         if ($this->Attribute->save($attribute)) {
-            $event = $this->Attribute->Event->find('first', array(
-                'recursive' => -1,
-                'fields' => array('id', 'published', 'timestamp', 'info', 'uuid'),
-                'conditions' => array(
-                    'id' => $attribute['Attribute']['event_id'],
-            )));
-            $event['Event']['timestamp'] = $date->getTimestamp();
-            $event['Event']['published'] = 0;
-            $this->Attribute->Event->save($event, array('fieldList' => array('published', 'timestamp', 'info')));
+            $this->Attribute->Event->unpublishEvent($attribute['Attribute']['event_id']);
+
             if ($attribute['Attribute']['object_id'] != 0) {
                 $this->Attribute->Object->updateTimestamp($attribute['Attribute']['object_id'], $date->getTimestamp());
             }
@@ -1102,31 +993,10 @@ class AttributesController extends AppController
 
     public function view($id)
     {
-        if (Validation::uuid($id)) {
-            $temp = $this->Attribute->find('first', array(
-                'recursive' => -1,
-                'conditions' => array('Attribute.uuid' => $id),
-                'fields' => array('Attribute.id', 'Attribute.uuid')
-            ));
-            if (empty($temp)) {
-                throw new NotFoundException(__('Invalid attribute'));
-            }
-            $id = $temp['Attribute']['id'];
-        } elseif (!is_numeric($id)) {
-            throw new NotFoundException(__('Invalid attribute id.'));
-        }
-        $this->Attribute->id = $id;
-        if (!$this->Attribute->exists()) {
-            throw new NotFoundException('Invalid attribute');
-        }
-        $conditions = array('conditions' => array('Attribute.id' => $id), 'withAttachments' => true, 'flatten' => true);
-        $conditions['includeAllTags'] = false;
-        $conditions['includeAttributeUuid'] = true;
-        $attribute = $this->Attribute->fetchAttributes($this->Auth->user(), $conditions);
+        $attribute = $this->__fetchAttribute($id);
         if (empty($attribute)) {
-            throw new MethodNotAllowedException('Invalid attribute');
+            throw new MethodNotAllowedException(__('Invalid attribute'));
         }
-        $attribute = $attribute[0];
         if ($this->_isRest()) {
             if (isset($attribute['AttributeTag'])) {
                 foreach ($attribute['AttributeTag'] as $k => $tag) {
@@ -1144,14 +1014,7 @@ class AttributesController extends AppController
 
     public function viewPicture($id, $thumbnail=false)
     {
-        if (Validation::uuid($id)) {
-            $conditions = array('Attribute.uuid' => $id);
-        } elseif (is_numeric($id)) {
-            $conditions = array('Attribute.id' => $id);
-        } else {
-            throw new NotFoundException(__('Invalid attribute id.'));
-        }
-
+        $conditions = $this->__idToConditions($id);
         $conditions['Attribute.type'] = 'attachment';
         $options = array(
             'conditions' => $conditions,
@@ -1335,8 +1198,8 @@ class AttributesController extends AppController
                     'recursive' => -1,
                     'fields' => array('id', 'orgc_id', 'user_id')
             ));
-            if ($event['Event']['orgc_id'] != $this->Auth->user('org_id') || (!$this->userRole['perm_modify_org'] && !($this->userRole['perm_modify'] && $event['Event']['user_id'] == $this->Auth->user('id')))) {
-                throw new MethodNotAllowedException(__('Invalid Event.'));
+            if (!$this->__canModifyEvent($event)) {
+                throw new ForbiddenException(__('You do not have permission to do that.'));
             }
         }
         if (empty($ids)) {
@@ -1612,7 +1475,7 @@ class AttributesController extends AppController
                 }
                 if ($saveSuccess) {
                     if (!$this->_isRest()) {
-                        $this->Attribute->Event->insertLock($this->Auth->user(), $id);
+                        $this->Attribute->Event->insertLock($this->Auth->user(), $event['Event']['id']);
                     }
                     $event['Event']['timestamp'] = $date->getTimestamp();
                     $event['Event']['published'] = 0;
@@ -1914,13 +1777,7 @@ class AttributesController extends AppController
         if (!$user) {
             throw new UnauthorizedException(__('This authentication key is not authorized to be used for exports. Contact your administrator.'));
         }
-        if (is_numeric($id)) {
-            $conditions = array('Attribute.id' => $id);
-        } elseif (Validation::uuid($id)) {
-            $conditions = array('Attribute.uuid' => $id);
-        } else {
-            throw new NotFoundException(__('Invalid attribute id.'));
-        }
+        $conditions = $this->__idToConditions($id);
         $conditions['Attribute.type'] = array('attachment', 'malware-sample');
         $attributes = $this->Attribute->fetchAttributes($user, array('conditions' => $conditions, 'flatten' => true));
         if (empty($attributes)) {
@@ -2125,10 +1982,6 @@ class AttributesController extends AppController
         if (!$this->request->is('ajax')) {
             throw new MethodNotAllowedException(__('This function can only be accessed via AJAX.'));
         }
-        $this->Attribute->id = $id;
-        if (!$this->Attribute->exists()) {
-            throw new NotFoundException(__('Invalid attribute'));
-        }
         $params = array(
                 'conditions' => array('Attribute.id' => $id),
                 'fields' => array('id', 'distribution', 'event_id', $field),
@@ -2145,13 +1998,11 @@ class AttributesController extends AppController
         }
         $attribute = $attribute[0];
         $result = $attribute['Attribute'][$field];
-        if ($field == 'distribution') {
-            $result=$this->Attribute->shortDist[$result];
-        }
-        if ($field == 'to_ids') {
+        if ($field === 'distribution') {
+            $result = $this->Attribute->shortDist[$result];
+        } elseif ($field === 'to_ids') {
             $result = ($result == 0 ? 'No' : 'Yes');
-        }
-        if ($field == 'timestamp') {
+        } elseif ($field === 'timestamp') {
             if (isset($result)) {
                 $result = date('Y-m-d', $result);
             } else {
@@ -2172,11 +2023,6 @@ class AttributesController extends AppController
         if (!$this->request->is('ajax')) {
             throw new MethodNotAllowedException(__('This function can only be accessed via AJAX.'));
         }
-        $this->Attribute->id = $id;
-        if (!$this->Attribute->exists()) {
-            throw new NotFoundException(__('Invalid attribute'));
-        }
-
         $fields = array('id', 'distribution', 'event_id');
         if ($field == 'category' || $field == 'type') {
             $fields[] = 'type';
@@ -2199,22 +2045,15 @@ class AttributesController extends AppController
             throw new NotFoundException(__('Invalid attribute'));
         }
         $attribute = $attribute[0];
-        if (!$this->_isSiteAdmin()) {
-            if ($attribute['Event']['orgc_id'] == $this->Auth->user('org_id')
-            && (($this->userRole['perm_modify'] && $attribute['Event']['user_id'] != $this->Auth->user('id'))
-                    || $this->userRole['perm_modify_org'])) {
-                // Allow the edit
-            } else {
-                throw new ForbiddenException(__('You do not have permission to do that'));
-            }
+        if (!$this->__canModifyEvent($attribute)) {
+            throw new ForbiddenException(__('You do not have permission to do that'));
         }
         $this->layout = 'ajax';
-        if ($field == 'distribution') {
+        if ($field === 'distribution') {
             $distributionLevels = $this->Attribute->shortDist;
             unset($distributionLevels[4]);
             $this->set('distributionLevels', $distributionLevels);
-        }
-        if ($field == 'category') {
+        } elseif ($field === 'category') {
             $typeCategory = array();
             foreach ($this->Attribute->categoryDefinitions as $k => $category) {
                 foreach ($category['types'] as $type) {
@@ -2222,8 +2061,7 @@ class AttributesController extends AppController
                 }
             }
             $this->set('typeCategory', $typeCategory);
-        }
-        if ($field == 'type') {
+        } elseif ($field === 'type') {
             $this->set('categoryDefinitions', $this->Attribute->categoryDefinitions);
         }
         $this->set('object', $attribute['Attribute']);
@@ -2235,14 +2073,14 @@ class AttributesController extends AppController
     public function attributeReplace($id)
     {
         if (!$this->userRole['perm_add']) {
-            throw new MethodNotAllowedException(__('Event not found or you don\'t have permissions to create attributes'));
+            throw new ForbiddenException(__('Event not found or you don\'t have permissions to create attributes'));
         }
         $event = $this->Attribute->Event->find('first', array(
                 'conditions' => array('Event.id' => $id),
-                'fields' => array('id', 'orgc_id', 'distribution'),
+                'fields' => array('id', 'orgc_id', 'distribution', 'user_id'),
                 'recursive' => -1
         ));
-        if (empty($event) || (!$this->_isSiteAdmin() && ($event['Event']['orgc_id'] != $this->Auth->user('org_id') || !$this->userRole['perm_add']))) {
+        if (empty($event) || !$this->__canModifyEvent($event)) {
             throw new MethodNotAllowedException(__('Event not found or you don\'t have permissions to create attributes'));
         }
         $this->set('event_id', $id);
@@ -3083,30 +2921,16 @@ class AttributesController extends AppController
 
     public function toggleCorrelation($id)
     {
-        if (!$this->_isSiteAdmin() && !Configure::read('MISP.allow_disabling_correlation')) {
-            throw new MethodNotAllowedException(__('Disabling the correlation is not permitted on this instance.'));
-        }
-        $this->Attribute->id = $id;
-        if (!$this->Attribute->exists()) {
-            throw new NotFoundException(__('Invalid Attribute.'));
-        }
-        if (!$this->Auth->user('Role')['perm_modify']) {
-            throw new MethodNotAllowedException(__('You do not have permission to do that.'));
-        }
-        $conditions = array('Attribute.id' => $id);
-        if (!$this->_isSiteAdmin()) {
-            $conditions['Event.orgc_id'] = $this->Auth->user('org_id');
-        }
         $attribute = $this->Attribute->find('first', array(
-            'conditions' => $conditions,
+            'conditions' => array('Attribute.id' => $id),
             'recursive' => -1,
             'contain' => array('Event')
         ));
         if (empty($attribute)) {
             throw new NotFoundException(__('Invalid Attribute.'));
         }
-        if (!$this->Auth->user('Role')['perm_modify_org'] && $this->Auth->user('id') != $attribute['Event']['user_id']) {
-            throw new MethodNotAllowedException(__('You do not have permission to do that.'));
+        if (!$this->__canModifyEvent($attribute)) {
+            throw new ForbiddenException(__('You do not have permission to do that.'));
         }
         if (!$this->_isRest()) {
             $this->Attribute->Event->insertLock($this->Auth->user(), $attribute['Event']['id']);
@@ -3199,5 +3023,38 @@ class AttributesController extends AppController
             );
         }
         return $info;
+    }
+
+    private function __fetchAttribute($id)
+    {
+        $options = array(
+            'conditions' => $this->__idToConditions($id),
+            'contain' => array(
+                'Event',
+            ),
+            'withAttachments' => $this->_isRest(),
+            'flatten' => true,
+            'includeAllTags' => false,
+            'includeAttributeUuid' => true,
+            'limit' => 1,
+        );
+        $attributes = $this->Attribute->fetchAttributes($this->Auth->user(), $options);
+        if (!empty($attributes)) {
+            return $attributes[0];
+        } else {
+            return null;
+        }
+    }
+
+    private function __idToConditions($id)
+    {
+        if (is_numeric($id)) {
+            $conditions = array('Attribute.id' => $id);
+        } elseif (Validation::uuid($id)) {
+            $conditions = array('Attribute.uuid' => $id);
+        } else {
+            throw new NotFoundException(__('Invalid attribute ID.'));
+        }
+        return $conditions;
     }
 }

--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -1419,13 +1419,12 @@ class AttributesController extends AppController
             $changeInAttribute = ($this->request->data['Attribute']['to_ids'] != 2) || ($this->request->data['Attribute']['distribution'] != 6) || ($this->request->data['Attribute']['comment'] != null);
 
             if (!$changeInAttribute && !$changeInTagOrCluster) {
-                $this->autoRender = false;
                 return new CakeResponse(array('body'=> json_encode(array('saved' => true)), 'status' => 200, 'type' => 'json'));
             }
 
             if ($this->request->data['Attribute']['to_ids'] != 2) {
                 foreach ($attributes as $key => $attribute) {
-                    $attributes[$key]['Attribute']['to_ids'] = ($this->request->data['Attribute']['to_ids'] == 0 ? false : true);
+                    $attributes[$key]['Attribute']['to_ids'] = $this->request->data['Attribute']['to_ids'] == 0 ? false : true;
                 }
             }
 
@@ -1477,30 +1476,28 @@ class AttributesController extends AppController
                     if (!$this->_isRest()) {
                         $this->Attribute->Event->insertLock($this->Auth->user(), $event['Event']['id']);
                     }
-                    $event['Event']['timestamp'] = $date->getTimestamp();
+                    $event['Event']['timestamp'] = $timestamp;
                     $event['Event']['published'] = 0;
-                    $this->Attribute->Event->save($event, array('fieldList' => array('published', 'timestamp', 'info', 'id')));
-                    $this->autoRender = false;
+                    $this->Attribute->Event->save($event, array('fieldList' => array('published', 'timestamp', 'id')));
                     return new CakeResponse(array('body'=> json_encode(array('saved' => true)), 'status' => 200, 'type' => 'json'));
                 } else {
-                    $this->autoRender = false;
                     return new CakeResponse(array('body'=> json_encode(array('saved' => false, 'validationErrors' => $this->Attribute->validationErrors)), 'status' => 200, 'type' => 'json'));
                 }
             }
 
             // apply changes in tag/cluster
             foreach ($attributes as $key => $attribute) {
-                foreach ($tags_ids_remove as $t => $tag_id) {
+                foreach ($tags_ids_remove as $tag_id) {
                     $this->removeTag($attributes[$key]['Attribute']['id'], $tag_id);
                 }
-                foreach ($tags_ids_add as $t => $tag_id) {
+                foreach ($tags_ids_add as $tag_id) {
                     $this->addTag($attributes[$key]['Attribute']['id'], $tag_id);
                 }
                 $this->Galaxy = ClassRegistry::init('Galaxy');
-                foreach ($clusters_ids_remove as $c => $cluster_id) {
+                foreach ($clusters_ids_remove as $cluster_id) {
                     $this->Galaxy->detachCluster($this->Auth->user(), 'attribute', $attributes[$key]['Attribute']['id'], $cluster_id);
                 }
-                foreach ($clusters_ids_add as $c => $cluster_id) {
+                foreach ($clusters_ids_add as $cluster_id) {
                     $this->Galaxy->attachCluster($this->Auth->user(), 'attribute', $attributes[$key]['Attribute']['id'], $cluster_id);
                 }
             }

--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -805,13 +805,13 @@ class AttributesController extends AppController
             if ($existingAttribute['Attribute']['object_id']) {
                 $result = $this->Attribute->save($this->request->data, array('fieldList' => $this->Attribute->editableFields));
                 if ($result) {
-                    $this->Attribute->AttributeTag->handleAttributeTags($this->Auth->user(), $this->request->data['Attribute'], $event['Event']['id'], $capture=true);
+                    $this->Attribute->AttributeTag->handleAttributeTags($this->Auth->user(), $this->request->data['Attribute'], $attribute['Event']['id'], $capture=true);
                 }
                 $this->Attribute->Object->updateTimestamp($existingAttribute['Attribute']['object_id']);
             } else {
                 $result = $this->Attribute->save($this->request->data);
                 if ($result) {
-                    $this->Attribute->AttributeTag->handleAttributeTags($this->Auth->user(), $this->request->data['Attribute'], $event['Event']['id'], $capture=true);
+                    $this->Attribute->AttributeTag->handleAttributeTags($this->Auth->user(), $this->request->data['Attribute'], $attribute['Event']['id'], $capture=true);
                 }
                 if ($this->request->is('ajax')) {
                     $this->autoRender = false;

--- a/app/Controller/ObjectReferencesController.php
+++ b/app/Controller/ObjectReferencesController.php
@@ -167,10 +167,10 @@ class ObjectReferencesController extends AppController
             'contain' => array('Object' => array('Event'))
         ));
         if (empty($objectReference)) {
-            throw new NotFoundException('Invalid object reference.');
+            throw new NotFoundException(__('Invalid object reference.'));
         }
-        if (!$this->__canModifyEvent($objectReference['Object']['Event'])) {
-            throw new ForbiddenException('Invalid object reference.');
+        if (!$this->__canModifyEvent($objectReference['Object'])) {
+            throw new ForbiddenException(__('Invalid object reference.'));
         }
         if ($this->request->is('post') || $this->request->is('put') || $this->request->is('delete')) {
             $result = $this->ObjectReference->smartDelete($objectReference['ObjectReference']['id'], $hard);

--- a/app/Controller/ObjectReferencesController.php
+++ b/app/Controller/ObjectReferencesController.php
@@ -41,12 +41,12 @@ class ObjectReferencesController extends AppController
             'recursive' => -1,
             'contain' => array(
                 'Event' => array(
-                    'fields' => array('Event.id', 'Event.orgc_id')
+                    'fields' => array('Event.id', 'Event.orgc_id', 'Event.user_id')
                 )
             )
         ));
-        if (empty($object) || (!$this->_isSiteAdmin() && $object['Event']['orgc_id'] != $this->Auth->user('org_id'))) {
-            throw new MethodNotAllowedException('Invalid object.');
+        if (empty($object) || !$this->__canModifyEvent($object)) {
+            throw new NotFoundException('Invalid object.');
         }
         $this->set('objectId', $objectId);
         if ($this->request->is('post')) {
@@ -60,7 +60,6 @@ class ObjectReferencesController extends AppController
                 $relationship_type = $this->request->data['ObjectReference']['relationship_type_select'];
             }
             $data = array(
-                'referenced_type' => $referenced_type,
                 'referenced_id' => $referenced_id,
                 'referenced_uuid' => $referenced_uuid,
                 'relationship_type' => $relationship_type,
@@ -168,10 +167,10 @@ class ObjectReferencesController extends AppController
             'contain' => array('Object' => array('Event'))
         ));
         if (empty($objectReference)) {
-            throw new MethodNotAllowedException('Invalid object reference.');
+            throw new NotFoundException('Invalid object reference.');
         }
-        if (!$this->_isSiteAdmin() && $this->Auth->user('org_id') != $objectReference['Object']['Event']['orgc_id']) {
-            throw new MethodNotAllowedException('Invalid object reference.');
+        if (!$this->__canModifyEvent($objectReference['Object']['Event'])) {
+            throw new ForbiddenException('Invalid object reference.');
         }
         if ($this->request->is('post') || $this->request->is('put') || $this->request->is('delete')) {
             $result = $this->ObjectReference->smartDelete($objectReference['ObjectReference']['id'], $hard);

--- a/app/Controller/ObjectsController.php
+++ b/app/Controller/ObjectsController.php
@@ -416,10 +416,10 @@ class ObjectsController extends AppController
             }
             $savedObject = array();
             if (is_numeric($objectToSave)) {
-                $savedObject = $this->MispObject->fetchObjects($this->Auth->user(), array('conditions' => array('Object.id' => $id)));
+                $savedObject = $this->MispObject->fetchObjects($this->Auth->user(), array('conditions' => array('Object.id' => $object['Object']['id'])));
                 if (isset($this->request->data['deleted']) && $this->request->data['deleted']) {
                     $this->MispObject->deleteObject($savedObject[0], $hard=false, $unpublish=false);
-                    $savedObject = $this->MispObject->fetchObjects($this->Auth->user(), array('conditions' => array('Object.id' => $id))); // make sure the object is deleted
+                    $savedObject = $this->MispObject->fetchObjects($this->Auth->user(), array('conditions' => array('Object.id' => $object['Object']['id']))); // make sure the object is deleted
                 }
             }
             // we pre-validate the attributes before we create an object at this point

--- a/app/Controller/ShadowAttributesController.php
+++ b/app/Controller/ShadowAttributesController.php
@@ -3,6 +3,9 @@ App::uses('AppController', 'Controller');
 App::uses('Folder', 'Utility');
 App::uses('File', 'Utility');
 
+/**
+ * @property ShadowAttribute $ShadowAttribute
+ */
 class ShadowAttributesController extends AppController
 {
     public $components = array('Acl', 'Security', 'RequestHandler', 'Email');
@@ -23,31 +26,15 @@ class ShadowAttributesController extends AppController
         // convert uuid to id if present in the url, and overwrite id field
         if (isset($this->params->query['uuid'])) {
             $params = array(
-                    'conditions' => array('ShadowAttribute.uuid' => $this->params->query['uuid']),
-                    'recursive' => 0,
-                    'fields' => 'ShadowAttribute.id'
-                    );
+                'conditions' => array('ShadowAttribute.uuid' => $this->params->query['uuid']),
+                'recursive' => 0,
+                'fields' => 'ShadowAttribute.id'
+            );
             $result = $this->ShadowAttribute->find('first', $params);
             if (isset($result['ShadowAttribute']) && isset($result['ShadowAttribute']['id'])) {
                 $id = $result['ShadowAttribute']['id'];
                 $this->params->addParams(array('pass' => array($id))); // FIXME find better way to change id variable if uuid is found. params->url and params->here is not modified accordingly now
             }
-        }
-
-        // if not admin or own org, check private as well..
-        if (!$this->_isSiteAdmin()) {
-            $this->paginate = Set::merge($this->paginate, array(
-            'conditions' =>
-                    array('OR' =>
-                            array(
-                                'Event.org =' => $this->Auth->user('org_id'),
-                                'AND' => array(
-                                    'ShadowAttribute.org =' => $this->Auth->user('org_id'),
-                                    'Event.distribution >' => 0,
-                                    Configure::read('MISP.unpublishedprivate') ? array('Event.published =' => 1) : array(),
-                                ),
-                            )
-            )));
         }
     }
 
@@ -80,18 +67,16 @@ class ShadowAttributesController extends AppController
             $this->Attribute->contain = 'Event';
             $activeAttribute = $this->Attribute->findByUuid($shadow['uuid']);
 
-            // Send those away that shouldn't be able to see this
-            if (!$this->_isSiteAdmin()) {
-                if ($activeAttribute['Event']['orgc_id'] != $this->Auth->user('org_id') || (!$this->userRole['perm_modify'])) {
-                    if ($this->_isRest()) {
-                        return array('false' => true, 'errors' => 'Proposal not found or you are not authorised to accept it.');
-                    } else {
-                        $this->Flash->error('You don\'t have permission to do that');
-                        $this->redirect(array('controller' => 'events', 'action' => 'view', $shadow['event_id']));
-                    }
+            // Send those away that shouldn't be able to edit this
+            if (!$this->__canModifyEvent($activeAttribute)) {
+                if ($this->_isRest()) {
+                    return array('false' => true, 'errors' => 'Proposal not found or you are not authorised to accept it.');
+                } else {
+                    $this->Flash->error('You don\'t have permission to do that');
+                    $this->redirect(array('controller' => 'events', 'action' => 'view', $shadow['event_id']));
                 }
             }
-            $date = new DateTime();
+
             if (isset($shadow['proposal_to_delete']) && $shadow['proposal_to_delete']) {
                 $this->Attribute->delete($activeAttribute['Attribute']['id']);
             } else {
@@ -100,6 +85,7 @@ class ShadowAttributesController extends AppController
                 foreach ($fieldsToUpdate as $f) {
                     $activeAttribute['Attribute'][$f] = $shadow[$f];
                 }
+                $date = new DateTime();
                 $activeAttribute['Attribute']['timestamp'] = $date->getTimestamp();
                 $this->Attribute->save($activeAttribute['Attribute']);
             }
@@ -133,11 +119,9 @@ class ShadowAttributesController extends AppController
             $this->Event->recursive = -1;
             $event = $this->Event->read(null, $shadow['event_id']);
 
-            if (!$this->_isSiteAdmin()) {
-                if (($event['Event']['orgc_id'] != $this->Auth->user('org_id')) || (!$this->userRole['perm_modify'])) {
-                    $this->Flash->error('You don\'t have permission to do that');
-                    $this->redirect(array('controller' => 'events', 'action' => 'index'));
-                }
+            if (!$this->__canModifyEvent($event)) {
+                $this->Flash->error('You don\'t have permission to do that');
+                $this->redirect(array('controller' => 'events', 'action' => 'index'));
             }
             if (!$this->_isRest()) {
                 $this->Event->insertLock($this->Auth->user(), $event['Event']['id']);
@@ -203,6 +187,7 @@ class ShadowAttributesController extends AppController
                 'first',
                 array(
                     'recursive' => -1,
+                    'contain' => 'Event',
                     'conditions' => array(
                         'ShadowAttribute.id' => $id,
                         'deleted' => 0
@@ -212,33 +197,18 @@ class ShadowAttributesController extends AppController
         if (empty($sa)) {
             return false;
         }
-        $this->ShadowAttribute->publishKafkaNotification('shadow_attribute', $sa, 'discard');
-        $eventId = $sa['ShadowAttribute']['event_id'];
-        $this->loadModel('Event');
-        $this->Event->Behaviors->detach('SysLogLogable.SysLogLogable');
-        $this->Event->recursive = -1;
-        $this->Event->id = $eventId;
-        $this->Event->read();
         // Send those away that shouldn't be able to see this
-        if (!$this->_isSiteAdmin()) {
-            if ((($this->Event->data['Event']['orgc_id'] != $this->Auth->user('org_id')) && ($this->Auth->user('org_id') != $sa['ShadowAttribute']['org_id'])) || (!$this->userRole['perm_modify'])) {
-                return false;
-            }
+        if (!$this->__canModifyEvent($sa)) {
+            return false;
         }
+        $this->ShadowAttribute->publishKafkaNotification('shadow_attribute', $sa, 'discard');
         if ($this->ShadowAttribute->setDeleted($id)) {
-            if ($this->Auth->user('org_id') == $this->Event->data['Event']['orgc_id']) {
-                $this->ShadowAttribute->setProposalLock($eventId, false);
+            if ($this->Auth->user('org_id') == $sa['Event']['orgc_id']) {
+                $this->ShadowAttribute->setProposalLock($sa['Event']['id'], false);
             }
+            $logTitle = "Proposal ({$sa['ShadowAttribute']['id']}) of {$sa['ShadowAttribute']['org_id']} discarded - {$sa['ShadowAttribute']['category']}/{$sa['ShadowAttribute']['type']} {$sa['ShadowAttribute']['value']}";
             $this->Log = ClassRegistry::init('Log');
-            $this->Log->create();
-            $this->Log->save(array(
-                        'org_id' => $this->Auth->user('org_id'),
-                        'model' => 'ShadowAttribute',
-                        'model_id' => $id,
-                        'email' => $this->Auth->user('email'),
-                        'action' => 'discard',
-                        'title' => 'Proposal (' . $sa['ShadowAttribute']['id'] . ') of ' . $sa['ShadowAttribute']['org_id'] . ' discarded - ' . $sa['ShadowAttribute']['category'] . '/' . $sa['ShadowAttribute']['type'] . ' ' . $sa['ShadowAttribute']['value'],
-                ));
+            $this->Log->createLogEntry($this->Auth->user(), 'discard', 'ShadowAttribute', $id,  $logTitle);
             return true;
         }
         return false;
@@ -260,7 +230,7 @@ class ShadowAttributesController extends AppController
                 }
             } else {
                 if ($this->_isRest()) {
-                    throw new MethodNotAllowedException(__('Could not discard proposal.'));
+                    throw new InternalErrorException(__('Could not discard proposal.'));
                 } else {
                     $this->autoRender = false;
                     return new CakeResponse(array('body'=> json_encode(array('false' => true, 'errors' => 'Could not discard proposal.')), 'status'=>200, 'type' => 'json'));
@@ -290,11 +260,10 @@ class ShadowAttributesController extends AppController
         } else {
             $this->set('ajax', false);
         }
-        $event = $this->ShadowAttribute->Event->fetchEvent($this->Auth->user(), array('eventid' => $eventId));
+        $event = $this->ShadowAttribute->Event->fetchSimpleEvent($this->Auth->user(), $eventId);
         if (empty($event)) {
             throw new NotFoundException(__('Invalid Event'));
         }
-        $event = $event[0];
 
         if ($this->request->is('post')) {
             if (isset($this->request->data['request'])) {
@@ -317,9 +286,9 @@ class ShadowAttributesController extends AppController
             // TODO change behavior attachment options - this is bad ... it should rather by a messagebox or should be filtered out on the view level
             if (isset($this->request->data['ShadowAttribute']['type']) && $this->ShadowAttribute->typeIsAttachment($this->request->data['ShadowAttribute']['type']) && !$this->_isRest()) {
                 $this->Flash->error(__('Attribute has not been added: attachments are added by "Add attachment" button', true), 'default', array(), 'error');
-                $this->redirect(array('controller' => 'events', 'action' => 'view', $eventId));
+                $this->redirect(array('controller' => 'events', 'action' => 'view', $event['Event']['id']));
             }
-            $this->request->data['ShadowAttribute']['event_id'] = $eventId;
+            $this->request->data['ShadowAttribute']['event_id'] = $event['Event']['id'];
             //
             // multiple attributes in batch import
             //
@@ -373,7 +342,7 @@ class ShadowAttributesController extends AppController
                     if ($successes) {
                         // list the ones that succeeded
                         $emailResult = "";
-                        if (!$this->ShadowAttribute->sendProposalAlertEmail($eventId) === false) {
+                        if (!$this->ShadowAttribute->sendProposalAlertEmail($event['Event']['id']) === false) {
                             $emailResult = " but nobody from the owner organisation could be notified by e-mail.";
                         }
                         $this->Flash->success(__('The lines' . $successes . ' have been saved' . $emailResult, true));
@@ -387,7 +356,6 @@ class ShadowAttributesController extends AppController
                 //
                 // create the attribute
                 $this->ShadowAttribute->create();
-                $savedId = $this->ShadowAttribute->getID();
                 $this->request->data['ShadowAttribute']['email'] = $this->Auth->user('email');
                 $this->request->data['ShadowAttribute']['org_id'] = $this->Auth->user('org_id');
                 $this->request->data['ShadowAttribute']['event_uuid'] = $event['Event']['uuid'];
@@ -436,9 +404,9 @@ class ShadowAttributesController extends AppController
             }
         } else {
             // set the event_id in the form
-            $this->request->data['ShadowAttribute']['event_id'] = $eventId;
+            $this->request->data['ShadowAttribute']['event_id'] = $event['Event']['id'];
         }
-        $this->set('event_id', $eventId);
+        $this->set('event_id', $event['Event']['id']);
         // combobox for types
         $types = array_keys($this->ShadowAttribute->typeDefinitions);
         foreach ($types as $key => $value) {
@@ -466,17 +434,16 @@ class ShadowAttributesController extends AppController
 
     public function download($id = null)
     {
-        $this->ShadowAttribute->id = $id;
-        if (!$this->ShadowAttribute->exists()) {
-            throw new NotFoundException(__('Invalid Proposal'));
-        }
+        $conditions = $this->ShadowAttribute->buildConditions($this->Auth->user());
+        $conditions['ShadowAttribute.id'] = $id;
+        $conditions['ShadowAttribute.deleted'] = 0;
+
         $sa = $this->ShadowAttribute->find('first', array(
             'recursive' => -1,
-            'contain' => array('Event' => array('fields' => array('Event.org_id', 'Event.distribution', 'Event.id'))),
-            'conditions' => array('ShadowAttribute.id' => $id)
+            'conditions' => $conditions,
         ));
-        if (!$this->ShadowAttribute->Event->checkIfAuthorised($this->Auth->user(), $sa['Event']['id'])) {
-            throw new UnauthorizedException(__('You do not have the permission to view this event.'));
+        if (!$sa) {
+            throw new NotFoundException(__('Invalid Proposal'));
         }
         $this->__downloadAttachment($sa['ShadowAttribute']);
     }
@@ -507,12 +474,10 @@ class ShadowAttributesController extends AppController
 
     public function add_attachment($eventId = null)
     {
-        $event = $this->ShadowAttribute->Event->fetchEvent($this->Auth->user(), array('eventid' => $eventId));
+        $event = $this->ShadowAttribute->Event->fetchSimpleEvent($this->Auth->user(), $eventId);
         if (empty($event)) {
             throw new NotFoundException(__('Invalid Event'));
         }
-        $event = $event[0];
-
         if ($this->request->is('post')) {
             // Check if there were problems with the file upload
             // only keep the last part of the filename, this should prevent directory attacks
@@ -526,7 +491,7 @@ class ShadowAttributesController extends AppController
                     throw new InternalErrorException(__('PHP says file was not uploaded. Are you attacking me?'));
                 }
             } else {
-                $this->Flash->error(__('There was a problem to upload the file.', true));
+                $this->Flash->error(__('There was a problem to upload the file.'));
                 $this->redirect(array('controller' => 'events', 'action' => 'view', $this->request->data['ShadowAttribute']['event_id']));
             }
 
@@ -536,7 +501,7 @@ class ShadowAttributesController extends AppController
             if ($this->request->data['ShadowAttribute']['malware']) {
                 $result = $this->ShadowAttribute->Event->Attribute->handleMaliciousBase64($this->request->data['ShadowAttribute']['event_id'], $filename, base64_encode($tmpfile->read()), array_keys($hashes));
                 if (!$result['success']) {
-                    $this->Flash->error(__('There was a problem to upload the file.', true), 'default', array(), 'error');
+                    $this->Flash->error(__('There was a problem to upload the file.'), 'default', array(), 'error');
                     $this->redirect(array('controller' => 'events', 'action' => 'view', $this->request->data['ShadowAttribute']['event_id']));
                 }
                 foreach ($hashes as $hash => $typeName) {
@@ -604,7 +569,7 @@ class ShadowAttributesController extends AppController
             $this->redirect(array('controller' => 'events', 'action' => 'view', $this->request->data['ShadowAttribute']['event_id']));
         } else {
             // set the event_id in the form
-            $this->request->data['ShadowAttribute']['event_id'] = $eventId;
+            $this->request->data['ShadowAttribute']['event_id'] = $event['Event']['id'];
         }
 
         // combobox for categories
@@ -648,14 +613,13 @@ class ShadowAttributesController extends AppController
     // if any of these fields is set, it will create a proposal
     public function edit($id = null)
     {
-        $id = $this->Toolbox->findIdByUuid($this->ShadowAttribute->Event->Attribute, $id);
         $existingAttribute = $this->ShadowAttribute->Event->Attribute->fetchAttributes($this->Auth->user(), array(
                 'contain' => array('Event' => array('fields' => array('Event.id', 'Event.orgc_id', 'Event.org_id', 'Event.distribution', 'Event.uuid'))),
-                'conditions' => array('Attribute.id' => $id),
+                'conditions' => $this->__attributeIdToConditions($id),
                 'flatten' => 1
         ));
         if (empty($existingAttribute)) {
-            throw new MethodNotAllowedException(__('Invalid Attribute.'));
+            throw new NotFoundException(__('Invalid Attribute.'));
         }
         $existingAttribute = $existingAttribute[0];
 
@@ -742,7 +706,7 @@ class ShadowAttributesController extends AppController
                     foreach ($this->ShadowAttribute->validationErrors as $k => $v) {
                         $message .= '[' . $k . ']: ' . $v[0] . PHP_EOL;
                     }
-                    throw new NotFoundException(__('Could not save the proposal. Errors: %s', $message));
+                    throw new InternalErrorException(__('Could not save the proposal. Errors: %s', $message));
                 } else {
                     $this->Flash->error(__('The ShadowAttribute could not be saved. Please, try again.'));
                 }
@@ -799,17 +763,9 @@ class ShadowAttributesController extends AppController
 
     public function delete($id)
     {
-        if (is_numeric($id)) {
-            $conditions = ['Attribute.id' => $id];
-        } else if (Validation::uuid($id)) {
-            $conditions = ['Attribute.uuid' => $id];
-        } else {
-            throw new NotFoundException(__('Invalid attribute'));
-        }
-
         $existingAttribute = $this->ShadowAttribute->Event->Attribute->fetchAttributes(
             $this->Auth->user(),
-            array('conditions' => $conditions, 'flatten' => true)
+            array('conditions' => $this->__attributeIdToConditions($id), 'flatten' => true)
         );
         if ($this->request->is('post')) {
             if (empty($existingAttribute)) {
@@ -847,7 +803,7 @@ class ShadowAttributesController extends AppController
                 throw new NotFoundException(__('Invalid attribute'));
             }
             $existingAttribute = $existingAttribute[0];
-            $this->set('id', $id);
+            $this->set('id', $existingAttribute['Attribute']['id']);
             $this->set('event_id', $existingAttribute['Attribute']['event_id']);
             $this->render('ajax/deletionProposalConfirmationForm');
         }
@@ -855,39 +811,20 @@ class ShadowAttributesController extends AppController
 
     public function view($id)
     {
-        $distConditions = array();
-        if (!$this->_isSiteAdmin()) {
-            $distConditions = array(
-                    'OR' => array(
-                            'Event.distribution >' => 0,
-                            'Event.org_id' => $this->Auth->user('org_id'),
-                            'Event.orgc_id' => $this->Auth->user('org_id'),
-                    ),
-            );
-        }
+        $conditions = $this->ShadowAttribute->buildConditions($this->Auth->user());
+        $conditions['ShadowAttribute.id'] = $id;
+        $conditions['ShadowAttribute.deleted'] = 0;
+
         $sa = $this->ShadowAttribute->find('first', array(
-                'recursive' => -1,
-                'contain' => 'Event',
-                'fields' => array(
-                    'ShadowAttribute.id', 'ShadowAttribute.old_id', 'ShadowAttribute.event_id', 'ShadowAttribute.type', 'ShadowAttribute.category', 'ShadowAttribute.uuid', 'ShadowAttribute.to_ids', 'ShadowAttribute.value', 'ShadowAttribute.comment', 'ShadowAttribute.org_id', 'ShadowAttribute.first_seen', 'ShadowAttribute.last_seen',
-                    'Event.id', 'Event.orgc_id', 'Event.org_id', 'Event.distribution', 'Event.uuid'
-                ),
-                'conditions' => array('AND' => array('ShadowAttribute.id' => $id, $distConditions, 'ShadowAttribute.deleted' => 0))
+            'recursive' => -1,
+            'contain' => 'Event',
+            'fields' => array(
+                'ShadowAttribute.id', 'ShadowAttribute.old_id', 'ShadowAttribute.event_id', 'ShadowAttribute.type', 'ShadowAttribute.category', 'ShadowAttribute.uuid', 'ShadowAttribute.to_ids', 'ShadowAttribute.value', 'ShadowAttribute.comment', 'ShadowAttribute.org_id', 'ShadowAttribute.first_seen', 'ShadowAttribute.last_seen',
+            ),
+            'conditions' => $conditions,
         ));
         if (empty($sa)) {
             throw new NotFoundException(__('Invalid proposal.'));
-        }
-        if (!$this->_isSiteAdmin()) {
-            if ($sa['ShadowAttribute']['old_id'] != 0 && $sa['Event']['org_id'] != $this->Auth->user('org_id') && $sa['Event']['orgc_id'] != $this->Auth->user('org_id')) {
-                $a = $this->ShadowAttribute->Event->Attribute->find('first', array(
-                    'recursive' => -1,
-                    'fields' => array('Attribute.id', 'Attribute.distribution'),
-                    'conditions' => array('Attribute.id' => $sa['ShadowAttribute']['old_id'], 'Attribute.distribution >' => 0)
-                ));
-                if (empty($a)) {
-                    throw new NotFoundException(__('Invalid proposal.'));
-                }
-            }
         }
         $this->set('ShadowAttribute', $sa['ShadowAttribute']);
         $this->set('_serialize', array('ShadowAttribute'));
@@ -902,7 +839,7 @@ class ShadowAttributesController extends AppController
             $all = 1;
         }
         $eventId = $this->Toolbox->findIdByUuid($this->ShadowAttribute->Event, $eventId, true);
-        if ($eventId && is_numeric($eventId)) {
+        if ($eventId) {
             $conditions['ShadowAttribute.event_id'] = $eventId;
         }
         $temp = $this->ShadowAttribute->buildConditions($this->Auth->user());
@@ -914,15 +851,16 @@ class ShadowAttributesController extends AppController
             $conditions['AND'][] = array('Event.orgc_id' =>$this->Auth->user('org_id'));
         }
         if (!empty($this->request['named']['searchall'])) {
+            $term = '%' . strtolower(trim($this->request['named']['searchall'])) . '%';
             $conditions['AND'][] = array('OR' => array(
-                'LOWER(ShadowAttribute.value1) LIKE' => '%' . strtolower(trim($this->request['named']['searchall'])) . '%',
-                'LOWER(ShadowAttribute.value2) LIKE' => '%' . strtolower(trim($this->request['named']['searchall'])) . '%',
-                'LOWER(ShadowAttribute.comment) LIKE' => '%' . strtolower(trim($this->request['named']['searchall'])) . '%',
-                'LOWER(Event.info) LIKE' => '%' . strtolower(trim($this->request['named']['searchall'])) . '%',
-                'LOWER(Org.name) LIKE' => '%' . strtolower(trim($this->request['named']['searchall'])) . '%',
-                'LOWER(Org.uuid) LIKE' => '%' . strtolower(trim($this->request['named']['searchall'])) . '%',
-                'LOWER(ShadowAttribute.uuid) LIKE' => '%' . strtolower(trim($this->request['named']['searchall'])) . '%',
-                'LOWER(Event.uuid) LIKE' => '%' . strtolower(trim($this->request['named']['searchall'])) . '%'
+                'LOWER(ShadowAttribute.value1) LIKE' => $term,
+                'LOWER(ShadowAttribute.value2) LIKE' => $term,
+                'LOWER(ShadowAttribute.comment) LIKE' => $term,
+                'LOWER(Event.info) LIKE' => $term,
+                'LOWER(Org.name) LIKE' => $term,
+                'LOWER(Org.uuid) LIKE' => $term,
+                'LOWER(ShadowAttribute.uuid) LIKE' => $term,
+                'LOWER(Event.uuid) LIKE' => $term,
             ));
         }
         if (isset($this->request['named']['deleted'])) {
@@ -1012,21 +950,24 @@ class ShadowAttributesController extends AppController
                     'recursive' => -1,
                     'fields' => array('id', 'orgc_id', 'user_id')
             ));
-            if ($event['Event']['orgc_id'] != $this->Auth->user('org_id') || (!$this->userRole['perm_modify_org'] && !($this->userRole['perm_modify'] && $event['Event']['user_id'] == $this->Auth->user('id')))) {
+            if (!$event) {
+                return new CakeResponse(array('body'=> json_encode(array('false' => true, 'errors' => 'Invalid event.')), 'status' => 200, 'type' => 'json'));
+            }
+            if (!$this->__canModifyEvent($event)) {
                 return new CakeResponse(array('body'=> json_encode(array('false' => true, 'errors' => 'You don\'t have permission to do that.')), 'status'=>200, 'type' => 'json'));
             }
         }
 
         // find all attributes from the ID list that also match the provided event ID.
-        $shadowAttributes = $this->ShadowAttribute->find('all', array(
+        $shadowAttributes = $this->ShadowAttribute->find('list', array(
                 'recursive' => -1,
                 'conditions' => array('id' => $ids, 'event_id' => $id),
-                'fields' => array('id', 'event_id')
+                'fields' => array('id')
         ));
         $successes = array();
-        foreach ($shadowAttributes as $a) {
-            if ($this->discard($a['ShadowAttribute']['id'])) {
-                $successes[] = $a['ShadowAttribute']['id'];
+        foreach ($shadowAttributes as $id) {
+            if ($this->__discard($id)) {
+                $successes[] = $id;
             }
         }
         $fails = array_diff($ids, $successes);
@@ -1053,22 +994,25 @@ class ShadowAttributesController extends AppController
                     'recursive' => -1,
                     'fields' => array('id', 'orgc_id', 'user_id')
             ));
-            if ($event['Event']['orgc_id'] != $this->Auth->user('org_id') || (!$this->userRole['perm_modify_org'] && !($this->userRole['perm_modify'] && $event['Event']['user_id'] == $this->Auth->user('id')))) {
+            if (!$event) {
+                return new CakeResponse(array('body'=> json_encode(array('false' => true, 'errors' => 'Invalid event.')), 'status' => 200, 'type' => 'json'));
+            }
+            if (!$this->__canModifyEvent($event)) {
                 return new CakeResponse(array('body'=> json_encode(array('false' => true, 'errors' => 'You don\'t have permission to do that.')), 'status'=>200, 'type' => 'json'));
             }
         }
 
         // find all attributes from the ID list that also match the provided event ID.
-        $shadowAttributes = $this->ShadowAttribute->find('all', array(
+        $shadowAttributes = $this->ShadowAttribute->find('list', array(
                 'recursive' => -1,
                 'conditions' => array('id' => $ids, 'event_id' => $id),
-                'fields' => array('id', 'event_id')
+                'fields' => array('id')
         ));
         $successes = array();
-        foreach ($shadowAttributes as $a) {
-            $response = $this->__accept($a['ShadowAttribute']['id']);
+        foreach ($shadowAttributes as $shadowAttributeId) {
+            $response = $this->__accept($shadowAttributeId);
             if (isset($response['saved'])) {
-                $successes[] = $a['ShadowAttribute']['id'];
+                $successes[] = $shadowAttributeId;
             }
         }
         $this->ShadowAttribute->Event->unpublishEvent($id, true);
@@ -1113,5 +1057,17 @@ class ShadowAttributesController extends AppController
             $this->Flash->success(__('Job queued. You can view the progress if you navigate to the active jobs view (administration -> jobs).'));
             $this->redirect(array('controller' => 'pages', 'action' => 'display', 'administration'));
         }
+    }
+
+    private function __attributeIdToConditions($id)
+    {
+        if (is_numeric($id)) {
+            $conditions = array('Attribute.id' => $id);
+        } elseif (Validation::uuid($id)) {
+            $conditions = array('Attribute.uuid' => $id);
+        } else {
+            throw new NotFoundException(__('Invalid attribute ID.'));
+        }
+        return $conditions;
     }
 }

--- a/app/Controller/ShadowAttributesController.php
+++ b/app/Controller/ShadowAttributesController.php
@@ -817,7 +817,7 @@ class ShadowAttributesController extends AppController
 
         $sa = $this->ShadowAttribute->find('first', array(
             'recursive' => -1,
-            'contain' => 'Event',
+            'contain' => ['Event', 'Attribute'],
             'fields' => array(
                 'ShadowAttribute.id', 'ShadowAttribute.old_id', 'ShadowAttribute.event_id', 'ShadowAttribute.type', 'ShadowAttribute.category', 'ShadowAttribute.uuid', 'ShadowAttribute.to_ids', 'ShadowAttribute.value', 'ShadowAttribute.comment', 'ShadowAttribute.org_id', 'ShadowAttribute.first_seen', 'ShadowAttribute.last_seen',
             ),

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -3417,7 +3417,8 @@ class Attribute extends AppModel
         if (isset($options['group'])) {
             $params['group'] = empty($options['group']) ? $options['group'] : false;
         }
-        if (Configure::read('MISP.unpublishedprivate')) {
+        // Site admin can access even unpublished event attributes if `unpublishedprivate` option is enabled
+        if (!$user['Role']['perm_site_admin'] && Configure::read('MISP.unpublishedprivate')) {
             $params['conditions']['AND'][] = array('OR' => array('Event.published' => 1, 'Event.orgc_id' => $user['org_id'], 'Event.org_id' => $user['org_id']));
         }
         if (!empty($options['list'])) {

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -3341,9 +3341,6 @@ class Attribute extends AppModel
         if (isset($options['limit'])) {
             $params['limit'] = $options['limit'];
         }
-        if (!empty($options['includeGalaxy'])) {
-            $this->GalaxyCluster = ClassRegistry::init('GalaxyCluster');
-        }
         if (
             Configure::read('MISP.proposals_block_attributes') &&
             !empty($options['allow_proposal_blocking'])

--- a/app/Model/AttributeTag.php
+++ b/app/Model/AttributeTag.php
@@ -236,22 +236,12 @@ class AttributeTag extends AppModel
 
 
     // find all tags that belong to a list of attributes (contained in the same event)
-    public function getAttributesTags($user, $requestedEventId, $attributeIds=false, $includeGalaxies=false) {
-        $conditions = array('Attribute.event_id' => $requestedEventId);
-        if (is_array($attributeIds) && $attributeIds !== false) {
-            $conditions['Attribute.id'] = $attributeIds;
-        }
-
-        $allTags = array();
-        $attributes = $this->Attribute->fetchAttributes($user, array(
-            'conditions' => $conditions,
-            'flatten' => 1,
-            'includeAllTags' => 1
-        ));
-
+    public function getAttributesTags(array $attributes, $includeGalaxies=false)
+    {
         if (empty($attributes)) {
             return array();
         }
+
         $this->GalaxyCluster = ClassRegistry::init('GalaxyCluster');
         $cluster_names = $this->GalaxyCluster->find('list', array(
                 'recursive' => -1,
@@ -260,7 +250,7 @@ class AttributeTag extends AppModel
         $allTags = array();
         foreach ($attributes as $attribute) {
             $attributeTags = $attribute['AttributeTag'];
-            foreach ($attributeTags as $k => $attributeTag) {
+            foreach ($attributeTags as $attributeTag) {
                 if ($includeGalaxies || !isset($cluster_names[$attributeTag['Tag']['name']])) {
                     $allTags[$attributeTag['Tag']['id']] = $attributeTag['Tag'];
                 }
@@ -270,16 +260,8 @@ class AttributeTag extends AppModel
     }
 
     // find all galaxies that belong to a list of attributes (contains in the same event)
-    public function getAttributesClusters($user, $requestedEventId, $attributeIds=false) {
-        $conditions = array('Attribute.event_id' => $requestedEventId);
-        if (is_array($attributeIds) && $attributeIds !== false) {
-            $conditions['Attribute.id'] = $attributeIds;
-        }
-
-        $attributes = $this->Attribute->fetchAttributes($user, array(
-            'conditions' => $conditions,
-            'flatten' => 1,
-        ));
+    public function getAttributesClusters(array $attributes)
+    {
         if (empty($attributes)) {
             return array();
         }
@@ -294,7 +276,7 @@ class AttributeTag extends AppModel
         foreach ($attributes as $attribute) {
             $attributeTags = $attribute['AttributeTag'];
 
-            foreach ($attributeTags as $k => $attributeTag) {
+            foreach ($attributeTags as $attributeTag) {
                 if (isset($cluster_names[$attributeTag['Tag']['name']])) {
                     $cluster = $this->GalaxyCluster->find('first', array(
                             'conditions' => array('GalaxyCluster.tag_name' => $attributeTag['Tag']['name']),

--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -581,7 +581,7 @@ class MispObject extends AppModel
                 $params['page'] = $options['page'];
             }
         }
-        if (Configure::read('MISP.unpublishedprivate')) {
+        if (Configure::read('MISP.unpublishedprivate') && !$user['Role']['perm_site_admin']) {
             $params['conditions']['AND'][] = array('OR' => array('Event.published' => 1, 'Event.orgc_id' => $user['org_id']));
         }
         $results = $this->find('all', $params);

--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -4,6 +4,7 @@ App::uses('TmpFileTool', 'Tools');
 
 /**
  * @property Event $Event
+ * @property SharingGroup $SharingGroup
  */
 class MispObject extends AppModel
 {

--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -2,6 +2,9 @@
 App::uses('AppModel', 'Model');
 App::uses('TmpFileTool', 'Tools');
 
+/**
+ * @property Event $Event
+ */
 class MispObject extends AppModel
 {
     public $name = 'Object';

--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -1056,7 +1056,7 @@ class MispObject extends AppModel
         return true;
     }
 
-    public function deleteObject($object, $hard=false, $unpublish=true)
+    public function deleteObject(array $object, $hard=false, $unpublish=true)
     {
         $id = $object['Object']['id'];
         if ($hard) {

--- a/app/Model/ShadowAttribute.php
+++ b/app/Model/ShadowAttribute.php
@@ -4,6 +4,9 @@ App::uses('AppModel', 'Model');
 App::uses('Folder', 'Utility');
 App::uses('File', 'Utility');
 
+/**
+ * @property Event $Event
+ */
 class ShadowAttribute extends AppModel
 {
     public $combinedKeys = array('event_id', 'category', 'type');
@@ -757,19 +760,20 @@ class ShadowAttribute extends AppModel
                 $objectDistribution['(SELECT sharing_group_id FROM objects WHERE objects.id = Attribute.object_id)'] = $sgids;
                 $attributeDistribution['Attribute.sharing_group_id'] = $sgids;
             }
+            $unpublishedPrivate = Configure::read('MISP.unpublishedprivate');
             $conditions = array(
                 'AND' => array(
                     'OR' => array(
                         'Event.org_id' => $user['org_id'],
-                        'AND' => array(
-                            'OR' => array(
-                                'Event.distribution' => array(1,2,3,5),
-                                'AND '=> array(
-                                    'Event.distribution' => 4,
-                                    'Event.sharing_group_id' => $sgids,
-                                )
-                            )
-                        )
+                        ['AND' => [
+                            'Event.distribution' => array(1,2,3,5),
+                            $unpublishedPrivate ? ['Event.published' => 1] : [],
+                        ]],
+                        ['AND' => [
+                            'Event.distribution' => 4,
+                            'Event.sharing_group_id' => $sgids,
+                            $unpublishedPrivate ? ['Event.published' => 1] : [],
+                        ]],
                     ),
                     array(
                         'OR' => array(

--- a/app/Model/SharingGroup.php
+++ b/app/Model/SharingGroup.php
@@ -815,15 +815,6 @@ class SharingGroup extends AppModel
             } else {
                 $id = $id['SharingGroup']['id'];
             }
-        } else {
-            $temp = $this->find('first', array(
-                'conditions' => array('SharingGroup.id' => $id),
-                'recursive' => -1,
-                'fields' => array('SharingGroup.id')
-            ));
-            if (empty($temp)) {
-                return false;
-            }
         }
         if ($readOnly) {
             if (!$this->checkIfAuthorised($user, $id)) {

--- a/app/Model/Taxonomy.php
+++ b/app/Model/Taxonomy.php
@@ -197,8 +197,8 @@ class Taxonomy extends AppModel
         $conditions = array();
         if ($user) {
             if (!$user['Role']['perm_site_admin']) {
-                $conditions = array('Tag.org_id' => array(0, $user['org_id']));
-                $conditions = array('Tag.user_id' => array(0, $user['id']));
+                $conditions[] = array('Tag.org_id' => array(0, $user['org_id']));
+                $conditions[] = array('Tag.user_id' => array(0, $user['id']));
             }
         }
         if (Configure::read('MISP.incoming_tags_disabled_by_default')) {

--- a/app/View/Elements/galaxyQuickViewMini.ctp
+++ b/app/View/Elements/galaxyQuickViewMini.ctp
@@ -122,7 +122,7 @@
         }
         if (
             (!isset($local_tag_off) || !$local_tag_off) &&
-            ($isSiteAdmin || ($isAclTagger && Configure::read('MISP.host_org_id') == $me['org_id']))
+            ($isSiteAdmin || ($mayModify && $isAclTagger) || ($isAclTagger && Configure::read('MISP.host_org_id') == $me['org_id']))
         ) {
             echo sprintf(
                 '<button class="%s" data-target-type="%s" data-target-id="%s" data-local="true" role="button" tabindex="0" aria-label="' . __('Add new local cluster') . '" title="' . __('Add a local tag') . '" style="%s">%s</button>',

--- a/app/View/Objects/revise_object.ctp
+++ b/app/View/Objects/revise_object.ctp
@@ -1,6 +1,6 @@
 <div class="form">
   <h3><?php echo __('Object pre-save review');?></h3>
-  <p><?php echo __('Make sure that the below Object reflects your expectation before submiting it.');?></p>
+  <p><?php echo __('Make sure that the below Object reflects your expectation before submitting it.');?></p>
   <?php
     $url = ($action == 'add') ? '/objects/add/' . $event['Event']['id'] . '/' . $template['ObjectTemplate']['id'] : '/objects/edit/' . $object_id;
     echo $this->Form->create('Object', array('id', 'url' => $url));
@@ -39,7 +39,7 @@
               if ($data['Object']['distribution'] != 4) {
                 echo $distributionLevels[$data['Object']['distribution']];
               } else {
-                echo h($sharing_groups[$data['Object']['sharing_group_id']]['SharingGroup']['name']);
+                echo h($sharing_groups[$data['Object']['sharing_group_id']]);
               }
             ?></td>
           </tr>
@@ -51,7 +51,8 @@
             <td class="bold"><?php echo __('Comment');?></td>
             <td><?php echo h($data['Object']['comment']); ?></td>
           </tr>
-          <td class="bold"><?php echo __('First seen');?></td>
+          <tr>
+            <td class="bold"><?php echo __('First seen');?></td>
             <td><?php echo h($data['Object']['first_seen']); ?></td>
           </tr>
           <tr>
@@ -88,7 +89,7 @@
                           if ($attribute['distribution'] != 4) {
                             $attribute[$field] = $distributionLevels[$attribute['distribution']];
                           } else {
-                            $attribute[$field] = $sharing_groups[$attribute['sharing_group_id']]['SharingGroup']['name'];
+                            $attribute[$field] = $sharing_groups[$attribute['sharing_group_id']];
                           }
                         }
                         if ($field == 'to_ids') $attribute[$field] = $attribute[$field] ? __('Yes') : __('No');
@@ -109,7 +110,7 @@
       </table>
     </div>
 
-    <?php echo $this->Form->button(__('Create new object'), array('class' => 'btn btn-primary')); ?>
+    <?= $this->Form->button($action === 'add' ? __('Create new object') : __('Update object'), array('class' => 'btn btn-primary')); ?>
     <a href="#" style="margin-left:10px;" class="btn btn-inverse" onclick="window.history.back();"><?php echo __('Back to review');?></a>
     <a href="<?php echo $baseurl . '/events/view/' . h($event['Event']['id']); ?>" style="margin-left:10px;" class="btn btn-inverse"><?php echo __('Cancel');?></a>
     <?php if (!empty($similar_objects) && $action !== 'edit'): ?>

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -319,6 +319,7 @@ function submitGenericForm(url, form, target) {
         complete:function() {
             $(".loading").hide();
         },
+        error: xhrFailCallback,
         type:"post",
         cache: false,
         url:url,


### PR DESCRIPTION
This PR changes almost all event, attributes and objects controller methods to provide one code to checks ACLs. Before, different methods use different approach and for example just few respects "User can modify just own events" permission.

It also reduce a lot of code duplication. 

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
