### PR TITLE
Remove extraneous spaces from E-mail subject

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -3049,7 +3049,7 @@ class Event extends AppModel
         } else {
             $threatLevel = $event['ThreatLevel']['name'] . " - ";
         }
-        $subject = "[" . Configure::read('MISP.org') . " MISP] Event $id - $subject $threatLevel " . strtoupper($subjMarkingString);
+        $subject = "[" . Configure::read('MISP.org') . " MISP] Event $id - $subject$threatLevel" . strtoupper($subjMarkingString);
 
         $eventUrl = $this->__getAnnounceBaseurl() . "/events/view/" . $id;
         $bodyNoEnc = __("A new or modified event was just published on %s", $eventUrl) . "\n\n";


### PR DESCRIPTION
77833be9609f025c5375abb608eda94297c72db introduced two additional spaces in the E-mail subject that should not be there. This is especially apparent when `MISP.threatlevel_in_email_subject` and `MISP.extended_alert_subject` are set to false.