### PR TITLE
fix: [UI] Show properly formatted attribute value after quick edit

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -1950,14 +1950,10 @@ class AttributesController extends AppController
             throw new MethodNotAllowedException(__('This function can only be accessed via AJAX.'));
         }
         $params = array(
-                'conditions' => array('Attribute.id' => $id),
-                'fields' => array('id', 'distribution', 'event_id', $field),
-                'contain' => array(
-                        'Event' => array(
-                                'fields' => array('distribution', 'id', 'org_id'),
-                        )
-                ),
-                'flatten' => 1
+            'conditions' => array('Attribute.id' => $id),
+            'fields' => array('id', 'category', 'type', $field),
+            'contain' => ['Event'],
+            'flatten' => 1,
         );
         $attribute = $this->Attribute->fetchAttributes($this->Auth->user(), $params);
         if (empty($attribute)) {
@@ -1977,6 +1973,8 @@ class AttributesController extends AppController
             }
         }
         $this->set('value', $result);
+        $this->set('object', $attribute);
+        $this->set('field', $field);
         $this->layout = 'ajax';
         $this->render('ajax/attributeViewFieldForm');
     }

--- a/app/View/Attributes/ajax/attributeViewFieldForm.ctp
+++ b/app/View/Attributes/ajax/attributeViewFieldForm.ctp
@@ -1,8 +1,12 @@
 <?php
-if ($value === 'No') {
-    echo '<input type="checkbox" disabled>';
-} else if ($value === 'Yes') {
-    echo '<input type="checkbox" checked disabled>';
+if ($field === 'value') {
+    echo $this->element('Events/View/value_field', ['object' => $object['Attribute']]);
 } else {
-    echo nl2br(h($value)) . '&nbsp;';
+    if ($value === 'No') {
+        echo '<input type="checkbox" disabled>';
+    } else if ($value === 'Yes') {
+        echo '<input type="checkbox" checked disabled>';
+    } else {
+        echo nl2br(h($value)) . '&nbsp;';
+    }
 }


### PR DESCRIPTION
#### What does it do?

For example, when you quick edit `ip-src|port` type value, after edit MISP shows you value like this:

`::1|80`

and after page reload, value is shown like this::

`[::1]:80`

This patch changes this behavior and shows you properly formatted value.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
