### PR TITLE
Adds 'List Auth Keys' button to Administration in global menu

### DIFF
--- a/app/View/Elements/global_menu.ctp
+++ b/app/View/Elements/global_menu.ctp
@@ -336,6 +336,10 @@
                         'url' => $baseurl . '/admin/users/index'
                     ),
                     array(
+                        'text' => __('List Auth Keys'),
+                        'url' => $baseurl . '/auth_keys/index'
+                    ),
+                    array(
                         'text' => __('List User Settings'),
                         'url' => $baseurl . '/user_settings/index/user_id:all'
                     ),


### PR DESCRIPTION
#### What does it do?

Adds 'List Auth Keys' button to Administration in global menu.
We find this view useful with the new auth keys functionality and it seems there is no link to it in the menu yet.

#### Questions

- [ ] Does it require a DB change? No
- [ ] Are you using it in production? Not yet but we will
- [ ] Does it require a change in the API (PyMISP for example)? No
