### PR TITLE
fix: [correlations] Disable correlation for port part in hostname|port

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -381,7 +381,8 @@ class Attribute extends AppModel
 
     public $primaryOnlyCorrelatingTypes = array(
         'ip-src|port',
-        'ip-dst|port'
+        'ip-dst|port',
+        'hostname|port',
     );
 
     public $captureFields = array(


### PR DESCRIPTION
#### What does it do?

We already do that for `ip-src|port` and `ip-dst|port`, so this one is missing.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
