### PR TITLE
New feed cache format

### DIFF
--- a/app/Console/Command/AdminShell.php
+++ b/app/Console/Command/AdminShell.php
@@ -1275,9 +1275,9 @@ class AdminShell extends AppShell
 
         $output = [];
 
-        list($count, $size) = RedisTool::sizeByPrefix($redis, 'misp:feed_cache:*');
-        $output['feed_cache_count'] = $count;
-        $output['feed_cache_size'] = $size;
+        list($count, $size) = RedisTool::sizeByPrefix($redis, 'misp:cache:*');
+        $output['cache_count'] = $count;
+        $output['cache_size'] = $size;
 
         // Size of different feeds
         $feedIds = $this->Feed->find('column', [
@@ -1286,7 +1286,7 @@ class AdminShell extends AppShell
 
         $redis->pipeline();
         foreach ($feedIds as $feedId) {
-            $redis->rawCommand("memory", "usage", 'misp:feed_cache:' . $feedId);
+            $redis->rawCommand("memory", "usage", 'misp:cache:F' . $feedId);
         }
         $feedSizes = $redis->exec();
 

--- a/app/Console/Command/ServerShell.php
+++ b/app/Console/Command/ServerShell.php
@@ -544,6 +544,11 @@ class ServerShell extends AppShell
         echo $message . PHP_EOL;
     }
 
+    public function clearCached()
+    {
+        $this->Feed->clearCache();
+    }
+
     public function enqueuePull()
     {
         if (empty($this->args[0]) || empty($this->args[1]) || empty($this->args[2])) {

--- a/app/Controller/FeedsController.php
+++ b/app/Controller/FeedsController.php
@@ -731,7 +731,7 @@ class FeedsController extends AppController
         }
     }
 
-    private function __previewIndex(array $feed, $filterParams = array())
+    private function __previewIndex(array $feed, array $filterParams = [])
     {
         $urlparams = '';
         App::uses('CustomPaginationTool', 'Tools');
@@ -1053,15 +1053,14 @@ class FeedsController extends AppController
         }
     }
 
-    public function compareFeeds($id = false)
+    public function compareFeeds()
     {
         $limited = !$this->_isSiteAdmin() && $this->Auth->user('org_id') !== (int)Configure::read('MISP.host_org_id');
         $feeds = $this->Feed->compareFeeds($limited);
         if ($this->_isRest()) {
             return $this->RestResponse->viewData($feeds, $this->response->type());
-        } else {
-            $this->set('feeds', $feeds);
         }
+        $this->set('feeds', $feeds);
     }
 
     public function toggleSelected($enable = false, $cache = false, $feedList = false)

--- a/app/Lib/Tools/PubSubTool.php
+++ b/app/Lib/Tools/PubSubTool.php
@@ -79,7 +79,7 @@ class PubSubTool
         return false;
     }
 
-    public function publishEvent($event)
+    public function publishEvent(array $event)
     {
         App::uses('JSONConverterTool', 'Tools');
         $json = JSONConverterTool::convert($event, false, true);
@@ -160,7 +160,7 @@ class PubSubTool
      * @return bool
      * @throws JsonException
      */
-    public function modified($data, $type, $action = false)
+    public function modified(array $data, $type, $action = false)
     {
         if (!empty($action)) {
             $data['action'] = $action;
@@ -168,7 +168,7 @@ class PubSubTool
         return $this->pushToRedis('data:misp_json_' . $type, $data);
     }
 
-    public function publish($data, $type, $action = false)
+    public function publish(array $data, $type, $action = false)
     {
         if (!empty($action)) {
             $data['action'] = $action;
@@ -265,12 +265,12 @@ class PubSubTool
 
     /**
      * @param string $ns
-     * @param string|array $data
+     * @param array $data
      * @return bool
      * @throws JsonException
      * @throws RedisException
      */
-    private function pushToRedis($ns, $data)
+    private function pushToRedis($ns, array $data)
     {
         $data = JsonTool::encode($data);
         $this->redis->rPush($ns, $data);

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -2140,6 +2140,14 @@ class Event extends AppModel
         } else {
             $justExportableTags = false;
         }
+
+        if ($options['includeServerCorrelations'] && $options['includeFeedCorrelations']) {
+            $feedCorrelationsScope = 'Both';
+        } else if ($options['includeServerCorrelations']) {
+            $feedCorrelationsScope = 'Server';
+        } else if ($options['includeFeedCorrelations']) {
+            $feedCorrelationsScope = 'Feed';
+        }
         $overrideLimit = !empty($options['overrideLimit']);
 
         if (!empty($options['allow_proposal_blocking']) && !Configure::read('MISP.proposals_block_attributes')) {
@@ -2223,11 +2231,8 @@ class Event extends AppModel
             }
             $shadowAttributeByOldId = [];
             if (!empty($event['ShadowAttribute'])) {
-                if ($isSiteAdmin && $options['includeFeedCorrelations']) {
-                    $event['ShadowAttribute'] = $this->Feed->attachFeedCorrelations($event['ShadowAttribute'], $user, $event['Event'], $overrideLimit);
-                }
-                if ($options['includeServerCorrelations']) {
-                    $event['ShadowAttribute'] = $this->Feed->attachFeedCorrelations($event['ShadowAttribute'], $user, $event['Event'], $overrideLimit, 'Server');
+                if (isset($feedCorrelationsScope)) {
+                    $event['ShadowAttribute'] = $this->Feed->attachFeedCorrelations($event['ShadowAttribute'], $user, $event['Event'], $feedCorrelationsScope);
                 }
 
                 if ($options['includeAttachments']) {
@@ -2247,12 +2252,10 @@ class Event extends AppModel
                 $event['ShadowAttribute'] = $shadowAttributeByOldId[0] ?? [];
             }
             if (!empty($event['Attribute'])) {
-                if ($options['includeFeedCorrelations']) {
-                    $event['Attribute'] = $this->Feed->attachFeedCorrelations($event['Attribute'], $user, $event['Event'], $overrideLimit);
+                if (isset($feedCorrelationsScope)) {
+                    $event['Attribute'] = $this->Feed->attachFeedCorrelations($event['Attribute'], $user, $event['Event'], $feedCorrelationsScope);
                 }
-                if ($options['includeServerCorrelations']) {
-                    $event['Attribute'] = $this->Feed->attachFeedCorrelations($event['Attribute'], $user, $event['Event'], $overrideLimit, 'Server');
-                }
+
                 $event = $this->__filterBlockedAttributesByTags($event, $options, $user);
                 $event = $this->__filterBlockedEventReportsByTags($event, $options, $user);
                 if (!$sharingGroupReferenceOnly) {

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -90,10 +90,14 @@ class Feed extends AppModel
     {
         parent::__construct($id, $table, $ds);
 
-        // Convert to new format since 2020-02-04, can be removed in future
-        $redis = $this->setupRedis();
-        if ($redis && ($redis->exists('misp:feed_cache:combined') || $redis->exists('misp:server_cache:combined'))) {
-            $this->convertToNewRedisCacheFormat();
+        // Convert to new format since version 2.4.184, can be removed in future
+        try {
+            $redis = RedisTool::init();
+            if ($redis->exists('misp:feed_cache:combined', 'misp:server_cache:combined')) {
+                $this->convertToNewRedisCacheFormat($redis);
+            }
+        } catch (Exception $e) {
+            $this->logException('Could not convert cache to new format', $e);
         }
     }
 
@@ -2309,10 +2313,10 @@ class Feed extends AppModel
      * @param bool $withEventUuid
      * @throws Exception
      */
-    public function insertToRedisCache($type, $sourceId, Iterator $values, $withEventUuid = false)
+    public function insertToRedisCache(string $type, int $sourceId, Iterator $values, bool $withEventUuid = false)
     {
         if (!in_array($type, ['server', 'feed'], true)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException("Type must be 'server' or 'feed', '$type' provided.");
         }
         $source = ($type === 'server' ? 'S' : 'F') . $sourceId;
 
@@ -2360,21 +2364,22 @@ class Feed extends AppModel
     }
 
     /**
-     * Convert to new format, old format was used before 2.4.140
+     * Convert to new format, old format was used before 2.4.184
+     * @param Redis $redis
      * @throws Exception
      */
-    private function convertToNewRedisCacheFormat()
+    private function convertToNewRedisCacheFormat($redis)
     {
-        $redis = RedisTool::init();
-
         $this->Server = ClassRegistry::init('Server');
         $serverIds = $this->Server->find('column', ['fields' => ['id']]);
 
         foreach ($serverIds as $serverId) {
             $sourceHashes = $redis->sMembers('misp:server_cache:' . $serverId);
             $hashToInsert = [];
+            $dataToInsert = [];
             foreach ($sourceHashes as $sourceHash) {
-                $hashToInsert[] = hex2bin($sourceHash);
+                $binarySourceHash = hex2bin($sourceHash);
+                $hashToInsert[] = $binarySourceHash;
                 $uuids = $redis->sMembers('misp:server_cache:' . $sourceHash);
                 if ($uuids) {
                     $uuidToInsert = [];
@@ -2388,11 +2393,20 @@ class Feed extends AppModel
                 } else {
                     $uuidToInsert = 0;
                 }
-                $redis->hSet(self::REDIS_CACHE_PREFIX . hex2bin($sourceHash), 'S' . $serverId, $uuidToInsert);
+                $dataToInsert[] = [$binarySourceHash, 'S' . $serverId, $uuidToInsert];
             }
-            $redis->sAddArray(self::REDIS_CACHE_PREFIX . 'S' . $serverId, $hashToInsert);
+
+            if (!empty($dataToInsert)) {
+                $redis->pipeline();
+                foreach ($dataToInsert as $d) {
+                    $redis->hSet(self::REDIS_CACHE_PREFIX . $d[0], $d[1], $d[2]);
+                }
+                $redis->sAddArray(self::REDIS_CACHE_PREFIX . 'S' . $serverId, $hashToInsert);
+                $redis->exec();
+            }
+
             $redis->set('misp:cache_timestamp:S' . $serverId, $redis->get('misp:server_cache_timestamp:' . $serverId));
-            $redis->del('misp:server_cache:' . $serverId);
+            RedisTool::unlink($redis,'misp:server_cache:' . $serverId);
         }
 
         $feedIds = $this->find('column', ['fields' => ['id']]);
@@ -2400,8 +2414,10 @@ class Feed extends AppModel
         foreach ($feedIds as $feedId) {
             $sourceHashes = $redis->sMembers('misp:feed_cache:' . $feedId);
             $hashToInsert = [];
+            $dataToInsert = [];
             foreach ($sourceHashes as $sourceHash) {
-                $hashToInsert[] = hex2bin($sourceHash);
+                $binarySourceHash = hex2bin($sourceHash);
+                $hashToInsert[] = $binarySourceHash;
                 $uuids = $redis->sMembers('misp:feed_cache:' . $sourceHash);
                 if ($uuids) {
                     $uuidToInsert = [];
@@ -2415,17 +2431,24 @@ class Feed extends AppModel
                 } else {
                     $uuidToInsert = 0;
                 }
-                $redis->hSet(self::REDIS_CACHE_PREFIX . hex2bin($sourceHash), 'F' . $feedId, $uuidToInsert);
+                $dataToInsert[] = [$binarySourceHash, 'F' . $feedId, $uuidToInsert];
             }
 
-            $redis->sAddArray(self::REDIS_CACHE_PREFIX . 'F' . $feedId, $hashToInsert);
+            if (!empty($dataToInsert)) {
+                $redis->pipeline();
+                foreach ($dataToInsert as $d) {
+                    $redis->hSet(self::REDIS_CACHE_PREFIX . $d[0], $d[1], $d[2]);
+                }
+                $redis->sAddArray(self::REDIS_CACHE_PREFIX . 'F' . $feedId, $hashToInsert);
+                $redis->exec();
+            }
+
             $redis->set('misp:cache_timestamp:F' . $feedId, $redis->get('misp:feed_cache_timestamp:' . $feedId));
-            $redis->del('misp:feed_cache:' . $feedId);
+            RedisTool::unlink($redis, 'misp:feed_cache:' . $feedId);
         }
 
         // Delete old keys
         RedisTool::unlink($redis, ['misp:feed_cache:combined', 'misp:server_cache:combined']);
-        RedisTool::deleteKeysByPattern($redis, 'misp:feed_cache_timestamp:*');
-        RedisTool::deleteKeysByPattern($redis, 'misp:server_cache_timestamp:*');
+        RedisTool::deleteKeysByPattern($redis, ['misp:feed_cache_timestamp:*', 'misp:server_cache_timestamp:*']);
     }
 }

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -559,7 +559,7 @@ class Feed extends AppModel
         }
         $compositeTypes = $this->Attribute->getCompositeTypes();
 
-        $pipe = $redis->pipeline();
+        $redis->pipeline();
         $redisResultToAttributePosition = [];
 
         foreach ($attributes as $k => $attribute) {
@@ -597,12 +597,12 @@ class Feed extends AppModel
         }
 
         if (empty($redisResultToAttributePosition)) {
-            $pipe->discard();
+            $redis->discard();
             // No attribute that can be correlated
             return $attributes;
         }
 
-        $results = $pipe->exec();
+        $results = $redis->exec();
 
         $sources = null;
         foreach ($results as $k => $result) {
@@ -2323,18 +2323,18 @@ class Feed extends AppModel
         // Delete existing values from current feed
         $existingMembers = $redis->sMembers(self::REDIS_CACHE_PREFIX . $source);
         if (!empty($existingMembers)) {
-            $pipe = $redis->pipeline();
+            $redis->pipeline();
             $i = 0;
             foreach ($existingMembers as $hash) {
-                $pipe->hDel(self::REDIS_CACHE_PREFIX . $hash, $source);
+                $redis->hDel(self::REDIS_CACHE_PREFIX . $hash, $source);
                 // Flush pipeline after every 1000 requests
                 if ($i++ % 1000 === 0) {
-                    $pipe->exec();
-                    $pipe = $redis->pipeline();
+                    $redis->exec();
+                    $redis->pipeline();
                 }
             }
-            $pipe->del(self::REDIS_CACHE_PREFIX . $source);
-            $pipe->exec();
+            $redis->del(self::REDIS_CACHE_PREFIX . $source);
+            $redis->exec();
         }
 
         if ($withEventUuid) {
@@ -2350,31 +2350,31 @@ class Feed extends AppModel
                     $toInsert[$hash] = $eventUuid;
                 }
             }
-            $pipe = $redis->pipeline();
+            $redis->pipeline();
             $i = 0;
             foreach ($toInsert as $hash => $value) {
-                $pipe->sAdd(self::REDIS_CACHE_PREFIX . $source, $hash);
-                $pipe->hSet(self::REDIS_CACHE_PREFIX . $hash, $source, $value);
+                $redis->sAdd(self::REDIS_CACHE_PREFIX . $source, $hash);
+                $redis->hSet(self::REDIS_CACHE_PREFIX . $hash, $source, $value);
                 // Flush pipeline after every 1000 requests
                 if ($i++ % 1000 === 0) {
-                    $pipe->exec();
-                    $pipe = $redis->pipeline();
+                    $redis->exec();
+                    $redis->pipeline();
                 }
             }
-            $pipe->exec();
+            $redis->exec();
         } else {
-            $pipe = $redis->pipeline();
+            $redis->pipeline();
             $i = 0;
             foreach ($values as $hash) {
-                $pipe->sAdd(self::REDIS_CACHE_PREFIX . $source, $hash);
-                $pipe->hSet(self::REDIS_CACHE_PREFIX . $hash, $source, 0);
+                $redis->sAdd(self::REDIS_CACHE_PREFIX . $source, $hash);
+                $redis->hSet(self::REDIS_CACHE_PREFIX . $hash, $source, '0');
                 // Flush pipeline after every 1000 requests
                 if ($i++ % 1000 === 0) {
-                    $pipe->exec();
-                    $pipe = $redis->pipeline();
+                    $redis->exec();
+                    $redis->pipeline();
                 }
             }
-            $pipe->exec();
+            $redis->exec();
         }
         $redis->set('misp:cache_timestamp:' . $source, time());
     }

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -1661,25 +1661,10 @@ class Feed extends AppModel
         return true;
     }
 
-    private function __cacheMISPFeed($feed, $redis, HttpSocket $HttpSocket = null, $jobId = false)
-    {
-        $result = true;
-        if (!$this->__cacheMISPFeedCache($feed, $redis, $HttpSocket, $jobId)) {
-            $result = $this->__cacheMISPFeedTraditional($feed, $redis, $HttpSocket, $jobId);
-            if ($result) {
-                $this->insertToRedisCache('feed', $feed['Feed']['id'], $result, true);
-            }
-        }
-        return $result;
-    }
-
     public function compareFeeds(bool $limited = false)
     {
-        $redis = $this->setupRedis();
-        if ($redis === false) {
-            return array();
-        }
-        $fields = array('id', 'input_source', 'source_format', 'url', 'provider', 'name', 'default');
+        $redis = RedisTool::init();
+        $fields = ['id', 'input_source', 'source_format', 'url', 'provider', 'name', 'default'];
         $conditions = ['Feed.caching_enabled' => 1];
         if ($limited) {
             $conditions['Feed.lookup_visible'] = 1;
@@ -1948,18 +1933,31 @@ class Feed extends AppModel
         return $result;
     }
 
+    /**
+     * @param string|array $value
+     * @param bool $limited
+     * @return array
+     * @throws RedisException
+     */
     public function searchCaches($value, bool $limited = false)
     {
         $sources = [];
-        $feeds = $this->find('all', array(
-            'conditions' => array('caching_enabled' => 1),
+
+        // Fetch feeds
+        $feedConditions = ['caching_enabled' => 1];
+        if ($limited) {
+            $feedConditions['lookup_visible'] = 1;
+        }
+        $feeds = $this->find('all', [
+            'conditions' => $feedConditions,
             'recursive' => -1,
-            'fields' => array('Feed.id', 'Feed.name', 'Feed.url', 'Feed.source_format')
-        ));
+            'fields' => ['Feed.id', 'Feed.name', 'Feed.url', 'Feed.source_format'],
+        ]);
         foreach ($feeds as $feed) {
             $sources['F' . $feed['Feed']['id']] = $feed['Feed'];
         }
 
+        // Fetch servers
         $this->Server = ClassRegistry::init('Server');
         $servers = $this->Server->find('all', array(
             'conditions' => array('caching_enabled' => 1),
@@ -1984,7 +1982,7 @@ class Feed extends AppModel
 
             foreach ($results as $sourceId => $uuids) {
                 if (!isset($sources[$sourceId])) {
-                    continue;
+                    continue; // user don't have access to given source
                 }
                 $hit = $sources[$sourceId];
                 if ($uuids) {

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -1461,9 +1461,9 @@ class Feed extends AppModel
         if ($scope !== 'all') {
             if (is_numeric($scope)) {
                 $params['conditions']['id'] = $scope;
-            } elseif ($scope == 'freetext' || $scope == 'csv') {
+            } elseif ($scope === 'freetext' || $scope === 'csv') {
                 $params['conditions']['source_format'] = array('csv', 'freetext');
-            } elseif ($scope == 'misp') {
+            } elseif ($scope === 'misp') {
                 $params['conditions']['source_format'] = 'misp';
             } else {
                 throw new InvalidArgumentException("Invalid value for scope, it must be integer or 'freetext', 'csv', 'misp' or 'all' string.");
@@ -1499,11 +1499,11 @@ class Feed extends AppModel
             return $feeds;
         }
 
-        $pipe = $redis->pipeline();
-        foreach ($feeds as $feed) {
-            $pipe->get('misp:cache_timestamp:F' . $feed['Feed']['id']);
-        }
-        $result = $redis->exec();
+        $redisKeys = array_map(function($feed) {
+            return 'misp:cache_timestamp:F' . $feed['Feed']['id'];
+        }, $feeds);
+
+        $result = $redis->mGet($redisKeys);
         foreach ($feeds as $k => $feed) {
             $feeds[$k]['Feed']['cache_timestamp'] = $result[$k];
         }
@@ -1727,7 +1727,7 @@ class Feed extends AppModel
                     'overlap_percentage' => round(100 * count($intersect) / $feeds[$k]['Feed']['values']),
                 ));
             }
-            foreach ($servers as $k2 => $server) {
+            foreach ($servers as $server) {
                 $intersect = $redis->sInter('misp:cache:F' . $feed['Feed']['id'], 'misp:cache:S' . $server['Server']['id']);
                 $feeds[$k]['Feed']['ComparedFeed'][] = array_merge(array_intersect_key($server['Server'], $fields), array(
                     'overlap_count' => count($intersect),
@@ -1736,7 +1736,7 @@ class Feed extends AppModel
             }
         }
         foreach ($servers as $k => $server) {
-            foreach ($feeds as $k2 => $feed2) {
+            foreach ($feeds as $feed2) {
                 $intersect = $redis->sInter('misp:cache:S' . $server['Server']['id'], 'misp:cache:F' . $feed2['Feed']['id']);
                 $servers[$k]['Server']['ComparedFeed'][] = array_merge(array_intersect_key($feed2['Feed'], $fields), array(
                     'overlap_count' => count($intersect),
@@ -1754,7 +1754,7 @@ class Feed extends AppModel
                 ));
             }
         }
-        foreach ($servers as $k => $server) {
+        foreach ($servers as $server) {
             $server['Feed'] = $server['Server'];
             unset($server['Server']);
             $feeds[] = $server;
@@ -1837,8 +1837,9 @@ class Feed extends AppModel
 
     public function getFeedCoverage($id, $source_scope = 'feed', $dataset = 'all')
     {
-        $redis = $this->setupRedis();
-        if ($redis === false) {
+        try {
+            $redis = RedisTool::init();
+        } catch (Exception $e) {
             return 'Could not reach Redis.';
         }
         $this->Server = ClassRegistry::init('Server');
@@ -1883,8 +1884,8 @@ class Feed extends AppModel
             call_user_func_array(array($redis, 'sinterstore'), array('misp:feed_temp:' . $temp_store . '_intersect', 'misp:cache:F' . $id, 'misp:feed_temp:' . $temp_store));
             $cardinality_intersect = $redis->scard('misp:feed_temp:' . $temp_store . '_intersect');
             $coverage = round(100 * $cardinality_intersect / $feed_element_count, 2);
-            $redis->del('misp:feed_temp:' . $temp_store);
-            $redis->del('misp:feed_temp:' . $temp_store . '_intersect');
+            // Cleanup
+            RedisTool::unlink(['misp:feed_temp:' . $temp_store, 'misp:feed_temp:' . $temp_store . '_intersect']);
         } else {
             $coverage = 0;
         }
@@ -2423,7 +2424,7 @@ class Feed extends AppModel
         }
 
         // Delete old keys
-        $redis->del('misp:feed_cache:combined', 'misp:server_cache:combined');
+        RedisTool::unlink($redis, ['misp:feed_cache:combined', 'misp:server_cache:combined']);
         RedisTool::deleteKeysByPattern($redis, 'misp:feed_cache_timestamp:*');
         RedisTool::deleteKeysByPattern($redis, 'misp:server_cache_timestamp:*');
     }

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -2286,6 +2286,21 @@ class Feed extends AppModel
     }
 
     /**
+     * Remove all cached serves and feeds from Redis.
+     * @throws Exception
+     */
+    public function clearCache()
+    {
+        $redis = $this->setupRedisWithException();
+        $keys = $redis->keys(self::REDIS_CACHE_PREFIX . '*');
+        $redis->pipeline();
+        foreach ($keys as $key) {
+            $redis->del($key);
+        }
+        $redis->exec();
+    }
+
+    /**
      * Insert feed to Redis cache.
      *
      * @param string $type Can be 'feed' or 'server'

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -2343,7 +2343,7 @@ class Feed extends AppModel
             foreach ($values as $value) {
                 list($hash, $eventUuid) = $value;
                 if (isset($toInsert[$hash])) {
-                    if (strpos($toInsert[$hash], $eventUuid) === false) { // do not insert duplicates
+                    if (!str_contains($toInsert[$hash], $eventUuid)) { // do not insert duplicates
                         $toInsert[$hash] .= ',' . $eventUuid;
                     }
                 } else {

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -84,8 +84,24 @@ class Feed extends AppModel
 
     const CACHE_DIR = APP . 'tmp' . DS . 'cache' . DS . 'feeds' . DS;
 
+    const REDIS_CACHE_PREFIX = 'misp:cache:';
+
+    public function __construct($id = false, $table = null, $ds = null)
+    {
+        parent::__construct($id, $table, $ds);
+
+        // Convert to new format since 2020-02-04, can be removed in future
+        $redis = $this->setupRedis();
+        if ($redis && ($redis->exists('misp:feed_cache:combined') || $redis->exists('misp:server_cache:combined'))) {
+            $this->convertToNewRedisCacheFormat();
+        }
+    }
+
     /*
-     *  Cleanup of empty belongsTo relationships
+     * Cleanup of empty belongsTo relationships
+     * @param mixed $results
+     * @param false $primary
+     * @return mixed
      */
     public function afterFind($results, $primary = false)
     {
@@ -154,11 +170,11 @@ class Feed extends AppModel
 
     public function getFeedTypesOptions()
     {
-        $result = array();
+        $output = [];
         foreach ($this->feed_types as $key => $value) {
-            $result[$key] = $value['name'];
+            $output[$key] = $value['name'];
         }
-        return $result;
+        return $output;
     }
 
     private function checkEventAgainstRules(array $event, array $rules): bool
@@ -255,7 +271,7 @@ class Feed extends AppModel
      * @return Generator<string>
      * @throws Exception
      */
-    public function getCache(array $feed, HttpSocket $HttpSocket = null)
+    private function getCache(array $feed, HttpSocket $HttpSocket = null)
     {
         $uri = $feed['Feed']['url'] . '/hashes.csv';
         $data = $this->feedGetUri($feed, $uri, $HttpSocket);
@@ -479,7 +495,7 @@ class Feed extends AppModel
                 'fields' => array('id', 'name', 'url', 'provider', 'source_format')
             ));
             foreach ($feeds as $k => $v) {
-                if (!$redis->exists('misp:feed_cache:' . $v['Feed']['id'])) {
+                if (!$redis->exists('misp:cache:F' . $v['Feed']['id'])) {
                     unset($feeds[$k]);
                 }
             }
@@ -497,7 +513,7 @@ class Feed extends AppModel
             }
             if ($redis) {
                 foreach ($feeds as $k => $v) {
-                    if ($redis->sismember('misp:feed_cache:' . $v['Feed']['id'], md5($value['value']))) {
+                    if ($redis->sismember('misp:cache:F' . $v['Feed']['id'], md5($value['value'], true))) {
                         $data[$key]['feed_correlations'][] = array($v);
                     }
                 }
@@ -512,14 +528,16 @@ class Feed extends AppModel
      * @param array $attributes
      * @param array $user
      * @param array $event
-     * @param bool $overrideLimit Override hardcoded limit for 10 000 correlations.
-     * @param string $scope `Feed` or `Server`
+     * @param string $scope `Feed`, `Server` or `Both`
      * @return array
      */
-    public function attachFeedCorrelations(array $attributes, array $user, array &$event, $overrideLimit = false, $scope = 'Feed')
+    public function attachFeedCorrelations(array $attributes, array $user, array &$event, $scope = 'Feed')
     {
         if (!isset($user['Role']['perm_view_feed_correlations']) || $user['Role']['perm_view_feed_correlations'] != true) {
             return $attributes;
+        }
+        if (!in_array($scope, ['Feed', 'Server', 'Both'], true)) {
+            throw new InvalidArgumentException("Invalid scope `$scope` provided.");
         }
         if (empty($attributes)) {
             return $attributes;
@@ -531,20 +549,12 @@ class Feed extends AppModel
             return $attributes;
         }
 
-        $cachePrefix = 'misp:' . strtolower($scope) . '_cache:';
-
-        // Skip if redis cache for $scope is empty.
-        if ($redis->sCard($cachePrefix . 'combined') === 0) {
-            return $attributes;
-        }
-
         if (!isset($this->Attribute)) {
             $this->Attribute = ClassRegistry::init('MispAttribute');
         }
         $compositeTypes = $this->Attribute->getCompositeTypes();
 
         $pipe = $redis->pipeline();
-        $hashTable = [];
         $redisResultToAttributePosition = [];
 
         foreach ($attributes as $k => $attribute) {
@@ -576,134 +586,93 @@ class Feed extends AppModel
             }
 
             foreach ($parts as $part) {
-                $md5 = md5($part);
-                $hashTable[] = $md5;
-                $redis->sismember($cachePrefix . 'combined', $md5);
+                $redis->hGetAll(self::REDIS_CACHE_PREFIX . md5($part, true));
                 $redisResultToAttributePosition[] = $k;
             }
         }
 
         if (empty($redisResultToAttributePosition)) {
-            // No attribute that can be correlated
             $pipe->discard();
+            // No attribute that can be correlated
             return $attributes;
         }
 
         $results = $pipe->exec();
 
-        $hitIds = [];
+        $sources = null;
         foreach ($results as $k => $result) {
-            if ($result) {
-                $hitIds[] = $k;
+            if (!$result) {
+                continue;
             }
-        }
-
-        if (empty($hitIds)) {
-            return $attributes; // nothing matches, skip
-        }
-
-        $hitCount = count($hitIds);
-        if (!$overrideLimit && $hitCount > 10000) {
-            $event['FeedCount'] = $hitCount;
-            foreach ($hitIds as $k) {
-                $attributes[$redisResultToAttributePosition[$k]]['FeedHit'] = true;
+            if (!isset($sources)) {
+                $sources = $this->getCachedFeedsOrServers($user, $scope); // lazy load sources
             }
-            return $attributes;
-        }
-
-        $sources = $this->getCachedFeedsOrServers($user, $scope);
-        if ($scope == 'Server' && !$user['Role']['perm_site_admin'] && $user['org_id'] != Configure::read('MISP.host_org_id')) {
-            // Filter fields that shouldn't be visible to everyone
-            $allowedFieldsForAllUsers = array_flip(['id', 'name',]);
-            $sources = array_map(function($source) use($scope, $allowedFieldsForAllUsers) {
-                return [$scope => array_intersect_key($source[$scope], $allowedFieldsForAllUsers)];
-            }, $sources);
-        }
-        foreach ($sources as $source) {
-            $sourceId = $source[$scope]['id'];
-
-            $pipe = $redis->pipeline();
-            foreach ($hitIds as $k) {
-                $redis->sismember($cachePrefix . $sourceId, $hashTable[$k]);
-            }
-            $sourceHits = $pipe->exec();
-            $sourceHasHit = false;
-            foreach ($sourceHits as $k => $hit) {
-                if ($hit) {
-                    if (!isset($event[$scope][$sourceId])) {
-                        $event[$scope][$sourceId] = $source[$scope];
-                    }
-
-                    $attributePosition = $redisResultToAttributePosition[$hitIds[$k]];
-                    $alreadyAttached = isset($attributes[$attributePosition][$scope]) &&
-                        in_array($sourceId, array_column($attributes[$attributePosition][$scope], 'id'));
-                    if (!$alreadyAttached) {
-                        $attributes[$attributePosition][$scope][] = $source[$scope];
-                    }
-                    $sourceHasHit = true;
+            foreach ($result as $sourceId => $uuids) {
+                if (!isset($sources[$sourceId])) {
+                    continue; // source is not enabled
                 }
-            }
-            // Append also exact MISP feed or server event UUID
-            // TODO: This can be optimised in future to do that in one pass
-            if ($sourceHasHit && ($scope === 'Server' || $source[$scope]['source_format'] === 'misp')) {
-                if (
-                    $scope === 'Server' &&
-                    !$user['Role']['perm_site_admin'] && $user['org_id'] != Configure::read('MISP.host_org_id')
-                ) {
-                    continue; // Non-privileged users cannot see the hits for server
+                $scopeForSource = $sourceId[0] === 'S' ? 'Server' : 'Feed';
+                if (!isset($event[$scopeForSource][$sourceId])) {
+                    $event[$scopeForSource][$sourceId] = $sources[$sourceId];
                 }
-                $pipe = $redis->pipeline();
-                $eventUuidHitPosition = [];
-                foreach ($hitIds as $sourceHitPos => $k) {
-                    if ($sourceHits[$sourceHitPos]) {
-                        $redis->smembers($cachePrefix . 'event_uuid_lookup:' . $hashTable[$k]);
-                        $eventUuidHitPosition[] = $redisResultToAttributePosition[$k];
-                    }
-                }
-                $mispFeedHits = $pipe->exec();
-                foreach ($mispFeedHits as $sourceHitPos => $feedUuidMatches) {
-                    if (empty($feedUuidMatches)) {
-                        continue;
-                    }
-                    foreach ($feedUuidMatches as $url) {
-                        list($feedId, $eventUuid) = explode('/', $url);
-                        if ($feedId != $sourceId) {
-                            continue; // just process current source, skip others
+                if ($uuids) {
+                    $uuids = explode(',', $uuids);
+                    // Attach event UUIDs to Server or Feed
+                    foreach ($uuids as $uuid) {
+                        if (!isset($event[$scopeForSource][$sourceId]['event_uuids']) || !in_array($uuid, $event[$scopeForSource][$sourceId]['event_uuids'], true)) {
+                            $event[$scopeForSource][$sourceId]['event_uuids'][] = $uuid;
                         }
+                    }
+                }
 
-                        if (empty($event[$scope][$feedId]['event_uuids']) || !in_array($eventUuid, $event[$scope][$feedId]['event_uuids'])) {
-                            $event[$scope][$feedId]['event_uuids'][] = $eventUuid;
-                        }
-                        $attributePosition = $eventUuidHitPosition[$sourceHitPos];
-                        foreach ($attributes[$attributePosition][$scope] as $tempKey => $tempFeed) {
-                            if ($tempFeed['id'] == $feedId) {
-                                if (empty($attributes[$attributePosition][$scope][$tempKey]['event_uuids']) || !in_array($eventUuid, $attributes[$attributePosition][$scope][$tempKey]['event_uuids'])) {
-                                    $attributes[$attributePosition][$scope][$tempKey]['event_uuids'][] = $eventUuid;
+                $attributePosition = $redisResultToAttributePosition[$k];
+
+                $found = false;
+                if (isset($attributes[$attributePosition][$scopeForSource])) {
+                    foreach ($attributes[$attributePosition][$scopeForSource] as &$existing) {
+                        if ($existing['id'] == $sources[$sourceId]['id']) {
+                            $found = true;
+                            if ($uuids) {
+                                foreach ($uuids as $uuid) {
+                                    if (!isset($existing['event_uuids']) || !in_array($uuid, $existing['event_uuids'], true)) {
+                                        $existing['event_uuids'][] = $uuid;
+                                    }
                                 }
-                                break;
                             }
+                            break;
                         }
                     }
+                }
+
+                if (!$found) {
+                    $value = $sources[$sourceId];
+                    if ($uuids) {
+                        $value['event_uuids'] = $uuids;
+                    }
+                    $attributes[$attributePosition][$scopeForSource][] = $value;
                 }
             }
         }
 
-        if (isset($event[$scope])) {
-            $event[$scope] = array_values($event[$scope]);
+        if (isset($event['Feed'])) {
+            $event['Feed'] = array_values($event['Feed']);
+        }
+        if (isset($event['Server'])) {
+            $event['Server'] = array_values($event['Server']);
         }
 
         return $attributes;
     }
 
     /**
-     * Return just feeds or servers that has some data in Redis cache.
      * @param array $user
-     * @param string $scope 'Feed' or 'Server'
-     * @return array
+     * @param string $scope 'Feed', 'Server' or 'Both'
+     * @return array Where key is Feed or Server ID prefixed by 'F' or 'S' letter
      */
     private function getCachedFeedsOrServers(array $user, $scope)
     {
-        if ($scope === 'Feed') {
+        $output = [];
+        if ($scope === 'Feed' || $scope === 'Both') {
             $params = array(
                 'recursive' => -1,
                 'fields' => array('id', 'name', 'url', 'provider', 'source_format', 'lookup_visible')
@@ -711,8 +680,13 @@ class Feed extends AppModel
             if (!$user['Role']['perm_site_admin']) {
                 $params['conditions'] = array('Feed.lookup_visible' => 1);
             }
-            $sources = $this->find('all', $params);
-        } else {
+            $feeds = $this->find('all', $params);
+            foreach ($feeds as $feed) {
+                $output['F' . $feed['Feed']['id']] = $feed['Feed'];
+            }
+        }
+
+        if ($scope === 'Server' || $scope === 'Both') {
             $params = array(
                 'recursive' => -1,
                 'fields' => array('id', 'name', 'url')
@@ -721,26 +695,13 @@ class Feed extends AppModel
                 $params['conditions'] = array('Server.caching_enabled' => 1);
             }
             $this->Server = ClassRegistry::init('Server');
-            $sources = $this->Server->find('all', $params);
+            $servers = $this->Server->find('all', $params);
+            foreach ($servers as $server) {
+                $output['S' . $server['Server']['id']] = $server['Server'];
+            }
         }
 
-        try {
-            $redis = $this->setupRedisWithException();
-            $pipe = $redis->pipeline();
-            $cachePrefix = 'misp:' . strtolower($scope) . '_cache:';
-            foreach ($sources as $source) {
-                $pipe->exists($cachePrefix . $source[$scope]['id']);
-            }
-            $results = $pipe->exec();
-            foreach ($sources as $k => $source) {
-                if (!$results[$k]) {
-                    unset($sources[$k]);
-                }
-            }
-        } catch (Exception $e) {
-        }
-
-        return $sources;
+        return $output;
     }
 
     /**
@@ -1502,14 +1463,10 @@ class Feed extends AppModel
             } elseif ($scope == 'freetext' || $scope == 'csv') {
                 $params['conditions']['source_format'] = array('csv', 'freetext');
             } elseif ($scope == 'misp') {
-                $redis->del($redis->keys('misp:feed_cache:event_uuid_lookup:*'));
                 $params['conditions']['source_format'] = 'misp';
             } else {
                 throw new InvalidArgumentException("Invalid value for scope, it must be integer or 'freetext', 'csv', 'misp' or 'all' string.");
             }
-        } else {
-            $redis->del('misp:feed_cache:combined');
-            $redis->del($redis->keys('misp:feed_cache:event_uuid_lookup:*'));
         }
         $feeds = $this->find('all', $params);
 
@@ -1542,7 +1499,7 @@ class Feed extends AppModel
 
         $pipe = $redis->pipeline();
         foreach ($feeds as $feed) {
-            $pipe->get('misp:feed_cache_timestamp:' . $feed['Feed']['id']);
+            $pipe->get('misp:cache_timestamp:F' . $feed['Feed']['id']);
         }
         $result = $redis->exec();
         foreach ($feeds as $k => $feed) {
@@ -1581,6 +1538,7 @@ class Feed extends AppModel
      * @param HttpSocket|null $HttpSocket
      * @param int|false $jobId
      * @return bool
+     * @throws Exception
      */
     private function __cacheFreetextFeed(array $feed, $redis, HttpSocket $HttpSocket = null, $jobId = false)
     {
@@ -1597,32 +1555,27 @@ class Feed extends AppModel
         }
 
         // Convert values to MD5 hashes
-        $md5Values = array_map('md5', array_column($values, 'value'));
-
-        $redis->del('misp:feed_cache:' . $feedId);
-        foreach (array_chunk($md5Values, 5000) as $k => $chunk) {
-            $pipe = $redis->pipeline();
-            if (method_exists($redis, 'sAddArray')) {
-                $redis->sAddArray('misp:feed_cache:' . $feedId, $chunk);
-                $redis->sAddArray('misp:feed_cache:combined', $chunk);
-            } else {
-                foreach ($chunk as $value) {
-                    $redis->sAdd('misp:feed_cache:' . $feedId, $value);
-                    $redis->sAdd('misp:feed_cache:combined', $value);
+        $iterator = function () use ($values, $jobId, $feedId) {
+            $count = count($values);
+            foreach ($values as $i => $value) {
+                yield md5($value['value'], true);
+                if ($i % 5000 === 0) {
+                    $progress = $i === 0 ? 0 : ($count / $i) * 100;
+                    $this->jobProgress($jobId, __('Feed %s: %s/%s values cached.', $feedId, $i, $count), $progress);
                 }
             }
-            $pipe->exec();
-            $this->jobProgress($jobId, __('Feed %s: %s/%s values cached.', $feedId, $k * 5000, count($md5Values)));
-        }
+        };
+
+        $this->insertToRedisCache('feed', $feedId, $iterator());
         return true;
     }
 
     /**
-     * @param array $feed
-     * @param Redis $redis
+     * @param $feed
+     * @param $redis
      * @param HttpSocket|null $HttpSocket
      * @param false $jobId
-     * @return bool
+     * @return false|Generator
      */
     private function __cacheMISPFeedTraditional($feed, $redis, HttpSocket $HttpSocket = null, $jobId = false)
     {
@@ -1634,8 +1587,7 @@ class Feed extends AppModel
             return false;
         }
 
-        $redis->del('misp:feed_cache:' . $feedId);
-
+        $this->Attribute = ClassRegistry::init('Attribute');
         $k = 0;
         $this->Attribute = ClassRegistry::init('MispAttribute');
         foreach ($manifest as $uuid => $event) {
@@ -1643,11 +1595,10 @@ class Feed extends AppModel
                 $event = $this->downloadAndParseEventFromFeed($feed, $uuid, $HttpSocket);
             } catch (Exception $e) {
                 $this->logException("Could not get and parse event '$uuid' for feed $feedId.", $e);
-                return false;
+                continue;
             }
 
             if (!empty($event['Event']['Attribute'])) {
-                $pipe = $redis->pipeline();
                 foreach ($event['Event']['Attribute'] as $attribute) {
                     if (!in_array($attribute['type'], MispAttribute::NON_CORRELATING_TYPES, true)) {
                         if (in_array($attribute['type'], $this->Attribute->getCompositeTypes(), true)) {
@@ -1660,32 +1611,28 @@ class Feed extends AppModel
                         }
 
                         foreach ($value as $v) {
-                            $md5 = md5($v);
-                            $redis->sAdd('misp:feed_cache:' . $feedId, $md5);
-                            $redis->sAdd('misp:feed_cache:combined', $md5);
-                            $redis->sAdd('misp:feed_cache:event_uuid_lookup:' . $md5, $feedId . '/' . $event['Event']['uuid']);
+                            yield [md5($v, true), $event['Event']['uuid']];
                         }
                     }
                 }
-                $pipe->exec();
             }
 
             $k++;
-            if ($k % 10 == 0) {
+            if ($k % 10 === 0) {
                 $this->jobProgress($jobId, "Feed $feedId: $k/" . count($manifest) . " events cached.");
             }
         }
-        return true;
     }
 
     /**
      * @param array $feed
      * @param Redis $redis
      * @param HttpSocket|null $HttpSocket
-     * @param false $jobId
+     * @param int|false $jobId
      * @return bool
+     * @throws Exception
      */
-    private function __cacheMISPFeedCache($feed, $redis, HttpSocket $HttpSocket = null, $jobId = false)
+    private function __cacheMISPFeedCache(array $feed, $redis, HttpSocket $HttpSocket = null, $jobId = false)
     {
         $feedId = $feed['Feed']['id'];
 
@@ -1696,20 +1643,31 @@ class Feed extends AppModel
             return false;
         }
 
-        $pipe = $redis->pipeline();
-        $redis->del('misp:feed_cache:' . $feedId);
-        foreach ($cache as $v) {
-            list($hash, $eventUuid) = $v;
-            $redis->sAdd('misp:feed_cache:' . $feedId, $hash);
-            $redis->sAdd('misp:feed_cache:combined', $hash);
-            $redis->sAdd('misp:feed_cache:event_uuid_lookup:' . $hash, "$feedId/$eventUuid");
-        }
-        $pipe->exec();
-        $this->jobProgress($jobId, "Feed $feedId: cached via quick cache.");
+        $iterator = function ($cache) {
+            foreach ($cache as $c) {
+                yield [hex2bin($c[0]), $c[1]]; // Convert hash to binary format
+            }
+        };
+
+        $this->insertToRedisCache('feed', $feedId, $iterator($cache), true);
+
+        $this->jobProgress($jobId, __("Feed %s: cached via quick cache.", $feedId));
         return true;
     }
 
-    public function compareFeeds($limited = false)
+    private function __cacheMISPFeed($feed, $redis, HttpSocket $HttpSocket = null, $jobId = false)
+    {
+        $result = true;
+        if (!$this->__cacheMISPFeedCache($feed, $redis, $HttpSocket, $jobId)) {
+            $result = $this->__cacheMISPFeedTraditional($feed, $redis, $HttpSocket, $jobId);
+            if ($result) {
+                $this->insertToRedisCache('feed', $feed['Feed']['id'], $result, true);
+            }
+        }
+        return $result;
+    }
+
+    public function compareFeeds(bool $limited = false)
     {
         $redis = $this->setupRedis();
         if ($redis === false) {
@@ -1730,48 +1688,45 @@ class Feed extends AppModel
         $fields = array_flip($fields);
         // Get all of the feed cache cardinalities for all feeds - if a feed is not cached remove it from the list
         foreach ($feeds as $k => $feed) {
-            if (!$redis->exists('misp:feed_cache:' . $feed['Feed']['id'])) {
+            if (!$redis->exists(self::REDIS_CACHE_PREFIX . 'F' . $feed['Feed']['id'])) {
                 unset($feeds[$k]);
                 continue;
             }
-            $feeds[$k]['Feed']['values'] = $redis->sCard('misp:feed_cache:' . $feed['Feed']['id']);
+            $feeds[$k]['Feed']['values'] = $redis->sCard(self::REDIS_CACHE_PREFIX . 'F' . $feed['Feed']['id']);
         }
         $feeds = array_values($feeds);
-        $servers = [];
-        if (!$limited) {
-            $this->Server = ClassRegistry::init('Server');
-            $servers = $this->Server->find('all', array(
-                'recursive' => -1,
-                'fields' => array('id', 'url', 'name'),
-                'contain' => array('RemoteOrg' => array('fields' => array('RemoteOrg.id', 'RemoteOrg.name'))),
-                'conditions' => array('Server.caching_enabled' => 1)
-            ));
-            foreach ($servers as $k => $server) {
-                if (!$redis->exists('misp:server_cache:' . $server['Server']['id'])) {
-                    unset($servers[$k]);
-                    continue;
-                }
-                $servers[$k]['Server']['input_source'] = 'network';
-                $servers[$k]['Server']['source_format'] = 'misp';
-                $servers[$k]['Server']['provider'] = $servers[$k]['RemoteOrg']['name'];
-                $servers[$k]['Server']['default'] = false;
-                $servers[$k]['Server']['is_misp_server'] = true;
-                $servers[$k]['Server']['values'] = $redis->sCard('misp:server_cache:' . $server['Server']['id']);
+        $this->Server = ClassRegistry::init('Server');
+        $servers = $this->Server->find('all', array(
+            'recursive' => -1,
+            'fields' => array('id', 'url', 'name'),
+            'contain' => array('RemoteOrg' => array('fields' => array('RemoteOrg.id', 'RemoteOrg.name'))),
+            'conditions' => array('Server.caching_enabled' => 1)
+        ));
+        foreach ($servers as $k => $server) {
+            if (!$redis->exists(self::REDIS_CACHE_PREFIX . 'S' . $server['Server']['id'])) {
+                unset($servers[$k]);
+                continue;
             }
+            $servers[$k]['Server']['input_source'] = 'network';
+            $servers[$k]['Server']['source_format'] = 'misp';
+            $servers[$k]['Server']['provider'] = $servers[$k]['RemoteOrg']['name'];
+            $servers[$k]['Server']['default'] = false;
+            $servers[$k]['Server']['is_misp_server'] = true;
+            $servers[$k]['Server']['values'] = $redis->sCard(self::REDIS_CACHE_PREFIX . 'S' . $server['Server']['id']);
         }
         foreach ($feeds as $k => $feed) {
             foreach ($feeds as $k2 => $feed2) {
                 if ($k == $k2) {
                     continue;
                 }
-                $intersect = $redis->sInter('misp:feed_cache:' . $feed['Feed']['id'], 'misp:feed_cache:' . $feed2['Feed']['id']);
+                $intersect = $redis->sInter('misp:cache:F' . $feed['Feed']['id'], 'misp:cache:F' . $feed2['Feed']['id']);
                 $feeds[$k]['Feed']['ComparedFeed'][] = array_merge(array_intersect_key($feed2['Feed'], $fields), array(
                     'overlap_count' => count($intersect),
                     'overlap_percentage' => round(100 * count($intersect) / $feeds[$k]['Feed']['values']),
                 ));
             }
             foreach ($servers as $k2 => $server) {
-                $intersect = $redis->sInter('misp:feed_cache:' . $feed['Feed']['id'], 'misp:server_cache:' . $server['Server']['id']);
+                $intersect = $redis->sInter('misp:cache:F' . $feed['Feed']['id'], 'misp:cache:S' . $server['Server']['id']);
                 $feeds[$k]['Feed']['ComparedFeed'][] = array_merge(array_intersect_key($server['Server'], $fields), array(
                     'overlap_count' => count($intersect),
                     'overlap_percentage' => round(100 * count($intersect) / $feeds[$k]['Feed']['values']),
@@ -1780,7 +1735,7 @@ class Feed extends AppModel
         }
         foreach ($servers as $k => $server) {
             foreach ($feeds as $k2 => $feed2) {
-                $intersect = $redis->sInter('misp:server_cache:' . $server['Server']['id'], 'misp:feed_cache:' . $feed2['Feed']['id']);
+                $intersect = $redis->sInter('misp:cache:S' . $server['Server']['id'], 'misp:cache:F' . $feed2['Feed']['id']);
                 $servers[$k]['Server']['ComparedFeed'][] = array_merge(array_intersect_key($feed2['Feed'], $fields), array(
                     'overlap_count' => count($intersect),
                     'overlap_percentage' => round(100 * count($intersect) / $servers[$k]['Server']['values']),
@@ -1790,7 +1745,7 @@ class Feed extends AppModel
                 if ($k == $k2) {
                     continue;
                 }
-                $intersect = $redis->sInter('misp:server_cache:' . $server['Server']['id'], 'misp:server_cache:' . $server2['Server']['id']);
+                $intersect = $redis->sInter('misp:cache:S' . $server['Server']['id'], 'misp:cache:S' . $server2['Server']['id']);
                 $servers[$k]['Server']['ComparedFeed'][] = array_merge(array_intersect_key($server2['Server'], $fields), array(
                     'overlap_count' => count($intersect),
                     'overlap_percentage' => round(100 * count($intersect) / $servers[$k]['Server']['values']),
@@ -1904,28 +1859,26 @@ class Feed extends AppModel
                 $server_conditions['OR'] = array('Server.id' => $dataset['Server']);
             }
         }
-        $other_feeds = $this->find('list', array(
-            'recursive' => -1,
+        $other_feeds = $this->find('column', array(
             'conditions' => $feed_conditions,
-            'fields' => array('Feed.id', 'Feed.id')
+            'fields' => array('Feed.id')
         ));
-        $other_servers = $this->Server->find('list', array(
-            'recursive' => -1,
+        $other_servers = $this->Server->find('column', array(
             'conditions' => $server_conditions,
-            'fields' => array('Server.id', 'Server.id')
+            'fields' => array('Server.id')
         ));
-        $feed_element_count = $redis->scard('misp:feed_cache:' . $id);
+        $feed_element_count = $redis->scard('misp:cache:F' . $id);
         $temp_store = RandomTool::random_str(false, 12);
         $params = array('misp:feed_temp:' . $temp_store);
         foreach ($other_feeds as $other_feed) {
-            $params[] = 'misp:feed_cache:' . $other_feed;
+            $params[] = 'misp:cache:F' . $other_feed;
         }
         foreach ($other_servers as $other_server) {
-            $params[] = 'misp:server_cache:' . $other_server;
+            $params[] = 'misp:cache:S' . $other_server;
         }
         if (count($params) != 1 && $feed_element_count > 0) {
             call_user_func_array(array($redis, 'sunionstore'), $params);
-            call_user_func_array(array($redis, 'sinterstore'), array('misp:feed_temp:' . $temp_store . '_intersect', 'misp:feed_cache:' . $id, 'misp:feed_temp:' . $temp_store));
+            call_user_func_array(array($redis, 'sinterstore'), array('misp:feed_temp:' . $temp_store . '_intersect', 'misp:cache:F' . $id, 'misp:feed_temp:' . $temp_store));
             $cardinality_intersect = $redis->scard('misp:feed_temp:' . $temp_store . '_intersect');
             $coverage = round(100 * $cardinality_intersect / $feed_element_count, 2);
             $redis->del('misp:feed_temp:' . $temp_store);
@@ -1939,7 +1892,7 @@ class Feed extends AppModel
     public function getCachedElements($feedId)
     {
         $redis = $this->setupRedis();
-        $cardinality = $redis->sCard('misp:feed_cache:' . $feedId);
+        $cardinality = $redis->sCard('misp:cache:F' . $feedId);
         return $cardinality;
     }
 
@@ -1974,7 +1927,8 @@ class Feed extends AppModel
             foreach ($scopes as $scope) {
                 if (!empty($result[$scope])) {
                     foreach ($result[$scope] as $k => $feed) {
-                        $intersect = $redis->sInter('misp:feed_cache:' . $feedId, 'misp:' . lcfirst($scope) . '_cache:' . $feed['id']);
+                        $otherKey = 'misp:cache:' . ($scope === 'Server' ? 'S' : 'F') . $feed['id'];
+                        $intersect = $redis->sInter('misp:cache:F' . $feedId, $otherKey);
                         if (empty($intersect)) {
                             unset($result[$scope][$k]);
                         } else {
@@ -1989,112 +1943,91 @@ class Feed extends AppModel
 
     public function searchCaches($value, bool $limited = false)
     {
-        $hits = array();
+        $sources = [];
+        $feeds = $this->find('all', array(
+            'conditions' => array('caching_enabled' => 1),
+            'recursive' => -1,
+            'fields' => array('Feed.id', 'Feed.name', 'Feed.url', 'Feed.source_format')
+        ));
+        foreach ($feeds as $feed) {
+            $sources['F' . $feed['Feed']['id']] = $feed['Feed'];
+        }
+
         $this->Server = ClassRegistry::init('Server');
-        $redis = $this->setupRedis();
-        $is_array = true;
+        $servers = $this->Server->find('all', array(
+            'conditions' => array('caching_enabled' => 1),
+            'recursive' => -1,
+            'fields' => array('Server.id', 'Server.name', 'Server.url')
+        ));
+        foreach ($servers as $server) {
+            $sources['S' . $server['Server']['id']] = $server['Server'];
+        }
+
         if (!is_array($value)) {
-            $is_array = false;
-            if (empty($value)) {
-                // old behaviour allowed for empty values to return all data
-                $value = [false];
-            } else {
-                $value = [$value];
-            }
+            $value = [$value];
         }
+
+        $redis = $this->setupRedisWithException();
+
+        $hits = [];
         foreach ($value as $v) {
-            if ($v !== false) {
-                $v = strtolower(trim($v));
-            }
-            if ($v === false || $redis->sismember('misp:feed_cache:combined', md5($v))) {
-                $conditions = ['caching_enabled' => 1];
-                if ($limited) {
-                    $conditions['lookup_visible'] = 1;
+            $v = mb_strtolower(trim($v));
+
+            $results = $redis->hGetAll('misp:cache:' . md5($v, true));
+
+            foreach ($results as $sourceId => $uuids) {
+                if (!isset($sources[$sourceId])) {
+                    continue;
                 }
-                $feeds = $this->find('all', array(
-                    'conditions' => $conditions,
-                    'recursive' => -1,
-                    'fields' => array('Feed.id', 'Feed.name', 'Feed.url', 'Feed.source_format')
-                ));
-                foreach ($feeds as $feed) {
-                    if (($v === false) || $redis->sismember('misp:feed_cache:' . $feed['Feed']['id'], md5($v))) {
-                        if ($feed['Feed']['source_format'] === 'misp') {
-                            $uuid = $redis->smembers('misp:feed_cache:event_uuid_lookup:' . md5($v));
-                            foreach ($uuid as $k => $url) {
-                                $uuid[$k] = explode('/', $url)[1];
-                            }
-                            $feed['Feed']['uuid'] = $uuid;
-                            if (!empty($feed['Feed']['uuid'])) {
-                                foreach ($feed['Feed']['uuid'] as $uuid) {
-                                    $feed['Feed']['direct_urls'][] = array(
-                                        'url' => sprintf(
-                                            '%s/feeds/previewEvent/%s/%s',
-                                            Configure::read('MISP.baseurl'),
-                                            h($feed['Feed']['id']),
-                                            h($uuid)
-                                        ),
-                                        'name' => __('Event %s', $uuid)
-                                    );
-                                }
-                            }
-                            $feed['Feed']['type'] = 'MISP Feed';
-                        } else {
-                            $feed['Feed']['type'] = 'Feed';
-                            if (!empty($v)) {
-                                $feed['Feed']['direct_urls'][] = array(
-                                    'url' => sprintf(
-                                        '%s/feeds/previewIndex/%s',
-                                        Configure::read('MISP.baseurl'),
-                                        h($feed['Feed']['id'])
-                                    ),
-                                    'name' => __('Feed %s', $feed['Feed']['id'])
-                                );
-                            }
+                $hit = $sources[$sourceId];
+                if ($uuids) {
+                    $isServer = $sourceId[0] === 'S';
+                    $hit['type'] = $isServer ? 'MISP Server' : 'MISP Feed';
+                    $hit['uuid'] = explode(',', $uuids);
+                    if ($isServer) {
+                        foreach ($hit['uuid'] as $uuid) {
+                            $hit['direct_urls'][] = array(
+                                'url' => sprintf(
+                                    '%s/servers/previewEvent/%s/%s',
+                                    Configure::read('MISP.baseurl'),
+                                    h($hit['id']),
+                                    h($uuid)
+                                ),
+                                'name' => __('Event %s', h($uuid))
+                            );
                         }
-                        if ($is_array) {
-                            $hits[$v][] = $feed;
-                        } else {
-                            $hits[] = $feed;
+                    } else {
+                        foreach ($hit['uuid'] as $uuid) {
+                            $hit['direct_urls'][] = array(
+                                'url' => sprintf(
+                                    '%s/feeds/previewEvent/%s/%s',
+                                    Configure::read('MISP.baseurl'),
+                                    h($hit['id']),
+                                    h($uuid)
+                                ),
+                                'name' => __('Event %s', $uuid)
+                            );
                         }
                     }
+                } else {
+                    $hit['type'] = 'Feed';
+                    $hit['direct_urls'][] = array(
+                        'url' => sprintf(
+                            '%s/feeds/previewIndex/%s',
+                            Configure::read('MISP.baseurl'),
+                            h($hit['id'])
+                        ),
+                        'name' => __('Feed %s', h($hit['id']))
+                    );
                 }
-            }
-            if (!$limited && ($v === false || $redis->sismember('misp:server_cache:combined', md5($v)))) {
-                $servers = $this->Server->find('all', array(
-                    'conditions' => array(
-                        'caching_enabled' => 1
-                    ),
-                    'recursive' => -1,
-                    'fields' => array('Server.id', 'Server.name', 'Server.url')
-                ));
-                foreach ($servers as $server) {
-                    if ($v === false || $redis->sismember('misp:server_cache:' . $server['Server']['id'], md5($v))) {
-                        $uuid = $redis->smembers('misp:server_cache:event_uuid_lookup:' . md5($v));
-                        if (!empty($uuid)) {
-                            foreach ($uuid as $k => $url) {
-                                $uuid[$k] = explode('/', $url)[1];
-                                $server['Server']['direct_urls'][] = array(
-                                    'url' => sprintf(
-                                        '%s/servers/previewEvent/%s/%s',
-                                        Configure::read('MISP.baseurl'),
-                                        h($server['Server']['id']),
-                                        h($uuid[$k])
-                                    ),
-                                    'name' => __('Event %s', h($uuid[$k]))
-                                );
-                            }
-                        }
-                        $server['Server']['uuid'] = $uuid;
-                        $server['Server']['type'] = 'MISP Server';
-                        if ($is_array) {
-                            $hits[$v][] = array('Feed' => $server['Server']);
-                        } else {
-                            $hits[] = array('Feed' => $server['Server']);
-                        }
-                    }
+                if (is_array($value)) {
+                    $hits[$v][] = ['Feed' => $hit];
+                } else {
+                    $hits[] = ['Feed' => $hit];
                 }
             }
         }
+
         return $hits;
     }
 
@@ -2350,5 +2283,135 @@ class Feed extends AppModel
         }
 
         return FileAccessTool::readAndDelete($destinationFile);
+    }
+
+    /**
+     * Insert feed to Redis cache.
+     *
+     * @param string $type Can be 'feed' or 'server'
+     * @param int $sourceId Server or Feed ID
+     * @param Iterator|array $values Values can be array of binary MD5 hash when $withEventUuid is false or
+     * array of arrays [binary MD5, eventUuid] when $withEventUuid is true.
+     * @param bool $withEventUuid
+     * @throws Exception
+     */
+    public function insertToRedisCache($type, $sourceId, Iterator $values, $withEventUuid = false)
+    {
+        if (!in_array($type, ['server', 'feed'], true)) {
+            throw new InvalidArgumentException();
+        }
+        $source = ($type === 'server' ? 'S' : 'F') . $sourceId;
+
+        $redis = $this->setupRedisWithException();
+
+        // Delete existing values from current feed
+        $existingMembers = $redis->sMembers(self::REDIS_CACHE_PREFIX . $source);
+        if (!empty($existingMembers)) {
+            $pipe = $redis->pipeline();
+            foreach ($existingMembers as $hash) {
+                $pipe->hDel(self::REDIS_CACHE_PREFIX . $hash, $source);
+            }
+            $pipe->del(self::REDIS_CACHE_PREFIX . $source);
+            $pipe->exec();
+        }
+
+        if ($withEventUuid) {
+            // TODO: Maybe to split
+            $toInsert = [];
+            foreach ($values as $value) {
+                list($hash, $eventUuid) = $value;
+                if (isset($toInsert[$hash])) {
+                    if (strpos($toInsert[$hash], $eventUuid) === false) { // do not insert duplicates
+                        $toInsert[$hash] .= ',' . $eventUuid;
+                    }
+                } else {
+                    $toInsert[$hash] = $eventUuid;
+                }
+            }
+            $pipe = $redis->pipeline();
+            foreach ($toInsert as $hash => $value) {
+                $pipe->sAdd(self::REDIS_CACHE_PREFIX . $source, $hash);
+                $pipe->hSet(self::REDIS_CACHE_PREFIX . $hash, $source, $value);
+            }
+            $pipe->exec();
+        } else {
+            $pipe = $redis->pipeline();
+            foreach ($values as $hash) {
+                $pipe->sAdd(self::REDIS_CACHE_PREFIX . $source, $hash);
+                $pipe->hSet(self::REDIS_CACHE_PREFIX . $hash, $source, 0);
+            }
+            $pipe->exec();
+        }
+        $redis->set('misp:cache_timestamp:' . $source, time());
+    }
+
+    /**
+     * Convert to new format, old format was used before 2.4.140
+     * @throws Exception
+     */
+    private function convertToNewRedisCacheFormat()
+    {
+        $redis = $this->setupRedisWithException();
+
+        $this->Server = ClassRegistry::init('Server');
+        $serverIds = $this->Server->find('column', ['fields' => ['id']]);
+
+        foreach ($serverIds as $serverId) {
+            $sourceHashes = $redis->sMembers('misp:server_cache:' . $serverId);
+            $hashToInsert = [];
+            foreach ($sourceHashes as $sourceHash) {
+                $hashToInsert[] = hex2bin($sourceHash);
+                $uuids = $redis->sMembers('misp:server_cache:' . $sourceHash);
+                if ($uuids) {
+                    $uuidToInsert = [];
+                    foreach ($uuids as $uuid) {
+                        $parts = explode('/', $uuid);
+                        if ($parts[0] == $serverId) {
+                            $uuidToInsert[] = $parts[1];
+                        }
+                    }
+                    $uuidToInsert = empty($uuidToInsert) ? 0 : implode(',', $uuidToInsert);
+                } else {
+                    $uuidToInsert = 0;
+                }
+                $redis->hSet(self::REDIS_CACHE_PREFIX . hex2bin($sourceHash), 'S' . $serverId, $uuidToInsert);
+            }
+            $redis->sAddArray(self::REDIS_CACHE_PREFIX . 'S' . $serverId, $hashToInsert);
+            $redis->set('misp:cache_timestamp:S' . $serverId, $redis->get('misp:server_cache_timestamp:' . $serverId));
+            $redis->del('misp:server_cache:' . $serverId);
+        }
+
+        $feedIds = $this->find('column', ['fields' => ['id']]);
+
+        foreach ($feedIds as $feedId) {
+            $sourceHashes = $redis->sMembers('misp:feed_cache:' . $feedId);
+            $hashToInsert = [];
+            foreach ($sourceHashes as $sourceHash) {
+                $hashToInsert[] = hex2bin($sourceHash);
+                $uuids = $redis->sMembers('misp:feed_cache:' . $sourceHash);
+                if ($uuids) {
+                    $uuidToInsert = [];
+                    foreach ($uuids as $uuid) {
+                        $parts = explode('/', $uuid);
+                        if ($parts[0] == $feedId) {
+                            $uuidToInsert[] = $parts[1];
+                        }
+                    }
+                    $uuidToInsert = empty($uuidToInsert) ? 0 : implode(',', $uuidToInsert);
+                } else {
+                    $uuidToInsert = 0;
+                }
+                $redis->hSet(self::REDIS_CACHE_PREFIX . hex2bin($sourceHash), 'F' . $feedId, $uuidToInsert);
+            }
+
+            $redis->sAddArray(self::REDIS_CACHE_PREFIX . 'F' . $feedId, $hashToInsert);
+            $redis->set('misp:cache_timestamp:F' . $feedId, $redis->get('misp:feed_cache_timestamp:' . $feedId));
+            $redis->del('misp:feed_cache:' . $feedId);
+        }
+
+        // Delete old keys
+        $redis->del('misp:feed_cache:combined', 'misp:server_cache:combined');
+        $redis->del($redis->keys('misp:feed_cache_timestamp:*'));
+        $redis->del($redis->keys('misp:server_cache_timestamp:*'));
     }
 }

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -2324,8 +2324,14 @@ class Feed extends AppModel
         $existingMembers = $redis->sMembers(self::REDIS_CACHE_PREFIX . $source);
         if (!empty($existingMembers)) {
             $pipe = $redis->pipeline();
+            $i = 0;
             foreach ($existingMembers as $hash) {
                 $pipe->hDel(self::REDIS_CACHE_PREFIX . $hash, $source);
+                // Flush pipeline after every 1000 requests
+                if ($i++ % 1000 === 0) {
+                    $pipe->exec();
+                    $pipe = $redis->pipeline();
+                }
             }
             $pipe->del(self::REDIS_CACHE_PREFIX . $source);
             $pipe->exec();
@@ -2345,9 +2351,15 @@ class Feed extends AppModel
                 }
             }
             $pipe = $redis->pipeline();
+            $i = 0;
             foreach ($toInsert as $hash => $value) {
                 $pipe->sAdd(self::REDIS_CACHE_PREFIX . $source, $hash);
                 $pipe->hSet(self::REDIS_CACHE_PREFIX . $hash, $source, $value);
+                // Flush pipeline after every 1000 requests
+                if ($i++ % 1000 === 0) {
+                    $pipe->exec();
+                    $pipe = $redis->pipeline();
+                }
             }
             $pipe->exec();
         } else {

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -530,6 +530,7 @@ class Feed extends AppModel
      * @param array $event
      * @param string $scope `Feed`, `Server` or `Both`
      * @return array
+     * @throws RedisException
      */
     public function attachFeedCorrelations(array $attributes, array $user, array &$event, $scope = 'Feed')
     {
@@ -544,7 +545,7 @@ class Feed extends AppModel
         }
 
         try {
-            $redis = $this->setupRedisWithException();
+            $redis = RedisTool::init();
         } catch (Exception $e) {
             return $attributes;
         }
@@ -1456,7 +1457,7 @@ class Feed extends AppModel
             'recursive' => -1,
             'fields' => array('source_format', 'input_source', 'url', 'id', 'settings', 'headers')
         );
-        $redis = $this->setupRedisWithException();
+        $redis = RedisTool::init();
         if ($scope !== 'all') {
             if (is_numeric($scope)) {
                 $params['conditions']['id'] = $scope;
@@ -1488,11 +1489,12 @@ class Feed extends AppModel
     /**
      * @param array $feeds
      * @return array
+     * @throws RedisException
      */
     public function attachFeedCacheTimestamps(array $feeds)
     {
         try {
-            $redis = $this->setupRedisWithException();
+            $redis = RedisTool::init();
         } catch (Exception $e) {
             return $feeds;
         }
@@ -1513,6 +1515,7 @@ class Feed extends AppModel
      * @param Redis $redis
      * @param int|false $jobId
      * @return bool
+     * @throws RedisException
      */
     private function __cacheFeed($feed, $redis, $jobId = false)
     {
@@ -1587,7 +1590,6 @@ class Feed extends AppModel
             return false;
         }
 
-        $this->Attribute = ClassRegistry::init('Attribute');
         $k = 0;
         $this->Attribute = ClassRegistry::init('MispAttribute');
         foreach ($manifest as $uuid => $event) {
@@ -1891,7 +1893,7 @@ class Feed extends AppModel
 
     public function getCachedElements($feedId)
     {
-        $redis = $this->setupRedis();
+        $redis = RedisTool::init();
         $cardinality = $redis->sCard('misp:cache:F' . $feedId);
         return $cardinality;
     }
@@ -1899,7 +1901,7 @@ class Feed extends AppModel
     public function getAllCachingEnabledFeeds($feedId, $intersectingOnly = false)
     {
         if ($intersectingOnly) {
-            $redis = $this->setupRedis();
+            $redis = RedisTool::init();
         }
         $result['Feed'] = $this->find('all', array(
             'conditions' => array(
@@ -1967,7 +1969,7 @@ class Feed extends AppModel
             $value = [$value];
         }
 
-        $redis = $this->setupRedisWithException();
+        $redis = RedisTool::init();
 
         $hits = [];
         foreach ($value as $v) {
@@ -2288,16 +2290,12 @@ class Feed extends AppModel
     /**
      * Remove all cached serves and feeds from Redis.
      * @throws Exception
+     * @return int Number of deleted cached entries
      */
     public function clearCache()
     {
-        $redis = $this->setupRedisWithException();
-        $keys = $redis->keys(self::REDIS_CACHE_PREFIX . '*');
-        $redis->pipeline();
-        foreach ($keys as $key) {
-            $redis->del($key);
-        }
-        $redis->exec();
+        $redis = RedisTool::init();
+        return RedisTool::deleteKeysByPattern($redis, self::REDIS_CACHE_PREFIX . '*');
     }
 
     /**
@@ -2317,7 +2315,7 @@ class Feed extends AppModel
         }
         $source = ($type === 'server' ? 'S' : 'F') . $sourceId;
 
-        $redis = $this->setupRedisWithException();
+        $redis = RedisTool::init();
 
         // Delete existing values from current feed
         $existingMembers = $redis->sMembers(self::REDIS_CACHE_PREFIX . $source);
@@ -2366,7 +2364,7 @@ class Feed extends AppModel
      */
     private function convertToNewRedisCacheFormat()
     {
-        $redis = $this->setupRedisWithException();
+        $redis = RedisTool::init();
 
         $this->Server = ClassRegistry::init('Server');
         $serverIds = $this->Server->find('column', ['fields' => ['id']]);
@@ -2426,7 +2424,7 @@ class Feed extends AppModel
 
         // Delete old keys
         $redis->del('misp:feed_cache:combined', 'misp:server_cache:combined');
-        $redis->del($redis->keys('misp:feed_cache_timestamp:*'));
-        $redis->del($redis->keys('misp:server_cache_timestamp:*'));
+        RedisTool::deleteKeysByPattern($redis, 'misp:feed_cache_timestamp:*');
+        RedisTool::deleteKeysByPattern($redis, 'misp:server_cache_timestamp:*');
     }
 }

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -2308,12 +2308,12 @@ class Feed extends AppModel
      *
      * @param string $type Can be 'feed' or 'server'
      * @param int $sourceId Server or Feed ID
-     * @param Iterator|array $values Values can be array of binary MD5 hash when $withEventUuid is false or
+     * @param iterable $values Values can be array of binary MD5 hash when $withEventUuid is false or
      * array of arrays [binary MD5, eventUuid] when $withEventUuid is true.
      * @param bool $withEventUuid
      * @throws Exception
      */
-    public function insertToRedisCache(string $type, int $sourceId, Iterator $values, bool $withEventUuid = false)
+    public function insertToRedisCache(string $type, int $sourceId, iterable $values, bool $withEventUuid = false)
     {
         if (!in_array($type, ['server', 'feed'], true)) {
             throw new InvalidArgumentException("Type must be 'server' or 'feed', '$type' provided.");
@@ -2354,9 +2354,15 @@ class Feed extends AppModel
             $pipe->exec();
         } else {
             $pipe = $redis->pipeline();
+            $i = 0;
             foreach ($values as $hash) {
                 $pipe->sAdd(self::REDIS_CACHE_PREFIX . $source, $hash);
                 $pipe->hSet(self::REDIS_CACHE_PREFIX . $hash, $source, 0);
+                // Flush pipeline after every 1000 requests
+                if ($i++ % 1000 === 0) {
+                    $pipe->exec();
+                    $pipe = $redis->pipeline();
+                }
             }
             $pipe->exec();
         }

--- a/app/Model/Job.php
+++ b/app/Model/Job.php
@@ -125,7 +125,7 @@ class Job extends AppModel
             $jobData['message'] = $message;
         }
         if ($progress !== null) {
-            $jobData['progress'] = $progress;
+            $jobData['progress'] = (int)$progress;
             if ($progress >= 100) {
                 $jobData['status'] = self::STATUS_COMPLETED;
             }

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -4826,9 +4826,6 @@ class Server extends AppModel
         );
         if ($id !== 'all') {
             $params['conditions']['Server.id'] = $id;
-        } else {
-            $redis->del('misp:server_cache:combined');
-            $redis->del($redis->keys('misp:server_cache:event_uuid_lookup:*'));
         }
         $servers = $this->find('all', $params);
         if ($jobId) {
@@ -4839,7 +4836,7 @@ class Server extends AppModel
             }
         }
         foreach ($servers as $k => $server) {
-            $this->__cacheInstance($server, $redis, $jobId);
+            $this->__cacheInstance($server, $jobId);
             if ($jobId) {
                 $job->saveField('progress', 100 * $k / count($servers));
                 $job->saveField('message', 'Server ' . $server['Server']['id'] . ' cached.');
@@ -4848,61 +4845,52 @@ class Server extends AppModel
         return true;
     }
 
-    /**
-     * @param array $server
-     * @param Redis $redis
-     * @param int|false $jobId
-     * @return bool
-     * @throws JsonException
-     */
-    private function __cacheInstance($server, $redis, $jobId = false)
+    private function __cacheInstance(array $server, $jobId = false)
     {
-        $serverId = $server['Server']['id'];
-        $i = 0;
-        $chunk_size = 50000;
-        if ($jobId) {
-            $job = ClassRegistry::init('Job');
-            $job->id = $jobId;
-        }
-        $redis->del('misp:server_cache:' . $serverId);
+        $job = $jobId ? ClassRegistry::init('Job') : null;
 
-        $serverSync = new ServerSyncTool($server, $this->setupSyncRequest($server));
-        while (true) {
-            $i++;
-            $rules = [
-                'returnFormat' => 'cache',
-                'includeEventUuid' => 1,
-                'page' => $i,
-                'limit' => $chunk_size,
-            ];
-            try {
-                $data = $serverSync->attributeSearch($rules)->body();
-            } catch (Exception $e) {
-                $this->logException("Could not fetch cached attribute from server {$serverSync->serverId()}.", $e);
-                break;
-            }
+        // Use generator
+        $result = function () use ($server, $job, $jobId) {
+            $serverSync = new ServerSyncTool($server, $this->setupSyncRequest($server));
+            $i = 0;
 
-            $data = trim($data);
-            if (empty($data)) {
-                break;
-            }
-
-            $data = explode(PHP_EOL, $data);
-            $pipe = $redis->pipeline();
-            foreach ($data as $entry) {
-                list($value, $uuid) = explode(',', $entry);
-                if (!empty($value)) {
-                    $redis->sAdd('misp:server_cache:' . $serverId, $value);
-                    $redis->sAdd('misp:server_cache:combined', $value);
-                    $redis->sAdd('misp:server_cache:event_uuid_lookup:' . $value, $serverId . '/' . $uuid);
+            while (true) {
+                $i++;
+                $chunk_size = 50000;
+                $rules = [
+                    'returnFormat' => 'cache',
+                    'includeEventUuid' => 1,
+                    'page' => $i,
+                    'limit' => $chunk_size,
+                ];
+                try {
+                    $data = $serverSync->attributeSearch($rules)->body();
+                } catch (Exception $e) {
+                    $this->logException("Could not fetch cached attribute from server {$serverSync->serverId()}.", $e);
+                    break;
+                }
+                $data = trim($data);
+                if (empty($data)) {
+                    break;
+                }
+                $data = explode(PHP_EOL, $data);
+                foreach ($data as $entry) {
+                    list($value, $uuid) = explode(',', $entry);
+                    if (!Validation::uuid($uuid)) {
+                        break;
+                    }
+                    if (!empty($value)) {
+                        yield [hex2bin($value), $uuid];
+                    }
+                }
+                if ($jobId) {
+                    $job->saveProgress($jobId, 'Server ' . $server['Server']['id'] . ': ' . ((($i -1) * $chunk_size) + count($data)) . ' attributes cached.');
                 }
             }
-            $pipe->exec();
-            if ($jobId) {
-                $job->saveProgress($jobId, 'Server ' . $server['Server']['id'] . ': ' . ((($i -1) * $chunk_size) + count($data)) . ' attributes cached.');
-            }
-        }
-        $redis->set('misp:server_cache_timestamp:' . $serverId, time());
+        };
+
+        $this->Feed = ClassRegistry::init('Feed');
+        $this->Feed->insertToRedisCache('server', $server['Server']['id'], $result(), true);
         return true;
     }
 
@@ -4918,7 +4906,7 @@ class Server extends AppModel
         }
         $redis->pipeline();
         foreach ($servers as $server) {
-            $redis->get('misp:server_cache_timestamp:' . $server['Server']['id']);
+            $redis->get('misp:cache_timestamp:S' . $server['Server']['id']);
         }
         $results = $redis->exec();
         foreach ($servers as $k => $v) {


### PR DESCRIPTION
#### What does it do?

This patch changes way how feed/server data are stored in Redis – the new format is more efficient (takes less memory) and also much faster when fetching for given event.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
