### PR TITLE
Add warninglist wildlist feature

### DIFF
--- a/app/Controller/WarninglistsController.php
+++ b/app/Controller/WarninglistsController.php
@@ -282,10 +282,11 @@ class WarninglistsController extends AppController
 
             $hits = array();
             $warninglists = $this->Warninglist->getEnabled();
+            $wildlist = $this->Warninglist->getWildList($warninglists);
             foreach ($data as $dataPoint) {
                 foreach ($warninglists as $warninglist) {
                     $values = $this->Warninglist->getFilteredEntries($warninglist);
-                    $result = $this->Warninglist->quickCheckValue($values, $dataPoint, $warninglist['Warninglist']['type']);
+                    $result = $this->Warninglist->quickCheckValue($values, $dataPoint, $warninglist['Warninglist']['type'], $wildlist);
                     if ($result !== false) {
                         $hits[$dataPoint][] = array('id' => $warninglist['Warninglist']['id'], 'name' => $warninglist['Warninglist']['name']);
                     }

--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -509,7 +509,11 @@ class Warninglist extends AppModel
 		foreach ($warninglists as $warninglist) {
 			if ($warninglist['Warninglist']['type'] == 'wildmask') {
 				$mvalues = $this->getFilteredEntries($warninglist);
-				$wildlist = array_merge($wildlist, $mvalues);
+				foreach ($mvalues as $mvalue) {
+					if (substr($mvalue, 0,2) === "!.") {
+						array_push($wildlist, substr($mvalue, 2));
+					}
+				}
 			}
 		}
 		return $wildlist;

--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -477,11 +477,11 @@ class Warninglist extends AppModel
         if ($warninglists === null) {
             $warninglists = $this->getEnabled();
         }
-
+        $wildlist = $this->getWildList($warninglists = $this->getEnabled());
         if ($object['to_ids'] || $this->showForAll) {
             foreach ($warninglists as $list) {
                 if (in_array('ALL', $list['types']) || in_array($object['type'], $list['types'])) {
-                    $result = $this->__checkValue($this->getFilteredEntries($list), $object['value'], $object['type'], $list['Warninglist']['type']);
+                    $result = $this->__checkValue($this->getFilteredEntries($list), $object['value'], $object['type'], $list['Warninglist']['type'], $wildlist);
                     if ($result !== false) {
                         $object['warnings'][] = array(
                             'match' => $result[0],
@@ -495,6 +495,25 @@ class Warninglist extends AppModel
         }
         return $object;
     }
+    
+    /**
+     * @param array $listValues
+     * @return array
+     */
+    public function getWildList($warninglists)
+    {
+		if ($warninglists === null) {
+            $warninglists = $this->getEnabled();
+        }
+        $wildlist = array();
+		foreach ($warninglists as $warninglist) {
+			if ($warninglist['Warninglist']['type'] == 'wildmask') {
+				$mvalues = $this->getFilteredEntries($warninglist);
+				$wildlist = array_merge($wildlist, $mvalues);
+			}
+		}
+		return $wildlist;
+	}
 
     /**
      * @param array $listValues
@@ -503,7 +522,7 @@ class Warninglist extends AppModel
      * @param string $listType
      * @return array|false [Matched value, attribute value that matched]
      */
-    private function __checkValue($listValues, $value, $type, $listType)
+    private function __checkValue($listValues, $value, $type, $listType, $wildlist = array())
     {
         if ($type === 'malware-sample' || strpos($type, '|') !== false) {
             $value = explode('|', $value, 2);
@@ -518,7 +537,7 @@ class Warninglist extends AppModel
             } elseif ($listType === 'substring') {
                 $result = $this->__evalSubString($listValues, $v);
             } elseif ($listType === 'hostname') {
-                $result = $this->__evalHostname($listValues, $v);
+                $result = $this->__evalHostname($listValues, $v, $wildlist);
             } elseif ($listType === 'regex') {
                 $result = $this->__evalRegex($listValues, $v);
             } else {
@@ -531,9 +550,9 @@ class Warninglist extends AppModel
         return false;
     }
 
-    public function quickCheckValue($listValues, $value, $type)
+    public function quickCheckValue($listValues, $value, $type, $wildlist)
     {
-        return $this->__checkValue($listValues, $value, '', $type) !== false;
+        return $this->__checkValue($listValues, $value, '', $type, $wildlist) !== false;
     }
 
     private function __evalCidrList($listValues, $value)
@@ -630,7 +649,7 @@ class Warninglist extends AppModel
         return false;
     }
 
-    private function __evalHostname($listValues, $value)
+    private function __evalHostname($listValues, $value, $wildValues = array())
     {
         // php's parse_url is dumb, so let's use some hacky workarounds
         if (strpos($value, '//') === false) {
@@ -647,6 +666,8 @@ class Warninglist extends AppModel
         $hostname = rtrim($hostname, '.');
         $hostname = explode('.', $hostname);
         $rebuilt = '';
+        $lenght = count($hostname);
+        $i = 1;
         foreach (array_reverse($hostname) as $piece) {
             if (empty($rebuilt)) {
                 $rebuilt = $piece;
@@ -654,8 +675,17 @@ class Warninglist extends AppModel
                 $rebuilt = $piece . '.' . $rebuilt;
             }
             if (isset($listValues[$rebuilt])) {
-                return $rebuilt;
+                if ($i !== $lenght) {
+                    if (in_array($rebuilt, $wildValues)) {
+                        return false;
+                    } else { 
+                        return $rebuilt;
+                    }
+                } else {
+                    return $rebuilt;
+                }
             }
+            $i++;
         }
         return false;
     }
@@ -706,10 +736,10 @@ class Warninglist extends AppModel
         if ($warninglists === null) {
             $warninglists = $this->getEnabled();
         }
-
+        $wildlist = $this->getWildList($warninglists = $this->getEnabled());
         foreach ($warninglists as $warninglist) {
             if (in_array('ALL', $warninglist['types']) || in_array($attribute['type'], $warninglist['types'])) {
-                $result = $this->__checkValue($this->getFilteredEntries($warninglist), $attribute['value'], $attribute['type'], $warninglist['Warninglist']['type']);
+                $result = $this->__checkValue($this->getFilteredEntries($warninglist), $attribute['value'], $attribute['type'], $warninglist['Warninglist']['type'], $wildlist);
                 if ($result !== false) {
                     return false;
                 }


### PR DESCRIPTION
#### What does it do?

Adding new type "wildmask" in warninglist. This list will **exclude** all subdomains what is from warninglist, as at this moment all domains is working as wildmask.
For example. by default IOC **test.example.com** will be marked as warning because I have domain **example.com**in warninglist (type hostname). Adding domain **example.com* in warninglist by type **wildmask** will not mark as warning for example.com subdomains

Also domains included in **wildmask** warninglist wil not generate warn by self.
##### POC:
* type *wildmask* warninglist
```json
{
  "description": "List of wildmask domains",
  "list": [
    "armins.lv",
    "example.com"
  ],
  "matching_attributes": [
    "domain",
    "hostname"
  ],
  "name": "Wildmask domains",
  "type": "wildmask",
  "version": 19
}
```

* type *hostname* warninglist
```json
{
  "description": "My own list",
  "list": [
    "armins.lv",
    "palms.lv"
    
  ],
  "matching_attributes": [
    "domain",
    "hostname"
  ],
  "name": "My domains",
  "type": "hostname",
  "version": 19
}
```
##### Results:
* IOC `[test.armins.lv, armins,lv, test.palms.lv, palms.lv. test.example.com, example.com]`

![Screenshot from 2020-10-13 17-46-18](https://user-images.githubusercontent.com/17720113/95876916-420a2900-0d7c-11eb-9763-4de3df91bee5.png)
In this case warn IOC should be only armins.lv, palms.lv and test.palms.lv as domains armins.lv and palms.lv is added in "My domains" list
test.armins.lv is not in warn as domain armins.lv is added in "Wildmask domains" list


#### Questions

- [ ] Does it require a DB change?
NO
- [ ] Are you using it in production?
NO, but tested in Lab env.
- [ ] Does it require a change in the API (PyMISP for example)?
NO

