### PR TITLE
fix: [internal] Respect ACL for event attribute search

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -3360,8 +3360,8 @@ class Attribute extends AppModel
             $params['limit'] = $options['limit'];
         }
         if (
-            Configure::read('MISP.proposals_block_attributes') &&
-            !empty($options['allow_proposal_blocking'])
+            !empty($options['allow_proposal_blocking']) &&
+            Configure::read('MISP.proposals_block_attributes')
         ) {
             $this->bindModel(array('hasMany' => array('ShadowAttribute' => array('foreignKey' => 'old_id'))));
             $proposalRestriction =  array(

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -5,6 +5,9 @@ App::uses('RandomTool', 'Tools');
 App::uses('AttachmentTool', 'Tools');
 App::uses('TmpFileTool', 'Tools');
 
+/**
+ * @property Attribute $Attribute
+ */
 class Event extends AppModel
 {
     public $actsAs = array(


### PR DESCRIPTION
#### What does it do?

After this change, when doing event search attribute content, respect ACLs. Before this change, it was possible to check, if event (that user can access) contains attribute that user cannot see.

Also the SQL queries now fetch just necessary fields.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
