### PR TITLE
chg: [correlations] Refactor feed cached correlations

### DIFF
--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -1197,7 +1197,7 @@ class Feed extends AppModel
     private function __cacheFeed($feed, $redis, $jobId = false)
     {
         $HttpSocket = $this->isFeedLocal($feed) ? null : $this->__setupHttpSocket($feed);
-        if ($feed['Feed']['source_format'] == 'misp') {
+        if ($feed['Feed']['source_format'] === 'misp') {
             return $this->__cacheMISPFeed($feed, $redis, $HttpSocket, $jobId);
         } else {
             return $this->__cacheFreetextFeed($feed, $redis, $HttpSocket, $jobId);
@@ -1225,9 +1225,8 @@ class Feed extends AppModel
             return false;
         }
 
-        $redis->del('misp:feed_cache:' . $feedId);
-
         $pipe = $redis->multi(Redis::PIPELINE);
+        $pipe->del('misp:feed_cache:' . $feedId);
         foreach ($values as $k => $value) {
             $md5Value = md5($value['value']);
             $redis->sAdd('misp:feed_cache:' . $feedId, $md5Value);
@@ -1238,7 +1237,7 @@ class Feed extends AppModel
                 $pipe = $redis->multi(Redis::PIPELINE);
             }
         }
-        $redis->set('misp:feed_cache_timestamp:' . $feedId, time());
+        $pipe->set('misp:feed_cache_timestamp:' . $feedId, time());
         $pipe->exec();
         return true;
     }
@@ -1308,9 +1307,8 @@ class Feed extends AppModel
             return false;
         }
 
-        $redis->del('misp:feed_cache:' . $feedId);
-
         $pipe = $redis->multi(Redis::PIPELINE);
+        $pipe->del('misp:feed_cache:' . $feedId);
         foreach ($cache as $v) {
             list($hash, $eventUuid) = $v;
             $redis->sAdd('misp:feed_cache:' . $feedId, $hash);
@@ -1327,7 +1325,7 @@ class Feed extends AppModel
         $result = true;
         if (!$this->__cacheMISPFeedCache($feed, $redis, $HttpSocket, $jobId)) {
             $result = $this->__cacheMISPFeedTraditional($feed, $redis, $HttpSocket, $jobId);
-        };
+        }
         if ($result) {
             $redis->set('misp:feed_cache_timestamp:' . $feed['Feed']['id'], time());
         }

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -1226,7 +1226,7 @@ class Feed extends AppModel
         }
 
         $pipe = $redis->multi(Redis::PIPELINE);
-        $pipe->del('misp:feed_cache:' . $feedId);
+        $redis->del('misp:feed_cache:' . $feedId);
         foreach ($values as $k => $value) {
             $md5Value = md5($value['value']);
             $redis->sAdd('misp:feed_cache:' . $feedId, $md5Value);
@@ -1308,7 +1308,7 @@ class Feed extends AppModel
         }
 
         $pipe = $redis->multi(Redis::PIPELINE);
-        $pipe->del('misp:feed_cache:' . $feedId);
+        $redis->del('misp:feed_cache:' . $feedId);
         foreach ($cache as $v) {
             list($hash, $eventUuid) = $v;
             $redis->sAdd('misp:feed_cache:' . $feedId, $hash);
@@ -1835,8 +1835,10 @@ class Feed extends AppModel
     private function jobProgress($jobId = null, $message = null, $progress = null)
     {
         if ($jobId) {
-            $job = ClassRegistry::init('Job');
-            $job->saveProgress($jobId, $message, $progress);
+            if (!isset($this->Job)) {
+                $this->Job = ClassRegistry::init('Job');
+            }
+            $this->Job->saveProgress($jobId, $message, $progress);
         }
     }
 

--- a/app/View/Elements/Events/View/row_attribute.ctp
+++ b/app/View/Elements/Events/View/row_attribute.ctp
@@ -236,7 +236,7 @@
                         $popover .= '<span class=\'bold black\'>' . Inflector::humanize(h($k)) . '</span>: <span class="blue">' . $v . '</span><br />';
                     }
                     $liContents = '';
-                    if ($isSiteAdmin) {
+                    if ($isSiteAdmin || $hostOrgUser) {
                         if ($feed['source_format'] == 'misp') {
                             $liContents .= sprintf(
                                 '<form action="%s/feeds/previewIndex/%s" method="post" style="margin:0px;line-height:auto;">%s%s</form>',

--- a/app/View/Events/view.ctp
+++ b/app/View/Events/view.ctp
@@ -380,15 +380,20 @@
             <div class="correlation-container">
                 <?php
                         foreach ($event['Feed'] as $relatedFeed):
-                            $relatedData = array('Name' => $relatedFeed['name'], 'URL' => $relatedFeed['url'], 'Provider' => $relatedFeed['provider'], 'Source Format' => $relatedFeed['source_format'] == 'misp' ? 'MISP' : $relatedFeed['source_format']);
+                            $relatedData = array(
+                                'Name' => $relatedFeed['name'],
+                                'URL' => $relatedFeed['url'],
+                                'Provider' => $relatedFeed['provider'],
+                                'Source Format' => $relatedFeed['source_format'] === 'misp' ? 'MISP' : $relatedFeed['source_format'],
+                            );
                             $popover = '';
                             foreach ($relatedData as $k => $v) {
-                                $popover .= '<span class=\'bold\'>' . h($k) . '</span>: <span class="blue">' . h($v) . '</span><br />';
+                                $popover .= '<span class="bold">' . h($k) . '</span>: <span class="blue">' . h($v) . '</span><br>';
                             }
                 ?>
                                 <span style="white-space: nowrap;">
                                     <?php
-                                        if ($relatedFeed ['source_format'] == 'misp'):
+                                        if ($relatedFeed ['source_format'] === 'misp'):
                                     ?>
                                             <form action="<?php echo $baseurl; ?>/feeds/previewIndex/<?php echo h($relatedFeed['id']); ?>" method="post" style="margin:0px;">
                                                 <input type="hidden" name="data[Feed][eventid]" value="<?php echo h(json_encode($relatedFeed['event_uuids'], true)); ?>">


### PR DESCRIPTION
#### What does it do?

Refactoring how attributes are correlated with feed memory cache:
* Support also correlating second value of composite types (useful for example `filename|md5` type)
* Non-correlating types or attributes with disabled correlations are not checked, so loading event page with a lot of these attributes should be faster
* Support for showing event UUID also for MISP feeds, not just MISP servers
* Other small optimisations that should lead to load event page faster
  * Checking feeds correlations for event with 171 attributes took 0.26 second, after this patch just 0.032 second

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
