### PR TITLE
chg: [cookie] Set session cookie SameSite to Lax to avoid browser warnings

### DIFF
--- a/app/Config/core.default.php
+++ b/app/Config/core.default.php
@@ -181,8 +181,15 @@ Configure::write('Session', array(
 	'cookie_timeout' => 10080 ,  // Cookie timeout, default is 1 week
 	'defaults'       => 'php',
 	'autoRegenerate' => false,
-	'checkAgent' => false
+	'checkAgent' => false,
 ));
+
+// Set session cookie SameSite parameter to Lax if this param is supported and no default value is set
+if (PHP_VERSION_ID >= 70300 && empty(ini_get('session.cookie_samesite'))) {
+    Configure::write('Session.ini', ['
+        session.cookie_samesite' => 'Lax'
+    ]);
+}
 
 /**
  * The level of CakePHP security.


### PR DESCRIPTION
#### What does it do?

This change will affect just new installations.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
