### PR TITLE
fix: [internal] Avoid warnings in global_menu

### DIFF
--- a/app/View/Elements/global_menu.ctp
+++ b/app/View/Elements/global_menu.ctp
@@ -472,11 +472,11 @@
                     h($me['email']),
                     $this->UserName->prepend($me['email']),
                     h($loggedInUserName),
-                    sprintf(
+                    isset($notifications) ? sprintf(
                         '<i class="fa fa-envelope %s" role="img" aria-label="%s"></i>',
                         (($notifications['total'] == 0) ? 'white' : 'red'),
                         __('Notifications') . ': ' . $notifications['total']
-                    )
+                    ) : ''
                 )
             ),
             array(


### PR DESCRIPTION
#### What does it do?

After #6465, for AJAX requests thats ends with some error, $notification variable is not defined. This checks if variable is defined and if not, notification count is not show. 

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
