### PR TITLE
Typo caused fail of dependency installation

### DIFF
--- a/INSTALL/INSTALL.sh
+++ b/INSTALL/INSTALL.sh
@@ -1372,7 +1372,7 @@ installCore () {
     for dependency in CybOXProject/python-cybox STIXProject/python-stix MAECProject/python-maec CybOXProject/mixbox; do
       false; while [[ $? -ne 0 ]]; do checkAptLock; ${SUDO_WWW} git clone https://github.com/${dependency}.git ${PATH_TO_MISP_SCRIPTS}/${dependency##*/}; done
       ${SUDO_WWW} git -C ${PATH_TO_MISP_SCRIPTS}/${dependency##*/} config core.filemode false
-      ${SUDO_WWW} ${PATH_TO_MISP}/venv/bin/pip install ${PATH_TO_MISP_SCRIPTS}/${dependency##/*}
+      ${SUDO_WWW} ${PATH_TO_MISP}/venv/bin/pip install ${PATH_TO_MISP_SCRIPTS}/${dependency##*/}
     done
 
     debug "Install python-stix2"
@@ -1421,7 +1421,7 @@ installCore () {
     ${SUDO_WWW} ${PATH_TO_MISP}/venv/bin/pip install -U setuptools pip lief zmq redis python-magic plyara
     for dependency in CybOXProject/python-cybox STIXProject/python-stix MAECProject/python-maec CybOXProject/mixbox; do
       false; while [[ $? -ne 0 ]]; do checkAptLock; ${SUDO_WWW} git -C ${PATH_TO_MISP_SCRIPTS}/${dependency##*/} pull; done
-      ${SUDO_WWW} ${PATH_TO_MISP}/venv/bin/pip install -U ${PATH_TO_MISP_SCRIPTS}/${dependency##/*}
+      ${SUDO_WWW} ${PATH_TO_MISP}/venv/bin/pip install -U ${PATH_TO_MISP_SCRIPTS}/${dependency##*/}
     done
 
     ${SUDO_WWW} ${PATH_TO_MISP}/venv/bin/pip install -U ${PATH_TO_MISP}/cti-python-stix2


### PR DESCRIPTION
Hello,

During installation, I would get the following error :
```shell
Cloning into '/var/www/MISP/app/files/scripts/python-cybox'...
remote: Enumerating objects: 343, done.
remote: Counting objects: 100% (343/343), done.
remote: Compressing objects: 100% (191/191), done.
remote: Total 14731 (delta 180), reused 253 (delta 152), pack-reused 14388
Receiving objects: 100% (14731/14731), 7.39 MiB | 3.10 MiB/s, done.
Resolving deltas: 100% (10487/10487), done.
ERROR: Invalid requirement: '/var/www/MISP/app/files/scripts/CybOXProject/python-cybox'
Hint: It looks like a path. File '/var/www/MISP/app/files/scripts/CybOXProject/python-cybox' does not exist.
apt is maybe locked, waiting 3 seconds.
Cloning into '/var/www/MISP/app/files/scripts/python-stix'...
remote: Enumerating objects: 298, done.
remote: Counting objects: 100% (298/298), done.
remote: Compressing objects: 100% (215/215), done.
remote: Total 13777 (delta 190), reused 155 (delta 83), pack-reused 13479
Receiving objects: 100% (13777/13777), 5.78 MiB | 2.58 MiB/s, done.
Resolving deltas: 100% (10076/10076), done.
ERROR: Invalid requirement: '/var/www/MISP/app/files/scripts/STIXProject/python-stix'
Hint: It looks like a path. File '/var/www/MISP/app/files/scripts/STIXProject/python-stix' does not exist.
apt is maybe locked, waiting 3 seconds.
Cloning into '/var/www/MISP/app/files/scripts/python-maec'...
remote: Enumerating objects: 59, done.
remote: Counting objects: 100% (59/59), done.
remote: Compressing objects: 100% (39/39), done.
remote: Total 4472 (delta 32), reused 40 (delta 20), pack-reused 4413
Receiving objects: 100% (4472/4472), 1.29 MiB | 1.90 MiB/s, done.
Resolving deltas: 100% (2992/2992), done.
ERROR: Invalid requirement: '/var/www/MISP/app/files/scripts/MAECProject/python-maec'
Hint: It looks like a path. File '/var/www/MISP/app/files/scripts/MAECProject/python-maec' does not exist.
apt is maybe locked, waiting 3 seconds.
Cloning into '/var/www/MISP/app/files/scripts/mixbox'...
remote: Enumerating objects: 39, done.
remote: Counting objects: 100% (39/39), done.
remote: Compressing objects: 100% (26/26), done.
remote: Total 1055 (delta 20), reused 27 (delta 13), pack-reused 1016
Receiving objects: 100% (1055/1055), 278.98 KiB | 901.00 KiB/s, done.
Resolving deltas: 100% (696/696), done.
ERROR: Invalid requirement: '/var/www/MISP/app/files/scripts/CybOXProject/mixbox'
Hint: It looks like a path. File '/var/www/MISP/app/files/scripts/CybOXProject/mixbox' does not exist.
```

Making the modification fixed the installation of the dependencies.

Best regards,
Kamil

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2020-05-05: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

If it fixes an existing issue, please use github syntax: `#<IssueID>`

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
