### PR TITLE
fix: [internal] Empty object when getting event info for event report

### DIFF
--- a/app/Model/EventReport.php
+++ b/app/Model/EventReport.php
@@ -463,15 +463,17 @@ class EventReport extends AppModel
         $objects = [];
         $templateConditions = [];
         foreach ($event['Object'] as $k => $object) {
-            foreach ($object['Attribute'] as &$objectAttribute) {
-                unset($objectAttribute['ShadowAttribute']);
-                $objectAttribute['object_uuid'] = $object['uuid'];
-                $attributes[$objectAttribute['uuid']] = $objectAttribute;
+            if (isset($object['Attribute'])) {
+                foreach ($object['Attribute'] as &$objectAttribute) {
+                    unset($objectAttribute['ShadowAttribute']);
+                    $objectAttribute['object_uuid'] = $object['uuid'];
+                    $attributes[$objectAttribute['uuid']] = $objectAttribute;
 
-                foreach ($objectAttribute['AttributeTag'] as $at) {
-                    $allTagNames[$at['Tag']['name']] = $at['Tag'];
+                    foreach ($objectAttribute['AttributeTag'] as $at) {
+                        $allTagNames[$at['Tag']['name']] = $at['Tag'];
+                    }
+                    $this->Event->Attribute->removeGalaxyClusterTags($objectAttribute);
                 }
-                $this->Event->Attribute->removeGalaxyClusterTags($objectAttribute);
             }
             $objects[$object['uuid']] = $object;
 


### PR DESCRIPTION
#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
