### PR TITLE
fix: [pgp] Key info for older GPG versions

### DIFF
--- a/app/Lib/Tools/CryptGpgExtended.php
+++ b/app/Lib/Tools/CryptGpgExtended.php
@@ -73,7 +73,8 @@ class CryptGpgExtended extends Crypt_GPG
     }
 
     /**
-     * Return key info without importing it.
+     * Return key info without importing it when GPG supports --import-options show-only, otherwise just import and
+     * then return details.
      *
      * @param string $key
      * @return Crypt_GPG_Key[]
@@ -82,6 +83,18 @@ class CryptGpgExtended extends Crypt_GPG
      */
     public function keyInfo($key)
     {
+        $version = $this->engine->getVersion();
+        if (version_compare($version, '2.1.23', 'le')) {
+            $importResult = $this->importKey($key);
+            $keys = [];
+            foreach ($importResult['fingerprints'] as $fingerprint) {
+                foreach ($this->getKeys($fingerprint) as $key) {
+                    $keys[] = $key;
+                }
+            }
+            return $keys;
+        }
+
         $input = $this->_prepareInput($key, false, false);
 
         $output = '';


### PR DESCRIPTION
#### What does it do?

Fixes validating PGP keys for older GPG version. Should fix #6681 and #6575.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
