### PR TITLE
chg: [UI] Show event creator for users from event org

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -1612,10 +1612,6 @@ class EventsController extends AppController
         }
         $event = $results[0];
         $this->Event->id = $event['Event']['id'];
-        //if the current user is an org admin AND event belongs to his/her org, fetch also the event creator info
-        if ($this->userRole['perm_admin'] && !$this->_isSiteAdmin() && ($event['Org']['id'] == $this->Auth->user('org_id'))) {
-            $event['User']['email'] = $this->User->field('email', array('id' => $event['Event']['user_id']));
-        }
         if (isset($this->params['named']['searchFor']) && $this->params['named']['searchFor'] !== '') {
             $this->__applyQueryString($event, $this->params['named']['searchFor']);
         }

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -2144,9 +2144,6 @@ class Event extends AppModel
             unset($params['contain']['ShadowAttribute']);
             unset($params['contain']['Object']);
         }
-        if ($user['Role']['perm_site_admin']) {
-            $params['contain']['User'] = array('fields' => 'email');
-        }
         $results = $this->find('all', $params);
         if (empty($results)) {
             return array();
@@ -2155,8 +2152,9 @@ class Event extends AppModel
         if ($options['includeFeedCorrelations'] || $options['includeServerCorrelations']) {
             $this->Feed = ClassRegistry::init('Feed');
         }
+        // Precache current user email
+        $userEmails = array($user['id'] => $user['email']);
         // Do some refactoring with the event
-        $userEmails = array();
         $fields = array(
             'common' => array('distribution', 'sharing_group_id', 'uuid'),
             'Attribute' => array('value', 'type', 'category', 'to_ids'),
@@ -2192,13 +2190,24 @@ class Event extends AppModel
             if (!$options['sgReferenceOnly'] && $event['Event']['sharing_group_id']) {
                 $event['SharingGroup'] = $sharingGroupData[$event['Event']['sharing_group_id']]['SharingGroup'];
             }
-            // Add information for auditor user
-            if ($event['Event']['orgc_id'] === $user['org_id'] && $user['Role']['perm_audit']) {
+
+            // Include information about event creator user email. This information is included for:
+            // - users from event creator org
+            // - site admins
+            // In export, this information will be included in `event_creator_email` field just for auditors of event creator org.
+            $sameOrg = $event['Event']['orgc_id'] === $user['org_id'];
+            if ($sameOrg || $user['Role']['perm_site_admin']) {
                 if (!isset($userEmails[$event['Event']['user_id']])) {
                     $userEmails[$event['Event']['user_id']] = $this->User->getAuthUser($event['Event']['user_id'])['email'];
                 }
-                $event['Event']['event_creator_email'] = $userEmails[$event['Event']['user_id']];
+
+                $userEmail = $userEmails[$event['Event']['user_id']];
+                if ($sameOrg && $user['Role']['perm_auditor']) {
+                    $event['Event']['event_creator_email'] = $userEmail;
+                }
+                $event['User']['email'] = $userEmail;
             }
+
             $event = $this->massageTags($event, 'Event', $options['excludeGalaxy']);
             // Let's find all the related events and attach it to the event itself
             if ($options['includeEventCorrelations']) {

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -2198,7 +2198,7 @@ class Event extends AppModel
             $sameOrg = $event['Event']['orgc_id'] === $user['org_id'];
             if ($sameOrg || $user['Role']['perm_site_admin']) {
                 if (!isset($userEmails[$event['Event']['user_id']])) {
-                    $userEmails[$event['Event']['user_id']] = $this->User->getAuthUser($event['Event']['user_id'])['email'];
+                    $userEmails[$event['Event']['user_id']] = $this->User->field('email', ['id' => $event['Event']['user_id']]);
                 }
 
                 $userEmail = $userEmails[$event['Event']['user_id']];

--- a/app/View/Events/view.ctp
+++ b/app/View/Events/view.ctp
@@ -117,10 +117,10 @@
                 'html' => $contributorsContent
             );
         }
-        if (isset($event['User']['email']) && ($isSiteAdmin || ($isAdmin && $me['org_id'] == $event['Event']['org_id']))) {
+        if (isset($event['User']['email'])) {
             $table_data[] = array(
-                'key' => __('Email'),
-                'value' => h($event['User']['email'])
+                'key' => __('Creator user'),
+                'value' => h($event['User']['email']),
             );
         }
         $table_data[] = array(


### PR DESCRIPTION
#### What does it do?

Event creator e-mail should be shown for everybody that has audit permission and is from the same org or for site admins. 

And we should prefer putting that info into `event_creator_email` field that is defined by MISP core format RFC (`User.email` is not defined for Event).

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
