### PR TITLE
fix: [rest] Allow to edit roaming mode of sharing group

### DIFF
--- a/app/Model/SharingGroup.php
+++ b/app/Model/SharingGroup.php
@@ -700,7 +700,7 @@ class SharingGroup extends AppModel
                 if ($force) {
                     $sgids = $existingSG['SharingGroup']['id'];
                     $editedSG = $existingSG['SharingGroup'];
-                    $attributes = array('name', 'releasability', 'description', 'created', 'modified', 'active');
+                    $attributes = ['name', 'releasability', 'description', 'created', 'modified', 'active', 'roaming'];
                     foreach ($attributes as $a) {
                         if (isset($sg[$a])) {
                             $editedSG[$a] = $sg[$a];


### PR DESCRIPTION
#### What does it do?

It was not possible to edit sharing group roaming mode by API. 

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
