### PR TITLE
new: [auth] Allow to enforce auth plugin authentication

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -73,6 +73,9 @@ class AppController extends Controller
 
     protected $_legacyParams = array();
 
+    /** @var User */
+    public $User;
+
     public function __construct($id = false, $table = null, $ds = null)
     {
         parent::__construct($id, $table, $ds);
@@ -154,8 +157,8 @@ class AppController extends Controller
 
         $this->set('ajax', $this->request->is('ajax'));
         $this->set('queryVersion', $this->__queryVersion);
-        $this->loadModel('User');
-        $auth_user_fields = $this->User->describeAuthFields();
+        $this->User = ClassRegistry::init('User');
+
         $language = Configure::read('MISP.language');
         if (!empty($language) && $language !== 'eng') {
             Configure::write('Config.language', $language);
@@ -174,18 +177,19 @@ class AppController extends Controller
             $this->Server->serverSettingsSaveValue('MISP.uuid', CakeText::uuid());
         }
         // check if Apache provides kerberos authentication data
+        $authUserFields = $this->User->describeAuthFields();
         $envvar = Configure::read('ApacheSecureAuth.apacheEnv');
-        if (isset($_SERVER[$envvar])) {
+        if ($envvar && isset($_SERVER[$envvar])) {
             $this->Auth->className = 'ApacheSecureAuth';
             $this->Auth->authenticate = array(
                 'Apache' => array(
                     // envvar = field returned by Apache if user is authenticated
                     'fields' => array('username' => 'email', 'envvar' => $envvar),
-                    'userFields' => $auth_user_fields
+                    'userFields' => $authUserFields,
                 )
             );
         } else {
-            $this->Auth->authenticate['Form']['userFields'] = $auth_user_fields;
+            $this->Auth->authenticate[AuthComponent::ALL]['userFields'] = $authUserFields;
         }
         if (!empty($this->params['named']['disable_background_processing'])) {
             Configure::write('MISP.background_jobs', 0);
@@ -1152,13 +1156,24 @@ class AppController extends Controller
         $this->redirect($targetRoute);
     }
 
-    protected function _loadAuthenticationPlugins() {
+    /**
+     * @throws Exception
+     */
+    protected function _loadAuthenticationPlugins()
+    {
         // load authentication plugins from Configure::read('Security.auth')
         $auth = Configure::read('Security.auth');
-
-        if (!$auth) return;
-
+        if (!$auth) {
+            return;
+        }
+        if (!is_array($auth)) {
+            throw new Exception("`Security.auth` config value must be array.");
+        }
         $this->Auth->authenticate = array_merge($auth, $this->Auth->authenticate);
+        // Disable Form authentication
+        if (Configure::read('Security.auth_enforced')) {
+            unset($this->Auth->authenticate['Form']);
+        }
         if ($this->Auth->startup($this)) {
             $user = $this->Auth->user();
             if ($user) {

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -2542,19 +2542,6 @@ class AppModel extends Model
         $this->elasticSearchClient = $client;
     }
 
-    public function checkVersionRequirements($versionString, $minVersion)
-    {
-        $version = explode('.', $versionString);
-        $minVersion = explode('.', $minVersion);
-        if (count($version) > $minVersion) {
-            return true;
-        }
-        if (count($version) == 1) {
-            return $minVersion <= $version;
-        }
-        return ($version[0] >= $minVersion[0] && $version[1] >= $minVersion[1] && $version[2] >= $minVersion[2]);
-    }
-
     // generate a generic subquery - options needs to include conditions
     public function subQueryGenerator($model, $options, $lookupKey, $negation = false)
     {

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1343,6 +1343,14 @@ class Server extends AppModel
                                 'test' => 'testBool',
                                 'type' => 'boolean',
                         ),
+                    'auth_enforced' => [
+                        'level' => self::SETTING_OPTIONAL,
+                        'description' => __('This optional can be enabled if external auth provider is used and when set to true, it will disable default form authentication.'),
+                        'value' => false,
+                        'errorMessage' => '',
+                        'test' => 'testBool',
+                        'type' => 'boolean',
+                    ],
                         'rest_client_enable_arbitrary_urls' => array(
                             'level' => 0,
                             'description' => __('Enable this setting if you wish for users to be able to query any arbitrary URL via the rest client. Keep in mind that queries are executed by the MISP server, so internal IPs in your MISP\'s network may be reachable.'),

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -862,18 +862,19 @@ class User extends AppModel
         return $gpgTool->fetchGpgKey($fingerprint);
     }
 
+    /**
+     * Returns fields that should be fetched from database.
+     * @return array
+     */
     public function describeAuthFields()
     {
-        $fields = array();
-        $fields = array_merge($fields, array_keys($this->getColumnTypes()));
-        foreach ($fields as $k => $field) {
-            if (in_array($field, array('gpgkey', 'certif_public'))) {
-                unset($fields[$k]);
-            }
-        }
-        $fields = array_values($fields);
-        $relatedModels = array_keys($this->belongsTo);
-        foreach ($relatedModels as $relatedModel) {
+        $fields = $this->schema();
+        // Do not include keys, because they are big and usually not necessary
+        unset($fields['gpgkey']);
+        unset($fields['certif_public']);
+        $fields = array_keys($fields);
+
+        foreach ($this->belongsTo as $relatedModel => $foo) {
             $fields[] = $relatedModel . '.*';
         }
         return $fields;

--- a/app/View/Users/login.ctp
+++ b/app/View/Users/login.ctp
@@ -32,6 +32,7 @@
                 </div>
         <?php
             endif;
+            if ($formLoginEnabled):
             echo $this->Form->create('User');
         ?>
         <legend><?php echo __('Login');?></legend>
@@ -52,6 +53,7 @@
             <?= $this->Form->button(__('Login'), array('class' => 'btn btn-primary')); ?>
         <?php
             echo $this->Form->end();
+            endif;
             if (Configure::read('ApacheShibbAuth') == true) {
                 echo '<div class="clear"></div><a class="btn btn-info" href="/Shibboleth.sso/Login">Login with SAML</a>';
             }
@@ -65,7 +67,7 @@
 </div>
 
 <script>
-$(document).ready(function() {
+$(function() {
     $('#UserLoginForm').submit(function(event) {
         event.preventDefault()
         submitLoginForm()


### PR DESCRIPTION
#### What does it do?

Allow to enforce auth plugin authentication. This can be enabled by `Security.auth_enforced` option.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
