### PR TITLE
Experimental: new: [internal] Allow to output directly TmpFileTool

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -1324,7 +1324,7 @@ class AppController extends Controller
         $final = $this->$scope->restSearch($user, $returnFormat, $filters, false, false, $elementCounter, $renderView);
         if (!empty($renderView) && !empty($final)) {
             $this->layout = false;
-            $final = json_decode($final, true);
+            $final = json_decode($final->intoString(), true);
             foreach ($final as $key => $data) {
                 $this->set($key, $data);
             }

--- a/app/Controller/Component/RestResponseComponent.php
+++ b/app/Controller/Component/RestResponseComponent.php
@@ -548,7 +548,15 @@ class RestResponseComponent extends Component
                 }
             }
         }
-        $cakeResponse = new CakeResponse(array('body' => $response, 'status' => $code, 'type' => $type));
+
+        App::uses('TmpFileTool', 'Tools');
+        if ($response instanceof TmpFileTool) {
+            App::uses('CakeResponseTmp', 'Tools');
+            $cakeResponse = new CakeResponseTmp(['status' => $code, 'type' => $type]);
+            $cakeResponse->file($response);
+        } else {
+            $cakeResponse = new CakeResponse(array('body' => $response, 'status' => $code, 'type' => $type));
+        }
 
         if (Configure::read('Security.allow_cors')) {
             $headers["Access-Control-Allow-Headers"] =  "Origin, Content-Type, Authorization, Accept";

--- a/app/Lib/Tools/CakeResponseTmp.php
+++ b/app/Lib/Tools/CakeResponseTmp.php
@@ -1,0 +1,40 @@
+<?php
+class CakeResponseTmp extends CakeResponse
+{
+    public function file($path, $options = array())
+    {
+        if ($path instanceof TmpFileTool) {
+            $this->header('Content-Length', $path->size());
+            $this->_clearBuffer();
+            $this->_file = $path;
+        } else {
+            parent::file($path, $options);
+        }
+    }
+
+    /**
+     * @param File|TmpFileTool $file
+     * @param array $range
+     * @return bool
+     * @throws Exception
+     */
+    protected function _sendFile($file, $range)
+    {
+        if ($file instanceof TmpFileTool) {
+            set_time_limit(0);
+            session_write_close();
+
+            foreach ($file->intoChunks() as $chunk) {
+                if (!$this->_isActive()) {
+                    $file->close();
+                    return false;
+                }
+                echo $chunk;
+                $this->_flushBuffer();
+            }
+            return true;
+        } else {
+            return parent::_sendFile($file, $range);
+        }
+    }
+}

--- a/app/Lib/Tools/ComplexTypeTool.php
+++ b/app/Lib/Tools/ComplexTypeTool.php
@@ -177,7 +177,7 @@ class ComplexTypeTool
         unset($input);
 
         $iocArray = [];
-        foreach ($tmpFile->csv($delimiter) as $row) {
+        foreach ($tmpFile->intoParsedCsv($delimiter) as $row) {
             if (!empty($row[0][0]) && $row[0][0] === '#') { // Comment
                 continue;
             }

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -4697,7 +4697,7 @@ class Attribute extends AppModel
             $elementCounter = $this->__iteratedFetch($user, $params, $loop, $tmpfile, $exportTool, $exportToolParams);
         }
         $tmpfile->write($exportTool->footer($exportToolParams));
-        return $tmpfile->finish();
+        return $tmpfile;
     }
 
     /**

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -6999,7 +6999,7 @@ class Event extends AppModel
         unset($result);
         unset($temp);
         $tmpfile->write($exportTool->footer($exportToolParams));
-        return $tmpfile->finish();
+        return $tmpfile;
     }
 
     /*

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -180,7 +180,7 @@ class Feed extends AppModel
         $tmpFile->write(trim($data));
         unset($data);
 
-        return $tmpFile->csv();
+        return $tmpFile->intoParsedCsv();
     }
 
     /**

--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -1443,7 +1443,7 @@ class MispObject extends AppModel
         }
         $this->__iteratedFetch($user, $params, $loop, $tmpfile, $exportTool, $exportToolParams, $elementCounter);
         $tmpfile->write($exportTool->footer($exportToolParams));
-        return $tmpfile->finish();
+        return $tmpfile;
     }
 
     private function __iteratedFetch($user, &$params, &$loop, TmpFileTool $tmpfile, $exportTool, $exportToolParams, &$elementCounter = 0)

--- a/app/Model/Sighting.php
+++ b/app/Model/Sighting.php
@@ -908,7 +908,7 @@ class Sighting extends AppModel
         }
 
         $tmpfile->write($exportTool->footer($exportToolParams));
-        return $tmpfile->finish();
+        return $tmpfile;
     }
 
     /**


### PR DESCRIPTION
#### What does it do?

This is another step after #6496 how to save memory. Currently, for REST search the results are saved to temporary file, but the the whole file is loaded into memory and send to HTTP server. With this change, just small chunks are directly read from temporary file and send to HTTP server one by one. With this change, it is possible to send even results that are bigger than PHP memory limit. 

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
