### PR TITLE
Optimise cluster fetch

### DIFF
--- a/app/Model/GalaxyCluster.php
+++ b/app/Model/GalaxyCluster.php
@@ -4,6 +4,7 @@ App::uses('TmpFileTool', 'Tools');
 
 /**
  * @property Tag $Tag
+ * @property GalaxyClusterRelation $GalaxyClusterRelation
  */
 class GalaxyCluster extends AppModel
 {
@@ -967,7 +968,6 @@ class GalaxyCluster extends AppModel
         return $conditions;
     }
 
-
     /**
      * fetchGalaxyClusters Very flexible, it's basically a replacement for find, with the addition that it restricts access based on user
      *
@@ -988,7 +988,7 @@ class GalaxyCluster extends AppModel
                 'GalaxyElement',
                 'GalaxyClusterRelation' => array(
                     'conditions' => $this->GalaxyClusterRelation->buildConditions($user, false),
-                    'GalaxyClusterRelationTag' => array('Tag'),
+                    'GalaxyClusterRelationTag',
                     'SharingGroup',
                 ),
                 'Orgc',
@@ -1031,6 +1031,44 @@ class GalaxyCluster extends AppModel
         if (empty($clusters)) {
             return $clusters;
         }
+
+        if ($full) {
+            $clusterIds = array_column(array_column($clusters, 'GalaxyCluster'), 'id');
+            $targetingClusterRelations = $this->TargetingClusterRelation->fetchRelations($user, array(
+                'contain' => array(
+                    'GalaxyClusterRelationTag',
+                    'SharingGroup',
+                ),
+                'conditions' => array(
+                    'TargetingClusterRelation.referenced_galaxy_cluster_id' => $clusterIds,
+                )
+            ));
+
+            $tagsToFetch = Hash::extract($clusters, "{n}.GalaxyClusterRelation.{n}.GalaxyClusterRelationTag.{n}.tag_id");
+            $tagsToFetch = array_merge($tagsToFetch, Hash::extract($targetingClusterRelations, "GalaxyClusterRelationTag.{n}.tag_id"));
+
+            $tags = $this->GalaxyClusterRelation->GalaxyClusterRelationTag->Tag->find('all', [
+                'conditions' => ['id' => array_unique($tagsToFetch)],
+                'recursive' => -1,
+            ]);
+            $tags = array_column(array_column($tags, 'Tag'), null, 'id');
+
+            foreach ($targetingClusterRelations as $k => $targetingClusterRelation) {
+                if (!empty($targetingClusterRelation['GalaxyClusterRelationTag'])) {
+                    foreach ($targetingClusterRelation['GalaxyClusterRelationTag'] as $relationTag) {
+                        if (isset($tags[$relationTag['tag_id']])) {
+                            $targetingClusterRelation['TargetingClusterRelation']['Tag'][] = $tags[$relationTag['tag_id']];
+                        }
+                    }
+                }
+                unset($targetingClusterRelation['GalaxyClusterRelationTag']);
+                if (!empty($targetingClusterRelation['SharingGroup']['id'])) {
+                    $targetingClusterRelation['TargetingClusterRelation']['SharingGroup'] = $targetingClusterRelation['SharingGroup'];
+                }
+                $targetingClusterRelations[$k] = $targetingClusterRelation['TargetingClusterRelation'];
+            }
+        }
+
         $this->Event = ClassRegistry::init('Event');
         $sharingGroupData = $this->Event->__cacheSharingGroupData($user, false);
         foreach ($clusters as $i => $cluster) {
@@ -1042,31 +1080,22 @@ class GalaxyCluster extends AppModel
                     if (!empty($relation['sharing_group_id']) && isset($sharingGroupData[$relation['sharing_group_id']])) {
                         $clusters[$i]['GalaxyClusterRelation'][$j]['SharingGroup'] = $sharingGroupData[$relation['sharing_group_id']]['SharingGroup'];
                     }
+                    foreach ($relation['GalaxyClusterRelationTag'] as $relationTag) {
+                        if (isset($tags[$relationTag['tag_id']])) {
+                            $clusters[$i]['GalaxyClusterRelation'][$j]['Tag'][] = $tags[$relationTag['tag_id']];
+                        }
+                    }
+                    unset($clusters[$i]['GalaxyClusterRelation'][$j]['GalaxyClusterRelationTag']);
                 }
             }
-            if ($full && isset($cluster['GalaxyCluster']['id'])) {
-                $targetingClusterRelations = $this->TargetingClusterRelation->fetchRelations($user, array(
-                    'contain' => array(
-                        'GalaxyClusterRelationTag' => array('Tag'),
-                        'SharingGroup',
-                    ),
-                    'conditions' => array(
-                        'TargetingClusterRelation.referenced_galaxy_cluster_id' => $cluster['GalaxyCluster']['id']
-                    )
-                ));
-                foreach ($targetingClusterRelations as $k => $targetingClusterRelation) {
-                    if (!empty($targetingClusterRelation['GalaxyClusterRelationTag'])) {
-                        $targetingClusterRelation['TargetingClusterRelation']['Tag'] = Hash::extract($targetingClusterRelation['GalaxyClusterRelationTag'], '{n}.Tag');
+            if ($full) {
+                foreach ($targetingClusterRelations as $targetingClusterRelation) {
+                    if ($targetingClusterRelation['referenced_galaxy_cluster_id'] == $cluster['GalaxyCluster']['id']) {
+                        $clusters[$i]['TargetingClusterRelation'][] = $targetingClusterRelation;
                     }
-                    if (!empty($targetingClusterRelation['SharingGroup']['id'])) {
-                        $targetingClusterRelation['TargetingClusterRelation']['SharingGroup'] = $targetingClusterRelation['SharingGroup'];
-                    }
-                    $targetingClusterRelations[$k] = $targetingClusterRelation['TargetingClusterRelation'];
                 }
-                $clusters[$i]['TargetingClusterRelation'] = $targetingClusterRelations;
             }
             $clusters[$i] = $this->arrangeData($clusters[$i]);
-            $clusters[$i] = $this->GalaxyClusterRelation->massageRelationTag($clusters[$i]);
             $clusters[$i] = $this->TargetingClusterRelation->massageRelationTag($clusters[$i]);
         }
         return $clusters;

--- a/app/Model/GalaxyClusterRelation.php
+++ b/app/Model/GalaxyClusterRelation.php
@@ -163,21 +163,6 @@ class GalaxyClusterRelation extends AppModel
         $this->deleteAll($conditions, false, false);
     }
 
-    public function massageRelationTag($cluster)
-    {
-        if (!empty($cluster['GalaxyCluster'][$this->alias])) {
-            foreach ($cluster['GalaxyCluster'][$this->alias] as $k => $relation) {
-                if (!empty($relation['GalaxyClusterRelationTag'])) {
-                    foreach ($relation['GalaxyClusterRelationTag'] as $relationTag) {
-                        $cluster['GalaxyCluster'][$this->alias][$k]['Tag'][] = $relationTag['Tag'];
-                    }
-                }
-                unset($cluster['GalaxyCluster'][$this->alias][$k]['GalaxyClusterRelationTag']);
-            }
-        }
-        return $cluster;
-    }
-
     /**
      * saveRelations
      *


### PR DESCRIPTION
#### What does it do?

Drastically reduce number of SQL queries when fetching full galaxy clusters (for example when exporting event to JSON).

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
