### PR TITLE
fix: [internal] Initialize ZMQ just when necessary after setting change

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -3978,18 +3978,17 @@ class Server extends AppModel
 
     public function zmqAfterHook($setting, $value)
     {
-        $pubSubTool = $this->getPubSubTool();
         // If we are trying to change the enable setting to false, we don't need to test anything, just kill the server and return true.
-        if ($setting == 'Plugin.ZeroMQ_enable') {
+        if ($setting === 'Plugin.ZeroMQ_enable') {
             if ($value == false || $value == 0) {
-                $pubSubTool->killService();
+                $this->getPubSubTool()->killService();
                 return true;
             }
         } elseif (!Configure::read('Plugin.ZeroMQ_enable')) {
             // If we are changing any other ZeroMQ settings but the feature is disabled, don't reload the service
             return true;
         }
-        $pubSubTool->reloadServer();
+        $this->getPubSubTool()->reloadServer();
         return true;
     }
 


### PR DESCRIPTION
#### What does it do?

Should help for #6592

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
