### PR TITLE
new: [UI] Show link to event preview for ID translator

### DIFF
--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -150,9 +150,6 @@ class ServersController extends AppController
 
     public function previewEvent($serverId, $eventId, $all = false)
     {
-        if (!$this->_isSiteAdmin()) {
-            throw new MethodNotAllowedException('You are not authorised to do that.');
-        }
         $server = $this->Server->find('first', array(
             'conditions' => array('Server.id' => $serverId),
             'recursive' => -1,
@@ -202,6 +199,7 @@ class ServersController extends AppController
         }
         $threat_levels = $this->Event->ThreatLevel->find('all');
         $this->set('threatLevels', Set::combine($threat_levels, '{n}.ThreatLevel.id', '{n}.ThreatLevel.name'));
+        $this->set('title_for_layout', __('Remote event preview'));
     }
 
     public function filterEventIndex($id)
@@ -1331,13 +1329,12 @@ class ServersController extends AppController
                     try {
                         $remote_event = $this->Event->downloadEventFromServer($this->request->data['Event']['uuid'], $remote_server, null, true);
                     } catch (Exception $e) {
-                        $error_msg = __("Issue while contacting the remote server to retrieve event information");
-                        $this->Flash->error($error_msg);
+                        $this->Flash->error(__("Issue while contacting the remote server to retrieve event information"));
                         return;
                     }
 
                     $local_event = $this->Event->fetchSimpleEvent($this->Auth->user(), $remote_event[0]['uuid']);
-                    //we record it to avoid re-querying the same server in the 2nd phase
+                    // we record it to avoid re-querying the same server in the 2nd phase
                     if (!empty($local_event)) {
                         $remote_events[] = array(
                             "server_id" => $remote_server['Server']['id'],
@@ -1349,7 +1346,7 @@ class ServersController extends AppController
                 }
             }
             if (empty($local_event)) {
-                $this->Flash->error( __("This event could not be found or you don't have permissions to see it."));
+                $this->Flash->error(__("This event could not be found or you don't have permissions to see it."));
                 return;
             } else {
                 $this->Flash->success(__('The event has been found.'));
@@ -1379,6 +1376,7 @@ class ServersController extends AppController
             $this->set('local_event', $local_event);
             $this->set('remote_events', $remote_events);
         }
+        $this->set('title_for_layout', __('Event ID translator'));
     }
 
     public function getSubmodulesStatus() {

--- a/app/View/Elements/genericElements/SideMenu/side_menu.ctp
+++ b/app/View/Elements/genericElements/SideMenu/side_menu.ctp
@@ -780,7 +780,7 @@ $divider = $this->element('/genericElements/SideMenu/side_menu_divider');
                     if ($menuItem === 'id_translator') {
                         echo $this->element('/genericElements/SideMenu/side_menu_link', array(
                             'text' => __('Event ID translator'),
-                            'url' => '/servers/id_translator',
+                            'url' => '/servers/idTranslator',
                             'element_id' => 'id_translator'
                         ));
                     }

--- a/app/View/Servers/id_translator.ctp
+++ b/app/View/Servers/id_translator.ctp
@@ -1,61 +1,62 @@
 <?php
-    echo $this->element('/genericElements/SideMenu/side_menu', array('menuList' => 'sync', 'menuItem' => 'id_translator'));
-    echo $this->element('/genericElements/Form/genericForm', array(
-        'form' => $this->Form,
-        'data' => array(
-            'title' => __('Event ID translator'),
-            'description' => __('Allows to translate a local ID into the corresponding event ID on sync servers configured.'),
-            'model' => 'Event',
-            'fields' =>  array(
-                  array(
-                      "field" => "uuid",
-                      "label" => __("Event ID or UUID"),
-                      "type" => "text",
-                      "placeholder" => __("1234"),
-                      "stayInLine" => true,
-                    ),
-                    array(
-                      "field" => "local",
-                      "label" => __("Referencing an event which is"),
-                      "default" => "local",
-                      "options" => array("local" => __("local"), "remote" => __("remote")),
-                      "type" => "select",
-                      "stayInLine" => true,
-                    ),
-                    array(
-                        "field" => "Server.id",
-                        "div" => "input select optional-server-select hide",
-                        "options" => $servers,
-                        "label" => __("ID referenced on server"),
-                        "type" => "select",
-                    )
+echo $this->element('/genericElements/SideMenu/side_menu', array('menuList' => 'sync', 'menuItem' => 'id_translator'));
+echo $this->element('/genericElements/Form/genericForm', array(
+    'form' => $this->Form,
+    'data' => array(
+        'title' => __('Event ID translator'),
+        'description' => __('Allows to translate a local ID into the corresponding event ID on sync servers configured.'),
+        'model' => 'Event',
+        'fields' => array(
+            array(
+                "field" => "uuid",
+                "label" => __("Event ID or UUID"),
+                "type" => "text",
+                "placeholder" => __("1234"),
+                "stayInLine" => true,
             ),
-            "submit" => array (
-              "action" => "idTranslator",
-          ),
-        )
-        ));
-    echo '<div class="view">';
-    echo $this->Flash->render();
-    if (isset($remote_events) && isset($local_event)) {
-        $table_data = array();
-        $table_data[] = array('key' => __('UUID'), 'value' => $local_event['Event']['uuid']);
-        $table_data[] = array('key' => __('Info'), 'value' => $local_event['Event']['info']);
-        $link = '<a href="' . $baseurl . '/events/view/' . $local_event['Event']['id'] . '" rel="noreferrer noopener" target="_blank">' . $local_event['Event']['id'] . '</a>';
-        $table_data[] = array('key' => __('Local ID'), 'html' => $link);
-        foreach ($remote_events as $remote_event) {
-            if ($remote_event['remote_id']) {
-                $value = __('Remote ID:') . ' <a href="'.h($remote_event['url']).'" rel="noreferrer noopener" target="_blank">' . $remote_event['remote_id'] . '</a>';
-                $table_data[] = array('key' => h($remote_event['server_name']), 'html' => $value);
-            } else {
-                $table_data[] = array('key' => h($remote_event['server_name']), 'value' => __('Not found or server unreachable'));
+            array(
+                "field" => "local",
+                "label" => __("Referencing an event which is"),
+                "default" => "local",
+                "options" => array("local" => __("local"), "remote" => __("remote")),
+                "type" => "select",
+                "stayInLine" => true,
+            ),
+            array(
+                "field" => "Server.id",
+                "div" => "input select optional-server-select hide",
+                "options" => $servers,
+                "label" => __("ID referenced on server"),
+                "type" => "select",
+            )
+        ),
+        "submit" => array(
+            "action" => "idTranslator",
+        ),
+    )
+));
+echo '<div class="view">';
+echo $this->Flash->render();
+if (isset($remote_events) && isset($local_event)) {
+    $table_data = array();
+    $table_data[] = array('key' => __('UUID'), 'value' => $local_event['Event']['uuid']);
+    $table_data[] = array('key' => __('Info'), 'value' => $local_event['Event']['info']);
+    $link = '<a href="' . $baseurl . '/events/view/' . $local_event['Event']['id'] . '" rel="noreferrer noopener" target="_blank">' . $local_event['Event']['id'] . '</a>';
+    $table_data[] = array('key' => __('Local ID'), 'html' => $link);
+    foreach ($remote_events as $remote_event) {
+        if ($remote_event['remote_id']) {
+            $value = __('Remote ID:') . ' <a href="'.h($remote_event['url']).'" rel="noreferrer noopener" target="_blank">' . $remote_event['remote_id'] . '</a>';
+            if ($isSiteAdmin) {
+                $value .= ' (<a href="' . $baseurl . '/servers/previewEvent/' . $remote_event['server_id'] . '/' . $remote_event['remote_id'] . '">' . __('preview') .  '</a>)';
             }
+            $table_data[] = array('key' => h($remote_event['server_name']), 'html' => $value);
+        } else {
+            $table_data[] = array('key' => h($remote_event['server_name']), 'value' => __('Not found or server unreachable'));
         }
-        echo $this->element('genericElements/viewMetaTable', array('table_data' => $table_data));
     }
-
-    echo "</div>";
-
+    echo $this->element('genericElements/viewMetaTable', array('table_data' => $table_data));
+}
+echo "</div>";
 ?>
 <script type="text/javascript">
 function IDTranslatorUISetup() {


### PR DESCRIPTION
#### What does it do?

Add link to event ID translator to preview event directly in user interface of current MISP, so it is not necessary to log in too different MISP just to quickly check how event looks like on different server.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
