### PR TITLE
Fix date filter on to / from #6239

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -2877,9 +2877,17 @@ class Event extends AppModel
     public function set_filter_timestamp(&$params, $conditions, $options)
     {
         if ($options['filter'] == 'from') {
-            $conditions['AND']['Event.date >='] = $params['from'];
+            if (is_numeric($params['from'])) {
+                $conditions['AND']['Event.date >='] = date('Y-m-d', $params['from']);
+            } else {
+                $conditions['AND']['Event.date >='] = $params['from'];
+            }
         } elseif ($options['filter'] == 'to') {
-            $conditions['AND']['Event.date <='] = $params['to'];
+            if (is_numeric($params['to'])) {
+                $conditions['AND']['Event.date <='] = date('Y-m-d', $params['to']);
+            } else {
+                $conditions['AND']['Event.date <='] = $params['to'];
+            }
         } else {
             if (empty($options['scope'])) {
                 $scope = 'Attribute';


### PR DESCRIPTION
Fixes the to / from search filter issue described in #6239.  Event.date needs to be compared to a `Y-m-d` format.  PyMISP sends the date filter `date_from` and `date_to` as a timestamp, which was not converted in MISP.  This allows the MISP API to accept a timestamp for those filter dates.

#### Questions

- [ ] Does it require a DB change?   **No, but as a filter, an index on Event.date should be considered** 
- [X] Are you using it in production?  **Yes**
- [ ] Does it require a change in the API (PyMISP for example)? **No**