### PR TITLE
Add the possibility to have a '-' in the baseurl

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -3927,7 +3927,7 @@ class Server extends AppModel
         if ($this->testForEmpty($value) !== true) {
             return $this->testForEmpty($value);
         }
-        $regex = "/^(?<proto>https?):\/\/(?<host>([\w,\.]+))(?::(?<port>[0-9]+))?(?<base>\/[a-z0-9_\-\.]+)?$/i";
+        $regex = "/^(?<proto>https?):\/\/(?<host>([\w,\-,\.]+))(?::(?<port>[0-9]+))?(?<base>\/[a-z0-9_\-\.]+)?$/i";
 	if (
             !preg_match($regex, $value, $matches) ||
             strtolower($matches['proto']) != strtolower($this->getProto()) ||


### PR DESCRIPTION
With the actual regex in testBaseURL, we can not have a '-' inside the BaseURL, I did a quick fix

With the actual the domain must be: https://sub.mydomain.ext
Witht this PR we can have: https://sub.my-domain.ext

Best regards,