### PR TITLE
chg: [internal] Initialize UserSetting just when needed

### DIFF
--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -427,8 +427,8 @@ class Tag extends AppModel
     public function checkForOverride($tags)
     {
         $userId = Configure::read('CurrentUserId');
-        $this->UserSetting = ClassRegistry::init('UserSetting');
         if ($this->tagOverrides === false && $userId > 0) {
+            $this->UserSetting = ClassRegistry::init('UserSetting');
             $this->tagOverrides = $this->UserSetting->getTagNumericalValueOverride($userId);
         }
         foreach ($tags as $k => $tag) {


### PR DESCRIPTION
#### What does it do?

Should speed up loading a lot of tags.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
