### PR TITLE
User edit permissions

### DIFF
--- a/app/Controller/Component/ACLComponent.php
+++ b/app/Controller/Component/ACLComponent.php
@@ -608,7 +608,7 @@ class ACLComponent extends Component
             ),
             'users' => array(
                     'acceptRegistrations' => array('perm_site_admin'),
-                    'admin_add' => array('perm_admin'),
+                    'admin_add' => ['AND' => ['perm_admin', 'add_user_enabled']],
                     'admin_delete' => array('perm_admin'),
                     'admin_edit' => array('perm_admin'),
                     'admin_email' => array('perm_admin'),
@@ -699,6 +699,12 @@ class ACLComponent extends Component
         $this->dynamicChecks['password_change_enabled'] = function (array $user) {
             if (Configure::read('MISP.disable_user_password_change')) {
                 throw new MethodNotAllowedException('User password change has been disabled on this instance.');
+            }
+            return true;
+        };
+        $this->dynamicChecks['add_user_enabled'] = function (array $user) {
+            if (Configure::read('MISP.disable_user_add')) {
+                throw new MethodNotAllowedException('Adding users has been disabled on this instance.');
             }
             return true;
         };

--- a/app/Controller/Component/RestResponseComponent.php
+++ b/app/Controller/Component/RestResponseComponent.php
@@ -310,7 +310,7 @@ class RestResponseComponent extends Component
         foreach ($this->__scopedFieldsConstraint as $controller => $actions) {
             $controller = Inflector::tableize($controller);
             foreach ($actions as $action => $data) {
-                if ($this->ACL->checkAccess($user, $controller, $action, true) === true) {
+                if ($this->ACL->canUserAccess($user, $controller, $action)) {
                     $admin_routing = '';
                     if (substr($action, 0, 6) === 'admin_') {
                         $action = substr($action, 6);
@@ -331,7 +331,7 @@ class RestResponseComponent extends Component
         foreach ($this->__descriptions as $controller => $actions) {
             $controller = Inflector::tableize($controller);
             foreach ($actions as $action => $data) {
-                if ($this->ACL->checkAccess($user, $controller, $action, true) === true) {
+                if ($this->ACL->canUserAccess($user, $controller, $action)) {
                     $admin_routing = '';
                     if (substr($action, 0, 6) === 'admin_') {
                         $action = substr($action, 6);

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -338,9 +338,6 @@ class UsersController extends AppController
 
     public function admin_index()
     {
-        if (!$this->_isAdmin()) {
-            throw new NotFoundException(__('Invalid user or not authorised.'));
-        }
         $this->User->virtualFields['org_ci'] = 'UPPER(Organisation.name)';
         $urlParams = "";
         $passedArgsArray = array();
@@ -496,9 +493,6 @@ class UsersController extends AppController
 
     public function admin_filterUserIndex()
     {
-        if (!$this->_isAdmin() && !$this->_isSiteAdmin()) {
-            throw new MethodNotAllowedException();
-        }
         $passedArgsArray = array();
         $booleanFields = array('autoalert', 'contactalert', 'termsaccepted');
         $textFields = array('role', 'email', 'authkey');
@@ -632,9 +626,6 @@ class UsersController extends AppController
 
     public function admin_add()
     {
-        if (!$this->_isAdmin()) {
-            throw new Exception('Administrators only.');
-        }
         $params = null;
         if (!$this->_isSiteAdmin()) {
             $params = array('conditions' => array('perm_site_admin !=' => 1, 'perm_sync !=' => 1, 'perm_regexp_access !=' => 1));

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -907,7 +907,6 @@ class UsersController extends AppController
                     }
                 }
             }
-            $fail = false;
             if (!$this->_isSiteAdmin() && !$abortPost) {
                 $organisation = $this->User->Organisation->find('first', array(
                     'conditions' => array('Organisation.id' => $userToEdit['User']['org_id']),
@@ -941,6 +940,13 @@ class UsersController extends AppController
                 $blockedFields = array('id', 'invited_by');
                 if (!$this->_isSiteAdmin()) {
                     $blockedFields[] = 'org_id';
+                }
+                if (!$this->__canChangeLogin()) {
+                    $blockedFields[] = 'email';
+                }
+                if (!$this->__canChangePassword()) {
+                    $blockedFields[] = 'enable_password';
+                    $blockedFields[] = 'change_pw';
                 }
                 foreach (array_keys($this->request->data['User']) as $field) {
                     if (in_array($field, $blockedFields)) {
@@ -1080,6 +1086,8 @@ class UsersController extends AppController
         $this->set('id', $id);
         $this->set(compact('roles'));
         $this->set(compact('syncRoles'));
+        $this->set('canChangeLogin', $this->__canChangeLogin());
+        $this->set('canChangePassword', $this->__canChangePassword());
     }
 
     public function admin_delete($id = null)
@@ -2742,6 +2750,9 @@ class UsersController extends AppController
 
     private function __canChangeLogin()
     {
+        if ($this->_isSiteAdmin()) {
+            return true;
+        }
         return !Configure::read('MISP.disable_user_login_change');
     }
 }

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -182,7 +182,10 @@ class UsersController extends AppController
             }
             if (!$abortPost) {
                 // What fields should be saved (allowed to be saved)
-                $fieldList = array('email', 'autoalert', 'gpgkey', 'certif_public', 'nids_sid', 'contactalert', 'disabled');
+                $fieldList = array('autoalert', 'gpgkey', 'certif_public', 'nids_sid', 'contactalert', 'disabled');
+                if ($this->__canChangeLogin()) {
+                    $fieldList[] = 'email';
+                }
                 if ($this->__canChangePassword() && !empty($this->request->data['User']['password'])) {
                     $fieldList[] = 'password';
                     $fieldList[] = 'confirm_password';
@@ -243,6 +246,7 @@ class UsersController extends AppController
         $this->set('roles', $roles);
         $this->set('id', $id);
         $this->set('canChangePassword', $this->__canChangePassword());
+        $this->set('canChangeLogin', $this->__canChangeLogin());
     }
 
     public function change_pw()
@@ -2734,5 +2738,10 @@ class UsersController extends AppController
     private function __canChangePassword()
     {
         return $this->ACL->canUserAccess($this->Auth->user(), 'users', 'change_pw');
+    }
+
+    private function __canChangeLogin()
+    {
+        return !Configure::read('MISP.disable_user_login_change');
     }
 }

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -921,7 +921,7 @@ class Server extends AppModel
                         ),
                     'disable_user_login_change' => array(
                         'level' => self::SETTING_RECOMMENDED,
-                        'description' => __('When enabled only site admins can change user email.'),
+                        'description' => __('When enabled only Site admins can change user email. This should be enabled if you manage user logins by external system.'),
                         'value' => false,
                         'errorMessage' => '',
                         'test' => 'testBool',
@@ -930,7 +930,16 @@ class Server extends AppModel
                     ),
                     'disable_user_password_change' => array(
                         'level' => self::SETTING_RECOMMENDED,
-                        'description' => __('When enabled only site admins can change user password.'),
+                        'description' => __('When enabled only Site admins can change user password. This should be enabled if you manage user passwords by external system.'),
+                        'value' => false,
+                        'errorMessage' => '',
+                        'test' => 'testBool',
+                        'type' => 'boolean',
+                        'null' => false,
+                    ),
+                    'disable_user_add' => array(
+                        'level' => self::SETTING_RECOMMENDED,
+                        'description' => __('When enabled, Org Admins could not add new users. This should be enabled if you manage users by external system.'),
                         'value' => false,
                         'errorMessage' => '',
                         'test' => 'testBool',

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -918,8 +918,25 @@ class Server extends AppModel
                                 'test' => 'testBool',
                                 'type' => 'boolean',
                                 'null' => false,
-
                         ),
+                    'disable_user_login_change' => array(
+                        'level' => self::SETTING_RECOMMENDED,
+                        'description' => __('When enabled only site admins can change user email.'),
+                        'value' => false,
+                        'errorMessage' => '',
+                        'test' => 'testBool',
+                        'type' => 'boolean',
+                        'null' => false,
+                    ),
+                    'disable_user_password_change' => array(
+                        'level' => self::SETTING_RECOMMENDED,
+                        'description' => __('When enabled only site admins can change user password.'),
+                        'value' => false,
+                        'errorMessage' => '',
+                        'test' => 'testBool',
+                        'type' => 'boolean',
+                        'null' => false,
+                    ),
                         'block_event_alert' => array(
                                 'level' => 1,
                                 'description' => __('Enable this setting to start blocking alert e-mails for events with a certain tag. Define the tag in MISP.block_event_alert_tag.'),

--- a/app/View/Elements/Users/userIndexTable.ctp
+++ b/app/View/Elements/Users/userIndexTable.ctp
@@ -7,12 +7,12 @@
         <th><?php echo $this->Paginator->sort('authkey');?></th>
         <th><?php echo $this->Paginator->sort('autoalert');?></th>
         <th><?php echo $this->Paginator->sort('contactalert');?></th>
-        <th><?php echo $this->Paginator->sort('gpgkey');?></th>
+        <th><?php echo $this->Paginator->sort('gpgkey', __('PGP key'));?></th>
         <?php if (Configure::read('SMIME.enabled')): ?>
-            <th><?php echo $this->Paginator->sort('certif_public', 'SMIME');?></th>
+            <th><?php echo $this->Paginator->sort('certif_public', 'S/MIME');?></th>
         <?php endif; ?>
-        <th><?php echo $this->Paginator->sort('nids_sid');?></th>
-        <th><?php echo $this->Paginator->sort('termsaccepted');?></th>
+        <th><?php echo $this->Paginator->sort('nids_sid', __('NIDS SID'));?></th>
+        <th><?php echo $this->Paginator->sort('termsaccepted', __('Terms accepted'));?></th>
         <th><?php echo $this->Paginator->sort('current_login', __('Last login'));?></th>
         <th><?php echo $this->Paginator->sort('date_created', __('Created'));?></th>
         <?php
@@ -40,7 +40,7 @@
                 <td ondblclick="document.location ='<?php echo $this->Html->url(array('admin' => true, 'action' => 'view', $user['User']['id']), true);?>';">
                     <?php echo h($user['User']['email']); ?>&nbsp;
                 </td>
-                <td ondblclick="document.location ='<?php echo $this->Html->url(array('admin' => true, 'action' => 'view', $user['User']['id']), true);?>';" class="<?php echo $user['Role']['perm_auth'] ? 'bold' : 'grey'; ?>">
+                <td class="bold<?= $user['Role']['perm_auth'] ? '' : ' grey'; ?>">
                     <span class="privacy-value quickSelect" data-hidden-value="<?= h($user['User']['authkey']) ?>">****************************************</span>&nbsp;<i class="privacy-toggle fas fa-eye useCursorPointer" title="<?= __('Reveal hidden value') ?>"></i>
                 </td>
                 <td class="short" ondblclick="document.location ='<?php echo $this->Html->url(array('admin' => true, 'action' => 'view', $user['User']['id']), true);?>';">
@@ -64,10 +64,10 @@
                     <?php echo ($user['User']['termsaccepted'] == 1) ? __("Yes") : __("No"); ?>
                 </td>
                 <td class="short" ondblclick="document.location ='<?php echo $this->Html->url(array('admin' => true, 'action' => 'view', $user['User']['id']), true);?>';" title="<?php echo !$user['User']['current_login'] ? __('N/A') : h(date("Y-m-d H:i:s",$user['User']['current_login']));?>">
-                    <?php echo !$user['User']['current_login'] ? __('N/A') : h(date("Y-m-d",$user['User']['current_login'])); ?>&nbsp;
+                    <?php echo !$user['User']['current_login'] ? __('N/A') : h(date("Y-m-d", $user['User']['current_login'])); ?>&nbsp;
                 </td>
                 <td class="short" ondblclick="document.location ='<?php echo $this->Html->url(array('admin' => true, 'action' => 'view', $user['User']['id']), true);?>';" title="<?php echo !$user['User']['current_login'] ? 'N/A' : h(date("Y-m-d H:i:s",$user['User']['current_login']));?>">
-                    <?php echo !$user['User']['date_created'] ? __('N/A') : h(date("Y-m-d",$user['User']['date_created'])); ?>&nbsp;
+                    <?php echo !$user['User']['date_created'] ? __('N/A') : h(date("Y-m-d", $user['User']['date_created'])); ?>&nbsp;
                 </td>
                 <?php
                     if (Configure::read('Plugin.CustomAuth_enable') && !Configure::read('Plugin.CustomAuth_required')):

--- a/app/View/Elements/genericElements/SideMenu/side_menu.ctp
+++ b/app/View/Elements/genericElements/SideMenu/side_menu.ctp
@@ -778,13 +778,15 @@ $divider = $this->element('/genericElements/SideMenu/side_menu_divider');
                             'url' => $baseurl . '/admin/users/view/' . h($id),
                             'text' => __('View User')
                         ));
-                        echo $this->element('/genericElements/SideMenu/side_menu_link', array(
-                            'onClick' => array(
-                                'function' => 'initiatePasswordReset',
-                                'params' => array($id)
-                            ),
-                            'text' => __('Reset Password')
-                        ));
+                        if ($canAccess('users', 'initiatePasswordReset')) {
+                            echo $this->element('/genericElements/SideMenu/side_menu_link', array(
+                                'onClick' => array(
+                                    'function' => 'initiatePasswordReset',
+                                    'params' => array($id)
+                                ),
+                                'text' => __('Reset Password')
+                            ));
+                        }
                         echo $this->element('/genericElements/SideMenu/side_menu_link', array(
                             'element_id' => 'editUser',
                             'url' => $baseurl . '/admin/users/edit/' . h($id),

--- a/app/View/Elements/genericElements/SideMenu/side_menu.ctp
+++ b/app/View/Elements/genericElements/SideMenu/side_menu.ctp
@@ -1,10 +1,6 @@
 <?php
 $canAccess = function ($controller, $action) use ($me, $aclComponent) {
-    $response = $aclComponent->checkAccess($me, $controller, $action, true);
-    if ($response === 404) {
-        throw new Exception("Invalid controller '$controller' specified for menu requirements.");
-    }
-    return $response === true;
+    return $aclComponent->canUserAccess($me, $controller, $action);
 };
 
 $this->set('menuItem', $menuItem);
@@ -549,23 +545,28 @@ $divider = $this->element('/genericElements/SideMenu/side_menu_divider');
                     break;
 
                 case 'globalActions':
-                    if (((Configure::read('MISP.disableUserSelfManagement') && $isAdmin) || !Configure::read('MISP.disableUserSelfManagement')) && ($menuItem === 'edit' || $menuItem === 'view' || $menuItem === 'change_pw')) {
-                        echo $this->element('/genericElements/SideMenu/side_menu_link', array(
-                            'url' => $baseurl . '/users/edit',
-                            'text' => __('Edit My Profile')
-                        ));
-                        echo $this->element('/genericElements/SideMenu/side_menu_link', array(
-                            'url' => $baseurl . '/users/change_pw',
-                            'text' => __('Change Password')
-                        ));
+                    if ($menuItem === 'edit' || $menuItem === 'view' || $menuItem === 'change_pw') {
+                        if ($canAccess('users', 'edit')) {
+                            echo $this->element('/genericElements/SideMenu/side_menu_link', array(
+                                'url' => $baseurl . '/users/edit',
+                                'text' => __('Edit My Profile')
+                            ));
+                        }
+                        if ($canAccess('users', 'change_pw')) {
+                            echo $this->element('/genericElements/SideMenu/side_menu_link', array(
+                                'url' => $baseurl . '/users/change_pw',
+                                'text' => __('Change Password')
+                            ));
+                        } else if (Configure::read('Plugin.CustomAuth_custom_password_reset')) {
+                            echo $this->element('/genericElements/SideMenu/side_menu_link', array(
+                                'element_id' => 'custom_pw_reset',
+                                'url' => Configure::read('Plugin.CustomAuth_custom_password_reset'),
+                                'text' => __('Change Password')
+                            ));
+                        }
                         echo $divider;
-                    } else if (Configure::read('Plugin.CustomAuth_custom_password_reset')) {
-                        echo $this->element('/genericElements/SideMenu/side_menu_link', array(
-                            'element_id' => 'custom_pw_reset',
-                            'url' => Configure::read('Plugin.CustomAuth_custom_password_reset'),
-                            'text' => __('Reset Password')
-                        ));
                     }
+
                     echo $this->element('/genericElements/SideMenu/side_menu_link', array(
                         'element_id' => 'view',
                         'url' => $baseurl . '/users/view/me',

--- a/app/View/Elements/global_menu.ctp
+++ b/app/View/Elements/global_menu.ctp
@@ -3,11 +3,7 @@
         // New approach how to define menu requirements. It takes ACLs from ACLComponent.
         // TODO: Use for every menu item
         $canAccess = function ($controller, $action) use ($me, $aclComponent) {
-            $response = $aclComponent->checkAccess($me, $controller, $action, true);
-            if ($response === 404) {
-                throw new Exception("Invalid controller '$controller' specified for menu requirements.");
-            }
-            return $response === true;
+            return $aclComponent->canUserAccess($me, $controller, $action);
         };
 
         $menu = array(

--- a/app/View/Elements/global_menu.ctp
+++ b/app/View/Elements/global_menu.ctp
@@ -330,7 +330,8 @@
                     ),
                     array(
                         'text' => __('Add User'),
-                        'url' => $baseurl . '/admin/users/add'
+                        'url' => $baseurl . '/admin/users/add',
+                        'requirement' => $canAccess('users', 'admin_add'),
                     ),
                     array(
                         'text' => __('Contact Users'),

--- a/app/View/Helper/OrgImgHelper.php
+++ b/app/View/Helper/OrgImgHelper.php
@@ -2,61 +2,82 @@
 App::uses('AppHelper', 'View/Helper');
 
 // Helper to retrieve org images with the given parameters
-    class OrgImgHelper extends AppHelper {
-        const IMG_PATH = APP . WEBROOT_DIR . DS . 'img' . DS . 'orgs' . DS;
+class OrgImgHelper extends AppHelper
+{
+    const IMG_PATH = APP . WEBROOT_DIR . DS . 'img' . DS . 'orgs' . DS;
 
-        public function getOrgImg($options, $returnData = false, $raw = false) {
-            $imgOptions = array();
-            $possibleFields = array('id', 'name');
-            $size = !empty($options['size']) ? $options['size'] : 48;
-            foreach ($possibleFields as $field) {
-                if (isset($options[$field]) && file_exists(self::IMG_PATH . $options[$field] . '.png')) {
-                    $imgOptions[$field] = $options[$field] . '.png';
-                    break;
-                }
-            }
-            $baseurl = $this->_View->viewVars['baseurl'];
-            if (!empty($imgOptions)) {
-                foreach ($imgOptions as $field => $imgOption) {
-                    $result = sprintf(
-                        '<img src="%s/img/orgs/%s" title="%s" width="%s" height="%s">',
-                        $baseurl,
-                        $imgOption,
-                        isset($options['name']) ? h($options['name']) : h($options['id']),
-                        (int)$size,
-                        (int)$size
-                    );
+    public function getNameWithImg(array $organisation)
+    {
+        if (!isset($organisation['Organisation'])) {
+            return '';
+        }
 
-                    if (!$raw) {
-                        $result = sprintf(
-                            '<a href="%s/organisations/view/%s">%s</a>',
-                            $baseurl,
-                            empty($options['id']) ? h($options['name']) : h($options['id']),
-                            $result
-                        );
-                    }
-                    break;
-                }
-            } else {
-                if ($raw) {
-                    $result = sprintf(
-                        '<span class="welcome">%s</span>',
-                        h($options['name'])
-                    );
-                } else {
-                    $result = sprintf(
-                        '<a href="%s/organisations/view/%s"><span class="welcome">%s</span></a>',
-                        $baseurl,
-                        empty($options['id']) ? h($options['name']) : h($options['id']),
-                        h($options['name'])
-                    );
-                }
-
-            }
-            if ($returnData) {
-                return $result;
-            } else {
-                echo $result;
+        $orgImgName = null;
+        foreach (['id', 'name'] as $field) {
+            if (isset($organisation['Organisation'][$field]) && file_exists(self::IMG_PATH . $organisation['Organisation'][$field] . '.png')) {
+                $orgImgName = $organisation['Organisation'][$field] . '.png';
+                break;
             }
         }
+        $baseurl = $this->_View->viewVars['baseurl'];
+        $link = $baseurl . '/organisations/view/' . (empty($organisation['Organisation']['id']) ? h($organisation['Organisation']['name']) : h($organisation['Organisation']['id']));
+        if ($orgImgName) {
+            $orgImgUrl = $baseurl . '/img/orgs/' . $orgImgName;
+            return sprintf('<a href="%s" style="background-image: url(\'%s\')" class="orgImg">%s</a>', $link, $orgImgUrl, h($organisation['Organisation']['name']));
+        } else {
+            return sprintf('<a href="%s">%s</a>', $link, h($organisation['Organisation']['name']));
+        }
     }
+
+    public function getOrgImg($options, $returnData = false, $raw = false)
+    {
+        $orgImgName = null;
+        foreach (['id', 'name'] as $field) {
+            if (isset($options[$field]) && file_exists(self::IMG_PATH . $options[$field] . '.png')) {
+                $orgImgName = $options[$field] . '.png';
+                break;
+            }
+        }
+        $baseurl = $this->_View->viewVars['baseurl'];
+        if ($orgImgName) {
+            $size = !empty($options['size']) ? $options['size'] : 48;
+            $result = sprintf(
+                '<img src="%s/img/orgs/%s" title="%s" width="%s" height="%s">',
+                $baseurl,
+                $orgImgName,
+                isset($options['name']) ? h($options['name']) : h($options['id']),
+                (int)$size,
+                (int)$size
+            );
+
+            if (!$raw) {
+                $result = sprintf(
+                    '<a href="%s/organisations/view/%s">%s</a>',
+                    $baseurl,
+                    empty($options['id']) ? h($options['name']) : h($options['id']),
+                    $result
+                );
+            }
+        } else {
+            if ($raw) {
+                $result = sprintf(
+                    '<span class="welcome">%s</span>',
+                    h($options['name'])
+                );
+            } else {
+                $result = sprintf(
+                    '<a href="%s/organisations/view/%s"><span class="welcome">%s</span></a>',
+                    $baseurl,
+                    empty($options['id']) ? h($options['name']) : h($options['id']),
+                    h($options['name'])
+                );
+            }
+
+        }
+        if ($returnData) {
+            return $result;
+        } else {
+            echo $result;
+        }
+    }
+}

--- a/app/View/Users/admin_add.ctp
+++ b/app/View/Users/admin_add.ctp
@@ -37,7 +37,7 @@
                 $passwordPopover = '<span class="blue bold">' . __('Minimal length') . '</span>: ' . h($length) . '<br>';
                 $passwordPopover .= '<span class="blue bold">' . __('Complexity') . '</span>: ' . h($complexity);
                 echo $this->Form->input('password', array(
-                    'label' => __('Password') . ' <span id="PasswordPopover" class="fas fa-info-circle"></span>'
+                    'label' => __('Password') . ' <span id="PasswordPopover" data-content="' . h($passwordPopover) . '" class="fas fa-info-circle"></span>'
                 ));
                 echo $this->Form->input('confirm_password', array('type' => 'password', 'div' => array('class' => 'input password required')));
             ?>
@@ -59,9 +59,9 @@
         }
         echo $this->Form->input('role_id', $roleOptions);
         echo $this->Form->input('authkey', array('value' => $authkey, 'readonly' => 'readonly', 'div' => 'input clear'));
-        echo $this->Form->input('nids_sid');
+        echo $this->Form->input('nids_sid', ['label' => __('NIDS SID')]);
     ?>
-        <div id = "syncServers" class="hidden">
+        <div id="syncServers" class="hidden">
     <?php
             echo $this->Form->input('server_id', array('label' => __('Sync user for'), 'div' => 'clear', 'options' => $servers));
     ?>
@@ -70,6 +70,7 @@
         echo $this->Form->input('gpgkey', array('label' => __('GnuPG key'), 'div' => 'clear', 'class' => 'input-xxlarge', 'placeholder' => __('Paste the user\'s GnuPG key here or try to retrieve it from the CIRCL key server by clicking on "Fetch GnuPG key" below.')));
     ?>
         <div class="clear"><span  role="button" tabindex="0" aria-label="<?php echo __('Fetch the user\'s GnuPG key');?>" onClick="lookupPGPKey('UserEmail');" class="btn btn-inverse" style="margin-bottom:10px;"><?php echo __('Fetch GnuPG key');?></span></div>
+        <div class="user-edit-checkboxes" style="margin-bottom: 1em">
     <?php
         if (Configure::read('SMIME.enabled')) echo $this->Form->input('certif_public', array('label' => __('S/MIME Public certificate (PEM format)'), 'div' => 'clear', 'class' => 'input-xxlarge', 'placeholder' => __('Paste the user\'s S/MIME public key in PEM format here.')));
         $default_publish_alert = Configure::check('MISP.default_publish_alert') ? Configure::read('MISP.default_publish_alert') : true;
@@ -83,9 +84,6 @@
             'type' => 'checkbox',
             'checked' => isset($this->request->data['User']['contactalert']) ? $this->request->data['User']['contactalert'] : true
         ));
-    ?>
-        <div class="clear"></div>
-    <?php
         echo $this->Form->input('disabled', array('type' => 'checkbox', 'label' => __('Disable this user account')));
         echo $this->Form->input('notify', array(
             'label' => __('Send credentials automatically'),
@@ -93,9 +91,10 @@
             'checked' => isset($this->request->data['User']['notify']) ? $this->request->data['User']['notify'] : true
         ));
     ?>
+        </div>
     </fieldset>
 <?php
-    echo $this->Form->button(__('Submit'), array('class' => 'btn btn-primary'));
+    echo $this->Form->button(__('Create user'), array('class' => 'btn btn-primary'));
     echo $this->Form->end();?>
 </div>
 <?php
@@ -115,12 +114,6 @@ $(function() {
     });
     $('#UserExternalAuthRequired').change(function() {
         checkUserExternalAuth();
-    });
-    $('#PasswordPopover').popover("destroy").popover({
-        placement: 'right',
-        html: 'true',
-        trigger: 'hover',
-        content: <?= json_encode($passwordPopover); ?>
     });
 });
 </script>

--- a/app/View/Users/admin_edit.ctp
+++ b/app/View/Users/admin_edit.ctp
@@ -1,5 +1,5 @@
 <div class="users form">
-<?php echo $this->Form->create('User', array('novalidate'=>true));?>
+<?php echo $this->Form->create('User', array('novalidate' => true));?>
     <fieldset>
         <legend><?php echo __('Admin Edit User'); ?></legend>
     <?php
@@ -42,10 +42,10 @@
         <div id="PasswordDiv">
             <div class="clear"></div>
             <?php
-                $passwordPopover = '<span class=\"blue bold\">' . __('Length') .'</span>: ' . h($length) . '<br />';
-                $passwordPopover .= '<span class=\"blue bold\">' . __('Complexity') .'</span>: ' . h($complexity);
+                $passwordPopover = '<span class="blue bold">' . __('Length') .'</span>: ' . h($length) . '<br>';
+                $passwordPopover .= '<span class="blue bold">' . __('Complexity') .'</span>: ' . h($complexity);
                 echo $this->Form->input('password', array(
-                    'label' => __('Password') . ' <span id="PasswordPopover" class="fas fa-info-circle"></span>'
+                    'label' => __('Password') . ' <span id="PasswordPopover" data-content="' . h($passwordPopover) .'" class="fas fa-info-circle"></span>'
                 ));
                 echo $this->Form->input('confirm_password', array('type' => 'password', 'div' => array('class' => 'input password required')));
             ?>
@@ -74,7 +74,10 @@
     ?>
         <div class="clear"><span role="button" tabindex="0" aria-label="<?php echo __('Fetch the user\'s GnuPG key');?>" onClick="lookupPGPKey('UserEmail');" class="btn btn-inverse" style="margin-bottom:10px;"><?php echo __('Fetch GnuPG key');?></span></div>
     <?php
-        if (Configure::read('SMIME.enabled')) echo $this->Form->input('certif_public', array('label' => __('S/MIME Public certificate (PEM format)'), 'div' => 'clear', 'class' => 'input-xxlarge', 'placeholder' => __('Paste the user\'s S/MIME public key in PEM format here.')));
+        if (Configure::read('SMIME.enabled')) {
+            echo $this->Form->input('certif_public', array('label' => __('S/MIME Public certificate (PEM format)'), 'div' => 'clear', 'class' => 'input-xxlarge', 'placeholder' => __('Paste the user\'s S/MIME public key in PEM format here.')));
+        }
+        echo '<div class="user-edit-checkboxes">';
         echo $this->Form->input('termsaccepted', array('type' => 'checkbox', 'label' => __('Terms accepted')));
         echo $this->Form->input('change_pw', [
             'type' => 'checkbox',
@@ -84,11 +87,8 @@
         ]);
         echo $this->Form->input('autoalert', array('label' => __('Receive alerts when events are published'), 'type' => 'checkbox'));
         echo $this->Form->input('contactalert', array('label' => __('Receive alerts from "contact reporter" requests'), 'type' => 'checkbox'));
-    ?>
-        <div class="clear"></div>
-    <?php
         echo $this->Form->input('disabled', array('type' => 'checkbox', 'label' => __('Disable this user account')));
-
+        echo '</div>';
     ?>
     </fieldset>
     <div style="border-bottom: 1px solid #e5e5e5;width:100%;">&nbsp;</div>
@@ -100,7 +100,7 @@
 ?>
     </div>
 <?php
-    echo $this->Form->button(__('Submit'), array('class' => 'btn btn-primary'));
+    echo $this->Form->button(__('Edit user'), array('class' => 'btn btn-primary'));
     echo $this->Form->end();
     echo $this->Form->create('User', array(
         'url' => array('controller' => 'users', 'action' => 'resetauthkey', $id),
@@ -115,7 +115,7 @@
 
 <script type="text/javascript">
     var syncRoles = <?php echo json_encode($syncRoles); ?>;
-    $(document).ready(function() {
+    $(function() {
         syncUserSelected();
         $('#UserRoleId').change(function() {
             syncUserSelected();
@@ -127,12 +127,6 @@
         });
         $('#UserExternalAuthRequired').change(function() {
             checkUserExternalAuth();
-        });
-        $('#PasswordPopover').popover("destroy").popover({
-            placement: 'right',
-            html: 'true',
-            trigger: 'hover',
-            content: '<?php echo $passwordPopover; ?>'
         });
     });
 </script>

--- a/app/View/Users/admin_edit.ctp
+++ b/app/View/Users/admin_edit.ctp
@@ -3,7 +3,10 @@
     <fieldset>
         <legend><?php echo __('Admin Edit User'); ?></legend>
     <?php
-        echo $this->Form->input('email');
+        echo $this->Form->input('email', [
+            'disabled' => !$canChangeLogin,
+            'data-disabled-reason' => !$canChangePassword ? __('User login change is disabled on this instance') : '',
+        ]);
     ?>
         <div class="clear"></div>
     <?php
@@ -29,7 +32,12 @@
     <div class="clear"></div>
     <div id="passwordDivDiv">
         <?php
-            echo $this->Form->input('enable_password', array('type' => 'checkbox', 'label' => __('Set password')));
+            echo $this->Form->input('enable_password', [
+                'type' => 'checkbox',
+                'label' => __('Set password'),
+                'disabled' => !$canChangePassword,
+                'data-disabled-reason' => !$canChangePassword ? __('User password change is disabled on this instance') : '',
+            ]);
         ?>
         <a class="useCursorPointer" onclick="$('#resetAuthKeyForm').submit();"><?= __('Reset Auth Key') ?></a>
         <div id="PasswordDiv">
@@ -54,9 +62,9 @@
         }
         echo $this->Form->input('role_id', array('label' => __('Role')));   // TODO ACL, User edit role_id.
         echo $this->Form->input('authkey', array('disabled' => 'disabled', 'div' => 'input clear'));
-        echo $this->Form->input('nids_sid');
+        echo $this->Form->input('nids_sid', ['label' => __('NIDS SID')]);
     ?>
-        <div id = "syncServers" class="hidden">
+        <div id="syncServers" class="hidden">
     <?php
             echo $this->Form->input('server_id', array('label' => __('Sync user for'), 'div' => 'clear', 'options' => $servers));
     ?>
@@ -68,7 +76,12 @@
     <?php
         if (Configure::read('SMIME.enabled')) echo $this->Form->input('certif_public', array('label' => __('S/MIME Public certificate (PEM format)'), 'div' => 'clear', 'class' => 'input-xxlarge', 'placeholder' => __('Paste the user\'s S/MIME public key in PEM format here.')));
         echo $this->Form->input('termsaccepted', array('type' => 'checkbox', 'label' => __('Terms accepted')));
-        echo $this->Form->input('change_pw', array('type' => 'checkbox', 'label' => __('Change Password')));
+        echo $this->Form->input('change_pw', [
+            'type' => 'checkbox',
+            'label' => __('User must change password after next login'),
+            'disabled' => !$canChangePassword,
+            'data-disabled-reason' => !$canChangePassword ? __('User password change is disabled on this instance') : '',
+        ]);
         echo $this->Form->input('autoalert', array('label' => __('Receive alerts when events are published'), 'type' => 'checkbox'));
         echo $this->Form->input('contactalert', array('label' => __('Receive alerts from "contact reporter" requests'), 'type' => 'checkbox'));
     ?>

--- a/app/View/Users/admin_edit.ctp
+++ b/app/View/Users/admin_edit.ctp
@@ -39,7 +39,6 @@
                 'data-disabled-reason' => !$canChangePassword ? __('User password change is disabled on this instance') : '',
             ]);
         ?>
-        <a class="useCursorPointer" onclick="$('#resetAuthKeyForm').submit();"><?= __('Reset Auth Key') ?></a>
         <div id="PasswordDiv">
             <div class="clear"></div>
             <?php
@@ -61,7 +60,8 @@
             ));
         }
         echo $this->Form->input('role_id', array('label' => __('Role')));   // TODO ACL, User edit role_id.
-        echo $this->Form->input('authkey', array('disabled' => 'disabled', 'div' => 'input clear'));
+        $authkeyLabel = __('Authkey') . ' <a class="useCursorPointer" onclick="$(\'#resetAuthKeyForm\').submit();">' . __('(Reset)') . '</a>';
+        echo $this->Form->input('authkey', array('disabled' => true, 'div' => 'input clear', 'label' => $authkeyLabel));
         echo $this->Form->input('nids_sid', ['label' => __('NIDS SID')]);
     ?>
         <div id="syncServers" class="hidden">

--- a/app/View/Users/change_pw.ctp
+++ b/app/View/Users/change_pw.ctp
@@ -6,7 +6,7 @@
         $passwordPopover = '<span class="blue bold">' . __('Minimal length') . '</span>: ' . h($length) . '<br>';
         $passwordPopover .= '<span class="blue bold">' . __('Complexity') . '</span>: ' . h($complexity);
         echo $this->Form->input('password', array(
-            'label' => __('Password') . ' <span id="PasswordPopover" class="fas fa-info-circle"></span>', 'autofocus'
+            'label' => __('Password') . ' <span id="PasswordPopover" data-content="' . h($passwordPopover) . '" class="fas fa-info-circle"></span>', 'autofocus'
         ));
         echo $this->Form->input('confirm_password', array('type' => 'password', 'div' => array('class' => 'input password required')));
     ?>
@@ -24,16 +24,6 @@ echo $this->Form->button(__('Submit'), array('class' => 'btn btn-primary'));
 echo $this->Form->end();
 ?>
 </div>
-<script type="text/javascript">
-    $(function() {
-        $('#PasswordPopover').popover("destroy").popover({
-            placement: 'right',
-            html: 'true',
-            trigger: 'hover',
-            content: <?= json_encode($passwordPopover) ?>
-        });
-    });
-</script>
 <?php
     echo $this->element('/genericElements/SideMenu/side_menu', array('menuList' => 'globalActions', 'menuItem' => 'change_pw'));
 ?>

--- a/app/View/Users/edit.ctp
+++ b/app/View/Users/edit.ctp
@@ -7,12 +7,14 @@
     ?>
         <div class="input clear"></div>
     <?php
+    if ($canChangePassword) {
         $passwordPopover = '<span class="blue bold">' . __('Minimal length') . '</span>: ' . h($length) . '<br>';
         $passwordPopover .= '<span class="blue bold">' . __('Complexity') . '</span>: ' . h($complexity);
         echo $this->Form->input('password', array(
             'label' => __('Password') . ' <span id="PasswordPopover" class="fas fa-info-circle"></span>'
         ));
         echo $this->Form->input('confirm_password', array('type' => 'password', 'div' => array('class' => 'input password required')));
+    }
     ?>
         <div class="input clear"></div>
     <?php
@@ -46,6 +48,7 @@
     $user['User']['id'] = $id;
     echo $this->element('/genericElements/SideMenu/side_menu', array('menuList' => 'globalActions', 'menuItem' => 'edit', 'user' => $user));
 ?>
+<?php if ($canChangePassword): ?>
 <script type="text/javascript">
     $(function() {
         $('#PasswordPopover').popover("destroy").popover({
@@ -56,4 +59,5 @@
         });
     });
 </script>
+<?php endif; ?>
 <?php echo $this->Js->writeBuffer();

--- a/app/View/Users/edit.ctp
+++ b/app/View/Users/edit.ctp
@@ -3,7 +3,7 @@
     <fieldset>
         <legend><?php echo __('Edit My Profile'); ?></legend>
     <?php
-        echo $this->Form->input('email');
+        echo $this->Form->input('email', ['disabled' => $canChangeLogin ? false : 'disabled']);
     ?>
         <div class="input clear"></div>
     <?php
@@ -18,7 +18,7 @@
     ?>
         <div class="input clear"></div>
     <?php
-        echo $this->Form->input('nids_sid');
+        echo $this->Form->input('nids_sid', ['label' => __('NIDS SID')]);
     ?>
         <div class="input clear"></div>
     <?php

--- a/app/View/Users/edit.ctp
+++ b/app/View/Users/edit.ctp
@@ -11,7 +11,7 @@
         $passwordPopover = '<span class="blue bold">' . __('Minimal length') . '</span>: ' . h($length) . '<br>';
         $passwordPopover .= '<span class="blue bold">' . __('Complexity') . '</span>: ' . h($complexity);
         echo $this->Form->input('password', array(
-            'label' => __('Password') . ' <span id="PasswordPopover" class="fas fa-info-circle"></span>'
+            'label' => __('Password') . ' <span id="PasswordPopover" data-content="' . h($passwordPopover) . '" class="fas fa-info-circle"></span>'
         ));
         echo $this->Form->input('confirm_password', array('type' => 'password', 'div' => array('class' => 'input password required')));
     }
@@ -26,9 +26,13 @@
         ?>
             <div class="clear"><span role="button" tabindex="0" aria-label="<?php echo __('Fetch GnuPG key');?>" onClick="lookupPGPKey('UserEmail');" class="btn btn-inverse" style="margin-bottom:10px;"><?php echo __('Fetch GnuPG key');?></span></div>
         <?php
-        if (Configure::read('SMIME.enabled')) echo $this->Form->input('certif_public', array('label' => __('S/MIME Public certificate (PEM format)'), 'div' => 'clear', 'class' => 'input-xxlarge'));
+        if (Configure::read('SMIME.enabled')) {
+            echo $this->Form->input('certif_public', array('label' => __('S/MIME Public certificate (PEM format)'), 'div' => 'clear', 'class' => 'input-xxlarge'));
+        }
+        echo '<div class="user-edit-checkboxes">';
         echo $this->Form->input('autoalert', array('label' => __('Receive alerts when events are published'), 'type' => 'checkbox'));
         echo $this->Form->input('contactalert', array('label' => __('Receive alerts from "contact reporter" requests'), 'type' => 'checkbox'));
+        echo '</div>';
     ?>
     </fieldset>
     <div style="border-bottom: 1px solid #e5e5e5;width:100%;">&nbsp;</div>
@@ -40,7 +44,7 @@
 ?>
     </div>
 <?php
-    echo $this->Form->button(__('Submit'), array('class' => 'btn btn-primary'));
+    echo $this->Form->button(__('Edit'), array('class' => 'btn btn-primary'));
     echo $this->Form->end();
 ?>
 </div>
@@ -48,16 +52,4 @@
     $user['User']['id'] = $id;
     echo $this->element('/genericElements/SideMenu/side_menu', array('menuList' => 'globalActions', 'menuItem' => 'edit', 'user' => $user));
 ?>
-<?php if ($canChangePassword): ?>
-<script type="text/javascript">
-    $(function() {
-        $('#PasswordPopover').popover("destroy").popover({
-            placement: 'right',
-            html: 'true',
-            trigger: 'hover',
-            content: <?= json_encode($passwordPopover) ?>
-        });
-    });
-</script>
-<?php endif; ?>
 <?php echo $this->Js->writeBuffer();

--- a/app/View/Users/view.ctp
+++ b/app/View/Users/view.ctp
@@ -13,12 +13,7 @@
     );
     $table_data[] = array(
         'key' => __('Organisation'),
-        'html' => sprintf(
-            '<a href="%s/organisations/view/%s">%s</a>',
-            $baseurl,
-            h($user['Organisation']['id']),
-            h($user['Organisation']['name'])
-        )
+        'html' => $this->OrgImg->getNameWithImg($user),
     );
     $table_data[] = array('key' => __('Role'), 'html' => $this->Html->link($user['Role']['name'], array('controller' => 'roles', 'action' => 'view', $user['Role']['id'])));
     $table_data[] = array('key' => __('Autoalert'), 'boolean' => $user['User']['autoalert']);

--- a/app/View/Users/view.ctp
+++ b/app/View/Users/view.ctp
@@ -18,11 +18,15 @@
     $table_data[] = array('key' => __('Role'), 'html' => $this->Html->link($user['Role']['name'], array('controller' => 'roles', 'action' => 'view', $user['Role']['id'])));
     $table_data[] = array('key' => __('Autoalert'), 'boolean' => $user['User']['autoalert']);
     $table_data[] = array('key' => __('Contactalert'), 'boolean' => $user['User']['contactalert']);
-    $authkey_data = sprintf(
-        '<a onclick="requestAPIAccess();" style="cursor:pointer;"></a>',
-        __('Request API access')
-    );
-    if (empty(Configure::read('Security.advanced_authkeys'))) {
+
+    if (!$admin_view && !$user['Role']['perm_auth']) {
+        $table_data[] = array(
+            'key' => __('Auth key'),
+            'html' => sprintf('<a onclick="requestAPIAccess();" class="useCursorPointer">%s</a>', __('Request API access')),
+        );
+    }
+
+    if (empty(Configure::read('Security.advanced_authkeys')) && $user['Role']['perm_auth']) {
         $authkey_data = sprintf(
             '<span class="privacy-value quickSelect authkey" data-hidden-value="%s">****************************************</span>&nbsp;<i class="privacy-toggle fas fa-eye useCursorPointer" title="%s"></i>%s',
             h($user['User']['authkey']),
@@ -33,7 +37,7 @@
             )
         );
         $table_data[] = array(
-            'key' => __('Authkey'),
+            'key' => __('Auth key'),
             'html' => $authkey_data
         );
     }
@@ -132,24 +136,3 @@
         $this->element('/genericElements/accordion', array('title' => 'Events', 'url' => '/events/index/searchemail:' . urlencode(h($user['User']['email'])))),
         $this->element('/genericElements/SideMenu/side_menu', $current_menu[$admin_view ? 'admin_view' : 'view'])
     );
-?>
-<script type="text/javascript">
-    $(function () {
-        $.ajax({
-            url: '<?php echo $baseurl . "/events/index/searchemail:" . urlencode(h($user['User']['email'])); ?>',
-            type:'GET',
-            beforeSend: function () {
-                $(".loading").show();
-            },
-            error: function(){
-                $('#userEvents').html('An error has occurred, please reload the page.');
-            },
-            success: function(response){
-                $('#userEvents').html(response);
-            },
-            complete: function() {
-                $(".loading").hide();
-            }
-        });
-    });
-</script>

--- a/app/webroot/css/main.css
+++ b/app/webroot/css/main.css
@@ -2645,3 +2645,28 @@ table tr:hover .down-expand-button {
     font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
     font-size: 11px;
 }
+
+/*
+ Make user edit checkboxes nicer
+ */
+.user-edit-checkboxes div.input {
+    float: none;
+    width: inherit;
+    margin-top: 3px;
+}
+
+.user-edit-checkboxes .checkbox input[type="checkbox"] {
+    margin-top: 4px;
+}
+
+.user-edit-checkboxes label {
+    display: inline;
+}
+
+a.orgImg {
+    background-repeat: no-repeat;
+    background-size: 20px;
+    padding-left: 25px;
+    padding-top: 2px;
+    padding-bottom: 2px;
+}

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -35,7 +35,7 @@ function rgb2hex(rgb) {
 }
 
 function xhrFailCallback(xhr) {
-    if (xhr.status === 403) {
+    if (xhr.status === 403 || xhr.status === 405) {
         showMessage('fail', 'Not allowed.');
     } else if (xhr.status === 404) {
         showMessage('fail', 'Resource not found.');
@@ -300,18 +300,18 @@ function initiatePasswordReset(id) {
     $.get(baseurl + "/users/initiatePasswordReset/" + id, function(data) {
         $("#confirmation_box").html(data);
         openPopup("#confirmation_box");
-    });
+    }).fail(xhrFailCallback)
 }
 
 function submitPasswordReset(id) {
     var formData = $('#PromptForm').serialize();
     var url = baseurl + "/users/initiatePasswordReset/" + id;
     $.ajax({
-        beforeSend: function (XMLHttpRequest) {
+        beforeSend: function () {
             $(".loading").show();
         },
         data: formData,
-        success:function (data, textStatus) {
+        success: function (data) {
             handleGenericAjaxResponse(data);
         },
         complete:function() {
@@ -319,9 +319,9 @@ function submitPasswordReset(id) {
             $("#confirmation_box").fadeOut();
             $("#gray_out").fadeOut();
         },
-        type:"post",
+        type: "post",
         cache: false,
-        url:url,
+        url: url,
     });
 }
 

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -4684,6 +4684,14 @@ $(document).ready(function() {
             return $(this).data('disabled-reason');
         }
     });
+    $('#PasswordPopover').popover("destroy").popover({
+        placement: 'right',
+        html: 'true',
+        trigger: 'hover',
+        content: function () {
+            return $(this).data('content');
+        }
+    });
     $(".queryPopover").click(function() {
         url = $(this).data('url');
         id = $(this).data('id');


### PR DESCRIPTION
#### What does it do?

This MR introduces three new options:

* `MISP.disable_user_login_change` - just site admins can change user login (email).
* `MISP.disable_user_password_change` - just site admins can change user password.
* `MISP.disable_user_add` - org admins cannot add new user to their organisation.

All these options are useful when you use external authentication.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
