### PR TITLE
HTML alert email

### DIFF
--- a/app/Console/Command/EventShell.php
+++ b/app/Console/Command/EventShell.php
@@ -480,11 +480,8 @@ class EventShell extends AppShell
     {
         list($eventId, $userId) = $this->args;
 
-        $user = $this->User->getUserById($userId);
-        if (empty($user)) {
-            $this->error("User with ID $userId not found.");
-        }
-        $eventForUser = $this->Event->fetchEvent($this->User->rearrangeToAuthForm($user), [
+        $user = $this->getUser($userId);
+        $eventForUser = $this->Event->fetchEvent($user, [
             'eventid' => $eventId,
             'includeAllTags' => true,
             'includeEventCorrelations' => true,
@@ -496,13 +493,13 @@ class EventShell extends AppShell
             $this->error("Event with ID $eventId not exists or given user don't have permission to access it.");
         }
 
-        $emailTemplate = $this->Event->prepareAlertEmail($eventForUser[0], $this->User->rearrangeToAuthForm($user));
+        $emailTemplate = $this->Event->prepareAlertEmail($eventForUser[0], $user);
 
         App::uses('SendEmail', 'Tools');
         App::uses('GpgTool', 'Tools');
         $sendEmail = new SendEmail(GpgTool::initializeGpg());
         $sendEmail->setTransport('Debug');
-        $result = $sendEmail->sendToUser($user, null, $emailTemplate);
+        $result = $sendEmail->sendToUser(['User' => $user], null, $emailTemplate);
 
         echo $result['contents']['headers'] . "\n\n" . $result['contents']['message'] . "\n";
     }

--- a/app/Console/Command/EventShell.php
+++ b/app/Console/Command/EventShell.php
@@ -490,6 +490,7 @@ class EventShell extends AppShell
             'includeEventCorrelations' => true,
             'noEventReports' => true,
             'noSightings' => true,
+            'metadata' => Configure::read('MISP.event_alert_metadata_only') ?: false,
         ]);
         if (empty($eventForUser)) {
             $this->error("Event with ID $eventId not exists or given user don't have permission to access it.");

--- a/app/Lib/Tools/SendEmail.php
+++ b/app/Lib/Tools/SendEmail.php
@@ -469,7 +469,7 @@ class SendEmail
             $email->transport($this->transport);
         }
 
-        // Generate `In-Reply-To` and `References` to group emails
+        // Generate `In-Reply-To` and `References` headers to group emails
         if ($body instanceof SendEmailTemplate && $body->referenceId()) {
             $reference = sha1($body->referenceId() . '|' .  Configure::read('MISP.uuid'));
             $reference = "<$reference@{$email->domain()}>";
@@ -603,6 +603,14 @@ class SendEmail
     {
         $email = new CakeEmailExtended();
 
+        $fromEmail = Configure::read('MISP.email');
+
+        // Set correct domain when sending email from CLI
+        $fromEmailParts = explode('@', $fromEmail, 2);
+        if (isset($fromEmailParts[1])) {
+            $email->domain($fromEmailParts[1]);
+        }
+
         // We must generate message ID by own, because CakeEmail returns different message ID for every call of
         // getHeaders() method.
         $email->messageId($this->generateMessageId($email));
@@ -625,8 +633,8 @@ class SendEmail
             $email->replyTo(Configure::read('MISP.email_reply_to'));
         }
 
-        $email->from(Configure::read('MISP.email'), Configure::read('MISP.email_from_name'));
-        $email->returnPath(Configure::read('MISP.email')); // TODO?
+        $email->from($fromEmail, Configure::read('MISP.email_from_name'));
+        $email->returnPath($fromEmail); // TODO?
         $email->to($user['User']['email']);
         $email->subject($subject);
         $email->emailFormat($body->format());

--- a/app/Lib/Tools/SendEmail.php
+++ b/app/Lib/Tools/SendEmail.php
@@ -581,7 +581,7 @@ class SendEmail
             $email->replyTo(Configure::read('MISP.email_reply_to'));
         }
 
-        $email->from(Configure::read('MISP.email'));
+        $email->from(Configure::read('MISP.email'), Configure::read('MISP.email_from_name'));
         $email->returnPath(Configure::read('MISP.email')); // TODO?
         $email->to($user['User']['email']);
         $email->subject($subject);

--- a/app/Lib/Tools/SendEmail.php
+++ b/app/Lib/Tools/SendEmail.php
@@ -3,6 +3,36 @@ App::uses('CakeEmail', 'Network/Email');
 
 class SendEmailException extends Exception {}
 
+class CakeEmailBody
+{
+    /** @var string|null */
+    public $html;
+
+    /** @var string|null */
+    public $text;
+
+    public function __construct($text = null, $html = null)
+    {
+        $this->html = $html;
+        $this->text = $text;
+    }
+
+    /**
+     * @return string
+     */
+    public function format()
+    {
+        if (!empty($this->html) && !empty($this->text)) {
+            return 'both';
+        }
+
+        if (!empty($this->html)) {
+            return 'html';
+        }
+        return 'text';
+    }
+}
+
 /**
  * Class CakeEmailExtended
  *
@@ -14,7 +44,7 @@ class SendEmailException extends Exception {}
 class CakeEmailExtended extends CakeEmail
 {
     /**
-     * @var MimeMultipart|MessagePart
+     * @var MimeMultipart|MessagePart|CakeEmailBody
      */
     private $body;
 
@@ -30,7 +60,7 @@ class CakeEmailExtended extends CakeEmail
             $headers['Content-Type'] = $this->body->getContentType();
         } else if ($this->body instanceof MessagePart) {
             $headers = array_merge($headers, $this->body->getHeaders());
-        } else {
+        } else if ($this->_emailFormat !== 'both') { // generate correct content-type header for 'text' or 'html' format
             $headers['Content-Type'] = 'multipart/mixed; boundary="' . $this->boundary() . '"';
         }
 
@@ -71,18 +101,40 @@ class CakeEmailExtended extends CakeEmail
             return $this->body->render();
         } else if ($this->body instanceof MessagePart) {
             return $this->body->render(false);
+        } else if ($this->body instanceof CakeEmailBody) {
+            return $this->_render([]); // @see _renderTemplates
         }
 
-        return  $this->_render($this->_wrap($this->body));
+        throw new InvalidArgumentException("Expected that body is instance of MimeMultipart, MessagePart or CakeEmailBody, " . gettype($this->body) . " given.");
     }
 
-    // This is hack how to force CakeEmail to always generate multipart message.
     protected function _renderTemplates($content)
     {
+        if (!$this->body instanceof CakeEmailBody) {
+            throw new InvalidArgumentException("Expected instance of CakeEmailBody, " . gettype($this->body) . " given.");
+        }
+
         $this->_boundary = md5(uniqid());
-        $output = parent::_renderTemplates($content);
-        $output[''] = '';
-        return $output;
+
+        $rendered = [];
+        if (!empty($this->body->text)) {
+            $rendered['text'] = $this->body->text;
+        }
+        if (!empty($this->body->html)) {
+            $rendered['html'] = $this->body->html;
+        }
+
+        foreach ($rendered as $type => $content) {
+            $content = str_replace(array("\r\n", "\r"), "\n", $content);
+            $content = $this->_encodeString($content, $this->charset);
+            $content = $this->_wrap($content);
+            $content = implode("\n", $content);
+            $rendered[$type] = rtrim($content, "\n");
+        }
+
+        // This is hack how to force CakeEmail to always generate multipart message.
+        $rendered[''] = '';
+        return $rendered;
     }
 
     protected function _render($content)
@@ -101,7 +153,7 @@ class CakeEmailExtended extends CakeEmail
         if ($content !== null) {
             throw new InvalidArgumentException("Content must be null for CakeEmailExtended.");
         }
-        return parent::send($this->body);
+        return parent::send();
     }
 
     public function __toString()
@@ -285,7 +337,8 @@ class SendEmail
             }
         }
 
-        $params['body'] = str_replace('\n', PHP_EOL, $params['body']); // TODO: Why this?
+        $body = str_replace('\n', PHP_EOL, $params['body']); // TODO: Why this?
+        $body = new CakeEmailBody($body);
 
         $attachments = array();
         if (!empty($params['requestor_gpgkey'])) {
@@ -306,8 +359,8 @@ class SendEmail
         $email->returnPath(Configure::read('MISP.email'));
         $email->to($params['to']);
         $email->subject($params['subject']);
-        $email->emailFormat('text');
-        $email->body($params['body']);
+        $email->emailFormat($body->format());
+        $email->body($body);
         $email->attachments($attachments);
 
         $mock = false;
@@ -352,15 +405,15 @@ class SendEmail
     /**
      * @param array $user
      * @param string $subject
-     * @param string $body
-     * @param string|null $bodyWithoutEncryption
+     * @param CakeEmailBody $body
+     * @param CakeEmailBody|null $bodyWithoutEncryption
      * @param array $replyToUser
      * @return bool True if e-mail is encrypted, false if not.
      * @throws Crypt_GPG_BadPassphraseException
      * @throws Crypt_GPG_Exception
      * @throws SendEmailException
      */
-    public function sendToUser(array $user, $subject, $body, $bodyWithoutEncryption = null, array $replyToUser = array())
+    public function sendToUser(array $user, $subject, CakeEmailBody $body, CakeEmailBody $bodyWithoutEncryption = null, array $replyToUser = array())
     {
         if (Configure::read('MISP.disable_emailing')) {
             throw new SendEmailException('Emailing is currently disabled on this instance.');
@@ -383,9 +436,7 @@ class SendEmail
             $body = $bodyWithoutEncryption;
         }
 
-        $body = str_replace('\n', PHP_EOL, $body); // TODO: Why this?
-
-        $email = $this->create($user, $subject, $body, array(), $replyToUser);
+        $email = $this->create($user, $subject, $body, [], $replyToUser);
 
         $signed = false;
         if (Configure::read('GnuPG.sign')) {
@@ -499,12 +550,12 @@ class SendEmail
     /**
      * @param array $user User model
      * @param string $subject
-     * @param string $body
+     * @param CakeEmailBody $body
      * @param array $attachments
      * @param array $replyToUser User model
      * @return CakeEmailExtended
      */
-    private function create(array $user, $subject, $body, array $attachments = array(), array $replyToUser = array())
+    private function create(array $user, $subject, CakeEmailBody $body, array $attachments = array(), array $replyToUser = array())
     {
         $email = new CakeEmailExtended();
 
@@ -534,7 +585,7 @@ class SendEmail
         $email->returnPath(Configure::read('MISP.email')); // TODO?
         $email->to($user['User']['email']);
         $email->subject($subject);
-        $email->emailFormat('text');
+        $email->emailFormat($body->format());
         $email->body($body);
 
         foreach ($attachments as $key => $value) {

--- a/app/Lib/Tools/SendEmail.php
+++ b/app/Lib/Tools/SendEmail.php
@@ -442,6 +442,7 @@ class SendEmail
             $body->set('canEncryptSmime', $canEncryptSmime);
             $body->set('canEncryptGpg', $canEncryptGpg);
             $bodyContent = $body->render($hideDetails);
+            $subject = $body->subject() ?: $subject; // Get generated subject from template
         } else {
             if ($hideDetails && $bodyWithoutEncryption) {
                 $body = $bodyWithoutEncryption;

--- a/app/Lib/Tools/SendEmail.php
+++ b/app/Lib/Tools/SendEmail.php
@@ -661,14 +661,15 @@ class SendEmail
 
         $messagePart = new MessagePart();
         $messagePart->addHeader('Content-Type', array(
-            'multipart/mixed',
+            $email->emailFormat() === 'both' ? 'multipart/alternative' : 'multipart/mixed',
             'boundary="' . $email->boundary() . '"',
             'protected-headers="v1"',
         ));
 
-        // Protect User-Facing Headers according to https://tools.ietf.org/id/draft-autocrypt-lamps-protected-headers-01.html
+        // Protect User-Facing Headers and Structural Headers according to
+        // https://tools.ietf.org/id/draft-autocrypt-lamps-protected-headers-02.html
         $originalHeaders = $email->getHeaders(array('subject', 'from', 'to'));
-        $protectedHeaders = array('From', 'To', 'Date', 'Message-ID', 'Subject', 'Reply-To');
+        $protectedHeaders = ['From', 'To', 'Date', 'Message-ID', 'Subject', 'Reply-To', 'In-Reply-To', 'References'];
         foreach ($protectedHeaders as $header) {
             if (isset($originalHeaders[$header])) {
                 $messagePart->addHeader($header, $originalHeaders[$header]);
@@ -757,7 +758,7 @@ class SendEmail
 
         $messagePart = new MessagePart();
         $messagePart->addHeader('Content-Type', array(
-            'multipart/mixed',
+            $email->emailFormat() === 'both' ? 'multipart/alternative' : 'multipart/mixed',
             'boundary="' . $email->boundary() . '"',
         ));
         $messagePart->setPayload($renderedEmail);

--- a/app/Lib/Tools/SendEmailTemplate.php
+++ b/app/Lib/Tools/SendEmailTemplate.php
@@ -10,6 +10,9 @@ class SendEmailTemplate
     /** @var string|null */
     private $referenceId;
 
+    /** @var string|null */
+    private $subject;
+
     public function __construct($viewName)
     {
         $this->viewName = $viewName;
@@ -26,6 +29,15 @@ class SendEmailTemplate
             return $this->referenceId ;
         }
         $this->referenceId = $referenceId;
+    }
+
+    /**
+     * Get subject from template. Must be called after render method.
+     * @return string
+     */
+    public function subject()
+    {
+        return $this->subject;
     }
 
     /**
@@ -63,6 +75,9 @@ class SendEmailTemplate
         $View->viewPath = $View->layoutPath = 'Emails' . DS . 'text';
         $View->hasRendered = false;
         $text = $View->render($this->viewName);
+
+        // Template can change default subject.
+        $this->subject = $View->get('subject');
 
         return new CakeEmailBody($text, $html);
     }

--- a/app/Lib/Tools/SendEmailTemplate.php
+++ b/app/Lib/Tools/SendEmailTemplate.php
@@ -7,12 +7,29 @@ class SendEmailTemplate
     /** @var string */
     private $viewName;
 
+    /** @var string|null */
+    private $referenceId;
+
     public function __construct($viewName)
     {
         $this->viewName = $viewName;
     }
 
     /**
+     * This value will be used for grouping emails in mail client.
+     * @param string|null $referenceId
+     * @return string
+     */
+    public function referenceId($referenceId = null)
+    {
+        if ($referenceId === null) {
+            return $this->referenceId ;
+        }
+        $this->referenceId = $referenceId;
+    }
+
+    /**
+     * Set template variable.
      * @param string $key
      * @param mixed $value
      */
@@ -29,6 +46,7 @@ class SendEmailTemplate
     public function render($hideDetails = false)
     {
         $View = new View();
+        $View->autoLayout = false;
         $View->helpers = ['TextColour'];
         $View->loadHelpers();
 

--- a/app/Lib/Tools/SendEmailTemplate.php
+++ b/app/Lib/Tools/SendEmailTemplate.php
@@ -1,0 +1,51 @@
+<?php
+class SendEmailTemplate
+{
+    /** @var array  */
+    private $viewVars = [];
+
+    /** @var string */
+    private $viewName;
+
+    public function __construct($viewName)
+    {
+        $this->viewName = $viewName;
+    }
+
+    /**
+     * @param string $key
+     * @param mixed $value
+     */
+    public function set($key, $value)
+    {
+        $this->viewVars[$key] = $value;
+    }
+
+    /**
+     * @param bool $hideDetails True when GnuPG.bodyonlyencrypted is enabled and e-mail cannot be send in encrypted form
+     * @return CakeEmailBody
+     * @throws CakeException
+     */
+    public function render($hideDetails = false)
+    {
+        $View = new View();
+        $View->helpers = ['TextColour'];
+        $View->loadHelpers();
+
+        $View->set($this->viewVars);
+        $View->set('hideDetails', $hideDetails);
+
+        $View->viewPath = $View->layoutPath = 'Emails' . DS . 'html';
+        try {
+            $html = $View->render($this->viewName);
+        } catch (MissingViewException $e) {
+            $html = null; // HTMl template is optional
+        }
+
+        $View->viewPath = $View->layoutPath = 'Emails' . DS . 'text';
+        $View->hasRendered = false;
+        $text = $View->render($this->viewName);
+
+        return new CakeEmailBody($text, $html);
+    }
+}

--- a/app/Lib/Tools/SendEmailTemplate.php
+++ b/app/Lib/Tools/SendEmailTemplate.php
@@ -26,18 +26,22 @@ class SendEmailTemplate
     public function referenceId($referenceId = null)
     {
         if ($referenceId === null) {
-            return $this->referenceId ;
+            return $this->referenceId;
         }
         $this->referenceId = $referenceId;
     }
 
     /**
      * Get subject from template. Must be called after render method.
+     * @param string|null $subject
      * @return string
      */
-    public function subject()
+    public function subject($subject = null)
     {
-        return $this->subject;
+        if ($subject === null) {
+            return $this->subject;
+        }
+        $this->subject = $subject;
     }
 
     /**

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -3247,6 +3247,7 @@ class Event extends AppModel
         $template->set('distributionLevels', $this->distributionLevels);
         $template->set('analysisLevels', $this->analysisLevels);
         $template->set('tlp', $this->getEmailSubjectMarkForEvent($event));
+        $template->referenceId("event-alert|{$event['Event']['id']}");
         return $template;
     }
 

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -3196,6 +3196,7 @@ class Event extends AppModel
                 'includeEventCorrelations' => true,
                 'noEventReports' => true,
                 'noSightings' => true,
+                'metadata' => Configure::read('MISP.event_alert_metadata_only') ?: false,
             ])[0];
 
             if ($this->UserSetting->checkPublishFilter($user, $eventForUser)) {

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -4864,12 +4864,20 @@ class Server extends AppModel
                 ),
                 'extended_alert_subject' => array(
                     'level' => 1,
-                    'description' => __('enabling this flag will allow the event description to be transmitted in the alert e-mail\'s subject. Be aware that this is not encrypted by GnuPG, so only enable it if you accept that part of the event description will be sent out in clear-text.'),
+                    'description' => __('Enabling this flag will allow the event description to be transmitted in the alert e-mail\'s subject. Be aware that this is not encrypted by GnuPG, so only enable it if you accept that part of the event description will be sent out in clear-text.'),
                     'value' => false,
                     'errorMessage' => '',
                     'test' => 'testBool',
                     'type' => 'boolean'
                 ),
+                'event_alert_metadata_only' => [
+                    'level' => self::SETTING_OPTIONAL,
+                    'description' => __('Send just event metadata (attributes and objects will be omitted) for event alert.'),
+                    'value' => false,
+                    'errorMessage' => '',
+                    'test' => 'testBool',
+                    'type' => 'boolean'
+                ],
                 'default_event_distribution' => array(
                     'level' => 0,
                     'description' => __('The default distribution setting for events (0-3).'),

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -4739,6 +4739,14 @@ class Server extends AppModel
                     'test' => 'testBool',
                     'type' => 'boolean',
                 ),
+                'email_from_name' => [
+                    'level' => 2,
+                    'description' => __('Notification e-mail sender name.'),
+                    'value' => '',
+                    'errorMessage' => '',
+                    'test' => 'testForEmpty',
+                    'type' => 'string',
+                ],
                 'taxii_sync' => array(
                     'level' => 3,
                     'description' => __('This setting is deprecated and can be safely removed.'),

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -807,13 +807,7 @@ class User extends AppModel
         $sendEmail = new SendEmail($gpg);
 
         try {
-            $encrypted = $sendEmail->sendToUser(
-                $user,
-                $subject,
-                is_string($body) ? new CakeEmailBody($body) : $body,
-                $bodyNoEnc ? (is_string($bodyNoEnc) ? new CakeEmailBody($bodyNoEnc) : $bodyNoEnc): null,
-                $replyToUser ?: []
-            );
+            $encrypted = $sendEmail->sendToUser($user, $subject, $body, $bodyNoEnc,$replyToUser ?: []);
 
         } catch (SendEmailException $e) {
             $this->logException("Exception during sending e-mail", $e);

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -807,7 +807,7 @@ class User extends AppModel
         $sendEmail = new SendEmail($gpg);
 
         try {
-            $encrypted = $sendEmail->sendToUser($user, $subject, $body, $bodyNoEnc,$replyToUser ?: []);
+            $result = $sendEmail->sendToUser($user, $subject, $body, $bodyNoEnc,$replyToUser ?: []);
 
         } catch (SendEmailException $e) {
             $this->logException("Exception during sending e-mail", $e);
@@ -824,9 +824,9 @@ class User extends AppModel
             return false;
         }
 
-        $logTitle = $encrypted ? 'Encrypted email' : 'Email';
+        $logTitle = $result['encrypted'] ? 'Encrypted email' : 'Email';
         // Intentional two spaces to pass test :)
-        $logTitle .= $replyToLog  . '  to ' . $user['User']['email'] . ' sent, titled "' . $subject . '".';
+        $logTitle .= $replyToLog  . '  to ' . $user['User']['email'] . ' sent, titled "' . $result['subject'] . '".';
 
         $this->Log->create();
         $this->Log->save(array(

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -786,8 +786,8 @@ class User extends AppModel
      * the remaining two parameters are the e-mail subject and a secondary user object which will be used as the replyto address if set. If it is set and an encryption key for the replyTo user exists, then his/her public key will also be attached
      *
      * @param array $user
-     * @param CakeEmailBody|string $body
-     * @param CakeEmailBody|string|false $bodyNoEnc
+     * @param SendEmailTemplate|string $body
+     * @param string|false $bodyNoEnc
      * @param string $subject
      * @param array|false $replyToUser
      * @return bool

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -800,13 +800,20 @@ class User extends AppModel
             return true;
         }
 
-        $this->Log = ClassRegistry::init('Log');
+        $this->loadLog();
         $replyToLog = $replyToUser ? ' from ' . $replyToUser['User']['email'] : '';
 
         $gpg = $this->initializeGpg();
         $sendEmail = new SendEmail($gpg);
+
         try {
-            $encrypted = $sendEmail->sendToUser($user, $subject, $body, $bodyNoEnc ?: null, $replyToUser ?: array());
+            $encrypted = $sendEmail->sendToUser(
+                $user,
+                $subject,
+                new CakeEmailBody($body),
+                $bodyNoEnc ? new CakeEmailBody($bodyNoEnc): null,
+                $replyToUser ?: []
+            );
 
         } catch (SendEmailException $e) {
             $this->logException("Exception during sending e-mail", $e);

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -757,7 +757,7 @@ class User extends AppModel
             'conditions' => $conditions,
             'recursive' => -1,
             'fields' => array('id', 'email', 'gpgkey', 'certif_public', 'org_id', 'disabled'),
-            'contain' => ['Role' => ['fields' => ['perm_site_admin', 'perm_audit']], 'Organisation' => ['fields' => ['id']]],
+            'contain' => ['Role' => ['fields' => ['perm_site_admin', 'perm_audit']], 'Organisation' => ['fields' => ['id', 'name']]],
         ));
         foreach ($users as $k => $user) {
             $user = $user['User'];
@@ -786,8 +786,8 @@ class User extends AppModel
      * the remaining two parameters are the e-mail subject and a secondary user object which will be used as the replyto address if set. If it is set and an encryption key for the replyTo user exists, then his/her public key will also be attached
      *
      * @param array $user
-     * @param string $body
-     * @param string|false $bodyNoEnc
+     * @param CakeEmailBody|string $body
+     * @param CakeEmailBody|string|false $bodyNoEnc
      * @param string $subject
      * @param array|false $replyToUser
      * @return bool
@@ -810,8 +810,8 @@ class User extends AppModel
             $encrypted = $sendEmail->sendToUser(
                 $user,
                 $subject,
-                new CakeEmailBody($body),
-                $bodyNoEnc ? new CakeEmailBody($bodyNoEnc): null,
+                is_string($body) ? new CakeEmailBody($body) : $body,
+                $bodyNoEnc ? (is_string($bodyNoEnc) ? new CakeEmailBody($bodyNoEnc) : $bodyNoEnc): null,
                 $replyToUser ?: []
             );
 

--- a/app/View/Emails/text/alert.ctp
+++ b/app/View/Emails/text/alert.ctp
@@ -1,0 +1,101 @@
+<?php
+$renderAttributes = function(array $attributes, $indent = '  ') use ($oldPublishTimestamp) {
+    $appendlen = 20;
+    foreach ($attributes as $attribute) {
+        $ids = $attribute['to_ids'] ?  ' (IDS)' : '';
+
+        // Defanging URLs (Not "links") emails domains/ips in notification emails
+        $value = $attribute['value'];
+        if ('url' === $attribute['type'] || 'uri' === $attribute['type']) {
+            $value = str_ireplace("http", "hxxp", $value);
+            $value = str_ireplace(".", "[.]", $value);
+        } elseif (in_array($attribute['type'], ['email-src', 'email-dst', 'whois-registrant-email', 'dns-soa-email', 'email-reply-to'], true)) {
+            $value = str_replace("@", "[at]", $value);
+        } elseif (in_array($attribute['type'], ['hostname', 'domain', 'ip-src', 'ip-dst', 'domain|ip'], true)) {
+            $value = str_replace(".", "[.]", $value);
+        }
+
+        $strRepeatCount = $appendlen - 2 - strlen($attribute['type']);
+        $strRepeat = ($strRepeatCount > 0) ? str_repeat(' ', $strRepeatCount) : '';
+        if (isset($oldPublishTimestamp) && isset($attribute['timestamp']) && $attribute['timestamp'] > $oldPublishTimestamp) {
+            $line = '* ' . $indent . $attribute['category'] . '/' . $attribute['type'] . $strRepeat . ': ' . $value . $ids . " *\n";
+        } else {
+            $line = $indent . $attribute['category'] . '/' . $attribute['type'] . $strRepeat . ': ' . $value . $ids .  "\n";
+        }
+
+        if (!empty($attribute['AttributeTag'])) {
+            $tags = [];
+            foreach ($attribute['AttributeTag'] as $aT) {
+                $tags[] = $aT['Tag']['name'];
+            }
+            $line .= '  - Tags: ' . implode(', ', $tags) . "\n";
+        }
+        echo $line;
+    }
+};
+
+$renderObjects = function(array $objects) use ($renderAttributes, $oldPublishTimestamp) {
+    foreach ($objects as $object) {
+        $body = '';
+        if (isset($oldPublishTimestamp) && isset($object['timestamp']) && $object['timestamp'] > $oldPublishTimestamp) {
+            $body .= '* ';
+        } else {
+            $body .= '  ';
+        }
+        $body .= $object['name'] . '/' . $object['meta-category'] . "\n";
+        if (!empty($object['Attribute'])) {
+            $body .= $renderAttributes($object['Attribute'], '    ');
+        }
+        echo $body;
+    }
+};
+
+$tags = [];
+foreach ($event['EventTag'] as $tag) {
+    $tags[] = $tag['Tag']['name'];
+}
+?>
+==============================================
+URL         : <?= $baseurl ?>/events/view/<?= $event['Event']['id'] . PHP_EOL ?>
+Event ID    : <?= $event['Event']['id'] . PHP_EOL ?>
+Date        : <?= $event['Event']['date'] . PHP_EOL ?>
+<?php if (Configure::read('MISP.showorg')): ?>
+Reported by : <?= $event['Orgc']['name'] . PHP_EOL ?>
+Local owner of the event : <?= $event['Org']['name'] . PHP_EOL ?>
+<?php endif; ?>
+Distribution: <?= $distributionLevels[$event['Event']['distribution']] . PHP_EOL ?>
+<?php if ($event['Event']['distribution'] == 4): ?>
+Sharing Group: <?= $event['SharingGroup']['name'] . PHP_EOL ?>
+<?php endif; ?>
+Tags: <?= implode(", ", $tags) . PHP_EOL ?>
+Threat Level: <?= $event['ThreatLevel']['name'] . PHP_EOL ?>
+Analysis    : <?= $analysisLevels[$event['Event']['analysis']] . PHP_EOL ?>
+Description : <?= $event['Event']['info'] . PHP_EOL ?>
+<?php if (!empty($event['RelatedEvent'])): ?>
+==============================================
+Related to:
+<?php 
+foreach ($event['RelatedEvent'] as $relatedEvent) {
+    echo $baseurl . '/events/view/' . $relatedEvent['Event']['id'] . ' (' . $relatedEvent['Event']['date'] . ') ' . "\n";
+}
+?>
+==============================================
+<?php endif; ?>
+
+<?php if (!empty($event['Attribute'])): ?>
+Attributes<?= isset($oldPublishTimestamp) ? ' (* indicates a new or modified attribute since last update):' : ':' ?>
+<?= $renderAttributes($event['Attribute']) ?>
+<?php endif; ?>
+
+<?php if (!empty($event['Object'])): ?>
+Objects<?= isset($oldPublishTimestamp) ? ' (* indicates a new or modified object since last update):' : ':' ?>
+<?= $renderObjects($event['Object']) ?>
+<?php endif; ?>
+
+==============================================
+You receive this e-mail because the e-mail address <?= $user['email'] ?> is set 
+to receive <?= $contactAlert ? 'contact' : 'publish' ?> alerts on the MISP instance at <?= $baseurl ?>.
+
+If you would like to unsubscribe from receiving such alert e-mails, simply
+disable <?= $contactAlert ? 'contact' : 'publish' ?> alerts via <?= $baseurl ?>/users/edit
+==============================================

--- a/app/View/Emails/text/alert.ctp
+++ b/app/View/Emails/text/alert.ctp
@@ -1,4 +1,19 @@
 <?php
+if (!isset($oldPublishTimestamp)) {
+    $oldPublishTimestamp = null;
+}
+
+if (!isset($contactAlert)) {
+    $contactAlert = false;
+}
+
+if ($hideDetails) { // Used when GnuPG.bodyonlyencrypted is enabled and e-mail cannot be send in encrypted form
+    $eventUrl = $baseurl . "/events/view/" . $event['Event']['id'];
+    echo __("A new or modified event was just published on %s", $eventUrl) . PHP_EOL . PHP_EOL;
+    echo __("If you would like to unsubscribe from receiving such alert e-mails, simply\ndisable publish alerts via %s", $baseurl . '/users/edit');
+    return;
+}
+
 $renderAttributes = function(array $attributes, $indent = '  ') use ($oldPublishTimestamp) {
     $appendlen = 20;
     foreach ($attributes as $attribute) {
@@ -83,12 +98,12 @@ foreach ($event['RelatedEvent'] as $relatedEvent) {
 <?php endif; ?>
 
 <?php if (!empty($event['Attribute'])): ?>
-Attributes<?= isset($oldPublishTimestamp) ? ' (* indicates a new or modified attribute since last update):' : ':' ?>
+Attributes<?= isset($oldPublishTimestamp) ? " (* indicates a new or modified attribute since last update):\n" : ":\n" ?>
 <?= $renderAttributes($event['Attribute']) ?>
 <?php endif; ?>
 
 <?php if (!empty($event['Object'])): ?>
-Objects<?= isset($oldPublishTimestamp) ? ' (* indicates a new or modified object since last update):' : ':' ?>
+Objects<?= isset($oldPublishTimestamp) ? " (* indicates a new or modified object since last update):\n" : ":\n" ?>
 <?= $renderObjects($event['Object']) ?>
 <?php endif; ?>
 

--- a/app/View/Emails/text/alert_contact.ctp
+++ b/app/View/Emails/text/alert_contact.ctp
@@ -1,0 +1,23 @@
+Hello,
+
+Someone wants to get in touch with you concerning a MISP event.
+
+You can reach them at <?= $requestor['User']['email'] ?>
+<?php if (!empty($requestor['User']['gpgkey'])): ?>
+Their PGP key is added as attachment to this email.
+<?php endif; ?>
+<?php if (!empty($requestor['User']['certif_public'])): ?>
+Their Public certificate is added as attachment to this email.
+<?php endif; ?>
+
+They wrote the following message:
+<?= $message ?>
+
+
+The event is the following:
+<?php
+if ($hideDetails) {
+    echo $baseurl . ' /events/view/' . $event['Event']['id'];
+} else {
+    require __DIR__ . '/alert.ctp'; // include event details
+}

--- a/tests/curl_tests_GH.sh
+++ b/tests/curl_tests_GH.sh
@@ -6,9 +6,12 @@ set -x
 AUTH="$1"
 HOST="$2"
 
-curl -i -H "Accept: application/json" -H "content-type: application/json" -H "Authorization: $AUTH" --data "@event.json" -X POST http://${HOST}/events
+curl -i -H "Accept: application/json" -H "content-type: application/json" -H "Authorization: $AUTH" --data "@event.json" -X POST http://${HOST}/events > /dev/null
 curl -H "Authorization: $AUTH"  -X GET http://${HOST}/events/csv/download/1/ignore:1 | sed -e 's/^M//g' | cut -d, -f2 --complement | sort > 1.csv
 cat 1.csv
 cut -d, -f2 --complement event.csv | sort > compare.csv
 diff compare.csv 1.csv
+# Test alert email generating
+sudo -E su $USER -c '../app/Console/cake Event testEventNotificationEmail 1 1' > /dev/null
+# Delete created event
 curl -i -H "Accept: application/json" -H "content-type: application/json" -H "Authorization: $AUTH" -X POST http://${HOST}/events/delete/1


### PR DESCRIPTION
#### What does it do?

Move alert email generating to template and allow for user to use their own HTML version by putting `alert.ctp` file to `app/View/Emails/html/` folder.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
