### PR TITLE
chg: [galaxy] Make Galaxy cluster description optional

### DIFF
--- a/app/Model/GalaxyCluster.php
+++ b/app/Model/GalaxyCluster.php
@@ -24,15 +24,10 @@ class GalaxyCluster extends AppModel
                 'rule' => array('stringNotEmpty')
             )
         ),
-        'description' => array(
-            'stringNotEmpty' => array(
-                'rule' => array('stringNotEmpty')
-            )
-        ),
         'uuid' => array(
             'uuid' => array(
-                'rule' => array('custom', '/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/'),
-                'message' => 'Please provide a valid UUID'
+                'rule' => 'uuid',
+                'message' => 'Please provide a valid RFC 4122 UUID'
             ),
             'unique' => array(
                 'rule' => 'isUnique',


### PR DESCRIPTION
#### What does it do?

Sometimes, there are situations when you don't want to fill galaxy cluster description – for example you want to create cluster and fill description later. 

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
