### PR TITLE
Fix for ZeroMQ - #7040 and #7039

### DIFF
--- a/app/Lib/Tools/PubSubTool.php
+++ b/app/Lib/Tools/PubSubTool.php
@@ -273,6 +273,7 @@ class PubSubTool
             'redis_password' => '',
             'redis_database' => '1',
             'redis_namespace' => 'mispq',
+            'host' => '127.0.0.1',
             'port' => '50000',
             'username' => null,
             'password' => null,

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -6220,6 +6220,15 @@ class Server extends AppModel
                     'type' => 'boolean',
                     'afterHook' => 'zmqAfterHook',
                 ),
+                'ZeroMQ_host' => array(
+                    'level' => 2,
+                    'description' => __('The host that the pub/sub feature will use.'),
+                    'value' => '127.0.0.1',
+                    'errorMessage' => '',
+                    'test' => 'testForEmpty',
+                    'type' => 'string',
+                    'afterHook' => 'zmqAfterHook',
+                ),
                 'ZeroMQ_port' => array(
                     'level' => 2,
                     'description' => __('The port that the pub/sub feature will use.'),

--- a/app/files/scripts/mispzmq/mispzmq.py
+++ b/app/files/scripts/mispzmq/mispzmq.py
@@ -102,8 +102,8 @@ class MispZmq:
         self.socket = context.socket(zmq.PUB)
         if self.settings["username"]:
             self.socket.plain_server = True  # must come before bind
-        self.socket.bind("tcp://*:{}".format(self.settings["port"]))
-        self._logger.debug("ZMQ listening on tcp://*:{}".format(self.settings["port"]))
+        self.socket.bind("tcp://{}:{}".format(self.settings["host"], self.settings["port"]))
+        self._logger.debug("ZMQ listening on tcp://{}:{}".format(self.settings["host"], self.settings["port"]))
 
         if self._logger.isEnabledFor(logging.DEBUG):
             monitor = self.socket.get_monitor_socket()


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:

#### What does it do?
The following commit contains the fix for ZeroMQ only listening on 0.0.0.0 also mentioned in #7040 and #7039 there is now a feature under plugins/ZeroMQ allowing to configure what IP the ZeroMQ should be listening on. 

![image](https://user-images.githubusercontent.com/14878613/108627258-d4ba8300-7454-11eb-853c-82a4087ea811.png)

This is directly related to: #7039 and #7040 

#### Questions

- [No ] Does it require a DB change?
- [Yes] Are you using it in production?
- [Maybe] Does it require a change in the API (PyMISP for example)?  I'm unaware if there are any other places where the ZeroMQ can be configured from, so uncertain.
