### PR TITLE
chg: [rest] For attribute REST search with includeContext, fetch events just once

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -2252,7 +2252,7 @@ class Event extends AppModel
             return array();
         }
 
-        $sharingGroupData = $this->__cacheSharingGroupData($user, $useCache);
+        $sharingGroupData = $options['sgReferenceOnly'] ? [] : $this->__cacheSharingGroupData($user, $useCache);
 
         // Initialize classes that will be necessary during event fetching
         if ((empty($options['metadata']) && empty($options['noSightings'])) && !isset($this->Sighting)) {

--- a/app/Model/Organisation.php
+++ b/app/Model/Organisation.php
@@ -385,31 +385,31 @@ class Organisation extends AppModel
         return (empty($org)) ? false : $org[$this->alias];
     }
 
+    /**
+     * @param array $event
+     * @param array $fields
+     * @return array
+     */
     public function attachOrgsToEvent($event, $fields)
     {
-        if (empty($this->__orgCache[$event['Event']['orgc_id']])) {
-            $temp = $this->find('first', array(
-                'conditions' => array('id' => $event['Event']['orgc_id']),
+        $toFetch = [];
+        if (!isset($this->__orgCache[$event['Event']['orgc_id']])) {
+            $toFetch[] = $event['Event']['orgc_id'];
+        }
+        if (!isset($this->__orgCache[$event['Event']['org_id']]) && $event['Event']['org_id'] != $event['Event']['orgc_id']) {
+            $toFetch[] = $event['Event']['org_id'];
+        }
+        if (!empty($toFetch)) {
+            $orgs = $this->find('all', array(
+                'conditions' => array('id' => $toFetch),
                 'recursive' => -1,
                 'fields' => $fields
             ));
-            if (!empty($temp)) {
-                $temp = $temp[$this->alias];
+            foreach ($orgs as $org) {
+                $this->__orgCache[$org[$this->alias]['id']] = $org[$this->alias];
             }
-            $this->__orgCache[$event['Event']['orgc_id']] = $temp;
         }
         $event['Orgc'] = $this->__orgCache[$event['Event']['orgc_id']];
-        if (empty($this->__orgCache[$event['Event']['org_id']])) {
-            $temp = $this->find('first', array(
-                'conditions' => array('id' => $event['Event']['org_id']),
-                'recursive' => -1,
-                'fields' => $fields
-            ));
-            if (!empty($temp)) {
-                $temp = $temp[$this->alias];
-            }
-            $this->__orgCache[$event['Event']['org_id']] = $temp;
-        }
         $event['Org'] = $this->__orgCache[$event['Event']['org_id']];
         return $event;
     }


### PR DESCRIPTION
#### What does it do?

When fetching a lot of attributes with `includeContext`, a lot of information are fetched again and again from database. This should reduce that overhead and save server memory and also time.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
