### PR TITLE
new: [settings] Allow to use ThreatLevel.name for alert filter

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -3086,16 +3086,18 @@ class Event extends AppModel
         $userCount = count($usersWithAccess);
         $this->UserSetting = ClassRegistry::init('UserSetting');
         foreach ($usersWithAccess as $k => $user) {
-            if ($this->UserSetting->checkPublishFilter($user, $event)) {
-                // Fetch event for user that will receive alert e-mail to respect all ACLs
-                $eventForUser = $this->fetchEvent($user, [
-                    'eventid' => $id,
-                    'includeAllTags' => true,
-                    'includeEventCorrelations' => true,
-                ])[0];
+            // Fetch event for user that will receive alert e-mail to respect all ACLs
+            $eventForUser = $this->fetchEvent($user, [
+                'eventid' => $id,
+                'includeAllTags' => true,
+                'includeEventCorrelations' => true,
+                'noEventReports' => true,
+                'noSightings' => true,
+            ])[0];
 
+            if ($this->UserSetting->checkPublishFilter($user, $eventForUser)) {
                 $body = $this->__buildAlertEmailBody($eventForUser, $user, $oldpublish);
-                $this->User->sendEmail(array('User' => $user), $body, $bodyNoEnc, $subject);
+                $this->User->sendEmail(['User' => $user], $body, $bodyNoEnc, $subject);
             }
             if ($jobId) {
                 $this->Job->saveProgress($jobId, null, $k / $userCount * 100);

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -7,6 +7,7 @@ App::uses('SendEmail', 'Tools');
 
 /**
  * @property Log $Log
+ * @property UserSetting $UserSetting
  */
 class User extends AppModel
 {
@@ -314,6 +315,9 @@ class User extends AppModel
                     $kafkaPubTool->publishJson($kafkaTopic, $user, $action);
                 }
             }
+        }
+        if ($created) {
+            $this->UserSetting->createDefault($this->id);
         }
         return true;
     }

--- a/app/Model/UserSetting.php
+++ b/app/Model/UserSetting.php
@@ -116,6 +116,26 @@ class UserSetting extends AppModel
         return true;
     }
 
+    /**
+     * Create default user setting.
+     * @param int $userId
+     * @throws Exception
+     */
+    public function createDefault($userId)
+    {
+        foreach ($this->validSettings as $setting => $foo) {
+            $default = Configure::read("DefaultUserSetting.$setting");
+            if ($default) {
+                $this->create();
+                $this->save([
+                    'setting' => $setting,
+                    'user_id' => $userId,
+                    'value' => $default,
+                ]);
+            }
+        }
+    }
+
     // Once we run a find, let us decode the JSON field so we can interact with the contents as if it was an array
     public function afterFind($results, $primary = false)
     {
@@ -306,12 +326,6 @@ class UserSetting extends AppModel
      */
     private function __checkEvent($rule, $lookup_values, $event)
     {
-        if (!is_array($lookup_values)) {
-            $lookup_values = array($lookup_values);
-        }
-        foreach ($lookup_values as $k => $v) {
-            $lookup_values[$k] = mb_strtolower($v);
-        }
         if ($rule === 'AttributeTag.name') {
             $values = array_merge(
                 Hash::extract($event, 'Attribute.{n}.AttributeTag.{n}.Tag.name'),
@@ -333,6 +347,11 @@ class UserSetting extends AppModel
             $values = [$event['ThreatLevel']['name']];
         }
         if (!empty($values)) {
+            if (!is_array($lookup_values)) {
+                $lookup_values = array($lookup_values);
+            }
+            $lookup_values = array_map('mb_strtolower', $lookup_values);
+
             foreach ($values as $extracted_value) {
                 $extracted_value = mb_strtolower($extracted_value);
                 foreach ($lookup_values as $lookup_value) {


### PR DESCRIPTION
#### What does it do?

This will allow for example to receive emails just about e-mails with high threat level.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
