### PR TITLE
new: [test] Update github actions build to Ubuntu 20.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         php: ['7.2', '7.3', '7.4']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -66,9 +66,14 @@ jobs:
         run: |
               git submodule update --init --recursive
               sudo apt-get -y update
-              sudo apt-get -y install curl python3 python3-venv virtualenv python3-pip python3-nose python3-redis python3-lxml apache2 libapache2-mod-php$php_version php$php_version-xml php$php_version-mbstring php$php_version-mysql libfuzzy-dev libemail-address-perl libemail-outlook-message-perl
-              sudo pip3 install --upgrade pip setuptools requests pyzmq poetry
+              if [[ $php_version == "7.4" ]]; then
+                # Repo is missing for unknown reason
+                LC_ALL=C.UTF-8 sudo apt-add-repository ppa:ondrej/php -y
+              fi
+              sudo apt-get -y install curl python3 python3-zmq python3-requests python3-pip python3-nose python3-redis python3-lxml apache2 libapache2-mod-php$php_version libfuzzy-dev
+              sudo pip3 install virtualenv # virtualenv must be instaled from pip and not from ubuntu pacckages
               sudo pip3 install --upgrade -r requirements.txt
+              curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
               sudo chown $USER:www-data $HOME/.composer
               pushd app
               sudo -H -u $USER php composer.phar install --no-progress
@@ -185,7 +190,7 @@ jobs:
               sudo chmod -R 777 ./tests
               # Start workers
               # Dirty install python stuff
-              virtualenv -p python3 ./venv
+              python3 -m virtualenv -p python3 ./venv
               sudo -E su $USER -c 'app/Console/cake Admin setSetting "MISP.python_bin" "$GITHUB_WORKSPACE/venv/bin/python"'
               . ./venv/bin/activate
               pushd cti-python-stix2
@@ -209,6 +214,7 @@ jobs:
 
       - name: Run tests
         run: |
+              source $HOME/.poetry/env # enable poetry binary
               ./app/Vendor/bin/parallel-lint --exclude app/Lib/cakephp/ --exclude app/Vendor/ --exclude app/Lib/random_compat/ -e php,ctp app/
               ./app/Vendor/bin/phpunit app/Test/ComplexTypeToolTest.php
               ./app/Vendor/bin/phpunit app/Test/JSONConverterToolTest.php


### PR DESCRIPTION
#### What does it do?

This should fix long build times because LIEF is not precompiled for Python3.6 anymore, Ubuntu 20.04 contains Python 3.8.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
