### PR TITLE
Hide orgs from sharing group view

### DIFF
--- a/app/Controller/ObjectTemplatesController.php
+++ b/app/Controller/ObjectTemplatesController.php
@@ -21,12 +21,11 @@ class ObjectTemplatesController extends AppController
 
     public function objectMetaChoice($event_id)
     {
-        $metas = $this->ObjectTemplate->find('all', array(
-            'recursive' => -1,
+        $metas = $this->ObjectTemplate->find('column', array(
             'conditions' => array('ObjectTemplate.active' => 1),
-            'fields' => array('meta-category'),
-            'group' => array('ObjectTemplate.meta-category'),
-            'order' => array('ObjectTemplate.meta-category asc')
+            'fields' => array('ObjectTemplate.meta-category'),
+            'order' => array('ObjectTemplate.meta-category asc'),
+            'unique' => true,
         ));
 
         $eventId = h($event_id);
@@ -35,7 +34,6 @@ class ObjectTemplatesController extends AppController
             'value' => $this->baseurl . "/ObjectTemplates/objectChoice/$eventId/0"
         ]];
         foreach ($metas as $meta) {
-            $meta = $meta['ObjectTemplate']['meta-category'];
             $items[] = array(
                 'name' => $meta,
                 'value' => $this->baseurl . "/ObjectTemplates/objectChoice/$eventId/" . h($meta)

--- a/app/Lib/Tools/DistributionGraphTool.php
+++ b/app/Lib/Tools/DistributionGraphTool.php
@@ -1,12 +1,15 @@
 <?php
 class DistributionGraphTool
 {
-    private $__user = false;
+    /** @var array */
+    private $__user;
     private $__json = array();
     /** @var Event */
     private $__eventModel;
     /** @var Organisation */
     private $__organisationModel;
+    /** @var array */
+    private $__serverList;
 
     public function construct(Event $eventModel, array $servers, array $user, $extended_view=0)
     {
@@ -76,27 +79,27 @@ class DistributionGraphTool
         $this->__addAdditionalDistributionInfo(3, "All other communities"); // add current community
 
         // connected
-        $servers = $this->__serverList;
         $this->__addAdditionalDistributionInfo(2, "This community"); // add current community
-        foreach ($servers as $server) {
+        foreach ($this->__serverList as $server) {
             $this->__addAdditionalDistributionInfo(2, $server);
         }
 
         // community
+        $orgConditions = $this->__organisationModel->createConditions($this->__user);
+        $orgConditions['local'] = true;
         $orgs = $this->__organisationModel->find('list', array(
-            'fields' => array('name'),
-            'conditions' => array('local' => true)
+            'fields' => ['id', 'name'],
+            'conditions' => $orgConditions,
         ));
         $thisOrg = $this->__user['Organisation']['name'];
         $this->__addAdditionalDistributionInfo(1, $thisOrg); // add current community
-        foreach ($orgs as $org) {
-            if ($thisOrg != $org) {
-                $this->__addAdditionalDistributionInfo(1, $org);
+        foreach ($orgs as $orgId => $orgName) {
+            if ($thisOrg != $orgName) {
+                $this->__addAdditionalDistributionInfo(1, $orgName);
             }
         }
 
         // org only
-        $thisOrg = $this->__user['Organisation']['name'];
         $this->__addAdditionalDistributionInfo(0, $thisOrg); // add current community
     }
 

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -3017,6 +3017,21 @@ class AppModel extends Model
         }
     }
 
+    public function addCountField($field, AppModel $model, array $conditions)
+    {
+        $db = $this->getDataSource();
+        $subQuery = $db->buildStatement(
+            array(
+                'fields'     => ['COUNT(*)'],
+                'table'      => $db->fullTableName($model),
+                'alias'      => $model->alias,
+                'conditions' => $conditions,
+            ),
+            $model
+        );
+        $this->virtualFields[$field] = $subQuery;
+    }
+
     /**
      * Log exception with backtrace and with nested exceptions.
      *

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -2048,11 +2048,11 @@ class Attribute extends AppModel
                 }
             }
 
-            $ipList = $this->find('list', array(
+            $ipList = $this->find('column', array(
                 'conditions' => $conditions,
-                'group' => 'value1', // return just unique values
-                'fields' => array('value1'),
-                'order' => false
+                'fields' => ['Attribute.value1'],
+                'unique' => true,
+                'order' => false,
             ));
             foreach ($ipList as $ipToCheck) {
                 $ipToCheckVersion = filter_var($ipToCheck, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ? 4 : 6;
@@ -3981,13 +3981,13 @@ class Attribute extends AppModel
 
     private function __getCIDRList()
     {
-        return $this->find('list', array(
+        return $this->find('column', array(
             'conditions' => array(
                 'type' => array('ip-src', 'ip-dst'),
                 'value1 LIKE' => '%/%'
             ),
-            'fields' => array('value1'),
-            'group' => array('value1', 'id'), // return just unique value
+            'fields' => array('Attribute.value1'),
+            'unique' => true,
             'order' => false
         ));
     }

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -843,18 +843,16 @@ class Event extends AppModel
         //        ii. Atttibute has a distribution between 1-3 (community only, connected communities, all orgs)
         //        iii. Attribute has a sharing group that the user is accessible to view
         $conditionsCorrelation = $this->__buildEventConditionsCorrelation($user, $eventId, $sgids);
-        $correlations = $this->Correlation->find('list', array(
-                'fields' => array('Correlation.event_id', 'Correlation.event_id'),
-                'conditions' => $conditionsCorrelation,
-                'recursive' => 0,
-                'group' => 'Correlation.event_id',
-                'order' => array('Correlation.event_id DESC')));
+        $relatedEventIds = $this->Correlation->find('column', array(
+            'fields' => array('Correlation.event_id'),
+            'conditions' => $conditionsCorrelation,
+            'unique' => true,
+        ));
 
-        if (empty($correlations)) {
+        if (empty($relatedEventIds)) {
             return [];
         }
 
-        $relatedEventIds = array_values($correlations);
         // now look up the event data for these attributes
         $conditions = $this->createEventConditions($user);
         $conditions['AND'][] = array('Event.id' => $relatedEventIds);

--- a/app/Model/Organisation.php
+++ b/app/Model/Organisation.php
@@ -486,6 +486,7 @@ class Organisation extends AppModel
     /**
      * Hide organisation view from users if they haven't yet contributed data and Security.hide_organisation_index_from_users is enabled
      *
+     * @see Organisation::canSee if you want to check multiple orgs
      * @param array $user
      * @param int $orgId
      * @return bool
@@ -519,6 +520,42 @@ class Organisation extends AppModel
             }
         }
         return true;
+    }
+
+    /**
+     * Create conditions for fetching orgs based on user permission.
+     * @see Organisation::canSee if you want to check just one org
+     * @param array $user
+     * @return array|array[]
+     */
+    public function createConditions(array $user)
+    {
+        if (!$user['Role']['perm_sharing_group'] && Configure::read('Security.hide_organisation_index_from_users')) {
+            $allowedOrgs = [$user['org_id']];
+
+            $eventConditions = $this->Event->createEventConditions($user);
+            $orgsWithEvent = array_column(array_column($this->Event->find('all', [
+                'fields' => ['DISTINCT Event.orgc_id'],
+                'recursive' => -1,
+                'conditions' => $eventConditions,
+            ]), 'Event'), 'orgc_id');
+            $allowedOrgs = array_merge($allowedOrgs, $orgsWithEvent);
+
+            $proposalConditions = $this->Event->ShadowAttribute->buildConditions($user);
+            // Do not check orgs that we already can see
+            $proposalConditions['AND'][]['NOT'] = ['ShadowAttribute.org_id' => $allowedOrgs];
+            $orgsWithProposal = array_column(array_column($this->Event->ShadowAttribute->find('all', [
+                'fields' => ['DISTINCT ShadowAttribute.org_id'],
+                'recursive' => -1,
+                'conditions' => $proposalConditions,
+                'contain' => ['Event', 'Attribute'],
+            ]), 'ShadowAttribute'), 'org_id');
+
+            $allowedOrgs = array_merge($allowedOrgs, $orgsWithProposal);
+            return ['AND' => ['id' => $allowedOrgs]];
+        }
+
+        return [];
     }
 
     private function getCountryGalaxyCluster()

--- a/app/Model/Organisation.php
+++ b/app/Model/Organisation.php
@@ -534,22 +534,23 @@ class Organisation extends AppModel
             $allowedOrgs = [$user['org_id']];
 
             $eventConditions = $this->Event->createEventConditions($user);
-            $orgsWithEvent = array_column(array_column($this->Event->find('all', [
-                'fields' => ['DISTINCT Event.orgc_id'],
-                'recursive' => -1,
+            $orgsWithEvent = $this->Event->find('column', [
+                'fields' => ['Event.orgc_id'],
                 'conditions' => $eventConditions,
-            ]), 'Event'), 'orgc_id');
+                'unique' => true,
+            ]);
             $allowedOrgs = array_merge($allowedOrgs, $orgsWithEvent);
 
             $proposalConditions = $this->Event->ShadowAttribute->buildConditions($user);
             // Do not check orgs that we already can see
             $proposalConditions['AND'][]['NOT'] = ['ShadowAttribute.org_id' => $allowedOrgs];
-            $orgsWithProposal = array_column(array_column($this->Event->ShadowAttribute->find('all', [
-                'fields' => ['DISTINCT ShadowAttribute.org_id'],
-                'recursive' => -1,
+            $orgsWithProposal = $this->Event->ShadowAttribute->find('column', [
+                'fields' => ['ShadowAttribute.org_id'],
                 'conditions' => $proposalConditions,
                 'contain' => ['Event', 'Attribute'],
-            ]), 'ShadowAttribute'), 'org_id');
+                'unique' => true,
+                'order' => false,
+            ]);
 
             $allowedOrgs = array_merge($allowedOrgs, $orgsWithProposal);
             return ['AND' => ['id' => $allowedOrgs]];

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1558,6 +1558,15 @@ class Server extends AppModel
                             'type' => 'boolean',
                             'null' => true
                         ),
+                        'hide_organisations_in_sharing_groups' => [
+                            'level' => self::SETTING_RECOMMENDED,
+                            'description' => __('Enabling this setting will block the organisation list from being visible in sharing group besides user with sharing group permission.'),
+                            'value' => false,
+                            'errorMessage' => '',
+                            'test' => 'testBool',
+                            'type' => 'boolean',
+                            'null' => true
+                        ],
                         'disable_local_feed_access' => array(
                                 'level' => 0,
                                 'description' => __('Disabling this setting will allow the creation/modification of local feeds (as opposed to network feeds). Enabling this setting will restrict feed sources to be network based only. When disabled, keep in mind that a malicious site administrator could get access to any arbitrary file on the system that the apache user has access to. Make sure that proper safe-guards are in place. This setting can only be modified via the CLI.'),

--- a/app/Model/ShadowAttribute.php
+++ b/app/Model/ShadowAttribute.php
@@ -481,13 +481,13 @@ class ShadowAttribute extends AppModel
      */
     public function getEventContributors($eventId)
     {
-        $orgs = $this->find('all', array(
-            'fields' => array('DISTINCT(ShadowAttribute.org_id)'),
+        $orgIds = $this->find('column', array(
+            'fields' => array('ShadowAttribute.org_id'),
             'conditions' => array('event_id' => $eventId),
-            'recursive' => -1,
+            'unique' => true,
             'order' => false
         ));
-        if (empty($orgs)) {
+        if (empty($orgIds)) {
             return [];
         }
 
@@ -495,8 +495,8 @@ class ShadowAttribute extends AppModel
         return $this->Organisation->find('list', array(
             'recursive' => -1,
             'fields' => array('id', 'name'),
-            'conditions' => array('Organisation.id' => Hash::extract($orgs, "{n}.ShadowAttribute.org_id")))
-        );
+            'conditions' => array('Organisation.id' => $orgIds)
+        ));
     }
 
     /**

--- a/app/Model/SharingGroup.php
+++ b/app/Model/SharingGroup.php
@@ -145,11 +145,10 @@ class SharingGroup extends AppModel
         }
 
         if ($user['Role']['perm_site_admin']) {
-            $ids = array_values($this->find('list', array(
-                'recursive' => -1,
+            $ids = $this->find('column', array(
                 'fields' => array('id'),
                 'conditions' => $conditions
-            )));
+            ));
         } else {
             $ids = array_unique(array_merge(
                 $this->SharingGroupServer->fetchAllAuthorised(),

--- a/app/Model/SharingGroup.php
+++ b/app/Model/SharingGroup.php
@@ -204,13 +204,20 @@ class SharingGroup extends AppModel
         } elseif ($scope === 'distribution_graph') {
             // Specific scope that fetch just necessary information for distribution graph
             // @see DistributionGraphTool
+            $canSeeOrgs = $user['Role']['perm_sharing_group'] || !Configure::read('Security.hide_organisations_in_sharing_groups');
             $sgs = $this->find('all', array(
-                'contain' => ['SharingGroupOrg' => ['org_id']],
+                'contain' => $canSeeOrgs ? ['SharingGroupOrg' => ['org_id']] : [],
                 'conditions' => $conditions,
                 'fields' => ['SharingGroup.id', 'SharingGroup.name', 'SharingGroup.org_id'],
                 'order' => 'SharingGroup.name ASC'
             ));
-            return $this->appendOrgsAndServers($sgs, ['id', 'name'], []);
+            if ($canSeeOrgs) {
+                return $this->appendOrgsAndServers($sgs, ['id', 'name'], []);
+            }
+            foreach ($sgs as &$sg) {
+                $sg['SharingGroupOrg'] = [];
+            }
+            return $sgs;
         } elseif ($scope === 'name') {
             $sgs = $this->find('list', array(
                 'recursive' => -1,
@@ -241,8 +248,10 @@ class SharingGroup extends AppModel
     {
         $orgsToFetch = [];
         $serverToFetch = [];
-        foreach($sharingGroups as $sg) {
-            $orgsToFetch[$sg['SharingGroup']['org_id']] = true;
+        foreach ($sharingGroups as $sg) {
+            if (isset($sg['SharingGroup']['org_id'])) {
+                $orgsToFetch[$sg['SharingGroup']['org_id']] = true;
+            }
             if (isset($sg['SharingGroupOrg'])) {
                 foreach ($sg['SharingGroupOrg'] as $sgo) {
                     $orgsToFetch[$sgo['org_id']] = true;
@@ -283,7 +292,7 @@ class SharingGroup extends AppModel
         }
 
         foreach ($sharingGroups as &$sg) {
-            if (isset($orgsById[$sg['SharingGroup']['org_id']])) {
+            if (isset($sg['SharingGroup']['org_id']) && isset($orgsById[$sg['SharingGroup']['org_id']])) {
                 $sg['Organisation'] = $orgsById[$sg['SharingGroup']['org_id']];
             }
 

--- a/app/View/SharingGroups/index.ctp
+++ b/app/View/SharingGroups/index.ctp
@@ -10,6 +10,17 @@ echo $this->element('/genericElements/IndexTable/index_table', array(
                     'type' => 'simple',
                     'children' => array(
                         array(
+                            'text' => __('Add'),
+                            'fa-icon' => 'plus',
+                            'url' => $baseurl . '/sharing_groups/add',
+                            'requirement' => $isAclSharingGroup,
+                        )
+                    )
+                ),
+                array(
+                    'type' => 'simple',
+                    'children' => array(
+                        array(
                             'url' => $baseurl . '/sharing_groups/index',
                             'text' => __('Active Sharing Groups'),
                             'active' => !$passive,
@@ -68,36 +79,42 @@ echo $this->element('/genericElements/IndexTable/index_table', array(
             ),
             array(
                 'name' => __('Org count'),
-                'element' => 'custom',
                 'class' => 'short',
-                'function' => function (array $sharingGroup) {
-                    echo count($sharingGroup['SharingGroupOrg']);
-                }
+                'sort' => 'SharingGroup.org_count',
+                'data_path' => 'SharingGroup.org_count',
             ),
             array(
                 'name' => __('Releasable to'),
                 'element' => 'custom',
                 'function' => function (array $sharingGroup) use ($baseurl) {
                     $combined = __("Organisations:");
-                    if (empty($sharingGroup['SharingGroupOrg'])) $combined .= "<br>N/A";
-                    foreach ($sharingGroup['SharingGroupOrg'] as $sge) {
-                        if (!empty($sge['Organisation'])) {
-                            $combined .= "<br><a href='" . $baseurl . "/organisation/view/" . h($sge['Organisation']['id']) . "'>" . h($sge['Organisation']['name']) . "</a>";
-                            if ($sge['extend']) $combined .= ' (can extend)';
+                    if (empty($sharingGroup['SharingGroupOrg'])) {
+                        $combined .= "<br>N/A";
+                    } else {
+                        foreach ($sharingGroup['SharingGroupOrg'] as $sge) {
+                            if (!empty($sge['Organisation'])) {
+                                $combined .= "<br><a href='" . $baseurl . "/organisation/view/" . h($sge['Organisation']['id']) . "'>" . h($sge['Organisation']['name']) . "</a>";
+                                if ($sge['extend']) {
+                                    $combined .= ' (can extend)';
+                                }
+                            }
                         }
                     }
                     $combined .= '<hr style="margin:5px 0;"><br>Instances:';
-                    if (empty($sharingGroup['SharingGroupServer'])) $combined .= "<br>N/A";
-                    foreach ($sharingGroup['SharingGroupServer'] as $sgs) {
-                        if ($sgs['server_id'] != 0) {
-                            $combined .= "<br><a href='" . $baseurl . "/server/view/" . h($sgs['Server']['id']) . "'>" . h($sgs['Server']['name']) . "</a>";
-                        } else {
-                            $combined .= "<br>This instance";
-                        }
-                        if ($sgs['all_orgs']) {
-                            $combined .= ' (all organisations)';
-                        } else {
-                            $combined .= ' (as defined above)';
+                    if (empty($sharingGroup['SharingGroupServer'])) {
+                        $combined .= "<br>N/A";
+                    } else {
+                        foreach ($sharingGroup['SharingGroupServer'] as $sgs) {
+                            if ($sgs['server_id'] != 0) {
+                                $combined .= "<br><a href='" . $baseurl . "/server/view/" . h($sgs['Server']['id']) . "'>" . h($sgs['Server']['name']) . "</a>";
+                            } else {
+                                $combined .= "<br>This instance";
+                            }
+                            if ($sgs['all_orgs']) {
+                                $combined .= ' (all organisations)';
+                            } else {
+                                $combined .= ' (as defined above)';
+                            }
                         }
                     } ?>
                     <span data-toggle="popover" data-trigger="hover" title="<?= __('Distribution List') ?>" data-content="<?= h($combined) ?>">

--- a/app/View/SharingGroups/view.ctp
+++ b/app/View/SharingGroups/view.ctp
@@ -25,6 +25,12 @@ $tableData[] = [
     'key' => __('Events'),
     'html' => '<a href="' . $eventsLink . '">' . __n('%s event', '%s events', $sg['SharingGroup']['event_count'], $sg['SharingGroup']['event_count']) . '</a>',
 ];
+if (isset($sg['SharingGroup']['org_count'])) {
+    $tableData[] = [
+        'key' => __('Organisations'),
+        'html' => __n('%s organisation', '%s organisations', $sg['SharingGroup']['org_count'], $sg['SharingGroup']['org_count']),
+    ];
+}
 echo $this->element('genericElements/viewMetaTable', ['table_data' => $tableData]);
 ?>
 </div></div>
@@ -56,7 +62,7 @@ echo $this->element('genericElements/viewMetaTable', ['table_data' => $tableData
         </div>
     <?php
         endif;
-        if (!$sg['SharingGroup']['roaming']):
+        if (!$sg['SharingGroup']['roaming'] && isset($sg['SharingGroupServer'])):
     ?>
         <div class="span6">
             <b>Instances</b>

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -4200,12 +4200,18 @@ function initPopoverContent(context) {
 }
 
 function checkSharingGroup(context) {
+    var $sharingGroupSelect = $('#' + context + 'SharingGroupId');
     if ($('#' + context + 'Distribution').val() == 4) {
-        $('#' + context + 'SharingGroupId').show();
-        $('#' + context + 'SharingGroupId').closest("div").show();
+        $sharingGroupSelect.show();
+        $sharingGroupSelect.closest("div").show();
+
+        // For sharing group select with more than 10 items, use chosen
+        if ($sharingGroupSelect.find('option').length > 10) {
+            $sharingGroupSelect.chosen();
+        }
     } else {
-        $('#' + context + 'SharingGroupId').hide();
-        $('#' + context + 'SharingGroupId').closest("div").hide();
+        $sharingGroupSelect.hide();
+        $sharingGroupSelect.closest("div").hide();
     }
 }
 


### PR DESCRIPTION
#### What does it do?

This change introduce new option `Security.hide_organisations_in_sharing_groups`. When it is enabled, user without permission to edit sharing groups can just see number of organisation in sharing group, but not their names.

This is useful if you have big sharing groups, but you don't want to leak connected organisations, because even organisation name is confidential information.

It also brings small changes in user interface:
* New `Add` button on sharing group index 
* Add ability to sort sharing groups by number of organisation
* When choosing sharing group, use chosen for easier find requested sharing group.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
