### PR TITLE
fix: [internal] Destroy session just when session is started

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -586,7 +586,7 @@ class AppController extends Controller
 
     public function afterFilter()
     {
-        if ($this->isApiAuthed && $this->_isRest()) {
+        if ($this->isApiAuthed && $this->_isRest() && $this->Session->started()) {
             $this->Session->destroy();
         }
     }


### PR DESCRIPTION
#### What does it do?

Should help with nonsenses debug messages.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
