### PR TITLE
fix: [UI] Nicer error message for CSRF

### DIFF
--- a/app/View/Errors/error400.ctp
+++ b/app/View/Errors/error400.ctp
@@ -1,33 +1,19 @@
+<div class="misp-error-container">
 <?php
-/**
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org CakePHP(tm) Project
- * @package       app.View.Errors
- * @since         CakePHP(tm) v 0.10.0.1076
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
- */
-if ($message !== 'csrf'):
+if ($message !== 'The request has been black-holed'):
     ?>
     <h2><?php echo $message; ?></h2>
     <p class="error">
         <strong><?php echo __d('cake', 'Error'); ?>: </strong>
         <?php printf(
             __d('cake', 'The requested address %s was not found on this server.'),
-            "<strong>'{$url}'</strong>"
+            "<strong>'$url'</strong>"
         ); ?>
     </p>
     <?php
     if (Configure::read('debug') > 0):
         echo $this->element('exception_stack_trace');
     endif;
-
 else:
 ?>
     <h2><?php echo __('You have tripped the cross-site request forgery protection of MISP');?></h2>
@@ -43,3 +29,5 @@ else:
         echo $this->element('exception_stack_trace');
     endif;
 endif;
+?>
+</div>

--- a/app/webroot/css/main.css
+++ b/app/webroot/css/main.css
@@ -2683,3 +2683,7 @@ a.orgImg {
     padding-top: 3px;
     padding-bottom: 2px;
 }
+
+.misp-error-container {
+    margin: 0 20px;
+}


### PR DESCRIPTION
#### What does it do?

Provide better error message to user than 'The request has been black-holed'

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
