### PR TITLE
fix: [internal] Throw exception if session could not be started

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -1180,16 +1180,25 @@ class AppController extends Controller
         $this->redirect($targetRoute);
     }
 
-    protected function _loadAuthenticationPlugins() {
-        // load authentication plugins from Configure::read('Security.auth')
+    /**
+     * Authenticate user by authentication plugin defined in 'Security.auth' config.
+     * @throws Exception
+     */
+    protected function _loadAuthenticationPlugins()
+    {
         $auth = Configure::read('Security.auth');
-
-        if (!$auth) return;
+        if (!$auth) {
+            return;
+        }
 
         $this->Auth->authenticate = array_merge($auth, $this->Auth->authenticate);
         if ($this->Auth->startup($this)) {
             $user = $this->Auth->user();
             if ($user) {
+                if (!$this->Session->started()) {
+                    throw new Exception("Could not start sessions.");
+                }
+
                 $this->User->updateLoginTimes($user);
                 // User found in the db, add the user info to the session
                 $this->Session->renew();


### PR DESCRIPTION
#### What does it do?

This can be useful when sessions are stored in external system (like Redis).

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
