### PR TITLE
fix: [internal] Remove old code from event view template

### DIFF
--- a/app/View/Elements/Events/View/sighting_field.ctp
+++ b/app/View/Elements/Events/View/sighting_field.ctp
@@ -15,14 +15,14 @@
   <?php
     endif;
   ?>
-  <span id="sightingCount_<?php echo h($object['id']); ?>" class="bold sightingsCounter_<?php echo h($object['id']); ?>" data-placement="top" data-toggle="popover" data-trigger="hover" data-content="<?php echo isset($sightingsData['data'][$object['id']]['html']) ? $sightingsData['data'][$object['id']]['html'] : ''; ?>">
+  <span id="sightingCount_<?php echo h($object['id']); ?>" class="bold sightingsCounter_<?php echo h($object['id']); ?>">
     <?php
       $s = (!empty($sightingsData['data'][$object['id']]['sighting']['count']) ? $sightingsData['data'][$object['id']]['sighting']['count'] : 0);
       $f = (!empty($sightingsData['data'][$object['id']]['false-positive']['count']) ? $sightingsData['data'][$object['id']]['false-positive']['count'] : 0);
       $e = (!empty($sightingsData['data'][$object['id']]['expiration']['count']) ? $sightingsData['data'][$object['id']]['expiration']['count'] : 0);
     ?>
   </span>
-  <span id="ownSightingCount_<?php echo h($object['id']); ?>" class="bold sightingsCounter_<?php echo h($object['id']); ?>" data-placement="top" data-toggle="popover" data-trigger="hover" data-content="<?php echo isset($sightingsData['data'][$object['id']]['html']) ? $sightingsData['data'][$object['id']]['html'] : ''; ?>">
+  <span id="ownSightingCount_<?php echo h($object['id']); ?>" class="bold sightingsCounter_<?php echo h($object['id']); ?>">
     <?php echo '(<span class="green">' . h($s) . '</span>/<span class="red">' . h($f) . '</span>/<span class="orange">' . h($e) . '</span>)'; ?>
   </span>
 </td>

--- a/app/View/Elements/eventattribute.ctp
+++ b/app/View/Elements/eventattribute.ctp
@@ -18,24 +18,6 @@
         $page = 0;
     }
     $fieldCount = 11;
-    if (!empty($event['Sighting'])) {
-        foreach ($sightingsData['data'] as $aid => $data) {
-            $sightingsData['data'][$aid]['html'] = '';
-            foreach ($data as $type => $typeData) {
-                $name = (($type != 'expiration') ? Inflector::pluralize($type) : $type);
-                $sightingsData['data'][$aid]['html'] .= '<span class=\'blue bold\'>' . ucfirst(h($name)) . '</span><br />';
-                foreach ($typeData['orgs'] as $org => $orgData) {
-                    $extra = (($org == $me['Organisation']['name']) ? " class=  'bold'" : "");
-                    if ($type == 'expiration') {
-                        $sightingsData['data'][$aid]['html'] .= '<span ' . $extra . '>' . h($org) . '</span>: <span class=\'orange bold\'>' . date('Y-m-d H:i:s', $orgData['date']) . '</span><br />';
-                    } else {
-                        $sightingsData['data'][$aid]['html'] .= '<span ' . $extra . '>' . h($org) . '</span>: <span class=\'' . (($type == 'sighting') ? 'green' : 'red') . ' bold\'>' . h($orgData['count']) . ' (' . date('Y-m-d H:i:s', $orgData['date']) . ')</span><br />';
-                    }
-                }
-                $sightingsData['data'][$aid]['html'] .= '<br />';
-            }
-        }
-    }
     $filtered = false;
     if(isset($passedArgsArray)){
         if (count($passedArgsArray) > 0) {


### PR DESCRIPTION
#### What does it do?

Remove unused code that slows down viewing event with a lot of sightings.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
