### PR TITLE
fix: [internal] Do not load all attributes when editing event

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -4054,12 +4054,14 @@ class Event extends AppModel
 
         // reposition to get the event.id with given uuid
         if (isset($data['Event']['uuid'])) {
-            $existingEvent = $this->findByUuid($data['Event']['uuid']);
+            $conditions = ['Event.uuid' => $data['Event']['uuid']];
         } elseif ($id) {
-            $existingEvent = $this->findById($id);
+            $conditions = ['Event.id' => $id];
         } else {
             throw new InvalidArgumentException("No event UUID or ID provided.");
         }
+        $existingEvent = $this->find('first', ['conditions' => $conditions, 'recursive' => -1]);
+
         if ($passAlong) {
             $this->Server = ClassRegistry::init('Server');
             $server = $this->Server->find('first', array(


### PR DESCRIPTION
#### What does it do?

Before that change, all attributes was loaded, so that takes a lot of time and memory.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
