### PR TITLE
new: [API] Allow event existence check by HEAD method

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -1511,6 +1511,11 @@ class EventsController extends AppController
 
     public function view($id = null, $continue = false, $fromEvent = null)
     {
+        if ($this->request->is('head')) { // Just check if event exists
+            $exists = $this->Event->fetchSimpleEvent($this->Auth->user(), $id, ['fields' => ['id']]);
+            return new CakeResponse(['status' => $exists ? 200 : 404]);
+        }
+
         if (is_numeric($id)) {
             $conditions = array('eventid' => $id);
         } else if (Validation::uuid($id)) {


### PR DESCRIPTION
#### What does it do?

If you need to just check if event exists, you can use HEAD method. But now MISP will load and return whole event, so it will be slow. This change that to just provide very fast existence check and return just status code. 

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
