### PR TITLE
chg: [internal] Throw exception if setting name doesn't exists

### DIFF
--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -1416,6 +1416,9 @@ class ServersController extends AppController
         }
 
         $setting = $this->Server->getSettingData($setting_name);
+        if ($setting === false) {
+            throw new NotFoundException(__('Setting %s is invalid.', $setting_name));
+        }
         if (!empty($setting['cli_only'])) {
             throw new MethodNotAllowedException(__('This setting can only be edited via the CLI.'));
         }
@@ -1430,7 +1433,6 @@ class ServersController extends AppController
             if (isset($setting['optionsSource']) && !empty($setting['optionsSource'])) {
                 $setting['options'] = $this->{'__load' . $setting['optionsSource']}();
             }
-            $subGroup = 'general';
             $subGroup = explode('.', $setting['name']);
             if ($subGroup[0] === 'Plugin') {
                 $subGroup = explode('_', $subGroup[1])[0];

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -4316,7 +4316,7 @@ class Server extends AppModel
         return $setting;
     }
 
-    public function serverSettingsEditValue($user, $setting, $value, $forceSave = false)
+    public function serverSettingsEditValue(array $user, array $setting, $value, $forceSave = false)
     {
         if (isset($setting['beforeHook'])) {
             $beforeResult = call_user_func_array(array($this, $setting['beforeHook']), array($setting['name'], $value));


### PR DESCRIPTION
#### What does it do?

Throw NotFoundException when trying to modify invalid setting.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
