### PR TITLE
new: Add the ability to customize the IP header field when logging

### DIFF
--- a/app/Model/Log.php
+++ b/app/Model/Log.php
@@ -104,8 +104,15 @@ class Log extends AppModel
         if (!empty(Configure::read('MISP.log_skip_db_logs_completely'))) {
             return false;
         }
-        if (Configure::read('MISP.log_client_ip') && isset($_SERVER['REMOTE_ADDR'])) {
-            $this->data['Log']['ip'] = $_SERVER['REMOTE_ADDR'];
+        if (Configure::read('MISP.log_client_ip')) {
+            $ip_header = 'REMOTE_ADDR';
+            if (Configure::read('MISP.log_client_ip_header')) {
+                $ip_header = Configure::read('MISP.log_client_ip_header');
+            }
+
+            if (isset($_SERVER[$ip_header])) {
+                $this->data['Log']['ip'] = $_SERVER[$ip_header];
+            }
         }
         $setEmpty = array('title' => '', 'model' => '', 'model_id' => 0, 'action' => '', 'user_id' => 0, 'change' => '', 'email' => '', 'org' => '', 'description' => '');
         foreach ($setEmpty as $field => $empty) {

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -790,6 +790,15 @@ class Server extends AppModel
                                 'type' => 'boolean',
                                 'beforeHook' => 'ipLogBeforeHook'
                         ),
+                        'log_client_ip_header' => array(
+                            'level' => 1,
+                            'description' => __('If log_client_ip is enabled, you can customize which header field contains the client\'s IP address. This is generally used when you have a reverse proxy infront of your MISP instance.'),
+                            'value' => 'REMOTE_ADDR',
+                            'errorMessage' => '',
+                            'test' => 'testForEmpty',
+                            'type' => 'string',
+                            'null' => true,
+                        ),
                         'log_auth' => array(
                                 'level' => 1,
                                 'description' => __('If enabled, MISP will log all successful authentications using API keys. The requested URLs are also logged.'),


### PR DESCRIPTION
#### What does it do?

Fixes #5661

This change adds a new configuration value (`MISP.log_client_ip_header`) which lets you specify what header is used for "whose IP is connecting to me" when logging IPs. If this configuration value is not set, it'll fall back on the standard `REMOTE_ADDR`.

NB: Still working on getting a development environment setup, but the change looks relatively straight forward based on my code reading.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
