### PR TITLE
fix: [security] Check if user can access sharing group when uploading…

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -8,6 +8,9 @@ App::uses('RandomTool', 'Tools');
 App::uses('MalwareTool', 'Tools');
 App::uses('TmpFileTool', 'Tools');
 
+/**
+ * @property Event $Event
+ */
 class Attribute extends AppModel
 {
     public $combinedKeys = array('event_id', 'category', 'type');


### PR DESCRIPTION
#### What does it do?

When uploading attachment, check if user can use chosen sharing group.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
