### PR TITLE
fix: [internal] Remove warning when modules are not reachable

### DIFF
--- a/app/Model/Module.php
+++ b/app/Model/Module.php
@@ -289,7 +289,7 @@ class Module extends AppModel
     {
         $modules = $this->getModules($moduleFamily);
         $result = array();
-        if (!empty($modules)) {
+        if (is_array($modules)) {
             foreach ($modules as $module) {
                 if (array_intersect($this->__validTypes[$moduleFamily], $module['meta']['module-type'])) {
                     $moduleSettings = [


### PR DESCRIPTION
#### What does it do?

Should fix #6534

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
