### PR TITLE
new: [UI] Event locks for background jobs and automatic tools

### DIFF
--- a/app/Controller/Component/ACLComponent.php
+++ b/app/Controller/Component/ACLComponent.php
@@ -262,7 +262,9 @@ class ACLComponent extends Component
                     'viewEventAttributes' => array('*'),
                     'viewGraph' => array('*'),
                     'viewGalaxyMatrix' => array('*'),
-                    'xml' => array('*')
+                    'xml' => array('*'),
+                'addEventLock' => ['perm_auth'],
+                'removeEventLock' => ['perm_auth'],
             ),
             'favouriteTags' => array(
                 'toggle' => array('*'),

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -5280,9 +5280,43 @@ class EventsController extends AppController
         }
     }
 
+    public function addEventLock($id)
+    {
+        if (!$this->request->is('post')) {
+            throw new MethodNotAllowedException('This endpoint requires a POST request.');
+        }
+
+        $event = $this->Event->fetchSimpleEvent($this->Auth->User(), $id);
+        if (empty($event)) {
+            throw new MethodNotAllowedException(__('Invalid Event'));
+        }
+        if (!$this->__canModifyEvent($event)) {
+            throw new UnauthorizedException(__('You do not have permission to do that.'));
+        }
+
+        $this->loadModel('EventLock');
+        $lockId = $this->EventLock->insertLockApi($event['Event']['id'], $this->Auth->user());
+        return $this->RestResponse->viewData(['lock_id' => $lockId], $this->response->type());
+    }
+
+    public function removeEventLock($id, $lockId)
+    {
+        if (!$this->request->is('post')) {
+            throw new MethodNotAllowedException('This endpoint requires a POST request.');
+        }
+
+        $event = $this->Event->fetchSimpleEvent($this->Auth->User(), $id);
+        if (empty($event)) {
+            throw new MethodNotAllowedException(__('Invalid Event'));
+        }
+
+        $this->loadModel('EventLock');
+        $deleted = $this->EventLock->deleteApiLock($event['Event']['id'], $lockId, $this->Auth->user());
+        return $this->RestResponse->viewData(['deleted' => $deleted], $this->response->type());
+    }
+
     public function checkLocks($id)
     {
-        $this->loadModel('EventLock');
         $event = $this->Event->find('first', array(
             'recursive' => -1,
             'conditions' => array('Event.id' => $id),
@@ -5290,29 +5324,34 @@ class EventsController extends AppController
         ));
         $locks = array();
         if (!empty($event) && ($event['Event']['orgc_id'] == $this->Auth->user('org_id') || $this->_isSiteAdmin())) {
+            $this->loadModel('EventLock');
             $locks = $this->EventLock->checkLock($this->Auth->user(), $id);
         }
         if (!empty($locks)) {
             $temp = $locks;
             $locks = array();
             foreach ($temp as $t) {
-                if ($t['User']['id'] !== $this->Auth->user('id')) {
+                if ($t['type'] === 'user' && $t['User']['id'] !== $this->Auth->user('id')) {
                     if (!$this->_isSiteAdmin() && $t['User']['org_id'] != $this->Auth->user('org_id')) {
-                        continue;
+                        $locks[] = __('another user');
+                    } else {
+                        $locks[] = $t['User']['email'];
                     }
-                    $locks[] = $t['User']['email'];
+                } else if ($t['type'] === 'job') {
+                    $locks[] = __('background job');
+                } else if ($t['type'] === 'api') {
+                    $locks[] = __('external tool');
                 }
             }
         }
-        // TODO: i18n
-        if (!empty($locks)) {
-            $message = sprintf('Warning: Your view on this event might not be up to date as it is currently being edited by: %s', implode(', ', $locks));
-            $this->set('message', $message);
-            $this->layout = false;
-            $this->render('/Events/ajax/event_lock');
-        } else {
+        if (empty($locks)) {
             return $this->RestResponse->viewData('', $this->response->type(), false, true);
         }
+
+        $message = __('Warning: Your view on this event might not be up to date as it is currently being edited by: %s', implode(', ', $locks));
+        $this->set('message', $message);
+        $this->layout = false;
+        $this->render('/Events/ajax/event_lock');
     }
 
     public function getEditStrategy($id)

--- a/app/View/Events/view.ctp
+++ b/app/View/Events/view.ctp
@@ -540,7 +540,7 @@
 <script type="text/javascript">
 var showContext = false;
 $(function () {
-    queryEventLock('<?php echo h($event['Event']['id']); ?>', '<?php echo h($me['org_id']); ?>');
+    queryEventLock('<?php echo h($event['Event']['id']); ?>');
     popoverStartup();
 
     $("th, td, dt, div, span, li").tooltip({

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -4998,16 +4998,14 @@ $(document.body).on('click', 'a[data-paginator]', function (e) {
     });
 });
 
-function queryEventLock(event_id, user_org_id) {
+function queryEventLock(event_id) {
     if (tabIsActive) {
         $.ajax({
             url: baseurl + "/events/checkLocks/" + event_id,
             type: "get",
             success: function(data, statusText, xhr) {
                  if (xhr.status == 200) {
-                     if ($('#event_lock_warning').length != 0) {
-                         $('#event_lock_warning').remove();
-                     }
+                     $('#event_lock_warning').remove();
                      if (data != '') {
                          $('#main-view-container').append(data);
                      }
@@ -5015,7 +5013,7 @@ function queryEventLock(event_id, user_org_id) {
             }
         });
     }
-    setTimeout(function() { queryEventLock(event_id, user_org_id); }, 5000);
+    setTimeout(function() { queryEventLock(event_id); }, 5000);
 }
 
 function checkIfLoggedIn() {


### PR DESCRIPTION
#### What does it do?

Provide information to user that event is currently processed by background job and also allows for external tools to provide this information too. 

These information are saved to Redis if available instead of database to reduce number of database queries for every check.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
