### PR TITLE
chg: [schema] Convert GalaxyCluster tag name to case insensitive

### DIFF
--- a/INSTALL/MYSQL.sql
+++ b/INSTALL/MYSQL.sql
@@ -243,7 +243,8 @@ CREATE TABLE IF NOT EXISTS event_reports (
     `deleted` tinyint(1) NOT NULL DEFAULT 0,
     PRIMARY KEY (id),
     CONSTRAINT u_uuid UNIQUE (uuid),
-    INDEX `name` (`name`)
+    INDEX `name` (`name`),
+    INDEX `event_id` (`event_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------

--- a/INSTALL/MYSQL.sql
+++ b/INSTALL/MYSQL.sql
@@ -455,7 +455,7 @@ CREATE TABLE IF NOT EXISTS `galaxy_clusters` (
   `collection_uuid` varchar(255) COLLATE utf8_bin NOT NULL,
   `type` varchar(255) COLLATE utf8_bin NOT NULL,
   `value` text COLLATE utf8_bin NOT NULL,
-  `tag_name` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `tag_name` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   `description` text COLLATE utf8_bin NOT NULL,
   `galaxy_id` int(11) NOT NULL,
   `source` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -1568,6 +1568,9 @@ class AppModel extends Model
                     INDEX `value` (`value`(255))
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;";
                 break;
+            case 66:
+                $sqlArray[] = "ALTER TABLE `galaxy_clusters` MODIFY COLUMN `tag_name` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT '';";
+                break;
             case 'fixNonEmptySharingGroupID':
                 $sqlArray[] = 'UPDATE `events` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';
                 $sqlArray[] = 'UPDATE `attributes` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';

--- a/app/Model/GalaxyCluster.php
+++ b/app/Model/GalaxyCluster.php
@@ -915,7 +915,7 @@ class GalaxyCluster extends AppModel
             if (!$isGalaxyTag) {
                 return null;
             }
-            $conditions = array('LOWER(GalaxyCluster.tag_name)' => strtolower($name));
+            $conditions = array('GalaxyCluster.tag_name' => $name);
         }
         $cluster = $this->fetchGalaxyClusters($user, array(
             'conditions' => $conditions,
@@ -943,7 +943,7 @@ class GalaxyCluster extends AppModel
         if (count(array_filter($namesOrIds, 'is_numeric')) === count($namesOrIds)) { // all elements are numeric
             $conditions = array('GalaxyCluster.id' => $namesOrIds);
         } else {
-            $conditions = array('LOWER(GalaxyCluster.tag_name)' => array_map('strtolower', $namesOrIds));
+            $conditions = array('GalaxyCluster.tag_name' => $namesOrIds);
         }
 
         $options = ['conditions' => $conditions];
@@ -1470,7 +1470,7 @@ class GalaxyCluster extends AppModel
         foreach ($events as $event) {
             foreach ($event['EventTag'] as $eventTag) {
                 if ($eventTag['Tag']['is_galaxy']) {
-                    $clusterTagNames[$eventTag['Tag']['id']] = strtolower($eventTag['Tag']['name']);
+                    $clusterTagNames[$eventTag['Tag']['id']] = $eventTag['Tag']['name'];
                 }
             }
         }
@@ -1480,7 +1480,7 @@ class GalaxyCluster extends AppModel
         }
 
         $options = [
-            'conditions' => ['LOWER(GalaxyCluster.tag_name)' => $clusterTagNames],
+            'conditions' => ['GalaxyCluster.tag_name' => $clusterTagNames],
             'contain' => ['Galaxy', 'GalaxyElement'],
         ];
         $clusters = $this->fetchGalaxyClusters($user, $options);

--- a/db_schema.json
+++ b/db_schema.json
@@ -7654,7 +7654,8 @@
         "event_reports": {
             "id": true,
             "uuid": true,
-            "name": false
+            "name": false,
+            "event_id": false
         },
         "event_tags": {
             "id": true,

--- a/db_schema.json
+++ b/db_schema.json
@@ -2356,7 +2356,7 @@
                 "data_type": "varchar",
                 "character_maximum_length": "255",
                 "numeric_precision": null,
-                "collation_name": "utf8_bin",
+                "collation_name": "utf8_unicode_ci",
                 "column_type": "varchar(255)",
                 "column_default": "",
                 "extra": ""


### PR DESCRIPTION
#### What does it do?

Mark `GalaxyCluster.tag_name` column as case insensitive. Without this, index for this column is never used (`LOWER` function could not use index). So after this change, loading galaxy cluster for events will be faster. 

The only problem is that in default clusters there are two cluster with tags that differs just in letter cases `misp-galaxy:rat="VorteX"` and `misp-galaxy:rat="Vortex"`.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
