### PR TITLE
new: [settings] New security setting to allow id translation for all users (disabled by default)

### DIFF
--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -1272,7 +1272,7 @@ class ServersController extends AppController
     public function idTranslator() {
 
         // The id translation feature is limited to people from the host org
-        if (!$this->_isSiteAdmin() && $this->Auth->user('org_id') != Configure::read('MISP.host_org_id')) {
+        if (!$this->_isSiteAdmin() && $this->Auth->user('org_id') != Configure::read('MISP.host_org_id') && !Configure::read('Security.open_id_translation')) {
             throw new MethodNotAllowedException(__('You don\'t have the required privileges to do that.'));
         }
 

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1336,6 +1336,15 @@ class Server extends AppModel
                                 'type' => 'string',
                                 'null' => true,
                         ),
+                        'open_id_translation' => array (
+                            'level' => 2,
+                            'description' => __('Enabling this setting will allow all users in this instance the capability to use the id translation feature (by default only members of the host org are allowed). Only enable if you trust your local organisations.'),
+                            'value' => false,
+                            'errorMessage' => '',
+                            'test' => 'testBool',
+                            'type' => 'boolean',
+                            'null' => true
+                        ),
                         'allow_self_registration' => array(
                             'level' => 1,
                             'description' => __('Enabling this setting will allow users to have access to the pre-auth registration form. This will create an inbox entry for administrators to review.'),

--- a/app/View/Elements/genericElements/SideMenu/side_menu.ctp
+++ b/app/View/Elements/genericElements/SideMenu/side_menu.ctp
@@ -601,6 +601,10 @@ $divider = $this->element('/genericElements/SideMenu/side_menu_divider');
                             'url' => $baseurl . '/servers/createSync',
                             'text' => __('Create Sync Config')
                         ));
+                        echo $this->element('/genericElements/SideMenu/side_menu_link', array(
+                            'url' => $baseurl . '/servers/index',
+                            'text' => __('List Servers')
+                        ));
                     }
                     if ($menuItem === 'import' && ($me['Role']['perm_site_admin'])) {
                         echo $this->element('/genericElements/SideMenu/side_menu_link', array(
@@ -669,10 +673,6 @@ $divider = $this->element('/genericElements/SideMenu/side_menu_divider');
                             'message' => __('Are you sure you want to delete # %s?', $this->Form->value('Server.id'))
                         ));
                     }
-                    echo $this->element('/genericElements/SideMenu/side_menu_link', array(
-                        'url' => $baseurl . '/servers/index',
-                        'text' => __('List Servers')
-                    ));
                     if ($isSiteAdmin) {
                         echo $this->element('/genericElements/SideMenu/side_menu_link', array(
                             'url' => $baseurl . '/servers/add',

--- a/app/View/Elements/global_menu.ctp
+++ b/app/View/Elements/global_menu.ctp
@@ -257,7 +257,7 @@
             array(
                 'type' => 'root',
                 'text' => __('Sync Actions'),
-                'requirement' =>  ($isAclSync || $isAdmin || $hostOrgUser),
+                'requirement' =>  ($isAclSync || $isSiteAdmin || $hostOrgUser || Configure::read("Security.open_id_translation")),
                 'children' => array(
                     array(
                         'text' => __('Create Sync Config'),
@@ -272,7 +272,7 @@
                     array(
                         'text' => __('List Servers'),
                         'url' => $baseurl . '/servers/index',
-                        'requirement' => ($isAclSync || $isAdmin)
+                        'requirement' => ($isAclSync || $isSiteAdmin)
                     ),
                     array(
                         'text' => __('List Feeds'),
@@ -302,7 +302,7 @@
                     array(
                         'text' => __('Event ID translator'),
                         'url' => '/servers/idTranslator',
-                        'requirement' => ($isSiteAdmin || $hostOrgUser)
+                        'requirement' => ($isSiteAdmin || $hostOrgUser || Configure::read("Security.open_id_translation"))
                     )
                 )
             ),


### PR DESCRIPTION
#### What does it do?

The id translation feature might be useful for other orgs than just the host org. However it exposes a way to query remote servers. A new security setting is introduced to let administrators chose to open it to all users if they have enough trust in the local orgs (for instance on an internal instance).

Also fixing a small display bug for the "list servers" menu which was not following the ACL config.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
