### PR TITLE
fix: generate S/MIME Signature in DETACHED mode

### DIFF
--- a/app/Lib/Tools/SendEmail.php
+++ b/app/Lib/Tools/SendEmail.php
@@ -729,14 +729,14 @@ class SendEmail
         }
 
         list($inputFile, $outputFile) = $this->createInputOutputFiles($body);
-        $result = openssl_pkcs7_sign($inputFile->pwd(), $outputFile->pwd(), $certPublicSign, $keySign, array(), 0);
+        $result = openssl_pkcs7_sign($inputFile->pwd(), $outputFile->pwd(), $certPublicSign, $keySign, array(), PKCS7_DETACHED);
         $inputFile->delete();
 
         if ($result) {
             $data = $outputFile->read();
             $outputFile->delete();
             $parts = explode("\n\n", $data);
-            return $parts[1] . "\n";
+            return $parts[4] . "\n";
 
         } else {
             $outputFile->delete();


### PR DESCRIPTION
#### What does it do?

Fixes invalid S/MIME Signature, closes #6829

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
