### PR TITLE
chg: [permissions] User with Tag editor can edit and delete tags

### DIFF
--- a/app/Controller/Component/ACLComponent.php
+++ b/app/Controller/Component/ACLComponent.php
@@ -594,8 +594,8 @@ class ACLComponent extends Component
             'tags' => array(
                     'add' => array('perm_tag_editor'),
                     'attachTagToObject' => array('perm_tagger'),
-                    'delete' => array(),
-                    'edit' => array(),
+                    'delete' => array('perm_tag_editor'),
+                    'edit' => array('perm_tag_editor'),
                     'index' => array('*'),
                     'quickAdd' => array('perm_tag_editor'),
                     'removeTagFromObject' => array('perm_tagger'),

--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -4,6 +4,8 @@ App::uses('AppModel', 'Model');
 /**
  * @property EventTag $EventTag
  * @property AttributeTag $AttributeTag
+ * @property Organisation $Organisation
+ * @property User $User
  */
 class Tag extends AppModel
 {

--- a/app/View/Tags/edit.ctp
+++ b/app/View/Tags/edit.ctp
@@ -7,14 +7,15 @@
         ));
         echo $this->Form->input('colour', array(
         ));
-        echo $this->Form->input('org_id', array(
+
+        if ($isSiteAdmin) {
+            echo $this->Form->input('org_id', array(
                 'options' => $orgs,
                 'label' => __('Restrict tagging to org')
-        ));
-        if ($isSiteAdmin) {
+            ));
             echo $this->Form->input('user_id', array(
-                    'options' => $users,
-                    'label' => __('Restrict tagging to user')
+                'options' => $users,
+                'label' => __('Restrict tagging to user')
             ));
         }
     ?>


### PR DESCRIPTION
#### What does it do?

Currently, tag can modify or delete just site admin. But according to description of `perm_tag_editor` *This permission gives users the ability to create, modify or remove tags.* This patch changes the behavior according to permission description.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
