### PR TITLE
fix: [internal] Remove compact method call that do nothing

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -1505,7 +1505,6 @@ class AttributesController extends AppController
                 'request' => $this->request,
                 'named_params' => $this->params['named'],
                 'paramArray' => $paramArray,
-                'ordered_url_params' => @compact($paramArray),
                 'additional_delimiters' => PHP_EOL
             );
             $exception = false;

--- a/app/Controller/TagsController.php
+++ b/app/Controller/TagsController.php
@@ -41,7 +41,6 @@ class TagsController extends AppController
             'request' => $this->request,
             'named_params' => $this->params['named'],
             'paramArray' => ['favouritesOnly', 'filter', 'searchall', 'name', 'search', 'exclude_statistics'],
-            'ordered_url_params' => @compact($paramArray)
         );
         $exception = false;
         $passedArgsArray = $this->_harvestParameters($filterData, $exception);


### PR DESCRIPTION
#### What does it do?

Just generates noise inside logs.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
