### PR TITLE
chg: [feed] Check also URL without protocol

### DIFF
--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -380,6 +380,15 @@ class Feed extends AppModel
                 }
             } else {
                 $parts = [$attribute['value']];
+
+                // Some feeds contains URL without protocol, so if attribute is URL and value contains protocol,
+                // we will check also value without protocol.
+                if ($attribute['type'] === 'url' || $attribute['type'] === 'uri') {
+                    $protocolPos = strpos($attribute['value'], '://');
+                    if ($protocolPos !== false) {
+                        $parts[] = substr($attribute['value'], $protocolPos + 3);
+                    }
+                }
             }
 
             foreach ($parts as $part) {


### PR DESCRIPTION
#### What does it do?

Some feeds contains URL without protocol (like cybercrime-tracker.net - all), so if attribute is URL and value contains protocol, we will check also value without protocol.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
