### PR TITLE
new: [shibb] Allow to get organisation UUID from HTTP headers

### DIFF
--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -1364,6 +1364,28 @@ class User extends AppModel
     }
 
     /**
+     * Update field in user model and also set `date_modified`
+     *
+     * @param array $user
+     * @param string $name
+     * @param mixed $value
+     * @throws Exception
+     */
+    public function updateField(array $user, $name, $value)
+    {
+        if (!isset($user['id'])) {
+            throw new InvalidArgumentException("Invalid user object provided.");
+        }
+        $success = $this->save([
+            'id' => $user['id'],
+            $name => $value,
+        ], true, ['id', $name, 'date_modified']);
+        if (!$success) {
+            throw new RuntimeException("Could not save field `$name` with value `$value` for user `{$user['id']}`.");
+        }
+    }
+
+    /**
      * Initialize GPG. Returns `null` if initialization failed.
      *
      * @return null|CryptGpgExtended

--- a/app/Plugin/ShibbAuth/Controller/Component/Auth/ApacheShibbAuthenticate.php
+++ b/app/Plugin/ShibbAuth/Controller/Component/Auth/ApacheShibbAuthenticate.php
@@ -1,12 +1,11 @@
 <?php
-
 App::uses('BaseAuthenticate', 'Controller/Component/Auth');
-App::uses('RandomTool', 'Tools');
 
-if (session_status() == PHP_SESSION_NONE) {
-	session_start();
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
 }
 session_regenerate_id();
+
 /*
  * custom class for Apache-based authentication
  *
@@ -21,228 +20,223 @@ session_regenerate_id();
  * @see ApacheAuthComponent::$authenticate
  */
 
-class ApacheShibbAuthenticate extends BaseAuthenticate {
+class ApacheShibbAuthenticate extends BaseAuthenticate
+{
+    /**
+     * Authentication class
+     *
+     * Configuration in app/Config/Config.php is:
+     *
+     * 'ApacheShibbAuth' =>                      // Configuration for shibboleth authentication
+     *     array(
+     *      'MailTag' => 'EMAIL_TAG',
+     *      'OrgTag' => 'FEDERATION_TAG',
+     *      'GroupTag' => 'GROUP_TAG',
+     *      'GroupSeparator' => ';',
+     *      'GroupRoleMatching' => array(                // 3:User, 1:admin. May be good to set "1" for the first user
+     *          'group_three' => '3',
+     *          'group_two' => 2,
+     *          'group_one' => 1,
+     *       ),
+     *      'DefaultOrg' => 'MY_ORG',
+     * ),
+     * @param CakeRequest $request The request that contains login information.
+     * @param CakeResponse $response Unused response object.
+     * @return mixed False on login failure. An array of User data on success.
+     * @throws Exception
+     */
+    public function authenticate(CakeRequest $request, CakeResponse $response)
+    {
+        return self::getUser($request);
+    }
 
+    /**
+     * @param CakeRequest $request
+     * @return array|bool
+     * @throws Exception
+     */
+    public function getUser(CakeRequest $request)
+    {
+        // If the url contains sso=disable we return false so the main misp authentication form is used to log in
+        if (array_key_exists('sso', $request->query) && $request->query['sso'] == 'disable' || (isset($_SESSION["sso_disable"]) && $_SESSION["sso_disable"] === true)) {
+            $_SESSION["sso_disable"] = true;
+            return false;
+        }
 
-	/**
-	 * Authentication class
-	 *
-	 * Configuration in app/Config/Config.php is:
-	 *
-	 * 'ApacheShibbAuth' =>                      // Configuration for shibboleth authentication
-	 *     array(
-	 *      'MailTag' => 'EMAIL_TAG',
-	 *      'OrgTag' => 'FEDERATION_TAG',
-	 *      'GroupTag' => 'GROUP_TAG',
-	 *      'GroupSeparator' => ';',
-	 *      'GroupRoleMatching' => array(                // 3:User, 1:admin. May be good to set "1" for the first user
-	 *          'group_three' => '3',
-	 *          'group_two' => 2,
-	 *          'group_one' => 1,
-	 *       ),
-	 *      'DefaultOrg' => 'MY_ORG',
-	 * ),
-	 * @param CakeRequest $request The request that contains login information.
-	 * @param CakeResponse $response Unused response object.
-	 * @return mixed False on login failure. An array of User data on success.
-	 */
+        // Get Default parameters
+        $roleId = -1;
+        $org = Configure::read('ApacheShibbAuth.DefaultOrg');
+        $useDefaultOrg = Configure::read('ApacheShibbAuth.UseDefaultOrg');
+        // Get tags from SSO config
+        $mailTag = Configure::read('ApacheShibbAuth.MailTag');
+        $orgTag = Configure::read('ApacheShibbAuth.OrgTag');
+        $groupTag = Configure::read('ApacheShibbAuth.GroupTag');
+        $groupRoleMatching = Configure::read('ApacheShibbAuth.GroupRoleMatching');
 
-	public function authenticate(CakeRequest $request, CakeResponse $response)
-	{
-		return self::getUser($request);
-	}
+        // Get user values
+        if (!isset($_SERVER[$mailTag])) {
+            CakeLog::error('Mail tag is not given by the SSO SP. Not processing login.');
+            return false;
+        }
+        $mispUsername = $_SERVER[$mailTag];
 
-	/**
-	 * @return array|bool
-	 */
-	public function getUser(CakeRequest $request)
-	{
+        if (filter_var($mispUsername, FILTER_VALIDATE_EMAIL) === false) {
+            CakeLog::error( "Mail tag `$mispUsername` given by the SSO SP, but it is not valid email address.");
+            return false;
+        }
 
-		//If the url contains sso=disable we return false so the main misp authentication form is used to log in
-		if (array_key_exists('sso', $request->query) && $request->query['sso'] == 'disable' || (isset($_SESSION["sso_disable"]) &&  $_SESSION["sso_disable"] === True)) {
-			$_SESSION["sso_disable"]=True;
-			return false;
-		}
+        CakeLog::info("Trying login of user: `$mispUsername`.");
 
-		// Get Default parameters
-		$roleId = -1;
-		$org = Configure::read('ApacheShibbAuth.DefaultOrg');
-		$useDefaultOrg = Configure::read('ApacheShibbAuth.UseDefaultOrg');
-		// Get tags from SSO config
-		$mailTag = Configure::read('ApacheShibbAuth.MailTag');
-		$OrgTag = Configure::read('ApacheShibbAuth.OrgTag');
-		$groupTag = Configure::read('ApacheShibbAuth.GroupTag');
-		$groupRoleMatching = Configure::read('ApacheShibbAuth.GroupRoleMatching');
+        // Change username column for email (username in shibboleth attributes corresponds to the email in MISPs DB)
+        $this->settings['fields'] = array('username' => 'email');
 
-		// Get user values
-		if (!isset($_SERVER[$mailTag]) || filter_var($_SERVER[$mailTag], FILTER_VALIDATE_EMAIL) === FALSE) {
-			CakeLog::write('error', 'Mail tag is not given by the SSO SP. Not processing login.');
-			return false;
-		}
+        // Find user with real username (mail)
+        $user = $this->_findUser($mispUsername);
 
-		$mispUsername = $_SERVER[$mailTag];
-		CakeLog::write('info', "Trying login of user: ${mispUsername}.");
+        // Obtain default org. If default is not enforced and it is given, org keeps the default value
+        if (!$useDefaultOrg && isset($_SERVER[$orgTag])) {
+            $org = $_SERVER[$orgTag];
+        }
 
-		//Change username column for email (username in shibboleth attributes corresponds to the email in MISPs DB)
-		$this->settings['fields'] = array('username' => 'email');
+        // Check if the organization exits and create it if not
+        $org = $this->checkOrganization($org, $user);
+        if (!$org) {
+            return false;
+        }
 
-		// Find user with real username (mail)
-		$user = $this->_findUser($mispUsername);
+        // Get user role from its list of groups
+        list($roleChanged, $roleId) = $this->getUserRoleFromGroup($groupTag, $groupRoleMatching, $roleId);
+        if ($roleId < 0) {
+            CakeLog::error('No role was assigned, no egroup matched the configuration.');
+            return false; // Deny if the user is not in any egroup
+        }
 
-		//Obtain default org. If default is not enforced and it is given, org keeps the default value
-		if (!$useDefaultOrg && isset($_SERVER[$OrgTag])) {
-			$org = $_SERVER[$OrgTag];
-		}
+        /** @var User $userModel */
+        $userModel = ClassRegistry::init($this->settings['userModel']);
 
-		//Check if the organization exits and create it if not
-		$org = $this->checkOrganization($org, $user);
+        if ($user) { // User already exists
+            CakeLog::info( "User `$mispUsername` found in database.");
+            $user = $this->updateUserRole($roleChanged, $user, $roleId, $userModel);
+            $user = $this->updateUserOrg($org, $user, $userModel);
+            CakeLog::info("User `$mispUsername` logged in.");
+            return $user;
+        }
 
-		//Get user role from its list of groups
-		list($roleChanged, $roleId) = $this->getUserRoleFromGroup($groupTag, $groupRoleMatching, $roleId);
-		if($roleId < 0) {
-			CakeLog::write('error', 'No role was assigned, no egroup matched the configuration.');
-			return false; //Deny if the user is not in any egroup
-		}
+        CakeLog::info("User `$mispUsername` not found in database.");
 
-		// Database model object
-		$userModel = ClassRegistry::init($this->settings['userModel']);
+        // Insert user in database if not existent
+        $userData = array('User' => array(
+            'email' => $mispUsername,
+            'org_id' => $org,
+            'newsread' => time(),
+            'role_id' => $roleId,
+            'change_pw' => 0,
+            'date_created' => time(),
+        ));
 
-		if ($user) { // User already exists
-			CakeLog::write('info', "User ${mispUsername} found in database.");
-			$user = $this->updateUserRole($roleChanged, $user, $roleId, $userModel);
-			$user = $this->updateUserOrg($org, $user, $userModel);
-			CakeLog::write('info', "User ${mispUsername} logged in.");
-			return $user;
-		}
+        // save user
+        $userModel->save($userData);
+        CakeLog::info("User `$mispUsername` saved in database.");
+        CakeLog::info("User `$mispUsername` logged in.");
+        return $this->_findUser($mispUsername);
+    }
 
-		CakeLog::write('info', "User ${mispUsername} not found in database.");
-		//Insert user in database if not existent
+    /**
+     * @param string $org
+     * @param array $user
+     * @return int
+     */
+    private function checkOrganization($org, $user)
+    {
+        $orgIsUuid = Validation::uuid($org);
 
-		// Generate random password
-		$password = $userModel->generateRandomPassword();
-		// Generate random auth key
-		$authKey = $userModel->generateAuthKey();
-		// get maximum nids value
-		$nidsMax = $userModel->find('all', array(
-			'fields' => array('MAX(User.nids_sid) AS nidsMax'),
-			)
-		);
-		// create user
-		$userData = array('User' => array(
-			'email' => $mispUsername,
-			'org_id' => $org,
-			'password' => $password, //Since it is done via shibboleth the password will be a random 40 character string
-			'confirm_password' => $password,
-			'authkey' => $authKey,
-			'nids_sid' => ((int)$nidsMax[0][0]['nidsMax'])+1,
-			'newsread' => time(),
-			'role_id' => $roleId,
-			'change_pw' => 0,
-			'date_created' => time()
-		));
+        /** @var Organisation $orgModel */
+        $orgModel = ClassRegistry::init('Organisation');
+        $orgAux = $orgModel->find('first', [
+            'fields' => array('Organisation.id'),
+            'conditions' => $orgIsUuid ? ['uuid' => strtolower($org)] : ['name' => $org],
+        ]);
+        if (empty($orgAux)) {
+            if ($orgIsUuid) {
+                CakeLog::error("Could not found organisation with UUID `$org`.");
+                return false;
+            }
 
-		// save user
-		$userModel->save($userData, false);
-		CakeLog::write('info', "User ${mispUsername} saved in database.");
-		CakeLog::write('info', "User ${mispUsername} logged in.");
-		return $this->_findUser(
-			$mispUsername
-		);
-	}
+            $orgUserId = 1; // By default created by the admin
+            if ($user) {
+                $orgUserId = $user['id'];
+            }
+            $orgId = $orgModel->createOrgFromName($org, $orgUserId, 0); // Created with local set to 0 by default
+            CakeLog::info("User organisation `$org` created with ID $orgId.");
+        } else {
+            $orgId = $orgAux['Organisation']['id'];
+            CakeLog::info("User organisation `$org` found with ID $orgId.");
+        }
+        return $orgId;
+    }
 
-	/**
-	 * @param $roleChanged
-	 * @param $user
-	 * @param $roleId
-	 * @param $userModel
-	 * @return mixed
-	 */
-	public function updateUserRole($roleChanged, $user, $roleId, $userModel)
-	{
-		if ($roleChanged && $user['role_id'] != $roleId) {
-			CakeLog::write('warning', "User role changed from ${user['role_id']} to ${roleId}.");
-			$user['role_id'] = $roleId; // Different role either increase or decrease permissions
-			$userUpdatedData = array('User' => $user);
-			$userModel->set(array(
-				'role_id' => $roleId,
-				'id' => $user['id'],
-			)); // Update the user
-			$userModel->save($userUpdatedData, false);
-			return $user;
-		}
-		return $user;
-	}
+    /**
+     * @param string $groupTag
+     * @param array $groupRoleMatching
+     * @param int $roleId
+     * @return array
+     */
+    public function getUserRoleFromGroup($groupTag, $groupRoleMatching, $roleId)
+    {
+        // Check the role mapping to get the user's role level and update it if needed
+        $roleChanged = false;
+        if (isset($_SERVER[$groupTag])) {
+            $groupSeparator = Configure::read('ApacheShibbAuth.GroupSeparator');
+            $groupList = explode($groupSeparator, $_SERVER[$groupTag]);
+            // Check user roles and egroup match and update if needed
+            foreach ($groupList as $group) {
+                // TODO: Can be optimized inverting the search group and using only array_key_exists
+                if (array_key_exists($group, $groupRoleMatching)) { //In case there is an group not defined in the config.php file
+                    CakeLog::write('info', "User group ${group} found.");
+                    $roleVal = $groupRoleMatching[$group];
+                    if ($roleVal <= $roleId || $roleId == -1) {
+                        $roleId = $roleVal;
+                        $roleChanged = true;
+                    }
+                    CakeLog::write('info', "User role ${roleId} assigned.");
+                }
+            }
+            return array($roleChanged, $roleId);
+        }
+        return array($roleChanged, $roleId);
+    }
 
-	/**
-	 * @param $groupTag
-	 * @param $groupRoleMatching
-	 * @param $roleId
-	 * @return array
-	 */
-	public function getUserRoleFromGroup($groupTag, $groupRoleMatching, $roleId)
-	{
-		//Check the role mapping to get the user's role level and update it if needed
-		$roleChanged = false;
-		if (isset($_SERVER[$groupTag])) {
-			$groupSeparator = Configure::read('ApacheShibbAuth.GroupSeparator');
-			$groupList = explode($groupSeparator, $_SERVER[$groupTag]);
-			//Check user roles and egroup match and update if needed
-			foreach ($groupList as $group) {
-				//TODO: Can be optimized inverting the search group and using only array_key_exists
-				if (array_key_exists($group, $groupRoleMatching)) { //In case there is an group not defined in the config.php file
-					CakeLog::write('info', "User group ${group} found.");
-					$roleVal = $groupRoleMatching[$group];
-					if ($roleVal <= $roleId || $roleId == -1) {
-						$roleId = $roleVal;
-						$roleChanged = true;
-					}
-					CakeLog::write('info', "User role ${roleId} assigned.");
-				}
-			}
-			return array($roleChanged, $roleId);
-		}
-		return array($roleChanged, $roleId);
-	}
+    /**
+     * @param bool $roleChanged
+     * @param array $user
+     * @param int $roleId
+     * @param User $userModel
+     * @return array
+     * @throws Exception
+     */
+    private function updateUserRole($roleChanged, array $user, $roleId, User $userModel)
+    {
+        if ($roleChanged && $user['role_id'] != $roleId) {
+            CakeLog::write('warning', "User role changed from ${user['role_id']} to $roleId.");
+            $userModel->updateField($user, 'role_id', $roleId);
+        }
+        return $user;
+    }
 
-	/**
-	 * @param $org
-	 * @param $user
-	 * @return array|bool|int|mixed|string
-	 */
-	public function checkOrganization($org, $user)
-	{
-		$orgModel = ClassRegistry::init('Organisation');
-		$orgAux = $orgModel->find('first', array(
-				'fields' => array('Organisation.id'),
-				'conditions' => array('name' => $org),
-			)
-		);
-		if ($orgAux == null) {
-			$organisations = new Organisation();
-			$orgUserId = 1; //By default created by the admin
-			if ($user) $orgUserId = $user['id'];
-			$orgId = $organisations->createOrgFromName($org, $orgUserId, 0); //Created with local set to 0 by default
-			CakeLog::write('info', "User organisation ${org} created with id ${orgId}.");
-		} else {
-			$orgId = $orgAux['Organisation']['id'];
-			CakeLog::write('info', "User organisation ${org} found with id ${orgId}.");
-		}
-		return $orgId;
-	}
-
-	private function updateUserOrg($org, $user, $userModel)
-	{
-		if ($user['org_id'] != $org) {
-			CakeLog::write('warning', "User organisation ${org} changed.");
-			$user['org_id'] = $org; // Different role either increase or decrease permissions
-			$userUpdatedData = array('User' => $user);
-			$userModel->set(array(
-				'org_id' => $org,
-				'id' => $user['id'],
-			)); // Update the user
-			$userModel->save($userUpdatedData, false);
-			return $user;
-		}
-		return $user;
-	}
+    /**
+     * @param int $orgId
+     * @param array $user
+     * @param User $userModel
+     * @return array
+     * @throws Exception
+     */
+    private function updateUserOrg($orgId, array $user, User $userModel)
+    {
+        if ($user['org_id'] != $orgId) {
+            CakeLog::write('warning', "User organisation $orgId changed.");
+            $user['org_id'] = $orgId; // Different role either increase or decrease permissions
+            $userModel->updateField($user, 'org_id', $orgId);
+        }
+        return $user;
+    }
 }


### PR DESCRIPTION
#### What does it do?

Currently the only way how to pass correct organisation name trough shibboleth auth is to put organisation name. That can lead to typos and then duplicate organisation. This patch allow to pass organisation UUID to be sure which organisation user belongs to.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
