### PR TITLE
Tag info popover

### DIFF
--- a/app/Controller/TagsController.php
+++ b/app/Controller/TagsController.php
@@ -1108,8 +1108,12 @@ class TagsController extends AppController
                 $conditions['OR'][] = array('LOWER(Tag.name) LIKE' => $t);
             }
         } else {
-            foreach ($tag as $k => $t) {
-                $conditions['OR'][] = array('Tag.name' => $t);
+            foreach ($tag as $t) {
+                if (is_numeric($t)) {
+                    $conditions['OR'][] = ['Tag.id' => $t];
+                } else {
+                    $conditions['OR'][] = array('Tag.name' => $t);
+                }
             }
         }
         $tags = $this->Tag->find('all', array(

--- a/app/Model/GalaxyCluster.php
+++ b/app/Model/GalaxyCluster.php
@@ -867,8 +867,18 @@ class GalaxyCluster extends AppModel
         return $tags;
     }
 
+    /**
+     * @param string $name
+     * @param array $user
+     * @return array|mixed
+     */
     public function getCluster($name, $user)
     {
+        $isGalaxyTag = strpos($name, 'misp-galaxy:') === 0;
+        if (!$isGalaxyTag) {
+            return null;
+        }
+
         if (isset($this->__clusterCache[$name])) {
             return $this->__clusterCache[$name];
         }

--- a/app/View/Elements/ajaxTags.ctp
+++ b/app/View/Elements/ajaxTags.ctp
@@ -76,7 +76,7 @@
         );
         if (!empty($tag['Tag']['id'])) {
             $span_tag = sprintf(
-                '<a href="%s" style="%s" class="%s" title="%s">%s</a>',
+                '<a href="%s" style="%s" class="%s" title="%s" data-tag-id="%s">%s</a>',
                 sprintf(
                     '%s%s%s',
                     $baseurl,
@@ -86,6 +86,7 @@
                 $aStyle,
                 $aClass,
                 $aText,
+                h($tag['Tag']['id']),
                 isset($aTextModified) ? $aTextModified : $aText
             );
         } else {

--- a/app/View/Elements/galaxyQuickViewMini.ctp
+++ b/app/View/Elements/galaxyQuickViewMini.ctp
@@ -32,7 +32,7 @@
             foreach ($cluster_fields as $cluster_field) {
                 $key = sprintf('<span class="blue bold">%s</span>', Inflector::humanize(h($cluster_field['key'])));
                 if (is_array($cluster_field['value'])) {
-                    if ($cluster_field['key'] == 'refs') {
+                    if ($cluster_field['key'] === 'refs') {
                         $value = array();
                         foreach ($cluster_field['value'] as $k => $v) {
                             $v_name = $v;
@@ -41,25 +41,25 @@
                             }
                             $value[$k] = '<a href="' . h($v) . '" title="' . h($v) . '">' . h($v_name) . '</a>';
                         }
-                        $value_contents = nl2br(implode("\n", $value));
-                    } else if($cluster_field['key'] == 'country') {
+                        $value_contents = implode("<br>", $value);
+                    } else if ($cluster_field['key'] === 'country') {
                         $value = array();
                         foreach ($cluster_field['value'] as $k => $v) {
                             $value[] = $this->Icon->countryFlag($v) . '&nbsp;' . h($v);
                         }
-                        $value_contents = nl2br(implode("\n", $value));
+                        $value_contents = implode("<br>", $value);
                     } else {
-                        $value_contents = nl2br(h(implode("\n", $cluster_field['value'])));
+                        $value_contents = nl2br(h(implode("\n", $cluster_field['value'])), false);
                     }
                 } else {
-                     if ($cluster_field['key'] == 'source' && filter_var($cluster_field['value'], FILTER_VALIDATE_URL)) {
-                         $value_contents = '<a href="' . h($cluster_field['value']) . '">' . h($cluster_field['value']) . '</a>';;
+                     if ($cluster_field['key'] === 'source' && filter_var($cluster_field['value'], FILTER_VALIDATE_URL)) {
+                         $value_contents = '<a href="' . h($cluster_field['value']) . '">' . h($cluster_field['value']) . '</a>';
                      } else {
                         $value_contents = h($cluster_field['value']);
                      }
                 }
                 $value = sprintf('<span class="black">%s</span>', $value_contents);
-                $popover_data .= sprintf('<span>%s: %s</span><br />', $key, $value);
+                $popover_data .= "<span>$key: $value</span><br>";
             }
             echo sprintf(
                 '<div class="large-left-margin">%s %s %s %s</div>',
@@ -135,17 +135,3 @@
             );
         }
     }
-?>
-
-<script type="text/javascript">
-$(document).ready(function () {
-    $('<?= isset($rowId) ? '#'.$rowId : '' ?> .expandable')
-    .on('click', function() {
-        loadClusterRelations($(this).data('clusterid'));
-    })
-    .popover({
-        html: true,
-        trigger: 'hover'
-    });
-});
-</script>

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -4841,6 +4841,16 @@ $(document).ready(function() {
             $this.addClass('fa-eye');
         }
     });
+
+    // For galaxyQuickViewMini.ctp
+    $('.expandable[data-clusterid]')
+        .on('click', function() {
+            loadClusterRelations($(this).data('clusterid'));
+        })
+        .popover({
+            html: true,
+            trigger: 'hover'
+        });
 });
 
 $(document.body).on("click", ".correlation-expand-button", function() {
@@ -5484,6 +5494,7 @@ $('body').on('click', '.hex-value-convert', function() {
     }
 });
 
+// Tag popover with taxonomy description
 (function() {
     var tagDataCache = {};
     function fetchTagInfo(tagId, callback) {


### PR DESCRIPTION
#### What does it do?

Before I was sad, because useful info from taxonomy about tag is hard to find. For example if user wants to know more about `tlp:white` tag, he need to go to taxnomy and manually find correct tag.

Now it is easy with dynamic popover.

<img width="1251" alt="Snímek obrazovky 2020-12-18 v 20 54 21" src="https://user-images.githubusercontent.com/163343/102656056-9adab100-4173-11eb-98f8-33e0eea04542.png">

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
