### PR TITLE
fix: [pull] Check if url_params in pull filter is empty string

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -2714,7 +2714,7 @@ class Server extends AppModel
         foreach ($filter_rules as $field => $rules) {
             $temp = array();
             if ($field === 'url_params') {
-                $url_params = $this->jsonDecode($rules);
+                $url_params = empty($rules) ? [] : $this->jsonDecode($rules);
             } else {
                 foreach ($rules as $operator => $elements) {
                     foreach ($elements as $k => $element) {


### PR DESCRIPTION
#### What does it do?

Fixed "ERROR: Syntax error" when pulling from remote server.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
