### PR TITLE
fix: [server] Add application/x-pie-executable to the list of accepted mimetypes in testForBinExec

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1536,7 +1536,7 @@ class Server extends AppModel
             return true;
         }
         if (is_executable($value)) {
-            if (finfo_file($finfo, $value) == "application/x-executable" || finfo_file($finfo, $value) == "application/x-sharedlib") {
+            if (finfo_file($finfo, $value) == "application/x-executable" || finfo_file($finfo, $value) == "application/x-pie-executable" || finfo_file($finfo, $value) == "application/x-sharedlib") {
                 finfo_close($finfo);
                 return true;
             } else {


### PR DESCRIPTION
#### What does it do?

Fixes #7051 

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
