### PR TITLE
Syslog stderr disable

### DIFF
--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -1423,13 +1423,11 @@ class ServersController extends AppController
             throw new MethodNotAllowedException(__('This setting can only be edited via the CLI.'));
         }
         if ($this->request->is('get')) {
-            if ($setting != null) {
-                $value = Configure::read($setting['name']);
-                if ($value) {
-                    $setting['value'] = $value;
-                }
-                $setting['setting'] = $setting['name'];
+            $value = Configure::read($setting['name']);
+            if (isset($value)) {
+                $setting['value'] = $value;
             }
+            $setting['setting'] = $setting['name'];
             if (isset($setting['optionsSource']) && !empty($setting['optionsSource'])) {
                 $setting['options'] = $this->{'__load' . $setting['optionsSource']}();
             }
@@ -1446,8 +1444,7 @@ class ServersController extends AppController
                 $this->set('setting', $setting);
                 $this->render('ajax/server_settings_edit');
             }
-        }
-        if ($this->request->is('post')) {
+        } else if ($this->request->is('post')) {
             if (!isset($this->request->data['Server'])) {
                 $this->request->data = array('Server' => $this->request->data);
             }
@@ -1470,7 +1467,7 @@ class ServersController extends AppController
             $this->loadModel('Log');
             if (!is_writeable(APP . 'Config/config.php')) {
                 $this->Log->create();
-                $result = $this->Log->save(array(
+                $this->Log->save(array(
                         'org' => $this->Auth->user('Organisation')['name'],
                         'model' => 'Server',
                         'model_id' => 0,

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1369,6 +1369,24 @@ class Server extends AppModel
                             'type' => 'boolean',
                             'null' => true
                         ),
+                    'syslog_to_stderr' => array(
+                        'level' => self::SETTING_OPTIONAL,
+                        'description' => __('Write syslog messages also to standard error output.'),
+                        'value' => true,
+                        'errorMessage' => '',
+                        'test' => 'testBool',
+                        'type' => 'boolean',
+                        'null' => true
+                    ),
+                    'syslog_ident' => array(
+                        'level' => self::SETTING_OPTIONAL,
+                        'description' => __('Syslog message identifier.'),
+                        'value' => '',
+                        'errorMessage' => '',
+                        'test' => 'testForEmpty',
+                        'type' => 'string',
+                        'null' => true
+                    ),
                         'do_not_log_authkeys' => array(
                             'level' => 0,
                             'description' => __('If enabled, any authkey will be replaced by asterisks in Audit log.'),

--- a/app/Plugin/SysLog/Lib/SysLog.php
+++ b/app/Plugin/SysLog/Lib/SysLog.php
@@ -14,58 +14,60 @@
  * @subpackage    sunshine.cake.libs.log
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
+
 /**
  * SysLog for Logging.
  *
  * @package sunshine
  * @subpackage sunshine.cake.libs.log
  */
-class SysLog {
+class SysLog
+{
     /** @var bool */
     private $_log;
 
-	/**
-	 * Constructs a new SysLog Logger.
-	 *
-	 * Options
-	 *
-	 * - `ident` the ident to be added to each message.
-	 * - `facility` what type of application is recording a message. Default: LOG_LOCAL0. LOG_USER if Windows.
+    /**
+     * Constructs a new SysLog Logger.
+     *
+     * Options
+     *
+     * - `ident` the ident to be added to each message.
+     * - `facility` what type of application is recording a message. Default: LOG_LOCAL0. LOG_USER if Windows.
      * - `to_stderr` if true, print log message also to standard error
-	 *
-	 * @param array $options Options for the SysLog, see above.
-	 * @return void
-	 */
-	public function __construct($options = array())
+     *
+     * @param array $options Options for the SysLog, see above.
+     * @return void
+     */
+    public function __construct($options = array())
     {
-		$options += array('ident' => LOGS, 'facility' => LOG_LOCAL0, 'to_stderr' => true);
-		$option = LOG_PID; // include PID with each message
-		if ($options['to_stderr']) {
-		    $option |= LOG_PERROR; // print log message also to standard error
+        $options += array('ident' => LOGS, 'facility' => LOG_LOCAL0, 'to_stderr' => true);
+        $option = LOG_PID; // include PID with each message
+        if ($options['to_stderr']) {
+            $option |= LOG_PERROR; // print log message also to standard error
         }
-		$this->_log = openlog($options['ident'], $option, $options['facility']);
-	}
+        $this->_log = openlog($options['ident'], $option, $options['facility']);
+    }
 
-	/**
-	 * Implements writing to the specified syslog
-	 *
-	 * @param string $type The type of log you are making.
-	 * @param string $message The message you want to log.
-	 * @return boolean success of write.
-	 */
-	public function write($type, $message)
+    /**
+     * Implements writing to the specified syslog
+     *
+     * @param string $type The type of log you are making.
+     * @param string $message The message you want to log.
+     * @return boolean success of write.
+     */
+    public function write($type, $message)
     {
-	    if (!$this->_log) {
-	        return false;
+        if (!$this->_log) {
+            return false;
         }
-		$debugTypes = array('notice', 'info', 'debug');
-		$priority = LOG_INFO;
-		if ($type == 'error' || $type == 'warning') {
-			$priority = LOG_ERR;
-		} else if (in_array($type, $debugTypes)) {
-			$priority = LOG_DEBUG;
-		}
-		$output = date('Y-m-d H:i:s') . ' ' . ucfirst($type) . ': ' . $message;
-		return syslog($priority, $output);
-	}
+        $debugTypes = array('notice', 'info', 'debug');
+        $priority = LOG_INFO;
+        if ($type == 'error' || $type == 'warning') {
+            $priority = LOG_ERR;
+        } else if (in_array($type, $debugTypes)) {
+            $priority = LOG_DEBUG;
+        }
+        $output = date('Y-m-d H:i:s') . ' ' . ucfirst($type) . ': ' . $message;
+        return syslog($priority, $output);
+    }
 }


### PR DESCRIPTION
#### What does it do?

This MR introduce two new options:

* `Security.syslog_ident` to set syslog name (currently it is just log folder)
* `Security.syslog_to_stderr` can disable sending audit syslog messages to stderr

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
