### PR TITLE
 chg: [UI] Remove Source Format from related feed popover

### DIFF
--- a/app/View/Elements/Events/View/row_attribute.ctp
+++ b/app/View/Elements/Events/View/row_attribute.ctp
@@ -206,40 +206,38 @@ $quickEdit = function($fieldName) use ($editScope, $object, $event) {
     <td class="shortish">
       <ul class="inline" style="margin:0">
         <?php
-            if (!empty($object['Feed'])) {
+            if (isset($object['Feed'])) {
                 foreach ($object['Feed'] as $feed) {
-                    $popover = '';
-                    foreach ($feed as $k => $v) {
-                        if ($k == 'id') continue;
-                        if (is_array($v)) {
-                            foreach ($v as $k2 => $v2) {
-                                $v[$k2] = h($v2);
-                            }
-                            $v = implode('<br>', $v);
-                        } else {
-                            $v = h($v);
-                        }
-                        $popover .= '<span class="bold black">' . Inflector::humanize(h($k)) . '</span>: <span class="blue">' . $v . '</span><br>';
+                    $relatedData = array(
+                        __('Name') => $feed['name'],
+                        __('URL') => $feed['url'],
+                        __('Provider') => $feed['provider'],
+                    );
+                    if (isset($feed['event_uuids'])) {
+                        $relatedData[__('Event UUIDs')] = implode('<br>', $feed['event_uuids']);
                     }
-                    $liContents = '';
+                    $popover = '';
+                    foreach ($relatedData as $k => $v) {
+                        $popover .= '<span class="bold black">' . h($k) . '</span>: <span class="blue">' . h($v) . '</span><br>';
+                    }
                     if ($isSiteAdmin || $hostOrgUser) {
                         if ($feed['source_format'] === 'misp') {
-                            $liContents .= sprintf(
+                            $liContents = sprintf(
                                 '<form action="%s/feeds/previewIndex/%s" method="post" style="margin:0;line-height:auto;">%s%s</form>',
                                 $baseurl,
                                 h($feed['id']),
                                 sprintf(
                                     '<input type="hidden" name="data[Feed][eventid]" value="%s">',
-                                    h(json_encode($feed['event_uuids'], true))
+                                    h(json_encode($feed['event_uuids']))
                                 ),
                                 sprintf(
-                                    '<input type="submit" class="linkButton useCursorPointer" value="%s" data-toggle="popover" data-content="%s" data-trigger="hover" style="margin-right:3px;line-height:normal;vertical-align: text-top;" />',
+                                    '<input type="submit" class="linkButton useCursorPointer" value="%s" data-toggle="popover" data-content="%s" data-trigger="hover" style="margin-right:3px;line-height:normal;vertical-align: text-top;">',
                                     h($feed['id']),
                                     h($popover)
                                 )
                             );
                         } else {
-                            $liContents .= sprintf(
+                            $liContents = sprintf(
                                 '<a href="%s/feeds/previewIndex/%s" style="margin-right:3px;" data-toggle="popover" data-content="%s" data-trigger="hover">%s</a>',
                                 $baseurl,
                                 h($feed['id']),
@@ -248,7 +246,7 @@ $quickEdit = function($fieldName) use ($editScope, $object, $event) {
                             );
                         }
                     } else {
-                        $liContents .= sprintf(
+                        $liContents = sprintf(
                             '<span style="margin-right:3px;">%s</span>',
                             h($feed['id'])
                         );
@@ -259,7 +257,7 @@ $quickEdit = function($fieldName) use ($editScope, $object, $event) {
                     );
                 }
             }
-            if (!empty($object['Server'])) {
+            if (isset($object['Server'])) {
                 foreach ($object['Server'] as $server) {
                     $popover = '';
                     foreach ($server as $k => $v) {

--- a/app/View/Events/view.ctp
+++ b/app/View/Events/view.ctp
@@ -374,7 +374,7 @@
                 endif;
                 if (!empty($event['Feed']) || !empty($event['Event']['FeedCount'])):
             ?>
-                    <h3>Related Feeds</h3>
+                    <h3><?= __('Related Feeds') ?> <a href="#attributeList" title="<?= __('Show just attributes that has feed hits') ?>" onclick="toggleBoolFilter('<?= $baseurl ?>/events/view/<?= h($event['Event']['id']) ?>', 'feed')"><?= __('(show)') ?></a></h3>
             <?php
                     if (!empty($event['Feed'])):
             ?>
@@ -457,7 +457,10 @@
             ?>
             <?php if (!empty($event['warnings'])): ?>
                 <div class="warning_container">
-                    <h4 class="red"><?= __('Warning: Potential false positives') ?> <a href="#attributeList" onclick="toggleBoolFilter('<?= $baseurl ?>/events/view/<?= h($event['Event']['id']) ?>', 'warning')"><?= __('(show)') ?></a></h4>
+                    <h4 class="red">
+                        <?= __('Warning: Potential false positives') ?>
+                        <a href="#attributeList" title="<?= __('Show just attributes that has warning') ?>" onclick="toggleBoolFilter('<?= $baseurl ?>/events/view/<?= h($event['Event']['id']) ?>', 'warning')"><?= __('(show)') ?></a>
+                    </h4>
                     <?php
                         $links = [];
                         foreach ($event['warnings'] as $id => $name) {

--- a/app/View/Events/view.ctp
+++ b/app/View/Events/view.ctp
@@ -382,10 +382,9 @@
                 <?php
                         foreach ($event['Feed'] as $relatedFeed):
                             $relatedData = array(
-                                'Name' => $relatedFeed['name'],
-                                'URL' => $relatedFeed['url'],
-                                'Provider' => $relatedFeed['provider'],
-                                'Source Format' => $relatedFeed['source_format'] === 'misp' ? 'MISP' : $relatedFeed['source_format'],
+                                __('Name') => $relatedFeed['name'],
+                                __('URL') => $relatedFeed['url'],
+                                __('Provider') => $relatedFeed['provider'],
                             );
                             $popover = '';
                             foreach ($relatedData as $k => $v) {
@@ -397,13 +396,13 @@
                                         if ($relatedFeed ['source_format'] === 'misp'):
                                     ?>
                                             <form action="<?php echo $baseurl; ?>/feeds/previewIndex/<?php echo h($relatedFeed['id']); ?>" method="post" style="margin:0px;">
-                                                <input type="hidden" name="data[Feed][eventid]" value="<?php echo h(json_encode($relatedFeed['event_uuids'], true)); ?>">
-                                                <input type="submit" class="linkButton useCursorPointer" value="<?php echo h($relatedFeed['name']) . ' (' . $relatedFeed['id'] . ')'; ?>" data-toggle="popover" data-content="<?php echo h($popover); ?>" data-trigger="hover" />
+                                                <input type="hidden" name="data[Feed][eventid]" value="<?php echo h(json_encode($relatedFeed['event_uuids'])); ?>">
+                                                <input type="submit" class="linkButton useCursorPointer" value="<?php echo h($relatedFeed['name']) . ' (' . $relatedFeed['id'] . ')'; ?>" data-toggle="popover" data-content="<?php echo h($popover); ?>" data-trigger="hover">
                                             </form>
                                     <?php
                                         else:
                                     ?>
-                                            <a href="<?php echo $baseurl; ?>/feeds/previewIndex/<?php echo h($relatedFeed['id']); ?>" data-toggle="popover" data-content="<?php echo h($popover); ?>" data-trigger="hover"><?php echo h($relatedFeed['name']) . ' (' . $relatedFeed['id'] . ')'; ?></a><br />
+                                            <a href="<?php echo $baseurl; ?>/feeds/previewIndex/<?php echo h($relatedFeed['id']); ?>" data-toggle="popover" data-content="<?php echo h($popover); ?>" data-trigger="hover"><?php echo h($relatedFeed['name']) . ' (' . $relatedFeed['id'] . ')'; ?></a><br>
                                     <?php
                                         endif;
                                     ?>


### PR DESCRIPTION
#### What does it do?

I think that information is mostly irrelevant for user, if feed is MISP, CSV or text format.

<img width="332" alt="Snímek obrazovky 2020-10-29 v 16 25 03" src="https://user-images.githubusercontent.com/163343/97594935-7a0f9e00-1a03-11eb-9938-2db5a9d6c13a.png">

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
