### PR TITLE
fix: [email_otp] skip OTP for disabled users

### DIFF
--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -1138,7 +1138,7 @@ class UsersController extends AppController
         }
         if ($this->request->is('post') && Configure::read('Security.email_otp_enabled')) {
             $user = $this->Auth->identify($this->request, $this->response);
-            if ($user) {
+            if ($user && !$user['disabled']) {
               $this->Session->write('email_otp_user', $user);
               return $this->redirect('email_otp');
             }


### PR DESCRIPTION
#### What does it do?

With the implementation of the preauh_actions, a disabled user would still go to the OTP step after entering username/password correctly.
This small fix prevents this behavior, so that the user directly receives the feedback.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
