### PR TITLE
fix: [internal] User should be able to see his org

### DIFF
--- a/app/Controller/OrganisationsController.php
+++ b/app/Controller/OrganisationsController.php
@@ -485,6 +485,9 @@ class OrganisationsController extends AppController
      */
     private function __canSeeOrg(array $user, $orgId)
     {
+        if ($user['org_id'] == $orgId) {
+            return true; // User can see his own org.
+        }
         if (!$user['Role']['perm_sharing_group'] && Configure::read('Security.hide_organisation_index_from_users')) {
             $this->loadModel('Event');
             // Check if there is event from given org that can current user see

--- a/tests/testlive_security.py
+++ b/tests/testlive_security.py
@@ -961,6 +961,21 @@ class TestSecurity(unittest.TestCase):
 
             self.admin_misp_connector.delete_organisation(org)
 
+    def test_org_hide_org_can_see_his_own(self):
+        org = self.__create_org()
+        user = self.__create_user(org.id, ROLE.USER)
+
+        with self.__setting("Security.hide_organisation_index_from_users", True):
+            logged_in = PyMISP(url, user.authkey)
+            for key in (org.id, org.uuid, org.name):
+                fetched_org = logged_in.get_organisation(key)
+                check_response(fetched_org)
+                self.assertNotIn("created_by", fetched_org["Organisation"])
+                self.assertNotIn("created_by_email", fetched_org["Organisation"])
+
+            self.admin_misp_connector.delete_user(user)
+            self.admin_misp_connector.delete_organisation(org)
+
     def test_org_hide_org_cannot_see_event_after_contribution(self):
         org = self.__create_org()
         user = self.__create_user(org.id, ROLE.USER)


### PR DESCRIPTION
#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
