### PR TITLE
Event report optimisations

### DIFF
--- a/app/Controller/EventReportsController.php
+++ b/app/Controller/EventReportsController.php
@@ -84,8 +84,6 @@ class EventReportsController extends AppController
     public function viewSummary($reportId)
     {
         $report = $this->EventReport->simpleFetchById($this->Auth->user(), $reportId);
-        $proxyMISPElements = $this->EventReport->getProxyMISPElements($this->Auth->user(), $report['EventReport']['event_id']);
-        $this->set('proxyMISPElements', $proxyMISPElements);
         $this->set('id', $reportId);
         $this->set('report', $report);
         $this->__injectDistributionLevelToViewContext();

--- a/app/Model/EventReport.php
+++ b/app/Model/EventReport.php
@@ -1,6 +1,9 @@
 <?php
 App::uses('AppModel', 'Model');
 
+/**
+ * @property Event $Event
+ */
 class EventReport extends AppModel
 {
     public $actsAs = array(
@@ -416,7 +419,7 @@ class EventReport extends AppModel
      */
     public function getProxyMISPElements(array $user, $eventid)
     {
-        $event = $this->Event->fetchEvent($user, ['eventid' => $eventid]);
+        $event = $this->Event->fetchEvent($user, ['eventid' => $eventid, 'noSightings' => true]);
         if (empty($event)) {
             throw new NotFoundException(__('Invalid Event'));
         }
@@ -426,7 +429,7 @@ class EventReport extends AppModel
         ]]);
         $completeEvent = $event;
         if (!empty($parentEventId)) {
-            $parentEvent = $this->Event->fetchEvent($user, ['eventid' => $parentEventId, 'extended' => true]);
+            $parentEvent = $this->Event->fetchEvent($user, ['eventid' => $parentEventId, 'extended' => true, 'noSightings' => true]);
             if (!empty($parentEvent)) {
                 $parentEvent = $parentEvent[0];
                 $completeEvent = $parentEvent;

--- a/app/Model/EventReport.php
+++ b/app/Model/EventReport.php
@@ -448,12 +448,10 @@ class EventReport extends AppModel
         $templateConditions = [];
         foreach ($completeEvent['Object'] as $k => $object) {
             $objects[$object['uuid']] = $object;
-            $objectAttributes = [];
-            foreach ($object['Attribute'] as $i => $objectAttribute) {
-                $objectAttributes[$objectAttribute['uuid']] = $object['Attribute'][$i];
-                $objectAttributes[$objectAttribute['uuid']]['object_uuid'] = $object['uuid'];
+            foreach ($object['Attribute'] as $objectAttribute) {
+                $objectAttribute['object_uuid'] = $object['uuid'];
+                $attributes[$objectAttribute['uuid']] = $objectAttribute;
             }
-            $attributes = array_merge($attributes, $objectAttributes);
             $objectAttributeTags = Hash::combine($this->AttributeTag->getAttributesTags($object['Attribute'], true), '{n}.name', '{n}');
             $allTagNames = array_merge($allTagNames, $objectAttributeTags);
 

--- a/app/Model/EventReport.php
+++ b/app/Model/EventReport.php
@@ -23,8 +23,8 @@ class EventReport extends AppModel
         ),
         'uuid' => array(
             'uuid' => array(
-                'rule' => array('custom', '/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/'),
-                'message' => 'Please provide a valid UUID'
+                'rule' => 'uuid',
+                'message' => 'Please provide a valid RFC 4122 UUID'
             ),
             'unique' => array(
                 'rule' => 'isUnique',
@@ -66,6 +66,8 @@ class EventReport extends AppModel
         // generate UUID if it doesn't exist
         if (empty($this->data['EventReport']['uuid'])) {
             $this->data['EventReport']['uuid'] = CakeText::uuid();
+        } else {
+            $this->data['EventReport']['uuid'] = strtolower($this->data['EventReport']['uuid']);
         }
         // generate timestamp if it doesn't exist
         if (empty($this->data['EventReport']['timestamp'])) {
@@ -79,8 +81,8 @@ class EventReport extends AppModel
         // These fields all have sane defaults either based on another field, or due to server settings
         if (!isset($this->data['EventReport']['distribution'])) {
             $this->data['EventReport']['distribution'] = Configure::read('MISP.default_attribute_distribution');
-            if ($report['EventReport']['distribution'] == 'event') {
-                $report['EventReport']['distribution'] = 5;
+            if ($this->data['EventReport']['distribution'] == 'event') {
+                $this->data['EventReport']['distribution'] = 5;
             }
         }
         return true;

--- a/app/Model/EventReport.php
+++ b/app/Model/EventReport.php
@@ -413,9 +413,10 @@ class EventReport extends AppModel
     /**
      * getProxyMISPElements Extract MISP Elements from an event and make them accessible by their UUID
      *
-     * @param  array $user
-     * @param  int|string $eventid
+     * @param array $user
+     * @param int|string $eventid
      * @return array
+     * @throws Exception
      */
     public function getProxyMISPElements(array $user, $eventid)
     {
@@ -469,7 +470,7 @@ class EventReport extends AppModel
 
             $uniqueCondition = "{$object['template_uuid']}.{$object['template_version']}";
             if (!isset($templateConditions[$uniqueCondition])) {
-                $templateConditions[$uniqueCondition]['OR'] = [
+                $templateConditions[$uniqueCondition]['AND'] = [
                     'ObjectTemplate.uuid' => $object['template_uuid'],
                     'ObjectTemplate.version' => $object['template_version']
                 ];
@@ -478,7 +479,7 @@ class EventReport extends AppModel
         if (!empty($templateConditions)) {
             $this->ObjectTemplate = ClassRegistry::init('ObjectTemplate');
             $templates = $this->ObjectTemplate->find('all', array(
-                'conditions' => array_values($templateConditions),
+                'conditions' => ['OR' => array_values($templateConditions)],
                 'recursive' => -1,
                 'contain' => array(
                     'ObjectTemplateElement' => [

--- a/app/Model/EventReport.php
+++ b/app/Model/EventReport.php
@@ -424,12 +424,10 @@ class EventReport extends AppModel
             throw new NotFoundException(__('Invalid Event'));
         }
         $event = $event[0];
-        $parentEventId = $this->Event->fetchSimpleEventIds($user, ['conditions' => [
-            'uuid' => $event['Event']['extends_uuid']
-        ]]);
+
         $completeEvent = $event;
-        if (!empty($parentEventId)) {
-            $parentEvent = $this->Event->fetchEvent($user, ['eventid' => $parentEventId, 'extended' => true, 'noSightings' => true]);
+        if (!empty($event['Event']['extends_uuid'])) {
+            $parentEvent = $this->Event->fetchEvent($user, ['event_uuid' => $event['Event']['extends_uuid'], 'extended' => true, 'noSightings' => true]);
             if (!empty($parentEvent)) {
                 $parentEvent = $parentEvent[0];
                 $completeEvent = $parentEvent;

--- a/app/Model/EventReport.php
+++ b/app/Model/EventReport.php
@@ -274,27 +274,18 @@ class EventReport extends AppModel
      */
     public function simpleFetchById(array $user, $reportId, $throwErrors=true, $full=false)
     {
-        if (Validation::uuid($reportId)) {
-            $temp = $this->find('first', array(
-                'recursive' => -1,
-                'fields' => array("EventReport.id", "EventReport.uuid"),
-                'conditions' => array("EventReport.uuid" => $reportId)
-            ));
-            if (empty($temp)) {
-                if ($throwErrors) {
-                    throw new NotFoundException(__('Invalid report'));
-                }
-                return array();
-            }
-            $reportId = $temp['EventReport']['id'];
-        } elseif (!is_numeric($reportId)) {
+        if (is_numeric($reportId)) {
+            $options = array('conditions' => array("EventReport.id" => $reportId));
+        } elseif (Validation::uuid($reportId)) {
+            $options = array('conditions' => array("EventReport.uuid" => $reportId));
+        } else {
             if ($throwErrors) {
                 throw new NotFoundException(__('Invalid report'));
             }
             return array();
         }
-        $options = array('conditions' => array("EventReport.id" => $reportId));
-        $report = $this->fetchReports($user, $options, $full=$full);
+
+        $report = $this->fetchReports($user, $options, $full);
         if (!empty($report)) {
             return $report[0];
         }
@@ -310,7 +301,7 @@ class EventReport extends AppModel
      * @param  array $user
      * @param  array $options
      * @param  bool  $full
-     * @return void
+     * @return array
      */
     public function fetchReports(array $user, array $options = array(), $full=false)
     {

--- a/app/Model/EventReport.php
+++ b/app/Model/EventReport.php
@@ -419,7 +419,7 @@ class EventReport extends AppModel
      */
     public function getProxyMISPElements(array $user, $eventid)
     {
-        $event = $this->Event->fetchEvent($user, ['eventid' => $eventid, 'noSightings' => true]);
+        $event = $this->Event->fetchEvent($user, ['eventid' => $eventid, 'noSightings' => true, 'sgReferenceOnly' => true]);
         if (empty($event)) {
             throw new NotFoundException(__('Invalid Event'));
         }
@@ -427,7 +427,12 @@ class EventReport extends AppModel
 
         $completeEvent = $event;
         if (!empty($event['Event']['extends_uuid'])) {
-            $parentEvent = $this->Event->fetchEvent($user, ['event_uuid' => $event['Event']['extends_uuid'], 'extended' => true, 'noSightings' => true]);
+            $parentEvent = $this->Event->fetchEvent($user, [
+                'event_uuid' => $event['Event']['extends_uuid'],
+                'extended' => true,
+                'noSightings' => true,
+                'sgReferenceOnly' => true,
+            ]);
             if (!empty($parentEvent)) {
                 $parentEvent = $parentEvent[0];
                 $completeEvent = $parentEvent;

--- a/app/Model/EventReport.php
+++ b/app/Model/EventReport.php
@@ -416,7 +416,6 @@ class EventReport extends AppModel
         $options = [
             'noSightings' => true,
             'sgReferenceOnly' => true,
-            'excludeGalaxy' => true,
             'noEventReports' => true,
             'noShadowAttributes' => true,
         ];
@@ -438,19 +437,18 @@ class EventReport extends AppModel
 
         $attributes = [];
         foreach ($event['Attribute'] as $attribute) {
-            unset($attribute['Galaxy']);
             unset($attribute['ShadowAttribute']);
-            $attributes[$attribute['uuid']] = $attribute;
             foreach ($attribute['AttributeTag'] as $at) {
                 $allTagNames[$at['Tag']['name']] = $at['Tag'];
             }
+            $this->Event->Attribute->removeGalaxyClusterTags($attribute);
+            $attributes[$attribute['uuid']] = $attribute;
         }
 
         $objects = [];
         $templateConditions = [];
         foreach ($event['Object'] as $k => $object) {
             foreach ($object['Attribute'] as &$objectAttribute) {
-                unset($objectAttribute['Galaxy']);
                 unset($objectAttribute['ShadowAttribute']);
                 $objectAttribute['object_uuid'] = $object['uuid'];
                 $attributes[$objectAttribute['uuid']] = $objectAttribute;
@@ -458,6 +456,7 @@ class EventReport extends AppModel
                 foreach ($objectAttribute['AttributeTag'] as $at) {
                     $allTagNames[$at['Tag']['name']] = $at['Tag'];
                 }
+                $this->Event->Attribute->removeGalaxyClusterTags($objectAttribute);
             }
             $objects[$object['uuid']] = $object;
 

--- a/app/Model/EventReport.php
+++ b/app/Model/EventReport.php
@@ -419,7 +419,12 @@ class EventReport extends AppModel
      */
     public function getProxyMISPElements(array $user, $eventid)
     {
-        $event = $this->Event->fetchEvent($user, ['eventid' => $eventid, 'noSightings' => true, 'sgReferenceOnly' => true]);
+        $event = $this->Event->fetchEvent($user, [
+            'eventid' => $eventid,
+            'noSightings' => true,
+            'sgReferenceOnly' => true,
+            'excludeGalaxy' => true,
+        ]);
         if (empty($event)) {
             throw new NotFoundException(__('Invalid Event'));
         }
@@ -432,6 +437,7 @@ class EventReport extends AppModel
                 'extended' => true,
                 'noSightings' => true,
                 'sgReferenceOnly' => true,
+                'excludeGalaxy' => true,
             ]);
             if (!empty($parentEvent)) {
                 $parentEvent = $parentEvent[0];

--- a/app/View/EventReports/view_summary.ctp
+++ b/app/View/EventReports/view_summary.ctp
@@ -15,7 +15,6 @@
                         'variables' => [
                             'reportid' => $report['EventReport']['id'],
                             'eventid' => $report['EventReport']['event_id'],
-                            'proxyMISPElements' => $proxyMISPElements,
                         ]
                     ],
                     'additionalMarkdownHelpModalElements' => [[


### PR DESCRIPTION
#### What does it do?

Just optimisation for `getProxyMISPElements` method. For my test event with just few attributes, loading is twice faster than before. For big events, it must be much more with a lot of tags or sightings it must be much more. What do you think @mokaddem? It this OK for you?

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
