### PR TITLE
Document "cake Server pullAll"

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -153,6 +153,7 @@ class Server extends AppModel
             ),
             'console_automation_tasks' => array(
                 'data' => array(
+                    'PullAll' => 'MISP/app/Console/cake Server pullAll [user_id] [full|update]',
                     'Pull' => 'MISP/app/Console/cake Server pull [user_id] [server_id] [full|update]',
                     'Push' => 'MISP/app/Console/cake Server push [user_id] [server_id]',
                     'Cache feeds for quick lookups' => 'MISP/app/Console/cake Server cacheFeed [user_id] [feed_id|all|csv|text|misp]',


### PR DESCRIPTION
The very useful "cake Server pullAll" shell command from fdb7f1d78beb44b35503c6fbe6c802c7780e09cb was undocumented.