### PR TITLE
fix: [security] Remove hashed advanced keys from response

### DIFF
--- a/app/Controller/AuthKeysController.php
+++ b/app/Controller/AuthKeysController.php
@@ -1,5 +1,4 @@
 <?php
-
 App::uses('AppController', 'Controller');
 
 class AuthKeysController extends AppController
@@ -11,10 +10,10 @@ class AuthKeysController extends AppController
     );
 
     public $paginate = array(
-            'limit' => 60,
-            'order' => array(
-                'AuthKey.name' => 'ASC'
-            )
+        'limit' => 60,
+        'order' => array(
+            'AuthKey.name' => 'ASC',
+        )
     );
 
     public function index($id = false)
@@ -28,8 +27,13 @@ class AuthKeysController extends AppController
             'filters' => ['User.username', 'authkey', 'comment', 'User.id'],
             'quickFilters' => ['authkey', 'comment'],
             'contain' => ['User'],
-            'exclude_fields' => ['authkey'],
             'conditions' => $conditions,
+            'afterFind' => function (array $authKeys) {
+                foreach ($authKeys as &$authKey) {
+                    unset($authKey['AuthKey']['authkey']);
+                }
+                return $authKeys;
+            }
         ]);
         if ($this->IndexFilter->isRest()) {
             return $this->restResponsePayload;
@@ -86,14 +90,21 @@ class AuthKeysController extends AppController
 
     public function view($id = false)
     {
-        $this->set('menuData', array('menuList' => $this->_isSiteAdmin() ? 'admin' : 'globalActions', 'menuItem' => 'authKeyView'));
         $this->CRUD->view($id, [
             'contain' => ['User.id', 'User.email'],
             'conditions' => $this->__prepareConditions(),
+            'afterFind' => function (array $authKey) {
+                unset($authKey['AuthKey']['authkey']);
+                return $authKey;
+            }
         ]);
         if ($this->IndexFilter->isRest()) {
             return $this->restResponsePayload;
         }
+        $this->set('menuData', [
+            'menuList' => $this->_isSiteAdmin() ? 'admin' : 'globalActions',
+            'menuItem' => 'authKeyView',
+        ]);
     }
 
     /**

--- a/app/Controller/Component/CRUDComponent.php
+++ b/app/Controller/Component/CRUDComponent.php
@@ -184,6 +184,9 @@ class CRUDComponent extends Component
         if (empty($data)) {
             throw new NotFoundException(__('Invalid %s.', $modelName));
         }
+        if (isset($params['afterFind'])) {
+            $data = $params['afterFind']($data);
+        }
         if ($this->Controller->IndexFilter->isRest()) {
             $this->Controller->restResponsePayload = $this->Controller->RestResponse->viewData($data, 'json');
         } else {
@@ -249,7 +252,6 @@ class CRUDComponent extends Component
     protected function setFilters($params, $query)
     {
         $params = $this->massageFilters($params);
-        $conditions = array();
         if (!empty($params['simpleFilters'])) {
             foreach ($params['simpleFilters'] as $filter => $filterValue) {
                 if ($filter === 'quickFilter') {

--- a/tests/testlive_security.py
+++ b/tests/testlive_security.py
@@ -461,6 +461,24 @@ class TestSecurity(unittest.TestCase):
             self.__delete_advanced_authkey(auth_key["id"])
             # TODO: Delete new key
 
+    def test_advanced_authkeys_view(self):
+        with MISPSetting(self.admin_misp_connector, "Security.advanced_authkeys", True):
+            auth_key = self.__create_advanced_authkey(self.test_usr.id)
+            auth_key_id = auth_key["id"]
+            auth_key = send(self.admin_misp_connector, "GET", f'authKeys/view/{auth_key_id}')
+            self.__delete_advanced_authkey(auth_key_id)
+            self.assertNotIn("authkey", auth_key["AuthKey"], "Response should not contain hashed authkey")
+
+    def test_advanced_authkeys_index(self):
+        with MISPSetting(self.admin_misp_connector, "Security.advanced_authkeys", True):
+            auth_key_id = self.__create_advanced_authkey(self.test_usr.id)["id"]
+            auth_keys = send(self.admin_misp_connector, "GET", 'authKeys/index/')
+            self.__delete_advanced_authkey(auth_key_id)
+
+            self.assertGreaterEqual(len(auth_keys), 1, "Response should contains at least one key")
+            for auth_key in auth_keys:
+                self.assertNotIn("authkey", auth_key["AuthKey"], "Response should not contain hashed authkey")
+
     def test_change_login(self):
         new_email = 'testusr@user' + random() + '.local'
 


### PR DESCRIPTION
#### What does it do?

Hashed keys should not be accessible.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
