### PR TITLE
fix: [internal] Capturing sightings for attributes

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -12,6 +12,7 @@ App::uses('ComplexTypeTool', 'Tools');
 /**
  * @property Event $Event
  * @property AttributeTag $AttributeTag
+ * @property Sighting $Sighting
  * @property-read array $typeDefinitions
  * @property-read array $categoryDefinitions
  */
@@ -3979,7 +3980,7 @@ class Attribute extends AppModel
                 }
             }
             if (!empty($attribute['Sighting'])) {
-                $this->Sighting->captureSighting($attribute['Sighting'], $this->id, $eventId, $user);
+                $this->Sighting->captureSightings($attribute['Sighting'], $this->id, $eventId, $user);
             }
         }
         if (!empty($this->validationErrors)) {


### PR DESCRIPTION
#### What does it do?

Fixes bug `Error: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'captureSighting' at line 1`

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
