### PR TITLE
new: [build] Validate also feed metadata rules and settings JSON contents

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -162,9 +162,7 @@ script:
     - pushd PyMISP/examples/events/
     - poetry run python ./create_massive_dummy_events.py -l 5 -a 30
     - popd
-    - pushd app/files/feed-metadata
-    - jsonschema -i defaults.json schema.json
-    - popd
+    - python3 tools/misp-feed/validate.py
 
 after_failure:
     - ls -aRl `pwd`

--- a/tools/misp-feed/validate.py
+++ b/tools/misp-feed/validate.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import json
+import jsonschema
+
+script_path = os.path.dirname(os.path.realpath(__file__))
+default_feed_path = script_path + '/../../app/files/feed-metadata/defaults.json'
+schema_path = script_path + '/../../app/files/feed-metadata/schema.json'
+
+with open(default_feed_path) as feed_file:
+    feedlist = json.load(feed_file)
+
+with open(schema_path) as schema_file:
+    schema = json.load(schema_file)
+
+jsonschema.validate(instance=feedlist, schema=schema)
+
+valid = True
+
+for feed in feedlist:
+    for json_field in ("rules", "settings"):
+        if len(feed['Feed'][json_field]) == 0:
+            continue
+        try:
+            json.loads(feed['Feed'][json_field])
+        except ValueError:
+            valid = False
+            print("Invalid JSON for field `{}` for feed `{}`".format(json_field, feed['Feed']['name']))
+
+if not valid:
+    sys.exit(1)


### PR DESCRIPTION
#### What does it do?

Validate more than just schema during build.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
