### PR TITLE
new: [UI] Show number of events for sharing group

### DIFF
--- a/app/Controller/SharingGroupsController.php
+++ b/app/Controller/SharingGroupsController.php
@@ -376,6 +376,16 @@ class SharingGroupsController extends AppController
         if ($this->_isRest()) {
             return $this->RestResponse->viewData($sg, $this->response->type());
         }
+
+        $this->loadModel('Event');
+        $conditions = $this->Event->createEventConditions($this->Auth->user());
+        $conditions['AND']['sharing_group_id'] = $sg['SharingGroup']['id'];
+        $sg['SharingGroup']['event_count'] = $this->Event->find('count', [
+            'conditions' => $conditions,
+            'recursive' => -1,
+            'callbacks' => false,
+        ]);
+
         $this->set('mayModify', $this->SharingGroup->checkIfAuthorisedExtend($this->Auth->user(), $sg['SharingGroup']['id']));
         $this->set('id', $sg['SharingGroup']['id']);
         $this->set('sg', $sg);

--- a/app/View/SharingGroups/view.ctp
+++ b/app/View/SharingGroups/view.ctp
@@ -11,6 +11,11 @@ $tableData = [
     ['key' => __('Selectable'), 'boolean' => $sg['SharingGroup']['active']],
     ['key' => __('Created by'), 'html' => $this->OrgImg->getNameWithImg($sg)],
 ];
+$eventsLink = $baseurl . '/events/index/searchsharinggroup:' . $sg['SharingGroup']['id'];
+$tableData[] = [
+    'key' => __('Events'),
+    'html' => '<a href="' . $eventsLink . '">' . __n('%s event', '%s events', $sg['SharingGroup']['event_count'], $sg['SharingGroup']['event_count']) . '</a>',
+];
 if ($sg['SharingGroup']['sync_user_id']) {
     $tableData[] = [
         'key' => __('Synced by'),


### PR DESCRIPTION
#### What does it do?

Show number of events in sharing group view. This is useful if you want to quickly check what events are shared with given sharing group.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
