### PR TITLE
chg: [internal] Faster fetching galaxy clusters when fetching event

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -1025,7 +1025,17 @@ class EventsController extends AppController
         if (isset($filters['focus'])) {
             $this->set('focus', $filters['focus']);
         }
-        $conditions = array('eventid' => $id);
+        $conditions = [
+            'eventid' => $id,
+            'includeFeedCorrelations' => true,
+            'includeWarninglistHits' => true,
+            'fetchFullClusters' => false,
+            'includeAllTags' => true,
+            'includeGranularCorrelations' => true,
+            'includeEventCorrelations' => false,
+            'noEventReports' => true, // event reports for view are loaded dynamically
+            'noSightings' => true,
+        ];
         if (isset($filters['extended'])) {
             $conditions['extended'] = 1;
             $this->set('extended', 1);
@@ -1048,21 +1058,11 @@ class EventsController extends AppController
         if (isset($filters['toIDS']) && $filters['toIDS'] != 0) {
             $conditions['to_ids'] = $filters['toIDS'] == 2 ? 0 : 1;
         }
-        $conditions['includeFeedCorrelations'] = true;
-        $conditions['includeWarninglistHits'] = true;
         if (!isset($filters['includeServerCorrelations'])) {
             $conditions['includeServerCorrelations'] = 1;
-            if ($this->_isRest()) {
-                $conditions['includeServerCorrelations'] = 0;
-            }
         } else {
             $conditions['includeServerCorrelations'] = $filters['includeServerCorrelations'];
         }
-        $conditions['includeAllTags'] = true;
-        $conditions['includeGranularCorrelations'] = 1;
-        $conditions['includeEventCorrelations'] = false;
-        $conditions['noEventReports'] = true; // event reports for view are loaded dynamically
-        $conditions['noSightings'] = true;
         if (!empty($filters['includeRelatedTags'])) {
             $this->set('includeRelatedTags', 1);
             $conditions['includeRelatedTags'] = 1;
@@ -1512,6 +1512,7 @@ class EventsController extends AppController
             $conditions['includeAllTags'] = true;
             $conditions['noEventReports'] = true; // event reports for view are loaded dynamically
             $conditions['noSightings'] = true;
+            $conditions['fetchFullClusters'] = false;
         }
         $deleted = 0;
         if (isset($this->params['named']['deleted'])) {

--- a/app/Lib/Tools/DistributionGraphTool.php
+++ b/app/Lib/Tools/DistributionGraphTool.php
@@ -116,6 +116,7 @@ class DistributionGraphTool
             'noShadowAttributes' => true,
             'noEventReports' => true,
             'noSightings' => true,
+            'excludeGalaxy' => true,
             'includeEventCorrelations' => false,
             'extended' => $this->__extended_view,
         ));

--- a/app/Model/GalaxyClusterRelation.php
+++ b/app/Model/GalaxyClusterRelation.php
@@ -85,7 +85,6 @@ class GalaxyClusterRelation extends AppModel
         if (!$user['Role']['perm_site_admin']) {
             $alias = $this->alias;
             $sgids = $this->Event->cacheSgids($user, true);
-            $gcids = $this->SourceCluster->cacheGalaxyClusterIDs($user);
             $gcOwnerIds = $this->SourceCluster->cacheGalaxyClusterOwnerIDs($user);
             $conditionsRelations['AND']['OR'] = [
                 "${alias}.galaxy_cluster_id" => $gcOwnerIds,


### PR DESCRIPTION
#### What does it do?

Fetch all galaxy cluster in one query. This will speedup loading events where attributes are marked by galaxy cluster.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
