### PR TITLE
Travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,8 @@ before_install:
 install:
     - date
     - sudo apt-get -y update
-    # Travis lacks entropy.
-    - sudo apt-get -y install haveged
-    - sudo apt-get -y install python3 python3-venv python3-pip python3-dev python3-nose libxml2-dev libzmq3-dev zlib1g-dev apache2 curl php-mysql php-dev php-cli libapache2-mod-php libfuzzy-dev php-mbstring libonig4 php-json php-xml php-opcache php-readline php-redis php-gnupg php-gd
+    # Install haveged, because Travis lacks entropy.
+    - sudo apt-get -y install haveged python3 python3-venv python3-pip python3-dev python3-nose python3-lxml python3-dateutil python3-msgpack libxml2-dev libzmq3-dev zlib1g-dev apache2 curl php-mysql php-dev php-cli libapache2-mod-php libfuzzy-dev php-mbstring libonig4 php-json php-xml php-opcache php-readline php-redis php-gnupg php-gd
     - sudo apt-get -y dist-upgrade
     - sudo pip3 install --upgrade pip setuptools requests pyzmq
     - sudo pip3 install --upgrade -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ install:
     - sudo apt-get -y update
     # Install haveged, because Travis lacks entropy.
     - sudo apt-get -y install haveged python3 python3-venv python3-pip python3-dev python3-nose python3-lxml python3-dateutil python3-msgpack libxml2-dev libzmq3-dev zlib1g-dev apache2 curl php-mysql php-dev php-cli libapache2-mod-php libfuzzy-dev php-mbstring libonig4 php-json php-xml php-opcache php-readline php-redis php-gnupg php-gd
-    - sudo apt-get -y dist-upgrade
     - sudo pip3 install --upgrade pip setuptools requests pyzmq
     - sudo pip3 install --upgrade -r requirements.txt
     - sudo pip3 install poetry

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,7 @@ install:
     # /!\ VERY INSECURE BUT FASTER ON THE BUILD ENV OF TRAVIS
     - sudo cp -a /dev/urandom /dev/random
     - sudo gpg --no-tty --no-permission-warning --pinentry-mode=loopback --passphrase "travistest" --homedir `pwd`/.gnupg --gen-key --batch `pwd`/travis/gpg
+    - sudo gpg --list-secret-keys --homedir `pwd`/.gnupg
     - sudo chown $USER:www-data `pwd`/.gnupg
     - sudo chmod 700 `pwd`/.gnupg
     # change perms

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,7 @@ install:
     - sudo chmod -R 777 ./tests
     # Start workers
     - sudo chmod +x app/Console/worker/start.sh
-    - app/Console/worker/start.sh &
+    - sudo -E su $USER -c 'app/Console/worker/start.sh &'
     - sleep 10
     # Dirty install python stuff
     - virtualenv -p python3.6 ./venv

--- a/.travis.yml
+++ b/.travis.yml
@@ -173,6 +173,7 @@ after_failure:
     - sudo cat `pwd`/app/tmp/logs/error.log
     - sudo cat `pwd`/app/tmp/logs/exec-errors.log
     - sudo cat `pwd`/app/tmp/logs/debug.log
+    - sudo cat `pwd`/app/tmp/logs/resque-worker-error.log
     - sudo cat /var/log/apache2/error.log
     - sudo cat /var/log/apache2/misp.local_error.log
     - sudo cat /var/log/apache2/misp.local_access.log
@@ -187,6 +188,9 @@ notifications:
     on_start: never     # options: [always|never|change] default: always
 
 after_success:
+    - sudo cat `pwd`/app/tmp/logs/debug.log
+    - sudo cat `pwd`/app/tmp/logs/error.log
+    - sudo cat `pwd`/app/tmp/logs/resque-worker-error.log
     - coveralls
     - coverage report
     - coverage xml


### PR DESCRIPTION
#### What does it do?

* Run apt-get install just once to speed up build
* Remove dist-upgrade to speed up build
* Show generated gpg keys (for debugging)
* Start workers under www-data group (previously, it was broken and workers do not use www-data group)
* Show error and debug logs also after success test (useful for checking notices and warnings)

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
