### PR TITLE
chg: [complextype] Speedup hash parsing from CSVs and freetexts

### DIFF
--- a/app/Lib/Tools/ComplexTypeTool.php
+++ b/app/Lib/Tools/ComplexTypeTool.php
@@ -248,12 +248,23 @@ class ComplexTypeTool
         128 => array('single' => array('sha512'), 'composite' => array('filename|sha512'))
     );
 
-    // algorithms to run through in order
-    private $__checks = array('Hashes', 'Email', 'IP', 'DomainOrFilename', 'SimpleRegex', 'AS', 'BTC');
+    // algorithms to run through in order, without Hashes that are checked separately
+    private $__checks = array('Email', 'IP', 'DomainOrFilename', 'SimpleRegex', 'AS', 'BTC');
 
+    /**
+     * @param string $raw_input Trimmed value
+     * @return array|false
+     */
     private function __resolveType($raw_input)
     {
-        $input = array('raw' => trim($raw_input));
+        $input = array('raw' => $raw_input);
+
+        // Check hashes before refang and port extracting, it is not necessary for hashes. This speedups parsing
+        // freetexts or CSVs with a lot of hashes.
+        $hashes = $this->__checkForHashes($input);
+        if ($hashes) {
+            return $hashes;
+        }
 
         $input = $this->__refangInput($input);
         $input = $this->__extractPort($input);
@@ -320,7 +331,7 @@ class ComplexTypeTool
             if ($this->__checkForBTC($input)) {
                 $types[] = 'btc';
             }
-            return array('types' => $types, 'to_ids' => true, 'default_type' => $hash['single'][0], 'value' => $input['raw']);
+            return array('types' => $types, 'to_ids' => true, 'default_type' => $types[0], 'value' => $input['raw']);
         }
         // ssdeep has a different pattern
         if ($this->__resolveSsdeep($input['raw'])) {

--- a/app/Lib/Tools/ComplexTypeTool.php
+++ b/app/Lib/Tools/ComplexTypeTool.php
@@ -507,7 +507,7 @@ class ComplexTypeTool
     private function __resolveHash($value)
     {
         $strlen = strlen($value);
-        if (isset($this->__hexHashTypes[$strlen]) && preg_match("#[0-9a-f]{" . $strlen . "}$#i", $value)) {
+        if (isset($this->__hexHashTypes[$strlen]) && ctype_xdigit($value)) {
             return $this->__hexHashTypes[$strlen];
         }
         return false;

--- a/app/Test/ComplexTypeToolTest.php
+++ b/app/Test/ComplexTypeToolTest.php
@@ -438,6 +438,15 @@ EOT;
         $this->assertEquals('md5', $results[0]['default_type']);
     }
 
+    public function testCheckFreeTextMd5Uppercase(): void
+    {
+        $complexTypeTool = new ComplexTypeTool();
+        $results = $complexTypeTool->checkFreeText('9E107D9D372BB6826BD81D3542A419D6');
+        $this->assertCount(1, $results);
+        $this->assertEquals('9E107D9D372BB6826BD81D3542A419D6', $results[0]['value']);
+        $this->assertEquals('md5', $results[0]['default_type']);
+    }
+
     public function testCheckFreeTextSha1(): void
     {
         $complexTypeTool = new ComplexTypeTool();


### PR DESCRIPTION
#### What does it do?

Check hashes before refang and port extracting, it is not necessary for hashes. This speedups parsing freetexts or CSVs with a lot of hashes.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
