### PR TITLE
chg: [UI] Add can access check for correlation exclusions menu entry

### DIFF
--- a/app/View/Elements/global_menu.ctp
+++ b/app/View/Elements/global_menu.ctp
@@ -170,10 +170,11 @@
                         'text' => __('List Noticelists'),
                         'url' => $baseurl . '/noticelists/index'
                     ),
-                    [
+                    array(
                         'text' => __('List Correlation Exclusions'),
-                        'url' => $baseurl . '/correlation_exclusions/index'
-                    ]
+			'url' => $baseurl . '/correlation_exclusions/index',
+			'requirement' => $canAccess('correlation_exclusions', 'index'),
+                    )
                 )
             ),
             array(


### PR DESCRIPTION
#### What does it do?

Adds can access check to the global menu entry of correlation exclusions (to go to the index).

The following commit added correlation exclusions functionality:
https://github.com/MISP/MISP/commit/b8823b86e286ef0b821547f131f9e350a613a149

However, a menu entry shows up for read only users even though ACL blocks them from seeing that page. This change should fix that. Also changed the array format just to align with the rest of the file.

#### Questions

- [ ] Does it require a DB change? No
- [ ] Are you using it in production? No
- [ ] Does it require a change in the API (PyMISP for example)? No
