### PR TITLE
fix: [log] Allow to filter logs by org name

### DIFF
--- a/app/Controller/LogsController.php
+++ b/app/Controller/LogsController.php
@@ -108,7 +108,7 @@ class LogsController extends AppController
     }
 
     // Shows a minimalistic history for the currently selected event
-    public function event_index($id)
+    public function event_index($id, $org = null)
     {
         $this->loadModel('Event');
         $event = $this->Event->fetchEvent($this->Auth->user(), array(
@@ -183,6 +183,10 @@ class LogsController extends AppController
             );
         }
 
+        if ($org) {
+            $conditions['org'] = $org;
+        }
+
         $this->paginate['fields'] = array('title', 'created', 'model', 'model_id', 'action', 'change', 'org', 'email');
         $this->paginate['conditions'] = $conditions;
 
@@ -194,7 +198,7 @@ class LogsController extends AppController
                 'fields' => array('User.email')
             ));
             foreach ($list as $k => $item) {
-                if (!in_array($item['Log']['email'], $orgEmails)) {
+                if (!in_array($item['Log']['email'], $orgEmails, true)) {
                     $list[$k]['Log']['email'] = '';
                 }
             }


### PR DESCRIPTION
#### What does it do?

Fixes #6884

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
