### PR TITLE
Fix object conditions

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1518,7 +1518,6 @@ class Event extends AppModel
     {
         $conditions = array();
         if (!$user['Role']['perm_site_admin']) {
-            $unpublishedPrivate = Configure::read('MISP.unpublishedprivate');
             $sgids = $this->cacheSgids($user, true);
             $unpublishedPrivate = Configure::read('MISP.unpublishedprivate');
             $conditions['AND']['OR'] = array(

--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -549,9 +549,6 @@ class MispObject extends AppModel
                 $params['page'] = $options['page'];
             }
         }
-        if (Configure::read('MISP.unpublishedprivate') && !$user['Role']['perm_site_admin']) {
-            $params['conditions']['AND'][] = array('OR' => array('Event.published' => 1, 'Event.orgc_id' => $user['org_id']));
-        }
         $results = $this->find('all', $params);
         if ($options['enforceWarninglist']) {
             $this->Warninglist = ClassRegistry::init('Warninglist');

--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -5,6 +5,7 @@ App::uses('TmpFileTool', 'Tools');
 /**
  * @property Event $Event
  * @property SharingGroup $SharingGroup
+ * @property Attribute $Attribute
  */
 class MispObject extends AppModel
 {
@@ -557,8 +558,8 @@ class MispObject extends AppModel
         $results = array_values($results);
         $proposals_block_attributes = Configure::read('MISP.proposals_block_attributes');
         if (empty($options['metadata'])) {
-            foreach ($results as $key => $objects) {
-                foreach ($objects as $key2 => $attribute) {
+            foreach ($results as $key => $object) {
+                foreach ($object['Attribute'] as $key2 => $attribute) {
                     if ($options['enforceWarninglist'] && !$this->Warninglist->filterWarninglistAttributes($warninglists, $attribute['Attribute'], $this->Warninglist)) {
                         unset($results[$key][$key2]);
                         continue;
@@ -571,9 +572,9 @@ class MispObject extends AppModel
                         }
                     }
                     if ($options['withAttachments']) {
-                        if ($this->typeIsAttachment($attribute['Attribute']['type'])) {
-                            $encodedFile = $this->base64EncodeAttachment($attribute['Attribute']);
-                            $results[$key][$key2]['Attribute']['data'] = $encodedFile;
+                        if ($this->Attribute->typeIsAttachment($attribute['type'])) {
+                            $encodedFile = $this->Attribute->base64EncodeAttachment($attribute);
+                            $results[$key]['Attribute'][$key2]['data'] = $encodedFile;
                         }
                     }
                 }

--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -398,23 +398,12 @@ class MispObject extends AppModel
             $sgids = $this->Event->cacheSgids($user, true);
             $conditions = array(
                 'AND' => array(
+                    $this->Event->createEventConditions($user),
                     'OR' => array(
-                        array(
-                            'AND' => array(
-                                'Event.org_id' => $user['org_id'],
-                            )
-                        ),
-                        array(
-                            'AND' => array(
-                                $this->Event->createEventConditions($user),
-                                'OR' => array(
-                                    'Object.distribution' => array(1, 2, 3, 5),
-                                    'AND' => array(
-                                        'Object.distribution' => 4,
-                                        'Object.sharing_group_id' => $sgids,
-                                    )
-                                )
-                            )
+                        'Object.distribution' => array(1, 2, 3, 5),
+                        'AND' => array(
+                            'Object.distribution' => 4,
+                            'Object.sharing_group_id' => $sgids,
                         )
                     )
                 )

--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -425,27 +425,27 @@ class MispObject extends AppModel
     }
 
     public function fetchObjectSimple($user, $options = array())
-        {
-            $params = array(
-                'conditions' => $this->buildConditions($user),
-                'fields' => array(),
-                'recursive' => -1
-            );
-            if (isset($options['conditions'])) {
-                $params['conditions']['AND'][] = $options['conditions'];
-            }
-            if (isset($options['fields'])) {
-                $params['fields'] = $options['fields'];
-            }
-            $results = $this->find('all', array(
-                'conditions' => $params['conditions'],
-                'recursive' => -1,
-                'fields' => $params['fields'],
-                'contain' => array('Event' => array('distribution', 'id', 'user_id', 'orgc_id', 'org_id')),
-                'sort' => false
-            ));
-            return $results;
+    {
+        $params = array(
+            'conditions' => $this->buildConditions($user),
+            'fields' => array(),
+            'recursive' => -1
+        );
+        if (isset($options['conditions'])) {
+            $params['conditions']['AND'][] = $options['conditions'];
         }
+        if (isset($options['fields'])) {
+            $params['fields'] = $options['fields'];
+        }
+        $results = $this->find('all', array(
+            'conditions' => $params['conditions'],
+            'recursive' => -1,
+            'fields' => $params['fields'],
+            'contain' => array('Event' => array('distribution', 'id', 'user_id', 'orgc_id', 'org_id')),
+            'sort' => false
+        ));
+        return $results;
+    }
 
     // Method that fetches all objects
     // very flexible, it's basically a replacement for find, with the addition that it restricts access based on user

--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -392,41 +392,11 @@ class MispObject extends AppModel
         return $result;
     }
 
-    public function buildEventConditions($user, $sgids = false)
-    {
-        if ($user['Role']['perm_site_admin']) {
-            return array();
-        }
-        if ($sgids == false) {
-            $sgsids = $this->SharingGroup->fetchAllAuthorised($user);
-        }
-        return array(
-            'OR' => array(
-                array(
-                    'AND' => array(
-                        'Event.distribution >' => 0,
-                        'Event.distribution <' => 4,
-                        Configure::read('MISP.unpublishedprivate') ? array('Event.published' => 1) : array(),
-                    ),
-                ),
-                array(
-                    'AND' => array(
-                        'Event.sharing_group_id' => $sgids,
-                        'Event.distribution' => 4,
-                        Configure::read('MISP.unpublishedprivate') ? array('Event.published' => 1) : array(),
-                    )
-                )
-            )
-        );
-    }
-
-    public function buildConditions($user, $sgids = false)
+    public function buildConditions(array $user)
     {
         $conditions = array();
         if (!$user['Role']['perm_site_admin']) {
-            if ($sgids === false) {
-                $sgsids = $this->SharingGroup->fetchAllAuthorised($user);
-            }
+            $sgids = $this->Event->cacheSgids($user, true);
             $conditions = array(
                 'AND' => array(
                     'OR' => array(
@@ -437,12 +407,12 @@ class MispObject extends AppModel
                         ),
                         array(
                             'AND' => array(
-                                $this->buildEventConditions($user, $sgids),
+                                $this->Event->createEventConditions($user),
                                 'OR' => array(
-                                    'Object.distribution' => array('1', '2', '3', '5'),
-                                    'AND '=> array(
+                                    'Object.distribution' => array(1, 2, 3, 5),
+                                    'AND' => array(
                                         'Object.distribution' => 4,
-                                        'Object.sharing_group_id' => $sgsids,
+                                        'Object.sharing_group_id' => $sgids,
                                     )
                                 )
                             )

--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -455,9 +455,9 @@ class MispObject extends AppModel
     //     group
     public function fetchObjects($user, $options = array())
     {
-        $sgsids = $this->SharingGroup->fetchAllAuthorised($user);
         $attributeConditions = array();
         if (!$user['Role']['perm_site_admin']) {
+            $sgids = $this->Event->cacheSgids($user, true);
             $attributeConditions = array(
                 'OR' => array(
                     array(
@@ -468,7 +468,7 @@ class MispObject extends AppModel
                             'Attribute.distribution' => array(1, 2, 3, 5),
                             array(
                                 'Attribute.distribution' => 4,
-                                'Attribute.sharing_group_id' => $sgsids
+                                'Attribute.sharing_group_id' => $sgids,
                             )
                         )
                     )

--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -80,9 +80,9 @@ class MispObject extends AppModel
         )
     );
 
-    public function buildFilterConditions($user, &$params)
+    public function buildFilterConditions(&$params)
     {
-        $conditions = $this->buildConditions($user);
+        $conditions = [];
         if (isset($params['wildcard'])) {
             $temp = array();
             $options = array(
@@ -93,8 +93,6 @@ class MispObject extends AppModel
             );
             $conditions['AND'][] = array('OR' => $this->Event->set_filter_wildcard_attributes($params, $temp, $options));
         } else {
-            $attribute_conditions = array();
-            $object_conditions = array();
             if (isset($params['ignore'])) {
                 $params['to_ids'] = array(0, 1);
                 $params['published'] = array(0, 1);
@@ -1381,25 +1379,25 @@ class MispObject extends AppModel
         $subqueryElements = $this->Event->harvestSubqueryElements($filters);
         $filters = $this->Event->addFiltersFromSubqueryElements($filters, $subqueryElements);
         $filters = $this->Event->addFiltersFromUserSettings($user, $filters);
-        $conditions = $this->buildFilterConditions($user, $filters);
+        $conditions = $this->buildFilterConditions($filters);
         $params = array(
-                'conditions' => $conditions,
-                'fields' => array('Attribute.*', 'Event.org_id', 'Event.distribution', 'Object.*'),
-                'withAttachments' => !empty($filters['withAttachments']) ? $filters['withAttachments'] : 0,
-                'enforceWarninglist' => !empty($filters['enforceWarninglist']) ? $filters['enforceWarninglist'] : 0,
-                'includeAllTags' => !empty($filters['includeAllTags']) ? $filters['includeAllTags'] : 0,
-                'includeEventUuid' => !empty($filters['includeEventUuid']) ? $filters['includeEventUuid'] : 0,
-                'includeEventTags' => !empty($filters['includeEventTags']) ? $filters['includeEventTags'] : 0,
-                'includeProposals' => !empty($filters['includeProposals']) ? $filters['includeProposals'] : 0,
-                'includeWarninglistHits' => !empty($filters['includeWarninglistHits']) ? $filters['includeWarninglistHits'] : 0,
-                'includeContext' => !empty($filters['includeContext']) ? $filters['includeContext'] : 0,
-                'includeSightings' => !empty($filters['includeSightings']) ? $filters['includeSightings'] : 0,
-                'includeSightingdb' => !empty($filters['includeSightingdb']) ? $filters['includeSightingdb'] : 0,
-                'includeCorrelations' => !empty($filters['includeCorrelations']) ? $filters['includeCorrelations'] : 0,
-                'includeDecayScore' => !empty($filters['includeDecayScore']) ? $filters['includeDecayScore'] : 0,
-                'includeFullModel' => !empty($filters['includeFullModel']) ? $filters['includeFullModel'] : 0,
-                'allow_proposal_blocking' => !empty($filters['allow_proposal_blocking']) ? $filters['allow_proposal_blocking'] : 0,
-                'metadata' => !empty($filters['metadata']) ? $filters['metadata'] : 0,
+            'conditions' => $conditions,
+            'fields' => array('Attribute.*', 'Event.org_id', 'Event.distribution', 'Object.*'),
+            'withAttachments' => !empty($filters['withAttachments']) ? $filters['withAttachments'] : 0,
+            'enforceWarninglist' => !empty($filters['enforceWarninglist']) ? $filters['enforceWarninglist'] : 0,
+            'includeAllTags' => !empty($filters['includeAllTags']) ? $filters['includeAllTags'] : 0,
+            'includeEventUuid' => !empty($filters['includeEventUuid']) ? $filters['includeEventUuid'] : 0,
+            'includeEventTags' => !empty($filters['includeEventTags']) ? $filters['includeEventTags'] : 0,
+            'includeProposals' => !empty($filters['includeProposals']) ? $filters['includeProposals'] : 0,
+            'includeWarninglistHits' => !empty($filters['includeWarninglistHits']) ? $filters['includeWarninglistHits'] : 0,
+            'includeContext' => !empty($filters['includeContext']) ? $filters['includeContext'] : 0,
+            'includeSightings' => !empty($filters['includeSightings']) ? $filters['includeSightings'] : 0,
+            'includeSightingdb' => !empty($filters['includeSightingdb']) ? $filters['includeSightingdb'] : 0,
+            'includeCorrelations' => !empty($filters['includeCorrelations']) ? $filters['includeCorrelations'] : 0,
+            'includeDecayScore' => !empty($filters['includeDecayScore']) ? $filters['includeDecayScore'] : 0,
+            'includeFullModel' => !empty($filters['includeFullModel']) ? $filters['includeFullModel'] : 0,
+            'allow_proposal_blocking' => !empty($filters['allow_proposal_blocking']) ? $filters['allow_proposal_blocking'] : 0,
+            'metadata' => !empty($filters['metadata']) ? $filters['metadata'] : 0,
         );
         if (!empty($filters['attackGalaxy'])) {
             $params['attackGalaxy'] = $filters['attackGalaxy'];


### PR DESCRIPTION
#### What does it do?

Old code generates SQL that do not contains sharing group ID:

```sql
((((`Event`.`org_id` = 22) OR (((((((`Event`.`distribution` > 0) AND (`Event`.`distribution` < 4) AND (`Event`.`published` = '1'))) OR (((`Event`.`sharing_group_id` = '') AND (`Event`.`distribution` = 4) AND (`Event`.`published` = '1'))))) AND (((`Object`.`distribution` IN (1, 2, 3, 5)) OR (((`Object`.`distribution` = 4) AND  (`Object`.`sharing_group_id` = (2))))))))))
```

see:
```sql
`Event`.`sharing_group_id` = ''
```

and for REST search, the conditions was inserted two times.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
