### PR TITLE
Event UI changes and fixes for event reports

### DIFF
--- a/app/Controller/EventReportsController.php
+++ b/app/Controller/EventReportsController.php
@@ -1,7 +1,9 @@
 <?php
-
 App::uses('AppController', 'Controller');
 
+/**
+ * @property EventReport $EventReport
+ */
 class EventReportsController extends AppController
 {
     public $components = array(
@@ -184,6 +186,10 @@ class EventReportsController extends AppController
             $this->set('reports', $reports);
             $this->__injectIndexVariablesToViewContext($filters);
             if (!empty($filters['index_for_event'])) {
+                if (empty($filters['event_id'])) {
+                    throw new MethodNotAllowedException("When requesting index for event, event ID must be provided.");
+                }
+                $this->set('canModify', $this->__canModifyReport($filters['event_id']));
                 $this->set('extendedEvent', !empty($filters['extended_event']));
                 $fetcherModule = $this->EventReport->isFetchURLModuleEnabled();
                 $this->set('importModuleEnabled', is_array($fetcherModule));

--- a/app/Controller/EventReportsController.php
+++ b/app/Controller/EventReportsController.php
@@ -69,6 +69,7 @@ class EventReportsController extends AppController
         $this->set('ajax', $ajax);
         $this->set('id', $reportId);
         $this->set('report', $report);
+        $this->set('title_for_layout', __('Event report %s', $report['EventReport']['name']));
         $this->__injectDistributionLevelToViewContext();
         $this->__injectPermissionsToViewContext($this->Auth->user(), $report);
     }

--- a/app/View/Elements/genericElements/ListTopBar/element_simple.ctp
+++ b/app/View/Elements/genericElements/ListTopBar/element_simple.ctp
@@ -13,7 +13,7 @@
             }
             $onClickParams = implode(',', $onClickParams);
             $onClick = sprintf(
-                'onClick = "%s%s"',
+                'onClick="%s%s"',
                 (empty($data['url'])) ? 'event.preventDefault();' : '',
                 (!empty($data['onClick']) ? sprintf(
                     '%s(%s)',

--- a/app/View/EventReports/ajax/indexForEvent.ctp
+++ b/app/View/EventReports/ajax/indexForEvent.ctp
@@ -2,6 +2,7 @@
     <?php if ($extendedEvent): ?>
         <div class="alert alert-info"><?= __('Viewing reports in extended event view') ?></div>
     <?php endif; ?>
+    <?php if ($canModify): ?>
     <div style="margin-bottom: 10px;">
         <button class="btn btn-small btn-primary" onclick="openGenericModal(baseurl + '/eventReports/add/<?= h($event_id) ?>')">
             <i class="<?= $this->FontAwesome->getClass('plus') ?>"></i> <?= __('Add Event Report') ?>
@@ -12,6 +13,7 @@
             </button>
         <?php endif; ?>
     </div>
+    <?php endif; ?>
     <?php
         echo $this->element('/genericElements/IndexTable/index_table', array(
             'paginatorOptions' => array(

--- a/app/View/EventReports/ajax/indexForEvent.ctp
+++ b/app/View/EventReports/ajax/indexForEvent.ctp
@@ -148,10 +148,10 @@
 
 <script>
     var loadingSpanAnimation = '<span id="loadingSpan" class="fa fa-spin fa-spinner" style="margin-left: 5px;"></span>';
-    $(document).ready(function() {
+    $(function() {
         $('#eventReportQuickIndex td[data-path="EventReport.name"]').click(function() {
             var reportId = $(this).closest('tr').data('primary-id')
-            openGenericModal('/eventReports/viewSummary/' + reportId)
+            openGenericModal(baseurl + '/eventReports/viewSummary/' + reportId)
         })
 
         $('#eventReportSelectors a.btn').click(function(e) {

--- a/app/View/EventReports/ajax/indexForEvent.ctp
+++ b/app/View/EventReports/ajax/indexForEvent.ctp
@@ -2,18 +2,6 @@
     <?php if ($extendedEvent): ?>
         <div class="alert alert-info"><?= __('Viewing reports in extended event view') ?></div>
     <?php endif; ?>
-    <?php if ($canModify): ?>
-    <div style="margin-bottom: 10px;">
-        <button class="btn btn-small btn-primary" onclick="openGenericModal(baseurl + '/eventReports/add/<?= h($event_id) ?>')">
-            <i class="<?= $this->FontAwesome->getClass('plus') ?>"></i> <?= __('Add Event Report') ?>
-        </button>
-        <?php if ($importModuleEnabled): ?>
-            <button class="btn btn-small btn-primary" onclick="openGenericModal(baseurl + '/eventReports/importReportFromUrl/<?= h($event_id) ?>')" title="<?= __('Content for this URL will be downloaded and converted to Mardown') ?>">
-                <i class="<?= $this->FontAwesome->getClass('link') ?>"></i> <?= __('Import from URL') ?>
-            </button>
-        <?php endif; ?>
-    </div>
-    <?php endif; ?>
     <?php
         echo $this->element('/genericElements/IndexTable/index_table', array(
             'paginatorOptions' => array(
@@ -25,6 +13,29 @@
                     'children' => array(
                         array(
                             'type' => 'simple',
+                            'children' => array(
+                                array(
+                                    'onClick' => 'openGenericModal',
+                                    'onClickParams' => [$baseurl . '/eventReports/add/' . h($event_id)],
+                                    'active' => true,
+                                    'text' => __('Add Event Report'),
+                                    'fa-icon' => 'plus',
+                                    'requirement' => $canModify,
+                                ),
+                                array(
+                                    'onClick' => 'openGenericModal',
+                                    'onClickParams' => [$baseurl . '/eventReports/importReportFromUrl/' . h($event_id)],
+                                    'active' => true,
+                                    'text' => __('Import from URL'),
+                                    'title' => __('Content for this URL will be downloaded and converted to Mardown'),
+                                    'fa-icon' => 'link',
+                                    'requirement' => $canModify && $importModuleEnabled,
+                                ),
+                            )
+                        ),
+                        array(
+                            'type' => 'simple',
+                            'id' => 'eventReportSelectors',
                             'children' => array(
                                 array(
                                     'active' => $context === 'all',
@@ -50,7 +61,7 @@
                 'skip_pagination' => count($reports) < 10,
                 'fields' => array(
                     array(
-                        'name' => __('Id'),
+                        'name' => __('ID'),
                         'sort' => 'id',
                         'class' => 'short',
                         'data_path' => 'EventReport.id',
@@ -63,7 +74,6 @@
                     array(
                         'name' => __('Event ID'),
                         'requirement' => $extendedEvent,
-                        'data_path' => 'EventReport.event_id',
                         'class' => 'short',
                         'element' => 'links',
                         'data_path' => 'EventReport.event_id',
@@ -142,10 +152,9 @@
         $('#eventReportQuickIndex td[data-path="EventReport.name"]').click(function() {
             var reportId = $(this).closest('tr').data('primary-id')
             openGenericModal('/eventReports/viewSummary/' + reportId)
-
         })
 
-        $('#eventReportQuickIndex .btn-toolbar a.btn').click(function(e) {
+        $('#eventReportSelectors a.btn').click(function(e) {
             e.preventDefault()
             $("#eventreport_index_div").empty()
                 .append(
@@ -161,9 +170,9 @@
     })
 
     function reloadEventReportTable() {
-        var url = $("#eventReportQuickIndex a.defaultContext").attr('href')
+        var url = $("#eventReportSelectors a.defaultContext").attr('href')
         $.ajax({
-            dataType:"html",
+            dataType: "html",
             beforeSend: function() {
                 $("#eventreport_index_div").empty()
                 .append(

--- a/app/View/EventReports/index.ctp
+++ b/app/View/EventReports/index.ctp
@@ -41,7 +41,7 @@
             'primary_id_path' => 'EventReport.id',
             'fields' => array(
                 array(
-                    'name' => __('Id'),
+                    'name' => __('ID'),
                     'sort' => 'id',
                     'class' => 'short',
                     'data_path' => 'EventReport.id',

--- a/app/View/EventReports/view.ctp
+++ b/app/View/EventReports/view.ctp
@@ -1,34 +1,32 @@
 <?php
     $table_data = array();
     $table_data[] = array('key' => __('ID'), 'value' => $report['EventReport']['id']);
-    $table_data[] = array('key' => __('UUID'), 'value' => $report['EventReport']['uuid']);
-    $table_data[] = array('key' => __('Name'), 'value' => $report['EventReport']['name']);
+    $table_data[] = array('key' => __('UUID'), 'html' => '<span class="quickSelect">' . h($report['EventReport']['uuid']) . '</span>');
     $table_data[] = array(
-        'key' => __('Event ID'),
-        'html' => sprintf('%s', sprintf(
-            '<a href="%s">%s</a>',
-            sprintf('%s%s%s', $baseurl, '/events/view/', h($report['EventReport']['event_id'])),
-            h($report['EventReport']['event_id'])
-        ))
+        'key' => __('Event'),
+        'html' => sprintf(
+            '<a href="%s">#%s: %s</a>',
+            $baseurl . '/events/view/' . h($report['EventReport']['event_id']),
+            h($report['EventReport']['event_id']),
+            h($report['Event']['info'])
+        )
     );
     $table_data[] = array(
         'key' => __('Distribution'),
         'value_class' => ($report['EventReport']['distribution'] == 0) ? 'privateRedText' : '',
-        'html' => sprintf('%s',
-            ($report['EventReport']['distribution'] == 4) ?
+        'html' => $report['EventReport']['distribution'] == 4 ?
                 sprintf('<a href="%s%s">%s</a>', $baseurl . '/sharing_groups/view/', h($report['SharingGroup']['id']), h($report['SharingGroup']['name'])) :
                 h($distributionLevels[$report['EventReport']['distribution']])
-        )
     );
 
-    $table_data[] = array('key' => __('Timestamp'), 'value' => date('Y-m-d H:i:s', $report['EventReport']['timestamp']));
+    $table_data[] = array('key' => __('Last update'), 'value' => date('Y-m-d H:i:s', $report['EventReport']['timestamp']));
     $table_data[] = array('key' => __('Deleted'), 'boolean' => $report['EventReport']['deleted'], 'value_class' => $report['EventReport']['deleted'] ? 'red' : 'green');
 ?>
 
 <div class='<?= !isset($ajax) || !$ajax ? 'view' : '' ?>'>
     <div class="row-fluid">
         <h2><?= h($report['EventReport']['name']) ?></h2>
-        <div class="span8" style="margin-bottom: 10px;">
+        <div class="span8" style="margin-bottom: 10px; margin-left: 0">
             <?php echo $this->element('genericElements/viewMetaTable', array('table_data' => $table_data)); ?>
         </div>
         <div class="clear">
@@ -59,12 +57,6 @@
     </div>
     <div style="margin-bottom: 15px;"></div>
 </div>
-<script type="text/javascript">
-$(document).ready(function () {
-});
-</script>
-
-
 <?php
     if (!isset($ajax) || !$ajax) {
         echo $this->element('/genericElements/SideMenu/side_menu', array('menuList' => 'eventReports', 'menuItem' => 'view'));

--- a/app/webroot/css/markdownEditor/markdownEditor.css
+++ b/app/webroot/css/markdownEditor/markdownEditor.css
@@ -58,10 +58,9 @@
 #viewer-container {
     margin: 0 0;
     justify-content: center;
-    padding: 7px;
+    padding: 7px 15px;
     overflow-y: auto;
-    padding: 0 15px;
-    box-shadow: inset 0px 2px 6px #eee;
+    box-shadow: inset 0 2px 6px #eee;
 }
 
 #editor-container {

--- a/app/webroot/js/markdownEditor/event-report.js
+++ b/app/webroot/js/markdownEditor/event-report.js
@@ -1511,6 +1511,9 @@ function constructGalaxyInfo(tagData) {
     if (tagData.GalaxyCluster.meta !== undefined) {
         Object.keys(tagData.GalaxyCluster.meta).forEach(function(metaKey) {
             var metaValue = tagData.GalaxyCluster.meta[metaKey]
+            if (Array.isArray(metaValue)) {
+                metaValue = metaValue.join(', ')
+            }
             $clusterMeta.append(
                 $('<div/>').append(
                     $('<strong/>').addClass('blue').text(metaKey + ': '),

--- a/app/webroot/js/markdownEditor/event-report.js
+++ b/app/webroot/js/markdownEditor/event-report.js
@@ -603,32 +603,8 @@ function renderTemplateBasedOnRenderingOptions(scope, templateToRender, template
 }
 
 function setupMISPElementMarkdownListeners() {
-    $('.misp-element-wrapper').filter('.attribute:not(\'.suggestion\')').popover({
-        trigger: 'click',
-        html: true,
-        container: isInsideModal() ? 'body' : '#viewer-container',
-        placement: 'top',
-        title: getTitleFromMISPElementDOM,
-        content: getContentFromMISPElementDOM
-    })
-    $('.misp-picture-wrapper > img').popover({
-        trigger: 'click',
-        html: true,
-        container: isInsideModal() ? 'body' : '#viewer-container',
-        placement: 'top',
-        title: getTitleFromMISPElementDOM,
-        content: getContentFromMISPElementDOM,
-        placement: 'top'
-    })
-    $('.misp-element-wrapper').filter('.object').popover({
-        trigger: 'click',
-        html: true,
-        container: isInsideModal() ? 'body' : '#viewer-container',
-        placement: 'top',
-        title: getTitleFromMISPElementDOM,
-        content: getContentFromMISPElementDOM
-    })
-    $('.embeddedTag').popover({
+    var $elements = $('.misp-element-wrapper.attribute:not(".suggestion"), .misp-element-wrapper.object, .misp-picture-wrapper > img, .embeddedTag');
+    $elements.popover({
         trigger: 'click',
         html: true,
         container: isInsideModal() ? 'body' : '#viewer-container',
@@ -900,14 +876,14 @@ function reloadRenderingRuleEnabledUI() {
 
 
 /**
-   _____                             _   _             
-  / ____|                           | | (_)            
- | (___  _   _  __ _  __ _  ___  ___| |_ _  ___  _ __  
-  \___ \| | | |/ _` |/ _` |/ _ \/ __| __| |/ _ \| '_ \ 
+   _____                             _   _
+  / ____|                           | | (_)
+ | (___  _   _  __ _  __ _  ___  ___| |_ _  ___  _ __
+  \___ \| | | |/ _` |/ _` |/ _ \/ __| __| |/ _ \| '_ \
   ____) | |_| | (_| | (_| |  __/\__ \ |_| | (_) | | | |
  |_____/ \__,_|\__, |\__, |\___||___/\__|_|\___/|_| |_|
-                __/ | __/ |                            
-               |___/ |___/                             
+                __/ | __/ |
+               |___/ |___/
  */
 
 function automaticEntitiesExtraction() {
@@ -1299,8 +1275,8 @@ function buildTitleForMISPElement(data) {
     var title = invalidMessage
     var dismissButton = ''
     if (data !== false) {
-        var templateVariables =  sanitizeObject(data)
-        var dismissButton = dotCloseButtonTemplate(templateVariables)
+        var templateVariables = sanitizeObject(data)
+        dismissButton = dotCloseButtonTemplate(templateVariables)
         title = data.scope.charAt(0).toUpperCase() + templateVariables.scope.slice(1) + ' ' + templateVariables.elementID
     }
     return title + dismissButton
@@ -1318,8 +1294,7 @@ function closeThePopover(closeButton) {
     }
 }
 
-function constructAttributeRow(attribute, fromObject)
-{
+function constructAttributeRow(attribute, fromObject) {
     fromObject = fromObject !== undefined ? fromObject : false
     var attributeFieldsToRender = ['id', 'category', 'type'].concat(fromObject ? ['object_relation'] : [], ['value', 'comment'])
     var $tr = $('<tr/>')

--- a/app/webroot/js/markdownEditor/event-report.js
+++ b/app/webroot/js/markdownEditor/event-report.js
@@ -44,6 +44,7 @@ var renderingRules = {
 }
 var galaxyMatrixTimer, tagTimers = {};
 var cache_matrix = {}, cache_tag = {};
+var firstCustomPostRenderCall = true;
 var contentBeforeSuggestions
 var typeToCategoryMapping
 var entitiesFromComplexTool
@@ -645,7 +646,7 @@ function attachRemoteMISPElements() {
         if (cache_matrix[cacheKey] === undefined) {
             galaxyMatrixTimer = setTimeout(function() {
                 attachGalaxyMatrix($div, eventID, elementID)
-            }, slowDebounceDelay);
+            }, firstCustomPostRenderCall ? 0 : slowDebounceDelay);
         } else {
             $div.html(cache_matrix[cacheKey])
         }
@@ -662,11 +663,17 @@ function attachRemoteMISPElements() {
                 fetchTagInfo(eventID, elementID, function() {
                     attachTagInfo($div, eventID, elementID, true)
                 })
-            }, slowDebounceDelay);
+            }, firstCustomPostRenderCall ? 0 : slowDebounceDelay);
         } else {
             $div.html(cache_tag[cacheKey])
         }
     })
+    if (firstCustomPostRenderCall) {
+        // Wait, because .each calls are asynchronous
+        setTimeout(function() {
+            firstCustomPostRenderCall = false;
+        }, 1000)
+    }
 }
 
 function attachGalaxyMatrix($elem, eventid, elementID) {


### PR DESCRIPTION
#### What does it do?

This changes a lot but small in event view user interface. Most important changes:
* 'Add event report' button will not be shown when user don't have permission for event edit
* Do not debounce tag loading for event reports for first load 
* Move 'Add event report' button to one line with other buttons to match MISP style.
<img width="380" alt="Snímek obrazovky 2020-10-19 v 12 25 37" src="https://user-images.githubusercontent.com/163343/96436264-34cebd80-1206-11eb-950d-6969a5aa6abc.png">

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
