### PR TITLE
Warninglist Redis cache

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -3634,19 +3634,7 @@ class EventsController extends AppController
             $this->set('importComment', '');
             $this->set('title', 'Freetext Import Results');
             $this->loadModel('Warninglist');
-            $tldLists = $this->Warninglist->getTldLists();
-            $missingTldLists = array();
-            foreach ($tldLists as $tldList) {
-                $temp = $this->Warninglist->find('first', array(
-                    'recursive' => -1,
-                    'conditions' => array('Warninglist.name' => $tldList),
-                    'fields' => array('Warninglist.id')
-                ));
-                if (empty($temp)) {
-                    $missingTldLists[] = $tldList;
-                }
-            }
-            $this->set('missingTldLists', $missingTldLists);
+            $this->set('missingTldLists', $this->Warninglist->missingTldLists());
             $this->render('resolved_attributes');
         }
     }

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -1070,6 +1070,7 @@ class EventsController extends AppController
             $conditions['to_ids'] = $filters['toIDS'] == 2 ? 0 : 1;
         }
         $conditions['includeFeedCorrelations'] = true;
+        $conditions['includeWarninglistHits'] = true;
         if (!isset($filters['includeServerCorrelations'])) {
             $conditions['includeServerCorrelations'] = 1;
             if ($this->_isRest()) {
@@ -1567,6 +1568,7 @@ class EventsController extends AppController
             $this->set('extended', 0);
         }
         $conditions['excludeLocalTags'] = false;
+        $conditions['includeWarninglistHits'] = true;
         if (isset($this->params['named']['excludeLocalTags'])) {
             $conditions['excludeLocalTags'] = $this->params['named']['excludeLocalTags'];
         }

--- a/app/Controller/FeedsController.php
+++ b/app/Controller/FeedsController.php
@@ -773,6 +773,9 @@ class FeedsController extends AppController
             return $this->RestResponse->viewData($event, $this->response->type());
         }
         if (is_array($event)) {
+            $this->loadModel('Warninglist');
+            $this->Warninglist->attachWarninglistToAttributes($event['Event']['Attribute']);
+
             $this->loadModel('Event');
             $params = $this->Event->rearrangeEventForView($event, $this->passedArgs, $all);
             $this->params->params['paging'] = array('Feed' => $params);

--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -153,17 +153,29 @@ class ServersController extends AppController
         if (!$this->_isSiteAdmin()) {
             throw new MethodNotAllowedException('You are not authorised to do that.');
         }
-        $server = $this->Server->find('first', array('conditions' => array('Server.id' => $serverId), 'recursive' => -1, 'fields' => array('Server.id', 'Server.url', 'Server.name')));
+        $server = $this->Server->find('first', array(
+            'conditions' => array('Server.id' => $serverId),
+            'recursive' => -1,
+            'fields' => array('Server.id', 'Server.url', 'Server.name'))
+        );
         if (empty($server)) {
             throw new NotFoundException('Invalid server ID.');
         }
         try {
             $event = $this->Server->previewEvent($serverId, $eventId);
         } catch (NotFoundException $e) {
-            throw new NotFoundException(__("Event '$eventId' not found."));
+            throw new NotFoundException(__("Event '%s' not found.", $eventId));
         } catch (Exception $e) {
-            $this->Flash->error(__('Download failed.') . ' ' . $e->getMessage());
+            $this->Flash->error(__('Download failed. %s', $e->getMessage()));
             $this->redirect(array('action' => 'previewIndex', $serverId));
+        }
+
+        $this->loadModel('Warninglist');
+        if (isset($event['Event']['Attribute'])) {
+            $this->Warninglist->attachWarninglistToAttributes($event['Event']['Attribute']);
+        }
+        if (isset($event['Event']['ShadowAttribute'])) {
+            $this->Warninglist->attachWarninglistToAttributes($event['Event']['ShadowAttribute']);
         }
 
         $this->loadModel('Event');
@@ -171,7 +183,6 @@ class ServersController extends AppController
         $this->params->params['paging'] = array('Server' => $params);
         $this->set('event', $event);
         $this->set('server', $server);
-        $this->loadModel('Event');
         $dataForView = array(
                 'Attribute' => array('attrDescriptions' => 'fieldDescriptions', 'distributionDescriptions' => 'distributionDescriptions', 'distributionLevels' => 'distributionLevels'),
                 'Event' => array('eventDescriptions' => 'fieldDescriptions', 'analysisLevels' => 'analysisLevels'),

--- a/app/Controller/WarninglistsController.php
+++ b/app/Controller/WarninglistsController.php
@@ -189,7 +189,6 @@ class WarninglistsController extends AppController
             $this->Warninglist->regenerateWarninglistCaches($warningList['Warninglist']['id']);
         }
         if ($success) {
-            $this->Warninglist->regenerateWarninglistCaches($id);
             return new CakeResponse(array('body'=> json_encode(array('saved' => true, 'success' => $success . __(' warninglist(s) ') . $message)), 'status' => 200, 'type' => 'json')); // TODO: non-SVO lang considerations
         } else {
             return new CakeResponse(array('body'=> json_encode(array('saved' => false, 'errors' => __('Warninglist(s) could not be toggled.'))), 'status' => 200, 'type' => 'json'));

--- a/app/Controller/WarninglistsController.php
+++ b/app/Controller/WarninglistsController.php
@@ -107,9 +107,9 @@ class WarninglistsController extends AppController
             $message = __('Could not update any of the warning lists');
         } else {
             $flashType = 'success';
-            $message = __('Successfully updated ' . $successes . ' warninglists.');
+            $message = __('Successfully updated %s warninglists.', $successes);
             if ($fails != 0) {
-                $message . __(' However, could not update ') . $fails . ' warning list.'; // TODO: non-SVO languages need to be considered
+                $message .= __(' However, could not update %s warninglists.', $fails); // TODO: non-SVO languages need to be considered
             }
         }
         if ($this->_isRest()) {
@@ -279,12 +279,13 @@ class WarninglistsController extends AppController
             if (array_key_exists('[]', $data)) {
                 $data = $data['[]'];
             }
-            $hits = array();
 
-            $warninglists = $this->Warninglist->fetchForEventView();
+            $hits = array();
+            $warninglists = $this->Warninglist->getEnabled();
             foreach ($data as $dataPoint) {
                 foreach ($warninglists as $warninglist) {
-                    $result = $this->Warninglist->quickCheckValue($warninglist['values'], $dataPoint, $warninglist['Warninglist']['type']);
+                    $values = $this->Warninglist->getFilteredEntries($warninglist);
+                    $result = $this->Warninglist->quickCheckValue($values, $dataPoint, $warninglist['Warninglist']['type']);
                     if ($result !== false) {
                         $hits[$dataPoint][] = array('id' => $warninglist['Warninglist']['id'], 'name' => $warninglist['Warninglist']['name']);
                     }

--- a/app/Controller/WarninglistsController.php
+++ b/app/Controller/WarninglistsController.php
@@ -1,6 +1,9 @@
 <?php
 App::uses('AppController', 'Controller');
 
+/**
+ * @property Warninglist $Warninglist
+ */
 class WarninglistsController extends AppController
 {
     public $components = array('Session', 'RequestHandler');
@@ -267,7 +270,6 @@ class WarninglistsController extends AppController
     public function checkValue()
     {
         if ($this->request->is('post')) {
-            $warninglists = $this->Warninglist->getWarninglists(array());
             if (empty($this->request->data)) {
                 throw new NotFoundException(__('No valid data received.'));
             }
@@ -279,12 +281,12 @@ class WarninglistsController extends AppController
                 $data = $data['[]'];
             }
             $hits = array();
+
+            $warninglists = $this->Warninglist->fetchForEventView();
             foreach ($data as $dataPoint) {
                 foreach ($warninglists as $warninglist) {
-                    $listValues = $this->Warninglist->getWarninglistEntries($warninglist['Warninglist']['id']);
-                    $listValues = array_combine($listValues, $listValues);
-                    $result = $this->Warninglist->quickCheckValue($listValues, $dataPoint, $warninglist['Warninglist']['type']);
-                    if ($result) {
+                    $result = $this->Warninglist->quickCheckValue($warninglist['values'], $dataPoint, $warninglist['Warninglist']['type']);
+                    if ($result !== false) {
                         $hits[$dataPoint][] = array('id' => $warninglist['Warninglist']['id'], 'name' => $warninglist['Warninglist']['name']);
                     }
                 }

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -3468,7 +3468,7 @@ class Attribute extends AppModel
             return $results;
         }
 
-        if ($options['enforceWarninglist'] || $options['includeWarninglistHits']) {
+        if (($options['enforceWarninglist'] || $options['includeWarninglistHits']) && !isset($this->Warninglist)) {
             $this->Warninglist = ClassRegistry::init('Warninglist');
         }
         if (empty($params['limit'])) {
@@ -3539,11 +3539,12 @@ class Attribute extends AppModel
             $results = array_values($results);
             $proposals_block_attributes = Configure::read('MISP.proposals_block_attributes');
             foreach ($results as $key => $attribute) {
+                if ($options['enforceWarninglist'] && !$this->Warninglist->filterWarninglistAttribute($attribute['Attribute'])) {
+                    unset($results[$key]); // Remove attribute that match any enabled warninglists
+                    continue;
+                }
                 if (!empty($options['includeEventTags'])) {
                     $results = $this->__attachEventTagsToAttributes($eventTags, $results, $key, $options);
-                }
-                if ($options['enforceWarninglist'] && !$this->Warninglist->filterWarninglistAttribute($attribute['Attribute'])) {
-                    continue;
                 }
                 if ($options['includeWarninglistHits']) {
                     $results[$key]['Attribute'] = $this->Warninglist->checkForWarning($results[$key]['Attribute']);

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -3468,9 +3468,8 @@ class Attribute extends AppModel
             return $results;
         }
 
-        if (($options['enforceWarninglist'] || $options['includeWarninglistHits']) && !isset($this->warninglists)) {
+        if (($options['enforceWarninglist'] || $options['includeWarninglistHits'])) {
             $this->Warninglist = ClassRegistry::init('Warninglist');
-            $this->warninglists = $this->Warninglist->fetchForEventView();
         }
         if (empty($params['limit'])) {
             $loopLimit = 50000;
@@ -3543,11 +3542,11 @@ class Attribute extends AppModel
                 if (!empty($options['includeEventTags'])) {
                     $results = $this->__attachEventTagsToAttributes($eventTags, $results, $key, $options);
                 }
-                if ($options['enforceWarninglist'] && !$this->Warninglist->filterWarninglistAttributes($this->warninglists, $attribute['Attribute'])) {
+                if ($options['enforceWarninglist'] && !$this->Warninglist->filterWarninglistAttributes($attribute['Attribute'])) {
                     continue;
                 }
                 if ($options['includeWarninglistHits']) {
-                    $results[$key]['Attribute'] = $this->Warninglist->simpleCheckForWarning($results[$key]['Attribute'], $this->warninglists, true);
+                    $results[$key]['Attribute'] = $this->Warninglist->simpleCheckForWarning($results[$key]['Attribute']);
                 }
                 if (!empty($options['includeAttributeUuid']) || !empty($options['includeEventUuid'])) {
                     $results[$key]['Attribute']['event_uuid'] = $results[$key]['Event']['uuid'];
@@ -4120,10 +4119,7 @@ class Attribute extends AppModel
         }
         if (!empty($attribute['enforceWarninglist']) || !empty($params['enforceWarninglist'])) {
             $this->Warninglist = ClassRegistry::init('Warninglist');
-            if (empty($this->warninglists)) {
-                $this->warninglists = $this->Warninglist->fetchForEventView();
-            }
-            if (!$this->Warninglist->filterWarninglistAttributes($warninglists, $attributes[$k])) {
+            if (!$this->Warninglist->filterWarninglistAttributes($attribute)) {
                 $this->validationErrors['warninglist'] = 'Attribute could not be saved as it trips over a warninglist and enforceWarninglist is enforced.';
                 $validationErrors = $this->validationErrors['warninglist'];
                 $log->create();

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -3468,7 +3468,7 @@ class Attribute extends AppModel
             return $results;
         }
 
-        if (($options['enforceWarninglist'] || $options['includeWarninglistHits'])) {
+        if ($options['enforceWarninglist'] || $options['includeWarninglistHits']) {
             $this->Warninglist = ClassRegistry::init('Warninglist');
         }
         if (empty($params['limit'])) {
@@ -3546,7 +3546,7 @@ class Attribute extends AppModel
                     continue;
                 }
                 if ($options['includeWarninglistHits']) {
-                    $results[$key]['Attribute'] = $this->Warninglist->simpleCheckForWarning($results[$key]['Attribute']);
+                    $results[$key]['Attribute'] = $this->Warninglist->checkForWarning($results[$key]['Attribute']);
                 }
                 if (!empty($options['includeAttributeUuid']) || !empty($options['includeEventUuid'])) {
                     $results[$key]['Attribute']['event_uuid'] = $results[$key]['Event']['uuid'];
@@ -4130,7 +4130,7 @@ class Attribute extends AppModel
                         'email' => $user['email'],
                         'action' => 'add',
                         'user_id' => $user['id'],
-                        'title' => 'Attribute dropped due to validation for Event ' . $eventId . ' failed: ' . $attribute_short,
+                        'title' => 'Attribute dropped due to validation for Event ' . $eventId . ' failed',
                         'change' => 'Validation errors: ' . json_encode($this->validationErrors) . ' Full Attribute: ' . json_encode($attribute),
                 ));
                 return $attribute;

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -3542,7 +3542,7 @@ class Attribute extends AppModel
                 if (!empty($options['includeEventTags'])) {
                     $results = $this->__attachEventTagsToAttributes($eventTags, $results, $key, $options);
                 }
-                if ($options['enforceWarninglist'] && !$this->Warninglist->filterWarninglistAttributes($attribute['Attribute'])) {
+                if ($options['enforceWarninglist'] && !$this->Warninglist->filterWarninglistAttribute($attribute['Attribute'])) {
                     continue;
                 }
                 if ($options['includeWarninglistHits']) {
@@ -4119,7 +4119,7 @@ class Attribute extends AppModel
         }
         if (!empty($attribute['enforceWarninglist']) || !empty($params['enforceWarninglist'])) {
             $this->Warninglist = ClassRegistry::init('Warninglist');
-            if (!$this->Warninglist->filterWarninglistAttributes($attribute)) {
+            if (!$this->Warninglist->filterWarninglistAttribute($attribute)) {
                 $this->validationErrors['warninglist'] = 'Attribute could not be saved as it trips over a warninglist and enforceWarninglist is enforced.';
                 $validationErrors = $this->validationErrors['warninglist'];
                 $log->create();

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -2191,6 +2191,7 @@ class Event extends AppModel
             }
             if ($options['includeWarninglistHits'] || $options['enforceWarninglist']) {
                 $eventWarnings = $this->Warninglist->attachWarninglistToAttributes($event['Attribute']);
+                $this->Warninglist->attachWarninglistToAttributes($event['ShadowAttribute']);
                 $event['warnings'] = $eventWarnings;
             }
             $this->__attachReferences($event, $fields);
@@ -4994,9 +4995,9 @@ class Event extends AppModel
             if ($filterType['warning'] == 0) { // `both`
                 // pass, do not consider as `both` is selected
             } else if (!empty($proposal['warnings']) || !empty($proposal['validationIssue'])) { // `include only`
-                $include = $include && ($filterType['correlation'] == 1);
+                $include = $include && ($filterType['warning'] == 1);
             } else { // `exclude`
-                $include = $include && ($filterType['correlation'] == 2);
+                $include = $include && ($filterType['warning'] == 2);
             }
         }
 

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -6170,7 +6170,7 @@ class Event extends AppModel
                     }
                     // adhere to the warninglist
                     if ($adhereToWarninglists) {
-                        if (!$this->Warninglist->filterWarninglistAttributes($attribute)) {
+                        if (!$this->Warninglist->filterWarninglistAttribute($attribute)) {
                             if ($adhereToWarninglists === 'soft') {
                                 $attribute['to_ids'] = 0;
                             } else {

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -5265,45 +5265,56 @@ class Event extends AppModel
 
         $correlatedAttributes = isset($event['RelatedAttribute']) ? array_keys($event['RelatedAttribute']) : array();
         $correlatedShadowAttributes = isset($event['RelatedShadowAttribute']) ? array_keys($event['RelatedShadowAttribute']) : array();
-        $event['objects'] = array();
-        foreach ($event['Attribute'] as $attribute) {
-            $result = $this->__prepareAttributeForView(
-                $attribute,
-                $correlatedAttributes,
-                $correlatedShadowAttributes,
-                $filterType,
-                $sightingsData
-            );
-            if ($result) {
-                $event['objects'][] = $result;
+        $objects = array();
+
+        if (isset($event['Attribute'])) {
+            foreach ($event['Attribute'] as $attribute) {
+                $result = $this->__prepareAttributeForView(
+                    $attribute,
+                    $correlatedAttributes,
+                    $correlatedShadowAttributes,
+                    $filterType,
+                    $sightingsData
+                );
+                if ($result) {
+                    $objects[] = $result;
+                }
             }
+            unset($event['Attribute']);
         }
-        unset($event['Attribute']);
-        foreach ($event['ShadowAttribute'] as $proposal) {
-            $result = $this->__prepareProposalForView(
-                $proposal,
-                $correlatedShadowAttributes,
-                $filterType
-            );
-            if ($result) {
-                $event['objects'][] = $result;
+
+        if (isset($event['ShadowAttribute'])) {
+            foreach ($event['ShadowAttribute'] as $proposal) {
+                $result = $this->__prepareProposalForView(
+                    $proposal,
+                    $correlatedShadowAttributes,
+                    $filterType
+                );
+                if ($result) {
+                    $objects[] = $result;
+                }
             }
+            unset($event['ShadowAttribute']);
         }
-        foreach ($event['Object'] as $object) {
-            $object['objectType'] = 'object';
-            $result = $this->__prepareObjectForView(
-                $object,
-                $correlatedAttributes,
-                $correlatedShadowAttributes,
-                $filterType,
-                $sightingsData
-            );
-            if ($result) {
-                $event['objects'][] = $result;
+        if (isset($event['Object'])) {
+            foreach ($event['Object'] as $object) {
+                $object['objectType'] = 'object';
+                $result = $this->__prepareObjectForView(
+                    $object,
+                    $correlatedAttributes,
+                    $correlatedShadowAttributes,
+                    $filterType,
+                    $sightingsData
+                );
+                if ($result) {
+                    $objects[] = $result;
+                }
             }
+            unset($event['Object']);
         }
-        unset($event['Object']);
-        unset($event['ShadowAttribute']);
+
+        $event['objects'] = $objects;
+
         $referencedByArray = array();
         foreach ($event['objects'] as $object) {
             if (!in_array($object['objectType'], array('attribute', 'object'))) {

--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -545,16 +545,15 @@ class MispObject extends AppModel
             }
         }
         $results = $this->find('all', $params);
-        if ($options['enforceWarninglist']) {
+        if ($options['enforceWarninglist'] && !isset($this->Warninglist)) {
             $this->Warninglist = ClassRegistry::init('Warninglist');
-            $warninglists = $this->Warninglist->fetchForEventView();
         }
         $results = array_values($results);
         $proposals_block_attributes = Configure::read('MISP.proposals_block_attributes');
         if (empty($options['metadata'])) {
             foreach ($results as $key => $object) {
                 foreach ($object['Attribute'] as $key2 => $attribute) {
-                    if ($options['enforceWarninglist'] && !$this->Warninglist->filterWarninglistAttributes($warninglists, $attribute['Attribute'], $this->Warninglist)) {
+                    if ($options['enforceWarninglist'] && !$this->Warninglist->filterWarninglistAttributes($attribute['Attribute'])) {
                         unset($results[$key][$key2]);
                         continue;
                     }

--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -553,7 +553,7 @@ class MispObject extends AppModel
         if (empty($options['metadata'])) {
             foreach ($results as $key => $object) {
                 foreach ($object['Attribute'] as $key2 => $attribute) {
-                    if ($options['enforceWarninglist'] && !$this->Warninglist->filterWarninglistAttributes($attribute['Attribute'])) {
+                    if ($options['enforceWarninglist'] && !$this->Warninglist->filterWarninglistAttribute($attribute['Attribute'])) {
                         unset($results[$key][$key2]);
                         continue;
                     }

--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -416,33 +416,43 @@ class Warninglist extends AppModel
                 continue;
             }
 
-            $outputValues[$v] = $v;
+            $outputValues[$v] = true;
         }
         return $outputValues;
     }
 
+    /**
+     * For 'hostname', 'string' and 'cidr' warninglist type, values are just in keys to save memory.
+     *
+     * @param array $warninglist
+     * @return array
+     */
     public function getFilteredEntries(array $warninglist)
     {
-        if (isset($this->entriesCache[$warninglist['Warninglist']['id']])) {
-            return $this->entriesCache[$warninglist['Warninglist']['id']];
+        $id = $warninglist['Warninglist']['id'];
+        if (isset($this->entriesCache[$id])) {
+            return $this->entriesCache[$id];
         }
 
-        $values = $this->getWarninglistEntries($warninglist['Warninglist']['id']);
-
+        $values = $this->getWarninglistEntries($id);
         if ($warninglist['Warninglist']['type'] === 'hostname') {
             $output = [];
             foreach ($values as $v) {
                 $v = trim($v, '.');
-                $output[$v] = $v;
+                $output[$v] = true;
             }
             $values = $output;
         } else if ($warninglist['Warninglist']['type'] === 'string') {
-            $values = array_combine($values, $values);
+            $output = [];
+            foreach ($values as $v) {
+                $output[$v] = true;
+            }
+            $values = $output;
         } else if ($warninglist['Warninglist']['type'] === 'cidr') {
             $values = $this->filterCidrList($values);
         }
 
-        $this->entriesCache[$warninglist['Warninglist']['id']] = $values;
+        $this->entriesCache[$id] = $values;
 
         return $values;
     }

--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -24,12 +24,12 @@ class Warninglist extends AppModel
     );
 
     public $hasMany = array(
-            'WarninglistEntry' => array(
-                'dependent' => true
-            ),
-            'WarninglistType' => array(
-                'dependent' => true
-            )
+        'WarninglistEntry' => array(
+            'dependent' => true
+        ),
+        'WarninglistType' => array(
+            'dependent' => true
+        )
     );
 
     private $__tlds = array(
@@ -69,7 +69,7 @@ class Warninglist extends AppModel
                 return []; // no warninglist is enabled
             }
             foreach ($attributes as $pos => $attribute) {
-                $attributes[$pos] = $this->simpleCheckForWarning($attribute, $warninglists);
+                $attributes[$pos] = $this->checkForWarning($attribute, $warninglists);
                 if (isset($event['Attribute'][$pos]['warnings'])) {
                     foreach ($attribute['warnings'] as $match) {
                         $eventWarnings[$match['warninglist_id']] = $match['warninglist_name'];
@@ -108,7 +108,7 @@ class Warninglist extends AppModel
         foreach ($results as $pos => $result) {
             if ($result === false) { // not in cache
                 $attribute = $attributes[$redisResultToAttributePos[$pos]];
-                $attribute = $this->simpleCheckForWarning($attribute, $warninglists);
+                $attribute = $this->checkForWarning($attribute, $warninglists);
 
                 $store = [];
                 if (isset($attribute['warnings'])) {
@@ -441,7 +441,12 @@ class Warninglist extends AppModel
         return $warninglists;
     }
 
-    public function simpleCheckForWarning($object, $warninglists = null)
+    /**
+     * @param array $object
+     * @param array|null $warninglists If null, all enabled warninglists will be used
+     * @return array
+     */
+    public function checkForWarning(array $object, $warninglists = null)
     {
         if ($warninglists === null) {
             $warninglists = $this->getEnabled();

--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -684,4 +684,20 @@ class Warninglist extends AppModel
         }
         return true;
     }
+
+    public function missingTldLists()
+    {
+        $missingTldLists = array();
+        foreach ($this->__tlds as $tldList) {
+            $temp = $this->find('first', array(
+                'recursive' => -1,
+                'conditions' => array('Warninglist.name' => $tldList),
+                'fields' => array('Warninglist.id')
+            ));
+            if (empty($temp)) {
+                $missingTldLists[] = $tldList;
+            }
+        }
+        return $missingTldLists;
+    }
 }

--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -48,7 +48,7 @@ class Warninglist extends AppModel
     }
 
     /**
-     * Attach warninglist matches to attributes with IDS mark. Results are also saved to
+     * Attach warninglist matches to attributes or proposals with IDS mark.
      *
      * @param array $attributes
      * @return array Warninglist ID => name

--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -549,8 +549,8 @@ class Warninglist extends AppModel
             }
 
         } elseif (filter_var($value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
-            foreach ($listValues as $lv) {
-                if (strpos($lv, ':') !== false) { // IPv6 CIDR must contain dot
+            foreach ($listValues as $lv => $foo) {
+                if (strpos($lv, ':') !== false) { // Filter out IPv4 CIDR, IPv6 CIDR must contain colon
                     if ($this->__ipv6InCidr($value, $lv)) {
                         $match = $lv;
                         break;

--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -532,7 +532,8 @@ class Warninglist extends AppModel
             // This code converts IP address to all possible CIDRs that can contains given IP address
             // and then check if given hash table contains that CIDR.
             $ip = ip2long($value);
-            for ($bits = 0; $bits <= 32; $bits++) {
+            // Start from 1, because doesn't make sense to check 0.0.0.0/0 match
+            for ($bits = 1; $bits <= 32; $bits++) {
                 $mask = -1 << (32 - $bits);
                 $needle = long2ip($ip & $mask) . "/$bits";
                 if (isset($listValues[$needle])) {

--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -688,7 +688,7 @@ class Warninglist extends AppModel
      * @param array|null $warninglists If null, all enabled warninglists will be used
      * @return bool
      */
-    public function filterWarninglistAttributes(array $attribute, $warninglists = null)
+    public function filterWarninglistAttribute(array $attribute, $warninglists = null)
     {
         if ($warninglists === null) {
             $warninglists = $this->getEnabled();

--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -101,7 +101,7 @@ class Warninglist extends AppModel
         foreach ($attributes as $pos => $attribute) {
             if (($attribute['to_ids'] || $this->showForAll) && (isset($enabledTypes[$attribute['type']]) || isset($enabledTypes['ALL']))) {
                 $redisResultToAttributePos[] = $pos;
-                $redis->get('misp:wl-cache:' . md5($attribute['type'] . ':' .  $attribute['value']));
+                $redis->get('misp:wlc:' . md5($attribute['type'] . ':' . $attribute['value'], true));
             }
         }
         $results = $pipe->exec();
@@ -129,7 +129,7 @@ class Warninglist extends AppModel
                     }
                 }
 
-                $attributeHash = md5($attribute['type'] . ':' .  $attribute['value']);
+                $attributeHash = md5($attribute['type'] . ':' .  $attribute['value'], true);
                 $saveToCache[$attributeHash] = empty($store) ? '' : json_encode($store);
 
             } elseif (!empty($result)) { // empty string means no warning list match
@@ -149,7 +149,7 @@ class Warninglist extends AppModel
         if (!empty($saveToCache)) {
             $pipe = $redis->multi(Redis::PIPELINE);
             foreach ($saveToCache as $attributeHash => $json) {
-                $redis->setex('misp:wl-cache:' . $attributeHash, 3600 * 24, $json); // cache for one day
+                $redis->setex('misp:wlc:' . $attributeHash, 3600, $json); // cache for one hour
             }
             $pipe->exec();
         }

--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -496,30 +496,26 @@ class Warninglist extends AppModel
     private function __checkValue($listValues, $value, $type, $listType)
     {
         if ($type === 'malware-sample' || strpos($type, '|') !== false) {
-            $value = explode('|', $value);
+            $value = explode('|', $value, 2);
         } else {
             $value = array($value);
         }
-        $components = array(0, 1);
-        foreach ($components as $component) {
-            if (!isset($value[$component])) {
-                continue;
-            }
+        foreach ($value as $v) {
             if ($listType === 'cidr') {
-                $result = $this->__evalCidrList($listValues, $value[$component]);
+                $result = $this->__evalCidrList($listValues, $v);
             } elseif ($listType === 'string') {
-                $result = $this->__evalString($listValues, $value[$component]);
+                $result = $this->__evalString($listValues, $v);
             } elseif ($listType === 'substring') {
-                $result = $this->__evalSubString($listValues, $value[$component]);
+                $result = $this->__evalSubString($listValues, $v);
             } elseif ($listType === 'hostname') {
-                $result = $this->__evalHostname($listValues, $value[$component]);
+                $result = $this->__evalHostname($listValues, $v);
             } elseif ($listType === 'regex') {
-                $result = $this->__evalRegex($listValues, $value[$component]);
+                $result = $this->__evalRegex($listValues, $v);
             } else {
                 $result = false;
             }
             if ($result !== false) {
-                return [$result, $value[$component]];
+                return [$result, $v];
             }
         }
         return false;

--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -111,7 +111,7 @@ class Warninglist extends AppModel
         foreach ($results as $pos => $result) {
             if ($result === false) { // not in cache
                 $attribute = $attributes[$redisResultToAttributePos[$pos]];
-                $attribute = $this->checkForWarning($attribute);
+                $attribute = $this->checkForWarning($attribute, $enabledWarninglists);
 
                 $store = [];
                 if (isset($attribute['warnings'])) {
@@ -125,7 +125,7 @@ class Warninglist extends AppModel
                         ];
                         $eventWarnings[$warninglistId] = $warninglistIdToName[$warninglistId];
 
-                        $store[(int)$warninglistId] = [$match['value'], $match['match']];
+                        $store[$warninglistId] = [$match['value'], $match['match']];
                     }
                 }
 
@@ -544,7 +544,7 @@ class Warninglist extends AppModel
                 $mask = -1 << (32 - $bits);
                 $needle = long2ip($ip & $mask) . "/$bits";
                 if (isset($listValues[$needle])) {
-                    $match = $listValues[$needle];
+                    $match = $needle;
                     break;
                 }
             }
@@ -596,10 +596,17 @@ class Warninglist extends AppModel
         return true;
     }
 
+    /**
+     * Check for exact match.
+     *
+     * @param array $listValues
+     * @param string $value
+     * @return false
+     */
     private function __evalString($listValues, $value)
     {
         if (isset($listValues[$value])) {
-            return $listValues[$value];
+            return $value;
         }
         return false;
     }
@@ -638,7 +645,7 @@ class Warninglist extends AppModel
                 $rebuilt = $piece . '.' . $rebuilt;
             }
             if (isset($listValues[$rebuilt])) {
-                return $listValues[$rebuilt];
+                return $rebuilt;
             }
         }
         return false;

--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -398,6 +398,7 @@ class Warninglist extends AppModel
     {
         $outputValues = [];
         foreach ($inputValues as $v) {
+            $v = strtolower($v);
             $parts = explode('/', $v, 2);
             if (filter_var($parts[0], FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
                 $maximumNetmask = 32;
@@ -438,7 +439,7 @@ class Warninglist extends AppModel
         if ($warninglist['Warninglist']['type'] === 'hostname') {
             $output = [];
             foreach ($values as $v) {
-                $v = trim($v, '.');
+                $v = strtolower(trim($v, '.'));
                 $output[$v] = true;
             }
             $values = $output;

--- a/app/View/Elements/Events/View/row_attribute.ctp
+++ b/app/View/Elements/Events/View/row_attribute.ctp
@@ -142,14 +142,10 @@
         </span>
         <?php
           if (isset($object['warnings'])) {
-            $temp = '';
-            $components = array(1 => 0, 2 => 1);
-            $valueParts = explode('|', $object['value']);
-            foreach ($components as $component => $valuePart) {
-              if (isset($object['warnings'][$component]) && isset($valueParts[$valuePart])) {
-                foreach ($object['warnings'][$component] as $warning) $temp .= '<span class=\'bold\'>' . h($valueParts[$valuePart]) . '</span>: <span class=\'red\'>' . h($warning) . '</span><br />';
+              $temp = '';
+              foreach ($object['warnings'] as $warning) {
+                  $temp .= '<span class="bold">' . h($warning['match']) . '</span>: <span class="red">' . h($warning['warninglist_name']) . '</span><br>';
               }
-            }
             echo ' <span aria-label="' . __('warning') . '" role="img" tabindex="0" class="fa fa-exclamation-triangle" data-placement="right" data-toggle="popover" data-content="' . h($temp) . '" data-trigger="hover" data-placement="right">&nbsp;</span>';
           }
         ?>

--- a/app/View/Elements/Events/View/row_attribute.ctp
+++ b/app/View/Elements/Events/View/row_attribute.ctp
@@ -144,7 +144,7 @@
           if (isset($object['warnings'])) {
               $temp = '';
               foreach ($object['warnings'] as $warning) {
-                  $temp .= '<span class="bold">' . h($warning['match']) . '</span>: <span class="red">' . h($warning['warninglist_name']) . '</span><br>';
+                  $temp .= '<span class="bold">' . h($warning['match']) . ':</span> <span class="red">' . h($warning['warninglist_name']) . '</span><br>';
               }
             echo ' <span aria-label="' . __('warning') . '" role="img" tabindex="0" class="fa fa-exclamation-triangle" data-placement="right" data-toggle="popover" data-content="' . h($temp) . '" data-trigger="hover" data-placement="right">&nbsp;</span>';
           }

--- a/app/View/Elements/Events/View/row_proposal.ctp
+++ b/app/View/Elements/Events/View/row_proposal.ctp
@@ -103,13 +103,9 @@
       <?php
         if (isset($object['warnings'])) {
           $temp = '';
-          $components = array(1 => 0, 2 => 1);
-          $valueParts = explode('|', $object['value']);
-          foreach ($components as $component => $valuePart) {
-            if (isset($object['warnings'][$component]) && isset($valueParts[$valuePart])) {
-              foreach ($object['warnings'][$component] as $warning) $temp .= '<span class=\'bold\'>' . h($valueParts[$valuePart]) . '</span>: <span class=\'red\'>' . h($warning) . '</span><br />';
+            foreach ($object['warnings'] as $warning) {
+                $temp .= '<span class="bold" style="color: black">' . h($warning['match']) . ':</span> <span class="red">' . h($warning['warninglist_name']) . '</span><br>';
             }
-          }
           echo ' <span aria-label="' . __('warning') . '" role="img" tabindex="0" class="fa fa-exclamation-triangle white" data-placement="right" data-toggle="popover" data-content="' . h($temp) . '" data-trigger="hover">&nbsp;</span>';
         }
       ?>

--- a/app/View/Elements/Feeds/View/row_attribute.ctp
+++ b/app/View/Elements/Feeds/View/row_attribute.ctp
@@ -51,17 +51,13 @@
           ?>
         </span>
         <?php
-          if (isset($object['warnings'])) {
+        if (isset($object['warnings'])) {
             $temp = '';
-            $components = array(1 => 0, 2 => 1);
-            $valueParts = explode('|', $object['value']);
-            foreach ($components as $component => $valuePart) {
-              if (isset($object['warnings'][$component]) && isset($valueParts[$valuePart])) {
-                foreach ($object['warnings'][$component] as $warning) $temp .= '<span class=\'bold\'>' . h($valueParts[$valuePart]) . '</span>: <span class=\'red\'>' . h($warning) . '</span><br />';
-              }
+            foreach ($object['warnings'] as $warning) {
+                $temp .= '<span class="bold">' . h($warning['match']) . ':</span> <span class="red">' . h($warning['warninglist_name']) . '</span><br>';
             }
-            echo ' <span aria-label="' . __('warning') . '" role="img" tabindex="0" class="icon-warning-sign" data-placement="right" data-toggle="popover" data-content="' . h($temp) . '" data-trigger="hover">&nbsp;</span>';
-          }
+            echo ' <span aria-label="' . __('warning') . '" role="img" tabindex="0" class="fa fa-exclamation-triangle" data-placement="right" data-toggle="popover" data-content="' . h($temp) . '" data-trigger="hover" data-placement="right">&nbsp;</span>';
+        }
         ?>
       </div>
     </td>
@@ -89,5 +85,4 @@
         <?php echo $object['to_ids'] ? __('Yes') : __('No'); ?>
       </div>
     </td>
-  </td>
 </tr>

--- a/app/View/Elements/Servers/View/row_attribute.ctp
+++ b/app/View/Elements/Servers/View/row_attribute.ctp
@@ -58,17 +58,13 @@
           ?>
         </span>
         <?php
-          if (isset($object['warnings'])) {
+        if (isset($object['warnings'])) {
             $temp = '';
-            $components = array(1 => 0, 2 => 1);
-            $valueParts = explode('|', $object['value']);
-            foreach ($components as $component => $valuePart) {
-              if (isset($object['warnings'][$component]) && isset($valueParts[$valuePart])) {
-                foreach ($object['warnings'][$component] as $warning) $temp .= '<span class=\'bold\'>' . h($valueParts[$valuePart]) . '</span>: <span class=\'red\'>' . h($warning) . '</span><br />';
-              }
+            foreach ($object['warnings'] as $warning) {
+                $temp .= '<span class="bold">' . h($warning['match']) . ':</span> <span class="red">' . h($warning['warninglist_name']) . '</span><br>';
             }
-            echo ' <span aria-label="' . __('warning') . '" role="img" tabindex="0" class="icon-warning-sign" data-placement="right" data-toggle="popover" data-content="' . h($temp) . '" data-trigger="hover">&nbsp;</span>';
-          }
+            echo ' <span aria-label="' . __('warning') . '" role="img" tabindex="0" class="fa fa-exclamation-triangle" data-placement="right" data-toggle="popover" data-content="' . h($temp) . '" data-trigger="hover" data-placement="right">&nbsp;</span>';
+        }
         ?>
       </div>
     </td>

--- a/app/View/Events/view.ctp
+++ b/app/View/Events/view.ctp
@@ -455,12 +455,12 @@
                     endif;
                 endif;
             ?>
-            <?php if (!empty($event['Event']['warnings'])): ?>
+            <?php if (!empty($event['warnings'])): ?>
                 <div class="warning_container">
                     <h4 class="red"><?= __('Warning: Potential false positives') ?> <a href="#attributeList" onclick="toggleBoolFilter('<?= $baseurl ?>/events/view/<?= h($event['Event']['id']) ?>', 'warning')"><?= __('(show)') ?></a></h4>
                     <?php
                         $links = [];
-                        foreach ($event['Event']['warnings'] as $id => $name) {
+                        foreach ($event['warnings'] as $id => $name) {
                             $links[] = '<a href="' . $baseurl . '/warninglists/view/' . $id . '">' . h($name) . '</a>';
                         }
                         echo implode('<br>', $links);


### PR DESCRIPTION
#### What does it do?

This is major refactoring how warnings works in MISP. 
* Introduces new `MISP.warning_for_all` option to enable warnings for all attributes, not just IDS
* Supports for CIDR (show match if for example warning list contains 10.0.0.0/8 and attribute is CIDR inside that range)
* Warning results are cached in Redis for 1 hour
* Just necessary warning list are fetched from database or Redis
* Optimised list memory structure

All of that means that loading events is much faster, takes less memory and in future it allows us to support more complicated checks (for example check warninglist IP in URL).

I will be glad if you find time for testing.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
