### PR TITLE
Experimental: UUID validation

### DIFF
--- a/INSTALL/MYSQL.sql
+++ b/INSTALL/MYSQL.sql
@@ -604,7 +604,6 @@ CREATE TABLE IF NOT EXISTS `object_references` (
   `relationship_type` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci,
   `comment` text COLLATE utf8_bin NOT NULL,
   `deleted` tinyint(1) NOT NULL DEFAULT 0,
-
   PRIMARY KEY (id),
   INDEX `source_uuid` (`source_uuid`),
   INDEX `referenced_uuid` (`referenced_uuid`),
@@ -1012,8 +1011,8 @@ CREATE TABLE IF NOT EXISTS tag_collection_tags (
     `tag_collection_id` int(11) NOT NULL,
     `tag_id` int(11) NOT NULL,
     PRIMARY KEY (id),
-    INDEX `uuid` (`tag_collection_id`),
-    INDEX `user_id` (`tag_id`)
+    INDEX `tag_collection_id` (`tag_collection_id`),
+    INDEX `tag_id` (`tag_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- --------------------------------------------------------

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -547,7 +547,7 @@ class Attribute extends AppModel
         ),
         'uuid' => array(
             'uuid' => array(
-                'rule' => array('custom', '/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/'),
+                'rule' => 'uuid',
                 'message' => 'Please provide a valid UUID'
             ),
             'unique' => array(
@@ -870,6 +870,8 @@ class Attribute extends AppModel
         // generate UUID if it doesn't exist
         if (empty($this->data['Attribute']['uuid'])) {
             $this->data['Attribute']['uuid'] = CakeText::uuid();
+        } else {
+            $this->data['Attribute']['uuid'] = strtolower($this->data['Attribute']['uuid']);
         }
         // generate timestamp if it doesn't exist
         if (empty($this->data['Attribute']['timestamp'])) {

--- a/app/Model/Dashboard.php
+++ b/app/Model/Dashboard.php
@@ -14,7 +14,7 @@ class Dashboard extends AppModel
         'role_id' => 'numeric',
         'uuid' => array(
             'uuid' => array(
-                'rule' => array('custom', '/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/'),
+                'rule' => array('uuid'),
                 'message' => 'Please provide a valid UUID'
             ),
         )

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -242,7 +242,6 @@ class Event extends AppModel
             'message' => 'Options : 1, 2, 3, 4 (for High, Medium, Low, Undefined)',
             'required' => true
         ),
-
         'distribution' => array(
             'not_empty_if_sg' => array(
                 'rule' => array('inList', array('0', '1', '2', '3', '4')),
@@ -253,7 +252,6 @@ class Event extends AppModel
                 //'on' => 'create', // Limit validation to 'create' or 'update' operations
                 )
         ),
-
         'sharing_group_id' => array(
             'rule' => array('sharingGroupRequired'),
                 'message' => 'If the distribution is set to "Sharing Group", a sharing group has to be selected.',
@@ -292,13 +290,13 @@ class Event extends AppModel
         ),
         'uuid' => array(
             'uuid' => array(
-                'rule' => array('custom', '/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/'),
+                'rule' => 'uuid',
                 'message' => 'Please provide a valid UUID'
             ),
         ),
         'extends_uuid' => array(
             'uuid' => array(
-                'rule' => array('custom', '/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/'),
+                'rule' => 'uuid',
                 'message' => 'Please provide a valid UUID',
                 'allowEmpty' => true
             )
@@ -577,6 +575,8 @@ class Event extends AppModel
         // generate UUID if it doesn't exist
         if (empty($this->data['Event']['uuid'])) {
             $this->data['Event']['uuid'] = CakeText::uuid();
+        } else {
+            $this->data['Event']['uuid'] = strtolower($this->data['Event']['uuid'] );
         }
 
         // Convert event ID to uuid if needed
@@ -591,6 +591,8 @@ class Event extends AppModel
             } else {
                 $this->data['Event']['extends_uuid'] = $extended_event['Event']['uuid'];
             }
+        } else if (!empty($this->data['Event']['extends_uuid'])) {
+            $this->data['Event']['extends_uuid'] = strtolower($this->data['Event']['extends_uuid']);
         }
 
         // generate timestamp if it doesn't exist

--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -59,7 +59,7 @@ class MispObject extends AppModel
     public $validate = array(
         'uuid' => array(
             'uuid' => array(
-                'rule' => array('custom', '/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/'),
+                'rule' => 'uuid',
                 'message' => 'Please provide a valid UUID'
             ),
             'unique' => array(

--- a/app/Model/OrgBlocklist.php
+++ b/app/Model/OrgBlocklist.php
@@ -24,7 +24,7 @@ class OrgBlocklist extends AppModel
                             'message' => 'Organisation already blocklisted.'
                     ),
                     'uuid' => array(
-                        'rule' => array('custom', '/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/'),
+                        'rule' => 'uuid',
                         'message' => 'Please provide a valid UUID'
                     ),
             )

--- a/app/Model/Organisation.php
+++ b/app/Model/Organisation.php
@@ -33,8 +33,8 @@ class Organisation extends AppModel
                 'rule' => 'isUnique',
                 'message' => 'An organisation with this UUID already exists.'
             ),
-            'simpleuuid' => array(
-                'rule' => array('custom', '/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/'),
+            'uuid' => array(
+                'rule' => 'uuid',
                 'message' => 'Please provide a valid UUID',
                 'allowEmpty' => true
             ),
@@ -88,7 +88,7 @@ class Organisation extends AppModel
         if (empty($this->data['Organisation']['uuid'])) {
             $this->data['Organisation']['uuid'] = CakeText::uuid();
         } else {
-            $this->data['Organisation']['uuid'] = trim($this->data['Organisation']['uuid']);
+            $this->data['Organisation']['uuid'] = strtolower(trim($this->data['Organisation']['uuid']));
         }
         $date = date('Y-m-d H:i:s');
         if (!empty($this->data['Organisation']['restricted_to_domain'])) {

--- a/app/Model/ShadowAttribute.php
+++ b/app/Model/ShadowAttribute.php
@@ -128,7 +128,7 @@ class ShadowAttribute extends AppModel
         ),
         'uuid' => array(
             'uuid' => array(
-                'rule' => array('custom', '/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/'),
+                'rule' => 'uuid',
                 'message' => 'Please provide a valid UUID'
             ),
         ),
@@ -331,6 +331,8 @@ class ShadowAttribute extends AppModel
         // generate UUID if it doesn't exist
         if (empty($this->data['ShadowAttribute']['uuid'])) {
             $this->data['ShadowAttribute']['uuid'] = CakeText::uuid();
+        } else {
+            $this->data['ShadowAttribute']['uuid'] = strtolower($this->data['ShadowAttribute']['uuid']);
         }
 
         if (!empty($this->data['ShadowAttribute']['type']) && empty($this->data['ShadowAttribute']['category'])) {

--- a/app/Model/SharingGroup.php
+++ b/app/Model/SharingGroup.php
@@ -24,7 +24,7 @@ class SharingGroup extends AppModel
         ),
         'uuid' => array(
             'uuid' => array(
-                'rule' => array('custom', '/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/'),
+                'rule' => array('uuid'),
                 'message' => 'Please provide a valid UUID'
             ),
         )
@@ -65,6 +65,8 @@ class SharingGroup extends AppModel
         parent::beforeValidate();
         if (empty($this->data['SharingGroup']['uuid'])) {
             $this->data['SharingGroup']['uuid'] = CakeText::uuid();
+        } else {
+            $this->data['SharingGroup']['uuid'] = strtolower($this->data['SharingGroup']['uuid']);
         }
         $date = date('Y-m-d H:i:s');
         if (empty($this->data['SharingGroup']['created'])) {

--- a/app/Model/TagCollection.php
+++ b/app/Model/TagCollection.php
@@ -42,7 +42,13 @@ class TagCollection extends AppModel
                     'rule' => 'isUnique',
                     'message' => 'A similar name already exists.',
             ),
-        )
+        ),
+        'uuid' => array(
+            'uuid' => array(
+                'rule' => 'uuid',
+                'message' => 'Please provide a valid UUID'
+            ),
+        ),
     );
 
     public function beforeValidate($options = array())
@@ -51,6 +57,8 @@ class TagCollection extends AppModel
         // generate UUID if it doesn't exist
         if (empty($this->data['TagCollection']['uuid'])) {
             $this->data['TagCollection']['uuid'] = CakeText::uuid();
+        } else {
+            $this->data['TagCollection']['uuid'] = strtolower($this->data['TagCollection']['uuid']);
         }
         return true;
     }


### PR DESCRIPTION
#### What does it do?

UUID is validated that is is real UUID and not just fake one and also UUID is normalized to lowercase form.

@iglocska Is there any reason why „fake” UUID (not RFC 4122) are accepted? Because I think it is dangerous and it can break other tools and it is against MISP format RFC, that require RFC 4122 compliant UUID.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
