### PR TITLE
Fix: Fix spelling of sightings_anonymise_as description

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -2115,7 +2115,7 @@ class Server extends AppModel
                         ),
                         'Sightings_anonymise_as' => array(
                                 'level' => 1,
-                                'description' => __('When pushing sightings to another server, report all sightings from this instance as this orignisation. This effectively hides all sightings from this instance behind a single organisation to the outside world. Sightings pulled from this instance follow the Sightings_policy above.'),
+                                'description' => __('When pushing sightings to another server, report all sightings from this instance as this organisation. This effectively hides all sightings from this instance behind a single organisation to the outside world. Sightings pulled from this instance follow the Sightings_policy above.'),
                                 'value' => '0',
                                 'errorMessage' => '',
                                 'test' => 'testLocalOrg',


### PR DESCRIPTION
#### What does it do?

There is no existing issue as far as I can tell. 
I have found a spelling mistake in the description text for the Sightings Plugin (Plugin.Sightings_anonymise_as) and fixed it.

#### Questions

- [ ] Does it require a DB change? (No)  
- [x] Are you using it in production?  
- [ ] Does it require a change in the API (PyMISP for example)? (No)  
