### PR TITLE
chg: [optimisation] Load MISP version and commit just once

### DIFF
--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -580,7 +580,6 @@ class Feed extends AppModel
     {
         $version = $this->checkMISPVersion();
         $version = implode('.', $version);
-        $commit = trim(shell_exec('git log --pretty="%H" -n1 HEAD'));
 
         $result = array(
             'header' => array(
@@ -595,6 +594,7 @@ class Feed extends AppModel
             $result['header']['Accept-Encoding'] = 'gzip';
         }
 
+        $commit = $this->checkMIPSCommit();
         if ($commit) {
             $result['header']['commit'] = $commit;
         }


### PR DESCRIPTION
#### What does it do?

Store MISP version and commit in static variables, so it is not necessary to load that for every remote request.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
