### PR TITLE
chg: [optimisation] Decode JSON input from request just once

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -189,6 +189,27 @@ class AppController extends Controller
             $userLoggedIn = $this->__customAuthentication($_SERVER);
         }
         if ($this->_isRest()) {
+            $jsonDecode = function ($dataToDecode) {
+                if (empty($dataToDecode)) {
+                    return null;
+                }
+                try {
+                    if (defined('JSON_THROW_ON_ERROR')) {
+                        // JSON_THROW_ON_ERROR is supported since PHP 7.3
+                        return json_decode($dataToDecode, true, 512, JSON_THROW_ON_ERROR);
+                    } else {
+                        $decoded = json_decode($dataToDecode, true);
+                        if ($decoded === null) {
+                            throw new UnexpectedValueException('Could not parse JSON: ' . json_last_error_msg(), json_last_error());
+                        }
+                        return $decoded;
+                    }
+                } catch (Exception $e) {
+                    throw new HttpException('Invalid JSON input. Make sure that the JSON input is a correctly formatted JSON string. This request has been blocked to avoid an unfiltered request.', 405, $e);
+                }
+            };
+            //  Throw exception if JSON in request is invalid. Default CakePHP behaviour would just ignore that error.
+            $this->RequestHandler->addInputType('json', [$jsonDecode]);
             $this->Security->unlockedActions = array($this->action);
         }
 

--- a/app/Controller/Component/IndexFilterComponent.php
+++ b/app/Controller/Component/IndexFilterComponent.php
@@ -87,11 +87,6 @@ class IndexFilterComponent extends Component
         }
         $api = $this->isApiFunction($this->Controller->request->params['controller'], $this->Controller->request->params['action']);
         if (isset($this->Controller->RequestHandler) && ($api || $this->isJson() || $this->Controller->RequestHandler->isXml() || $this->isCsv())) {
-            if ($this->isJson()) {
-                if (!empty($this->Controller->request->input()) && empty($this->Controller->request->input('json_decode'))) {
-                    throw new MethodNotAllowedException('Invalid JSON input. Make sure that the JSON input is a correctly formatted JSON string. This request has been blocked to avoid an unfiltered request.');
-                }
-            }
             $this->isRest = true;
             return true;
         } else {
@@ -100,11 +95,8 @@ class IndexFilterComponent extends Component
         }
     }
 
-    public function isJson($data=false)
+    public function isJson()
     {
-        if ($data) {
-            return (json_decode($data) != null) ? true : false;
-        }
         return $this->Controller->request->header('Accept') === 'application/json' || $this->Controller->RequestHandler->prefers() === 'json';
     }
 


### PR DESCRIPTION
#### What does it do?

Optimise REST request when contain big JSON – before, we encoded JSON string twice.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
