### PR TITLE
fix: correctly show hidden tags in tag-list

### DIFF
--- a/app/View/Tags/index.ctp
+++ b/app/View/Tags/index.ctp
@@ -45,10 +45,10 @@
                 ],
                 [
                     'name' => __('Hidden'),
-                    'sort' => 'Tag.hidden',
+                    'sort' => 'Tag.hide_tag',
                     'element' => 'boolean',
                     'class' => 'short',
-                    'data_path' => 'Tag.hidden',
+                    'data_path' => 'Tag.hide_tag',
                 ],
                 [
                     'name' => __('Name'),


### PR DESCRIPTION
#### What does it do?

Fixes one part of #6912 
hidden tags not beeing shown as hidden in tag-list.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
