### PR TITLE
new: [internal] HTTP header with username in the reponse

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -333,6 +333,7 @@ class AppController extends Controller
             if ($this->Auth->user('Role')['perm_site_admin'] || (Configure::read('MISP.live') && !$this->_isRest())) {
                 $this->{$this->modelClass}->runUpdates();
             }
+            header('X-Username: '.$this->Auth->user('email'));
             $user = $this->Auth->user();
             if (!isset($user['force_logout']) || $user['force_logout']) {
                 $this->loadModel('User');


### PR DESCRIPTION
#### What does it do?

It sets the X-Username header in the HTTP response which allows Apache to log the username in the access logs

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
