### PR TITLE
chg: [search] Allow to search in attributes or objects UUID in quicksearch

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -8,6 +8,7 @@ App::uses('TmpFileTool', 'Tools');
 /**
  * @property User $User
  * @property Attribute $Attribute
+ * @property MispObject $Object
  * @property ShadowAttribute $ShadowAttribute
  * @property EventTag $EventTag
  */
@@ -1434,7 +1435,7 @@ class Event extends AppModel
         if (!$eventReportSupportedByRemote) {
             return [];
         }
-        
+
         // Downgrade the object from connected communities to community only
         if (!$server['Server']['internal'] && $report['distribution'] == 2) {
             $report['distribution'] = 1;


### PR DESCRIPTION
#### What does it do?

Currently, just event uuid is checked when searching. This can be useful if you know exact attribute or object UUID and you need to quickly go to event.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
