### PR TITLE
Syntax fix for session.cookie_samesite

### DIFF
--- a/app/Config/core.default.php
+++ b/app/Config/core.default.php
@@ -186,8 +186,8 @@ Configure::write('Session', array(
 
 // Set session cookie SameSite parameter to Lax if this param is supported and no default value is set
 if (PHP_VERSION_ID >= 70300 && empty(ini_get('session.cookie_samesite'))) {
-    Configure::write('Session.ini', ['
-        session.cookie_samesite' => 'Lax'
+    Configure::write('Session.ini', [
+        'session.cookie_samesite' => 'Lax'
     ]);
 }
 


### PR DESCRIPTION
Cakephp complains about not being able to set "session.cookie_samesite" with PHP 7.4 on Ubuntu 20.04 correcting syntax resolved this error.

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2020-05-05: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

If it fixes an existing issue, please use github syntax: `#<IssueID>`

#### Questions

- [ ] Does it require a DB change? No
- [ ] Are you using it in production? Yes
- [ ] Does it require a change in the API (PyMISP for example)? No
