### PR TITLE
new: [UI] Allow to disable hover enrichment

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -2251,6 +2251,14 @@ class Server extends AppModel
                                 'test' => 'testBool',
                                 'type' => 'boolean'
                         ),
+                        'Enrichment_hover_popover_only' => array(
+                            'level' => 0,
+                            'description' => __('When enabled, user have to click on magnifier icon to show enrichment'),
+                            'value' => false,
+                            'errorMessage' => '',
+                            'test' => 'testBool',
+                            'type' => 'boolean'
+                        ),
                         'Enrichment_hover_timeout' => array(
                                 'level' => 1,
                                 'description' => __('Set a timeout for the hover services'),

--- a/app/View/Elements/Events/View/row_attribute.ctp
+++ b/app/View/Elements/Events/View/row_attribute.ctp
@@ -129,12 +129,8 @@ $quickEdit = function($fieldName) use ($editScope, $object, $event) {
             $spanExtra = '';
             $popupButton = '';
             if (Configure::read('Plugin.Enrichment_hover_enable') && isset($modules) && isset($modules['hover_type'][$object['type']])) {
-                $commonDataFields = sprintf(
-                    'data-object-type="Attribute" data-object-id="%s"',
-                    $objectId
-                );
-
-                $spanExtra = sprintf(' class="eventViewAttributeHover" %s', $commonDataFields);
+                $commonDataFields = sprintf('data-object-type="Attribute" data-object-id="%s"', $objectId);
+                $spanExtra = Configure::read('Plugin.Enrichment_hover_popover_only') ? '' : sprintf(' class="eventViewAttributeHover" %s', $commonDataFields);
                 $popupButton = sprintf('<i class="fa fa-search-plus useCursorPointer eventViewAttributePopup noPrint" title="%s" %s></i>', __('Show hover enrichment'), $commonDataFields);
             }
             echo sprintf(


### PR DESCRIPTION
#### What does it do?

With new option `Plugin.Enrichment_hover_popover_only` you can disable automatic hover enrichment and keep just intentional enrichment by click on magnifier glass icon. This can be useful to have more control, what data user sends to external services.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
