### PR TITLE
Create JA3 Hash Suricata Rules

### DIFF
--- a/app/Lib/Export/NidsExport.php
+++ b/app/Lib/Export/NidsExport.php
@@ -189,6 +189,12 @@ class NidsExport
                 case 'user-agent':
                     $this->userAgentRule($ruleFormat, $item['Attribute'], $sid);
                     break;
+                case 'ja3-fingerprint-md5':
+                    $this->ja3Rule($ruleFormat, $item['Attribute'], $sid);
+                    break;
+                case 'ja3s-fingerprint-md5': // Atribute type doesn't exists yet (2020-12-10) but ready when created.
+                    $this->ja3sRule($ruleFormat, $item['Attribute'], $sid);
+                    break;
                 case 'snort':
                     $this->snortRule($ruleFormat, $item['Attribute'], $sid, $ruleFormatMsg, $ruleFormatReference);
                     // no break
@@ -501,6 +507,16 @@ class NidsExport
                 $sid,							// sid
                 1								// rev
         );
+    }
+
+    public function ja3Rule($ruleFormat, $attribute, &$sid)
+    {
+        //Empty because Snort doesn't support JA3 Rules
+    }
+
+    public function ja3sRule($ruleFormat, $attribute, &$sid)
+    {
+        //Empty because Snort doesn't support JA3S Rules
     }
 
     public function snortRule($ruleFormat, $attribute, &$sid, $ruleFormatMsg, $ruleFormatReference)

--- a/app/Lib/Export/NidsSuricataExport.php
+++ b/app/Lib/Export/NidsSuricataExport.php
@@ -229,4 +229,49 @@ class NidsSuricataExport extends NidsExport
                 1								// rev
         );
     }
+
+    public function ja3Rule($ruleFormat, $attribute, &$sid)
+    {
+        $overruled = $this->checkWhitelist($attribute['value']);
+        $attribute['value'] = NidsExport::replaceIllegalChars($attribute['value']);  // substitute chars not allowed in rule
+        $content = 'ja3.hash; content:"' . $attribute['value'] . '"; fast_pattern;';
+        $this->rules[] = sprintf(
+            $ruleFormat,
+                ($overruled) ? '#OVERRULED BY WHITELIST# ' : '',
+                'tls',						// proto
+                'any',					// src_ip
+                'any',							// src_port
+                '->',							// direction
+                'any',				// dst_ip
+                'any',					// dst_port
+                'JA3 Hash: ' . $attribute['value'],		// msg
+                $content,						// rule_content
+                'tag:session,600,seconds;',		// tag
+                $sid,							// sid
+                1								// rev
+        );
+    }
+
+    // For Future use once JA3S Hash Attribute type is created
+    public function ja3sRule($ruleFormat, $attribute, &$sid)
+    {
+        $overruled = $this->checkWhitelist($attribute['value']);
+        $attribute['value'] = NidsExport::replaceIllegalChars($attribute['value']);  // substitute chars not allowed in rule
+        $content = 'ja3s.hash; content:"' . $attribute['value'] . '"; fast_pattern;';
+        $this->rules[] = sprintf(
+            $ruleFormat,
+                ($overruled) ? '#OVERRULED BY WHITELIST# ' : '',
+                'tls',						// proto
+                'any',					// src_ip
+                'any',							// src_port
+                '->',							// direction
+                'any',				// dst_ip
+                'any',					// dst_port
+                'JA3S Hash: ' . $attribute['value'],		// msg
+                $content,						// rule_content
+                'tag:session,600,seconds;',		// tag
+                $sid,							// sid
+                1								// rev
+        );
+    }
 }


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2020-05-05: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?
Adds JA3 and JA3S Suricata rules to the export class. See #6355.  I did not add the bro rules because I am not familiar enough with bro rules to do so.  Also the JA3S attribute type doesn't exist yet but i added the case for future proofing. 

#### Questions

- [x] Does it require a DB change? No
- [x] Are you using it in production? Not Yet
- [x] Does it require a change in the API (PyMISP for example)? No
