### PR TITLE
fix: [internal] Remove undefined variable warning in ajaxTags template

### DIFF
--- a/app/View/Elements/ajaxTags.ctp
+++ b/app/View/Elements/ajaxTags.ctp
@@ -34,7 +34,7 @@
             }
             break;
     }
-    $full = $isAclTagger && $tagAccess && empty($static_tags_only);
+    $full = $isAclTagger && isset($tagAccess) && $tagAccess && empty($static_tags_only);
     $host_org_editor = (int)$me['org_id'] === Configure::read('MISP.host_org_id') && $isAclTagger && empty($static_tags_only);
     $tagData = "";
     foreach ($tags as $tag) {


### PR DESCRIPTION
#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
