### PR TITLE
Remove object checkbox

### DIFF
--- a/app/View/Elements/Events/View/row_object.ctp
+++ b/app/View/Elements/Events/View/row_object.ctp
@@ -18,15 +18,7 @@
   <?php
     if ($mayModify || $extended):
   ?>
-    <td style="width:10px;" data-position="<?php echo h($object['objectType']) . '_' . h($object['id']); ?>">
-      <?php
-        if ($mayModify):
-      ?>
-        <input id="select_object_<?php echo $object['id']; ?>" class="select_object row_checkbox" type="checkbox" data-id="<?php echo $object['id'];?>" />
-      <?php
-        endif;
-      ?>
-    </td>
+    <td style="width:10px;"></td>
   <?php
     endif;
   ?>

--- a/app/View/Elements/eventattribute.ctp
+++ b/app/View/Elements/eventattribute.ctp
@@ -246,7 +246,7 @@ attributes or the appropriate distribution level. If you think there is a mistak
         ?>
         setContextFields();
         popoverStartup();
-        $('.select_attribute').removeAttr('checked').click(function(e) {
+        $('.select_attribute').prop('checked', false).click(function(e) {
             if ($(this).is(':checked')) {
                 if (e.shiftKey) {
                     selectAllInbetween(lastSelected, this.id);
@@ -255,7 +255,7 @@ attributes or the appropriate distribution level. If you think there is a mistak
             }
             attributeListAnyAttributeCheckBoxesChecked();
         });
-        $('.select_proposal').removeAttr('checked').click(function(e){
+        $('.select_proposal').prop('checked', false).click(function(e){
             if ($(this).is(':checked')) {
                 if (e.shiftKey) {
                     selectAllInbetween(lastSelected, this.id);


### PR DESCRIPTION
#### What does it do?

Object checkboxes just do nothing, just makes confusion. So this patch removes them.

<img width="486" alt="Snímek obrazovky 2020-10-10 v 12 46 50" src="https://user-images.githubusercontent.com/163343/95653187-07dc2580-0af7-11eb-923b-06741bf60040.png">

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
