### PR TITLE
Fix handling deleted attributes when viewing event

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -1624,11 +1624,11 @@ class EventsController extends AppController
 
         if ($this->_isRest()) {
             $this->set('event', $event);
-        }
-        $this->set('deleted', isset($deleted) ? ($deleted == 2 ? 0 : 1) : 0);
-        $this->set('includeRelatedTags', (!empty($this->params['named']['includeRelatedTags'])) ? 1 : 0);
-        $this->set('includeDecayScore', (!empty($this->params['named']['includeDecayScore'])) ? 1 : 0);
-        if (!$this->_isRest()) {
+        } else {
+            $this->set('deleted', isset($deleted) ? ($deleted == 2 ? 0 : 1) : 0);
+            $this->set('includeRelatedTags', (!empty($this->params['named']['includeRelatedTags'])) ? 1 : 0);
+            $this->set('includeDecayScore', (!empty($this->params['named']['includeDecayScore'])) ? 1 : 0);
+
             if ($this->_isSiteAdmin() && $event['Event']['orgc_id'] !== $this->Auth->user('org_id')) {
                 $this->Flash->info(__('You are currently logged in as a site administrator and about to edit an event not belonging to your organisation. This goes against the sharing model of MISP. Use a normal user account for day to day work.'));
             }

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -1577,10 +1577,7 @@ class EventsController extends AppController
             $conditions['includeGranularCorrelations'] = 1;
         }
         if (!isset($this->params['named']['includeServerCorrelations'])) {
-            $conditions['includeServerCorrelations'] = 1;
-            if ($this->_isRest()) {
-                $conditions['includeServerCorrelations'] = 0;
-            }
+            $conditions['includeServerCorrelations'] = $this->_isRest() ? 0 : 1;
         } else {
             $conditions['includeServerCorrelations'] = $this->params['named']['includeServerCorrelations'];
         }

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -1257,10 +1257,6 @@ class EventsController extends AppController
         $warningTagConflicts = array();
         $filters = $this->_harvestParameters($filterData, $exception);
 
-        $this->loadModel('GalaxyCluster');
-        if (!$this->_isRest()) {
-            //$attack = $this->GalaxyCluster->Galaxy->constructAttackReport($event);
-        }
         $emptyEvent = (empty($event['Object']) && empty($event['Attribute']));
         $this->set('emptyEvent', $emptyEvent);
         $attributeCount = isset($event['Attribute']) ? count($event['Attribute']) : 0;

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -1539,7 +1539,7 @@ class EventsController extends AppController
             if (($this->userRole['perm_sync'] && $this->_isRest() && !$this->userRole['perm_site_admin']) && $deleted == 1) {
                 $conditions['deleted'] = array(0,1);
             } else {
-                $conditions['deleted'] = $deleted == 2 ? array(0,1) : $deleted;
+                $conditions['deleted'] = $deleted == 2 ? array(0, 1) : $deleted;
             }
         }
         if (isset($this->params['named']['toIDS']) && $this->params['named']['toIDS'] != 0) {


### PR DESCRIPTION
#### What does it do?

In current version, the behaviour for fetching deleted attributes is broken and is different for view event and AJAX fetch. This patch unite the behaviour:

* `deleted:2` - exclude deleted (default)
* `deleted:1` - show just deleted 
* `deleted:0` - show both

This patch also cleans some controller code.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
