### PR TITLE
Disable PHP 8 support

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -2,10 +2,12 @@
     "prefer-stable": true,
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.0.0",
+        "php": ">=7.2.0,<8.0.0",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-xml": "*",
+        "ext-dom": "*",
+        "ext-simplexml": "*",
         "ext-pcre": "*",
         "kamisama/cake-resque": "4.1.2",
         "pear/crypt_gpg": "1.6.3",


### PR DESCRIPTION
#### What does it do?

PHP 8.0 was released, but CakePHP 2.x will not support that version (see https://github.com/cakephp/cakephp/commit/b07bba4d4f6b37da104475eb7c2851a06b7f510f). So we should also disable support in composer.json.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
