### PR TITLE
fix: syntax error in constructTaxonomyInfo()

### DIFF
--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -5617,19 +5617,19 @@ $('body').on('click', '.hex-value-convert', function() {
         if (tagData.TaxonomyPredicate.description) {
             $predicate.append($('<p/>').css("margin-bottom", "5px").append(
                 $('<strong/>').text('Description: '),
-                $('<span/>').text(tagData.TaxonomyPredicate.description),
+                $('<span/>').text(tagData.TaxonomyPredicate.description)
             ));
         }
         if (tagData.TaxonomyPredicate.TaxonomyEntry && tagData.TaxonomyPredicate.TaxonomyEntry[0].numerical_value) {
             $predicate.append($('<p/>').css("margin-bottom", "5px").append(
                 $('<strong/>').text('Numerical value: '),
-                $('<span/>').text(tagData.TaxonomyPredicate.TaxonomyEntry[0].numerical_value),
+                $('<span/>').text(tagData.TaxonomyPredicate.TaxonomyEntry[0].numerical_value)
             ));
         }
         var $meta = $('<div/>').append(
             $('<h3/>').text('Taxonomy: ' + tagData.Taxonomy.namespace.toUpperCase()),
             $('<p/>').css("margin-bottom", "5px").append(
-                $('<span/>').text(tagData.Taxonomy.description),
+                $('<span/>').text(tagData.Taxonomy.description)
             )
         )
         return $('<div/>').append($predicate, $meta)


### PR DESCRIPTION
## What does it do?

Fixes a syntax error in misp.js that prevents login on a freshly installed system since when chaining expressions, trailing commas are not allowed which leads to error and stops further JS processing on firefox and chrome. 

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Unexpected_token

## Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
