### PR TITLE
fix: Don't fail writable attachment dir test for S3

### DIFF
--- a/app/Lib/Tools/CryptGpgExtended.php
+++ b/app/Lib/Tools/CryptGpgExtended.php
@@ -73,7 +73,8 @@ class CryptGpgExtended extends Crypt_GPG
     }
 
     /**
-     * Return key info without importing it.
+     * Return key info without importing it when GPG supports --import-options show-only, otherwise just import and
+     * then return details.
      *
      * @param string $key
      * @return Crypt_GPG_Key[]
@@ -82,6 +83,18 @@ class CryptGpgExtended extends Crypt_GPG
      */
     public function keyInfo($key)
     {
+        $version = $this->engine->getVersion();
+        if (version_compare($version, '2.1.23', 'le')) {
+            $importResult = $this->importKey($key);
+            $keys = [];
+            foreach ($importResult['fingerprints'] as $fingerprint) {
+                foreach ($this->getKeys($fingerprint) as $key) {
+                    $keys[] = $key;
+                }
+            }
+            return $keys;
+        }
+
         $input = $this->_prepareInput($key, false, false);
 
         $output = '';

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -3834,6 +3834,9 @@ class Server extends AppModel
         if (substr($value, 0, 7) === "phar://") {
             return 'Phar protocol not allowed.';
         }
+        if (substr($value, 0, 5) === "s3://") {
+            return true;
+        }
         if (!is_dir($value)) {
             return 'Not a valid directory.';
         }


### PR DESCRIPTION
#### What does it do?

Prevents a failure when using S3 attachment storage. There's a test in the code confirming if the directory is writable and it uses `is_dir()` to do so. Currently the following warning is written to the log on startup

```
2020-11-21 02:46:22 Warning: is_dir(): Unable to find the wrapper "s3" - did you forget to enable it when you configured PHP? in [/var/www/MISP/app/Model/Server.php, line 3589]
```

The same happens when running `cake Admin setSetting "MISP.attachments_dir" "s3://"`

#### Questions

- [ ] Does it require a DB change? No
- [ ] Are you using it in production? No
- [ ] Does it require a change in the API (PyMISP for example)? No
