### PR TITLE
Show proper number of attributes and events for tags

### DIFF
--- a/app/Controller/GalaxyClustersController.php
+++ b/app/Controller/GalaxyClustersController.php
@@ -1,6 +1,9 @@
 <?php
 App::uses('AppController', 'Controller');
 
+/**
+ * @property GalaxyCluster $GalaxyCluster
+ */
 class GalaxyClustersController extends AppController
 {
     public $components = array('Session', 'RequestHandler');
@@ -13,17 +16,6 @@ class GalaxyClustersController extends AppController
                 'GalaxyCluster.value' => 'ASC'
             ),
             'contain' => array(
-                'Tag' => array(
-                    'fields' => array('Tag.id'),
-                    /*
-                    'EventTag' => array(
-                        'fields' => array('EventTag.event_id')
-                    ),
-                    'AttributeTag' => array(
-                        'fields' => array('AttributeTag.event_id', 'AttributeTag.attribute_id')
-                    )
-                    */
-                ),
                 'GalaxyElement' => array(
                     'conditions' => array('GalaxyElement.key' => 'synonyms'),
                     'fields' => array('value')
@@ -34,7 +26,6 @@ class GalaxyClustersController extends AppController
     public function index($id)
     {
         $filters = $this->IndexFilter->harvestParameters(array('context', 'searchall'));
-        $contextConditions = array();
         if (empty($filters['context'])) {
             $filters['context'] = 'all';
         }
@@ -42,33 +33,46 @@ class GalaxyClustersController extends AppController
         $this->set('searchall', isset($filters['searchall']) ? $filters['searchall'] : '');
         $this->paginate['conditions'] = array('GalaxyCluster.galaxy_id' => $id);
         if (isset($filters['searchall']) && strlen($filters['searchall']) > 0) {
+            $search = '%' . strtolower($filters['searchall']) . '%';
             $synonym_hits = $this->GalaxyCluster->GalaxyElement->find(
                 'list',
                 array(
                     'recursive' => -1,
                     'conditions' => array(
-                        'LOWER(GalaxyElement.value) LIKE' => '%' . strtolower($filters['searchall']) . '%',
-                        'GalaxyElement.key' => 'synonyms' ),
-                        'fields' => array(
-                            'GalaxyElement.galaxy_cluster_id')
-                        )
+                        'LOWER(GalaxyElement.value) LIKE' => $search,
+                        'GalaxyElement.key' => 'synonyms',
+                    ),
+                    'fields' => array(
+                        'GalaxyElement.galaxy_cluster_id',
+                    )
+                )
             );
-            $this->paginate['conditions'] =
-                array("AND" => array(
+            $this->paginate['conditions'] = array(
+                "AND" => array(
                     'OR' => array(
-                        "LOWER(GalaxyCluster.value) LIKE" => '%'. strtolower($filters['searchall']) .'%',
-                        "LOWER(GalaxyCluster.description) LIKE" => '%'. strtolower($filters['searchall']) .'%',
+                        "LOWER(GalaxyCluster.value) LIKE" => $search,
+                        "LOWER(GalaxyCluster.description) LIKE" => $search,
                         "GalaxyCluster.id" => array_values($synonym_hits)
                     ),
                     "GalaxyCluster.galaxy_id" => $id
-                    ));
-            $this->set('passedArgsArray', array('all'=>$filters['searchall']));
+                )
+            );
+            $this->set('passedArgsArray', array('all' => $filters['searchall']));
         }
         $clusters = $this->paginate();
-        $sgs = $this->GalaxyCluster->Tag->EventTag->Event->SharingGroup->fetchAllAuthorised($this->Auth->user());
         foreach ($clusters as $k => $cluster) {
-            if (!empty($cluster['Tag']['id'])) {
-                $clusters[$k]['GalaxyCluster']['event_count'] = $this->GalaxyCluster->Tag->EventTag->countForTag($cluster['Tag']['id'], $this->Auth->user(), $sgs);
+            $tag = $this->GalaxyCluster->Tag->find('first', array(
+                'conditions' => array(
+                    'LOWER(name)' => strtolower($cluster['GalaxyCluster']['tag_name']),
+                ),
+                'fields' => array('id'),
+                'recursive' => -1,
+                'contain' => array('EventTag.event_id')
+            ));
+
+            if ($tag) {
+                $clusters[$k]['GalaxyCluster']['event_count'] = $this->GalaxyCluster->Tag->EventTag->countForTag($tag, $this->Auth->user());
+                $clusters[$k]['Tag'] = $tag['Tag'];
             } else {
                 $clusters[$k]['GalaxyCluster']['event_count'] = 0;
             }
@@ -76,7 +80,6 @@ class GalaxyClustersController extends AppController
         $tagIds = array();
         $sightings = array();
         if (!empty($clusters)) {
-            $galaxyType = $clusters[0]['GalaxyCluster']['type'];
             foreach ($clusters as $k => $v) {
                 $clusters[$k]['event_ids'] = array();
                 if (!empty($v['Tag'])) {
@@ -138,17 +141,16 @@ class GalaxyClustersController extends AppController
             'conditions' => $conditions
         ));
         if (!empty($cluster)) {
-            $this->loadModel('Tag');
-            $tag = $this->Tag->find('first', array(
+            $tag = $this->GalaxyCluster->Tag->find('first', array(
                 'conditions' => array(
                     'LOWER(name)' => strtolower($cluster['GalaxyCluster']['tag_name']),
                 ),
                 'fields' => array('id'),
                 'recursive' => -1,
-                'contain' => array('EventTag.tag_id')
+                'contain' => array('EventTag.event_id')
             ));
             if (!empty($tag)) {
-                $cluster['GalaxyCluster']['tag_count'] = count($tag['EventTag']);
+                $cluster['GalaxyCluster']['tag_count'] = $this->GalaxyCluster->Tag->EventTag->countForTag($tag, $this->Auth->user());
                 $cluster['GalaxyCluster']['tag_id'] = $tag['Tag']['id'];
             }
         } else {

--- a/app/Controller/TagsController.php
+++ b/app/Controller/TagsController.php
@@ -2,6 +2,9 @@
 
 App::uses('AppController', 'Controller');
 
+/**
+ * @property Tag $Tag
+ */
 class TagsController extends AppController
 {
     public $components = array('Security' ,'RequestHandler');
@@ -71,31 +74,31 @@ class TagsController extends AppController
         }
         if ($this->_isRest()) {
             unset($this->paginate['limit']);
-            unset($this->paginate['contain']['EventTag']);
-            unset($this->paginate['contain']['AttributeTag']);
             $paginated = $this->Tag->find('all', $this->paginate);
         } else {
             $paginated = $this->paginate();
         }
         $tagList = array();
         $csv = array();
-        $sgs = $this->Tag->EventTag->Event->SharingGroup->fetchAllAuthorised($this->Auth->user());
         foreach ($paginated as $k => $tag) {
             $tagList[] = $tag['Tag']['id'];
-            $paginated[$k]['Tag']['count'] = $this->Tag->EventTag->countForTag($tag['Tag']['id'], $this->Auth->user(), $sgs);
+            $paginated[$k]['Tag']['count'] = $this->Tag->EventTag->countForTag($tag, $this->Auth->user());
+            $paginated[$k]['Tag']['attribute_count'] = $this->Tag->AttributeTag->countForTag($tag, $this->Auth->user());
+
             if (!$this->_isRest()) {
                 $paginated[$k]['event_ids'] = array();
-                $paginated[$k]['attribute_ids'] = array();
                 foreach ($paginated[$k]['EventTag'] as $et) {
                     $paginated[$k]['event_ids'][] = $et['event_id'];
                 }
-                unset($paginated[$k]['EventTag']);
+                $paginated[$k]['attribute_ids'] = array();
                 foreach ($paginated[$k]['AttributeTag'] as $at) {
                     $paginated[$k]['attribute_ids'][] = $at['attribute_id'];
                 }
-                unset($paginated[$k]['AttributeTag']);
             }
-            $paginated[$k]['Tag']['attribute_count'] = $this->Tag->AttributeTag->countForTag($tag['Tag']['id'], $this->Auth->user(), $sgs);
+
+            unset($paginated[$k]['EventTag']);
+            unset($paginated[$k]['AttributeTag']);
+
             if (!empty($tag['FavouriteTag'])) {
                 foreach ($tag['FavouriteTag'] as $ft) {
                     if ($ft['user_id'] == $this->Auth->user('id')) {
@@ -395,58 +398,13 @@ class TagsController extends AppController
             if (empty($tag['EventTag'])) {
                 $tag['Tag']['count'] = 0;
             } else {
-                $eventIDs = array();
-                foreach ($tag['EventTag'] as $eventTag) {
-                    $eventIDs[] = $eventTag['event_id'];
-                }
-                $conditions = array('Event.id' => $eventIDs);
-                if (!$this->_isSiteAdmin()) {
-                    $conditions = array_merge(
-                        $conditions,
-                        array('OR' => array(
-                                array('AND' => array(
-                                        array('Event.distribution >' => 0),
-                                        array('Event.published =' => 1)
-                                )),
-                                array('Event.orgc_id' => $this->Auth->user('org_id'))
-                        ))
-                );
-                }
-                $events = $this->Tag->EventTag->Event->find('all', array(
-                        'fields' => array('Event.id', 'Event.distribution', 'Event.orgc_id'),
-                        'conditions' => $conditions
-                ));
-                $tag['Tag']['count'] = count($events);
+                $tag['Tag']['count'] = $this->Tag->EventTag->countForTag($tag, $this->Auth->user());
             }
             unset($tag['EventTag']);
             if (empty($tag['AttributeTag'])) {
                 $tag['Tag']['attribute_count'] = 0;
             } else {
-                $attributeIDs = array();
-                foreach ($tag['AttributeTag'] as $attributeTag) {
-                    $attributeIDs[] = $attributeTag['attribute_id'];
-                }
-                $conditions = array('Attribute.id' => $attributeIDs);
-                if (!$this->_isSiteAdmin()) {
-                    $conditions = array_merge(
-                        $conditions,
-                        array('OR' => array(
-                            array('AND' => array(
-                                array('Attribute.deleted =' => 0),
-                                array('Attribute.distribution >' => 0),
-                                array('Event.distribution >' => 0),
-                                array('Event.published =' => 1)
-                            )),
-                            array('Event.orgc_id' => $this->Auth->user('org_id'))
-                        ))
-                    );
-                }
-                $attributes = $this->Tag->AttributeTag->Attribute->find('all', array(
-                    'fields'     => array('Attribute.id', 'Attribute.deleted', 'Attribute.distribution', 'Event.id', 'Event.distribution', 'Event.orgc_id'),
-                    'contain'    => array('Event' => array('fields' => array('id', 'distribution', 'orgc_id'))),
-                    'conditions' => $conditions
-                ));
-                $tag['Tag']['attribute_count'] = count($attributes);
+                $tag['Tag']['attribute_count'] = $this->Tag->AttributeTag->countForTag($tag, $this->Auth->user());;
             }
             unset($tag['AttributeTag']);
             $this->set('Tag', $tag['Tag']);

--- a/app/Model/AttributeTag.php
+++ b/app/Model/AttributeTag.php
@@ -1,6 +1,9 @@
 <?php
 App::uses('AppModel', 'Model');
 
+/**
+ * @property Attribute $Attribute
+ */
 class AttributeTag extends AppModel
 {
     public $actsAs = array('Containable');
@@ -177,11 +180,30 @@ class AttributeTag extends AppModel
         }
     }
 
-    public function countForTag($tag_id, $user)
+    /**
+     * Count number of not deleted attributes that contains given tag for given user. Tag must contains 'AttributeTag'.
+     *
+     * @param array $tag
+     * @param array $user
+     * @return int
+     */
+    public function countForTag(array $tag, array $user)
     {
-        return $this->find('count', array(
-            'recursive' => -1,
-            'conditions' => array('AttributeTag.tag_id' => $tag_id)
+        $attributeIds = [];
+        foreach ($tag['AttributeTag'] as $attributeTag) {
+            $attributeIds[] = $attributeTag['attribute_id'];
+        }
+
+        if (empty($attributeIds)) {
+            return 0;
+        }
+
+        $conditions = $this->Attribute->buildConditions($user);
+        $conditions['Attribute.id'] = $attributeIds;
+        $conditions['Attribute.deleted'] = 0;
+        return $this->Attribute->find('count', array(
+            'recursive' => 0,
+            'conditions' => $conditions,
         ));
     }
 

--- a/app/Model/EventTag.php
+++ b/app/Model/EventTag.php
@@ -1,6 +1,9 @@
 <?php
 App::uses('AppModel', 'Model');
 
+/**
+ * @property Event $Event
+ */
 class EventTag extends AppModel
 {
     public $actsAs = array('Containable');
@@ -188,11 +191,29 @@ class EventTag extends AppModel
         return $tags;
     }
 
-    public function countForTag($tag_id, $user)
+    /**
+     * Count number of event that contains given tag for given user. Tag must contains 'EventTag'.
+     *
+     * @param array $tag
+     * @param array $user
+     * @return int
+     */
+    public function countForTag(array $tag, array $user)
     {
-        return $this->find('count', array(
+        $eventIds = [];
+        foreach ($tag['EventTag'] as $eventTag) {
+            $eventIds[] = $eventTag['event_id'];
+        }
+
+        if (empty($eventIds)) {
+            return 0;
+        }
+
+        $conditions = $this->Event->createEventConditions($user);
+        $conditions['Event.id'] = $eventIds;
+        return $this->Event->find('count', array(
             'recursive' => -1,
-            'conditions' => array('EventTag.tag_id' => $tag_id)
+            'conditions' => $conditions,
         ));
     }
 

--- a/app/Model/Sighting.php
+++ b/app/Model/Sighting.php
@@ -528,14 +528,6 @@ class Sighting extends AppModel
         $conditions = array(
             'Sighting.date_sighting >' => $this->getMaximumRange(),
             ucfirst($context) . 'Tag.tag_id' => $tagList
-
-        );
-        $contain = array(
-            ucfirst($context) => array(
-                ucfirst($context) . 'Tag' => array(
-                    'Tag'
-                )
-            )
         );
         if ($type !== false) {
             $conditions['Sighting.type'] = $type;
@@ -545,15 +537,16 @@ class Sighting extends AppModel
             'recursive' => -1,
             'contain' => array(ucfirst($context) . 'Tag'),
             'conditions' => $conditions,
-            'fields' => array('Sighting.id', 'Sighting.' . $context . '_id', 'Sighting.date_sighting', ucfirst($context) . 'Tag.tag_id')
+            'fields' => array('Sighting.' . $context . '_id', 'Sighting.date_sighting')
         ));
         $sightingsRearranged = array();
         foreach ($sightings as $sighting) {
             $date = date("Y-m-d", $sighting['Sighting']['date_sighting']);
-            if (isset($sightingsRearranged[$sighting['Sighting'][$context . '_id']][$date])) {
-                $sightingsRearranged[$sighting['Sighting'][$context . '_id']][$date]++;
+            $contextId = $sighting['Sighting'][$context . '_id'];
+            if (isset($sightingsRearranged[$contextId][$date])) {
+                $sightingsRearranged[$contextId][$date]++;
             } else {
-                $sightingsRearranged[$sighting['Sighting'][$context . '_id']][$date] = 1;
+                $sightingsRearranged[$contextId][$date] = 1;
             }
         }
         return $sightingsRearranged;

--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -1,6 +1,10 @@
 <?php
 App::uses('AppModel', 'Model');
 
+/**
+ * @property EventTag $EventTag
+ * @property AttributeTag $AttributeTag
+ */
 class Tag extends AppModel
 {
     public $useTable = 'tags';


### PR DESCRIPTION
#### What does it do?

Before that change, no ACL was applied, so MISP shows incorrect numbers.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
