### PR TITLE
fix: [sync] SG stay inactive after pull

### DIFF
--- a/app/Model/SharingGroup.php
+++ b/app/Model/SharingGroup.php
@@ -701,7 +701,7 @@ class SharingGroup extends AppModel
                 if ($force) {
                     $sgids = $existingSG['SharingGroup']['id'];
                     $editedSG = $existingSG['SharingGroup'];
-                    $attributes = ['name', 'releasability', 'description', 'created', 'modified', 'active', 'roaming'];
+                    $attributes = ['name', 'releasability', 'description', 'created', 'modified', 'roaming'];
                     foreach ($attributes as $a) {
                         if (isset($sg[$a])) {
                             $editedSG[$a] = $sg[$a];


### PR DESCRIPTION
#### What does it do?

Fix #6503 for existing SG. If existing SG are marked as inactive, they will no longer become active after a pull containing events distributed to that SG.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
