### PR TITLE
fix: [inernal] Remove duplicates from server correlations

### DIFF
--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -442,12 +442,17 @@ class Feed extends AppModel
                     if (!isset($event[$scope][$sourceId])) {
                         $event[$scope][$sourceId] = $source[$scope];
                     }
+
                     $attributePosition = $redisResultToAttributePosition[$hitIds[$k]];
-                    $attributes[$attributePosition][$scope][] = $source[$scope];
+                    $alreadyAttached = isset($attributes[$attributePosition][$scope]) &&
+                        in_array($sourceId, array_column($attributes[$attributePosition][$scope], 'id'));
+                    if (!$alreadyAttached) {
+                        $attributes[$attributePosition][$scope][] = $source[$scope];
+                    }
                     $sourceHasHit = true;
                 }
             }
-            // Append also exact MISP feed event UUID
+            // Append also exact MISP feed or server event UUID
             // TODO: This can be optimised in future to do that in one pass
             if ($sourceHasHit && ($scope === 'Server' || $source[$scope]['source_format'] === 'misp')) {
                 $pipe = $redis->multi(Redis::PIPELINE);
@@ -475,7 +480,9 @@ class Feed extends AppModel
                         $attributePosition = $eventUuidHitPosition[$sourceHitPos];
                         foreach ($attributes[$attributePosition][$scope] as $tempKey => $tempFeed) {
                             if ($tempFeed['id'] == $feedId) {
-                                $attributes[$attributePosition][$scope][$tempKey]['event_uuids'][] = $eventUuid;
+                                if (empty($attributes[$attributePosition][$scope][$tempKey]['event_uuids']) || !in_array($eventUuid, $attributes[$attributePosition][$scope][$tempKey]['event_uuids'])) {
+                                    $attributes[$attributePosition][$scope][$tempKey]['event_uuids'][] = $eventUuid;
+                                }
                                 break;
                             }
                         }


### PR DESCRIPTION
#### What does it do?

Remove duplicated correlation from server cached correlations.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
