### PR TITLE
chg: [internal] Small controller cleanup

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -1809,7 +1809,7 @@ class AttributesController extends AppController
 
             $sightingsData = array_merge(
                 $sightingsData,
-                $this->Sighting->attachToEvent($attribute, $user, $attributeId, $extraConditions = false)
+                $this->Sighting->attachToEvent($attribute, $user, $attribute, $extraConditions = false)
             );
             $correlations = $this->Attribute->Event->getRelatedAttributes($user, $attributeId, false, false, 'attribute');
             if (!empty($correlations)) {

--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -71,7 +71,8 @@ class AttributesController extends AppController
             'AttributeTag' => array('Tag'),
             'Object' => array(
                 'fields' => array('Object.id', 'Object.distribution', 'Object.sharing_group_id')
-            )
+            ),
+            'SharingGroup' => ['fields' => ['SharingGroup.name']],
         );
         $this->Attribute->contain(array('AttributeTag' => array('Tag')));
         $this->set('isSearch', 0);
@@ -82,20 +83,12 @@ class AttributesController extends AppController
             }
             return $this->RestResponse->viewData($attributes, $this->response->type());
         }
-        $org_ids = array();
-        $orgs = $this->Attribute->Event->Orgc->find('list', array(
-                'conditions' => array('Orgc.id' => $org_ids),
-                'fields' => array('Orgc.id', 'Orgc.name')
+        list($attributes, $sightingsData) = $this->__searchUI($attributes);
+        $this->set('sightingsData', $sightingsData);
+        $orgTable = $this->Attribute->Event->Orgc->find('list', array(
+            'fields' => array('Orgc.id', 'Orgc.name')
         ));
-        if (!$this->_isRest()) {
-            $temp = $this->__searchUI($attributes);
-            $this->loadModel('Galaxy');
-            $this->set('mitreAttackGalaxyId', $this->Galaxy->getMitreAttackGalaxyId());
-            $attributes = $temp[0];
-            $sightingsData = $temp[1];
-            $this->set('sightingsData', $sightingsData);
-        }
-        $this->set('orgs', $orgs);
+        $this->set('orgTable', $orgTable);
         $this->set('shortDist', $this->Attribute->shortDist);
         $this->set('attributes', $attributes);
         $this->set('attrDescriptions', $this->Attribute->fieldDescriptions);
@@ -1744,7 +1737,8 @@ class AttributesController extends AppController
                 'AttributeTag' => array('Tag'),
                 'Object' => array(
                     'fields' => array('Object.id', 'Object.distribution', 'Object.sharing_group_id')
-                )
+                ),
+                'SharingGroup' => ['fields' => ['SharingGroup.name']],
             );
             $attributes = $this->paginate();
             if (!$this->_isRest()) {
@@ -1803,6 +1797,10 @@ class AttributesController extends AppController
                     $attribute['Attribute']['image'] = $this->Attribute->base64EncodeAttachment($attribute['Attribute']);
                 }
                 $attributes[$k] = $attribute;
+            }
+
+            if ($attribute['Attribute']['distribution'] == 4) {
+                $attributes[$k]['Attribute']['SharingGroup'] = $attribute['SharingGroup'];
             }
 
             $attributes[$k]['Attribute']['AttributeTag'] = $attributes[$k]['AttributeTag'];

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -1130,6 +1130,7 @@ class EventsController extends AppController
         }
         $conditions['includeAllTags'] = true;
         $conditions['includeGranularCorrelations'] = 1;
+        $conditions['includeEventCorrelations'] = false;
         if (!empty($filters['includeRelatedTags'])) {
             $this->set('includeRelatedTags', 1);
             $conditions['includeRelatedTags'] = 1;
@@ -1266,9 +1267,12 @@ class EventsController extends AppController
         $this->set('advancedFilteringActive', $advancedFiltering['active'] ? 1 : 0);
         $this->set('advancedFilteringActiveRules', $advancedFiltering['activeRules']);
         $this->set('defaultFilteringRules', $this->defaultFilteringRules);
+        $orgTable = $this->Event->Orgc->find('list', array(
+            'fields' => array('Orgc.id', 'Orgc.name')
+        ));
+        $this->set('orgTable', $orgTable);
         $this->disableCache();
         $this->layout = 'ajax';
-        $this->loadModel('Sighting');
         $uriArray = explode('/', $this->params->here);
         foreach ($uriArray as $k => $v) {
             if (strpos($v, ':')) {
@@ -1282,7 +1286,6 @@ class EventsController extends AppController
         if (!empty($filters['includeSightingdb']) && Configure::read('Plugin.Sightings_sighting_db_enable')) {
             $this->set('sightingdbs', $this->Sightingdb->getSightingdbList($this->Auth->user()));
         }
-        $this->set('sightingTypes', $this->Sighting->type);
         $this->set('currentUri', $this->params->here);
         $this->layout = false;
         $this->render('/Elements/eventattribute');
@@ -1525,8 +1528,6 @@ class EventsController extends AppController
         }
         $this->set('contributors', $contributors);
         $this->set('typeGroups', array_keys($this->Event->Attribute->typeGroupings));
-        $this->loadModel('Sighting');
-        $this->set('sightingTypes', $this->Sighting->type);
         $attributeUri = '/events/viewEventAttributes/' . $event['Event']['id'];
         foreach ($this->params->named as $k => $v) {
             if (!is_numeric($k)) {

--- a/app/Controller/SightingsController.php
+++ b/app/Controller/SightingsController.php
@@ -1,6 +1,9 @@
 <?php
 App::uses('AppController', 'Controller');
 
+/**
+ * @property Sighting $Sighting
+ */
 class SightingsController extends AppController
 {
     public $components = array('Session', 'RequestHandler');
@@ -326,13 +329,13 @@ class SightingsController extends AppController
             foreach ($object as $k => $v) {
                 $eventIds[] = $v['Attribute']['event_id'];
             }
-            $events = $this->Event->fetchEvent($this->Auth->user(), array('eventid' => $eventIds));
+            $events = $this->Event->fetchEvent($this->Auth->user(), array('eventid' => $eventIds, 'metadata' => true));
         } else {
             $attribute_id = false;
             // let's set the context to event here, since we reuse the variable later on for some additional lookups.
             // Passing $context = 'org' could have interesting results otherwise...
             $context = 'event';
-            $events = $this->Event->fetchEvent($this->Auth->user(), array('eventid' => $id));
+            $events = $this->Event->fetchEvent($this->Auth->user(), array('eventid' => $id, 'metadata' => true));
         }
         if (empty($events)) {
             throw new MethodNotAllowedException('Invalid object.');
@@ -345,12 +348,9 @@ class SightingsController extends AppController
         foreach ($raw as $sighting) {
             $results[$sighting['type']][date('Ymd', $sighting['date_sighting'])][] = $sighting;
         }
-        $tsv = 'date\tSighting\tFalse-positive\n';
         $dataPoints = array();
-        $startDate = (date('Ymd'));
-        $details = array();
-        $range = (!empty(Configure::read('MISP.Sightings_range')) && is_numeric(Configure::read('MISP.Sightings_range'))) ? Configure::read('MISP.Sightings_range') : 365;
-        $range = date('Ymd', strtotime("-" . $range . " days", time()));
+        $startDate = date('Ymd');
+        $range = date('Ymd', $this->Sighting->getMaximumRange());
         foreach ($results as $type => $data) {
             foreach ($data as $date => $sighting) {
                 if ($date < $startDate) {
@@ -371,11 +371,10 @@ class SightingsController extends AppController
             }
         }
         $startDate = date('Ymd', strtotime("-3 days", strtotime($startDate)));
+        $tsv = 'date\tSighting\tFalse-positive\n';
         for ($i = $startDate; $i < date('Ymd') + 1; $i++) {
             if (checkdate(substr($i, 4, 2), substr($i, 6, 2), substr($i, 0, 4))) {
                 $tsv .= $i . '\t' . (isset($dataPoints[$i][0]['count']) ? $dataPoints[$i][0]['count'] : 0) . '\t' . (isset($dataPoints[$i][1]['count']) ? $dataPoints[$i][1]['count'] : 0) . '\n';
-                $details[$i][0] = isset($dataPoints[$i][0]['details']) ? $dataPoints[$i][0]['details'] : array();
-                $details[$i][1] = isset($dataPoints[$i][1]['details']) ? $dataPoints[$i][1]['details'] : array();
             }
         }
         $this->set('tsv', $tsv);

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -731,7 +731,7 @@ class Attribute extends AppModel
                         'perm_site_admin' => 1
                     )
                 );
-                $attribute['Attribute']['Sighting'] = $this->Sighting->attachToEvent($attribute, $user, $this->id);
+                $attribute['Attribute']['Sighting'] = $this->Sighting->attachToEvent($attribute, $user, $attribute);
                 if (empty($attribute['Object']['id'])) {
                     unset($attribute['Object']);
                 }


### PR DESCRIPTION
#### What does it do?

* Always show organisation name for correlated value
* Do not fetch related events when fetch just attributes
* Faster sightings loading

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
