### PR TITLE
Only push events/sightings when selected for server

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -2335,7 +2335,7 @@ class Event extends AppModel
                     $event['ShadowAttribute'] = $this->Feed->attachFeedCorrelations($event['ShadowAttribute'], $user, $event['Event'], $overrideLimit, 'Server');
                 }
             }
-            if (empty($options['metadata'])) {
+            if (empty($options['metadata']) && empty($options['noSightings'])) {
                 $this->Sighting = ClassRegistry::init('Sighting');
                 $event['Sighting'] = $this->Sighting->attachToEvent($event, $user);
             }

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -2933,8 +2933,8 @@ class Server extends AppModel
             return $push;
         }
 
-        // sync events if user is capable
-        if ($push['canPush']) {
+        // sync events if user is capable and server is configured for push
+        if ($push['canPush'] && $server['Server']['push']) {
             if ("full" == $technique) {
                 $eventid_conditions_key = 'Event.id >';
                 $eventid_conditions_value = 0;
@@ -3006,6 +3006,11 @@ class Server extends AppModel
                         'deleted' => array(0,1),
                         'excludeGalaxy' => 1
                     ));
+                    if (empty($server['Server']['push_sightings'])) {
+                        $params = array_merge($params, array(
+                            'noSightings' => 1
+                        ));
+                    }
                     $event = $this->Event->fetchEvent($user, $params);
                     $event = $event[0];
                     $event['Event']['locked'] = 1;


### PR DESCRIPTION
When pressing the "Push all" button on the Servers page, events were always pushed even when only "Push sightings" was selected for a server. Sightings were always synced even when "Push sightings" was not selected.

This patch fixes both issues. 