### PR TITLE
fix: Elasticsearch complains when an IP is an empty string

### DIFF
--- a/app/Lib/Tools/ElasticSearchClient.php
+++ b/app/Lib/Tools/ElasticSearchClient.php
@@ -40,6 +40,9 @@ class ElasticSearchClient
         // Format timestamp
         $time = strftime("%Y-%m-%d %H:%M:%S", strtotime($document["Log"]["created"]));
         $document["Log"]["created"] = $time;
+        if (empty($document["Log"]["ip"])) {
+            $document["Log"]["ip"] = null;
+        }
         $params = array(
             'index' => $index,
             'type' => $document_type,


### PR DESCRIPTION
#### What does it do?

Since the IP field was being populated with an empty string as part of commit https://github.com/MISP/MISP/commit/14ca7ddf49556e12a58a91929770a6219b3786c1, when this data is sent to ElasticSearch it crashes the log, due to the "IP not being a valid string literal" (this is when the IP field is set as type ip). Setting it to null if it is in fact empty allows this to continue.

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
