### PR TITLE
fix: Support IE with no template literal support

### DIFF
--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -3835,12 +3835,12 @@ function flashErrorPopover() {
 }
 
 function attributeHoverTitle(id, type) {
-  return `<span>Lookup results:</span>
-		<i class="fa fa-search-plus useCursorPointer eventViewAttributePopup"
-				style="float: right;"
-				data-object-id="${id}"
-				data-object-type="${type}">
-	</i>`;
+  return '<span>Lookup results:</span>\
+		<i class="fa fa-search-plus useCursorPointer eventViewAttributePopup"\
+				style="float: right;"\
+				data-object-id="${id}"\
+				data-object-type="${type}">\
+	</i>';
 }
 
 function attributeHoverPlacement(element) {


### PR DESCRIPTION
#### What does it do?

Fixes support for IE 10/11 by removing template literal in misp.js

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
