### PR TITLE
new: [authkeys] Allowed IPs

### DIFF
--- a/app/Controller/Component/ACLComponent.php
+++ b/app/Controller/Component/ACLComponent.php
@@ -687,7 +687,7 @@ class ACLComponent extends Component
                     'register' => array('*'),
                     'registrations' => array('perm_site_admin'),
                     'resetAllSyncAuthKeys' => array(),
-                    'resetauthkey' => array('*'),
+                    'resetauthkey' => ['AND' => ['self_management_enabled', 'perm_auth']],
                     'request_API' => array('*'),
                     'routeafterlogin' => array('*'),
                     'statistics' => array('*'),

--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -2434,9 +2434,9 @@ misp.direct_call(relative_path, body)
         }
 
         $message = 'CSP reported violation';
-        $ipHeader = Configure::read('MISP.log_client_ip_header') ?: 'REMOTE_ADDR';
-        if (isset($_SERVER[$ipHeader])) {
-            $message .= ' from IP ' . $_SERVER[$ipHeader];
+        $remoteIp = $this->_remoteIp();
+        if ($remoteIp) {
+            $message .= ' from IP ' . $remoteIp;
         }
         $this->log("$message: " . json_encode($report['csp-report'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -1294,24 +1294,22 @@ class UsersController extends AppController
 
     public function resetauthkey($id = null, $alert = false)
     {
-        if (!$this->_isAdmin() && Configure::read('MISP.disableUserSelfManagement')) {
-            throw new MethodNotAllowedException('User self-management has been disabled on this instance.');
-        }
         if (!$this->request->is('post') && !$this->request->is('put')) {
             throw new MethodNotAllowedException(__('This functionality is only accessible via POST requests.'));
         }
-        if ($id == 'me') {
+        if ($id === 'me') {
             $id = $this->Auth->user('id');
+            // Reset just current auth key
+            $keyId = isset($this->Auth->user()['authkey_id']) ? $this->Auth->user()['authkey_id'] : null;
+        } else {
+            $keyId = null;
         }
-        if (!$this->userRole['perm_auth']) {
-            throw new MethodNotAllowedException(__('Invalid action.'));
-        }
-        $newkey = $this->User->resetauthkey($this->Auth->user(), $id, $alert);
+        $newkey = $this->User->resetauthkey($this->Auth->user(), $id, $alert, $keyId);
         if ($newkey === false) {
             throw new MethodNotAllowedException(__('Invalid user.'));
         }
         if (!$this->_isRest()) {
-            $this->Flash->success(__('New authkey generated.', true));
+            $this->Flash->success(__('New authkey generated.'));
             $this->redirect($this->referer());
         } else {
             return $this->RestResponse->saveSuccessResponse('User', 'resetauthkey', $id, $this->response->type(), 'Authkey updated: ' . $newkey);

--- a/app/Lib/Tools/CidrTool.php
+++ b/app/Lib/Tools/CidrTool.php
@@ -67,6 +67,26 @@ class CidrTool
     }
 
     /**
+     * @param string $cidr
+     * @return bool
+     */
+    public static function validate($cidr)
+    {
+        $parts = explode('/', $cidr, 2);
+        $ipBytes = inet_pton($parts[0]);
+        if ($ipBytes === false) {
+            return false;
+        }
+
+        $maximumNetmask = strlen($ipBytes) === 4 ? 32 : 128;
+        if (isset($parts[1]) && ($parts[1] > $maximumNetmask || $parts[1] < 0)) {
+            return false; // Netmask part of CIDR is invalid
+        }
+
+        return true;
+    }
+
+    /**
      * Using solution from https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/IpUtils.php
      *
      * @param array $ip

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -89,7 +89,7 @@ class AppModel extends Model
         45 => false, 46 => false, 47 => false, 48 => false, 49 => false, 50 => false,
         51 => false, 52 => false, 53 => false, 54 => false, 55 => false, 56 => false,
         57 => false, 58 => false, 59 => false, 60 => false, 61 => false, 62 => false,
-        63 => true, 64 => false, 65 => false
+        63 => true, 64 => false, 65 => false, 66 => false, 67 => false,
     );
 
     public $advanced_updates_description = array(
@@ -1571,6 +1571,9 @@ class AppModel extends Model
             case 66:
                 $sqlArray[] = "ALTER TABLE `galaxy_clusters` MODIFY COLUMN `tag_name` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT '';";
                 $indexArray[] = ['event_reports', 'event_id'];
+                break;
+            case 67:
+                $sqlArray[] = "ALTER TABLE `auth_keys` ADD `allowed_ips` text DEFAULT NULL;";
                 break;
             case 'fixNonEmptySharingGroupID':
                 $sqlArray[] = 'UPDATE `events` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';

--- a/app/Model/AuthKey.php
+++ b/app/Model/AuthKey.php
@@ -1,6 +1,7 @@
 <?php
 App::uses('AppModel', 'Model');
 App::uses('RandomTool', 'Tools');
+App::uses('CidrTool', 'Tools');
 
 /**
  * @property User $User
@@ -26,7 +27,6 @@ class AuthKey extends AppModel
     // massage the data before we send it off for validation before saving anything
     public function beforeValidate($options = array())
     {
-        //parent::beforeValidate();
         if (empty($this->data['AuthKey']['id'])) {
             if (empty($this->data['AuthKey']['uuid'])) {
                 $this->data['AuthKey']['uuid'] = CakeText::uuid();
@@ -42,22 +42,66 @@ class AuthKey extends AppModel
             $this->data['AuthKey']['authkey_end'] = substr($authkey, -4);
             $this->data['AuthKey']['authkey_raw'] = $authkey;
             $this->authkey_raw = $authkey;
+        }
 
-            $validity = Configure::read('Security.advanced_authkeys_validity');
-            if (empty($this->data['AuthKey']['expiration'])) {
-                $this->data['AuthKey']['expiration'] = $validity ? strtotime("+$validity days") : 0;
+        if (!empty($this->data['AuthKey']['allowed_ips'])) {
+            if (is_string($this->data['AuthKey']['allowed_ips'])) {
+                $this->data['AuthKey']['allowed_ips'] = trim($this->data['AuthKey']['allowed_ips']);
+                if (empty($this->data['AuthKey']['allowed_ips'])) {
+                    $this->data['AuthKey']['allowed_ips'] = [];
+                } else {
+                    $this->data['AuthKey']['allowed_ips'] = explode("\n", $this->data['AuthKey']['allowed_ips']);
+                    $this->data['AuthKey']['allowed_ips'] = array_map('trim', $this->data['AuthKey']['allowed_ips']);
+                }
+            }
+            if (!is_array($this->data['AuthKey']['allowed_ips'])) {
+                $this->invalidate('allowed_ips', 'Allowed IPs must be array');
+            }
+            foreach ($this->data['AuthKey']['allowed_ips'] as $cidr) {
+                if (!CidrTool::validate($cidr)) {
+                    $this->invalidate('allowed_ips', "$cidr is not valid IP range");
+                }
+            }
+        }
+
+        $creationTime = isset($this->data['AuthKey']['created']) ? $this->data['AuthKey']['created'] : time();
+        $validity = Configure::read('Security.advanced_authkeys_validity');
+        if (empty($this->data['AuthKey']['expiration'])) {
+            $this->data['AuthKey']['expiration'] = $validity ? strtotime("+$validity days", $creationTime) : 0;
+        } else {
+            $expiration = is_numeric($this->data['AuthKey']['expiration']) ?
+                (int)$this->data['AuthKey']['expiration'] :
+                strtotime($this->data['AuthKey']['expiration']);
+
+            if ($expiration === false) {
+                $this->invalidate('expiration', __('Expiration must be in YYYY-MM-DD format.'));
+            }
+            if ($validity && $expiration > strtotime("+$validity days", $creationTime)) {
+                $this->invalidate('expiration', __('Maximal key validity is %s days.', $validity));
+            }
+            $this->data['AuthKey']['expiration'] = $expiration;
+        }
+
+        return true;
+    }
+
+    public function afterFind($results, $primary = false)
+    {
+        foreach ($results as $key => $val) {
+            if (isset($val['AuthKey']['allowed_ips'])) {
+                $results[$key]['AuthKey']['allowed_ips'] = $this->jsonDecode($val['AuthKey']['allowed_ips']);
+            }
+        }
+        return $results;
+    }
+
+    public function beforeSave($options = array())
+    {
+        if (isset($this->data['AuthKey']['allowed_ips'])) {
+            if (empty($this->data['AuthKey']['allowed_ips'])) {
+                $this->data['AuthKey']['allowed_ips'] = null;
             } else {
-                $expiration = is_numeric($this->data['AuthKey']['expiration']) ?
-                    (int)$this->data['AuthKey']['expiration'] :
-                    strtotime($this->data['AuthKey']['expiration']);
-
-                if ($expiration === false) {
-                    $this->invalidate('expiration', __('Expiration must be in YYYY-MM-DD format.'));
-                }
-                if ($validity && $expiration > strtotime("+$validity days")) {
-                    $this->invalidate('expiration', __('Maximal key validity is %s days.', $validity));
-                }
-                $this->data['AuthKey']['expiration'] = $expiration;
+                $this->data['AuthKey']['allowed_ips'] = json_encode($this->data['AuthKey']['allowed_ips']);
             }
         }
         return true;
@@ -71,9 +115,9 @@ class AuthKey extends AppModel
     {
         $start = substr($authkey, 0, 4);
         $end = substr($authkey, -4);
-        $existing_authkeys = $this->find('all', [
+        $possibleAuthkeys = $this->find('all', [
             'recursive' => -1,
-            'fields' => ['id', 'authkey', 'user_id', 'expiration'],
+            'fields' => ['id', 'authkey', 'user_id', 'expiration', 'allowed_ips'],
             'conditions' => [
                 'OR' => [
                     'expiration >' => time(),
@@ -84,12 +128,13 @@ class AuthKey extends AppModel
             ]
         ]);
         $passwordHasher = $this->getHasher();
-        foreach ($existing_authkeys as $existing_authkey) {
-            if ($passwordHasher->check($authkey, $existing_authkey['AuthKey']['authkey'])) {
-                $user = $this->User->getAuthUser($existing_authkey['AuthKey']['user_id']);
+        foreach ($possibleAuthkeys as $possibleAuthkey) {
+            if ($passwordHasher->check($authkey, $possibleAuthkey['AuthKey']['authkey'])) {
+                $user = $this->User->getAuthUser($possibleAuthkey['AuthKey']['user_id']);
                 if ($user) {
-                    $user['authkey_id'] = $existing_authkey['AuthKey']['id'];
-                    $user['authkey_expiration'] = $existing_authkey['AuthKey']['expiration'];
+                    $user['authkey_id'] = $possibleAuthkey['AuthKey']['id'];
+                    $user['authkey_expiration'] = $possibleAuthkey['AuthKey']['expiration'];
+                    $user['allowed_ips'] = $possibleAuthkey['AuthKey']['allowed_ips'];
                 }
                 return $user;
             }
@@ -173,6 +218,18 @@ class AuthKey extends AppModel
             $output[$id] = $lastUsages[$i] === false ? null : (int)$lastUsages[$i];
         }
         return $output;
+    }
+
+    /**
+     * When key is modified, update `date_modified` for user that was assigned to that key, so session data
+     * will be realoaded.
+     * @see AppController::_refreshAuth
+     */
+    public function afterSave($created, $options = array())
+    {
+        parent::afterSave($created, $options);
+        $userId = $this->data['AuthKey']['user_id'];
+        $this->User->updateAll(['date_modified' => time()], ['User.id' => $userId]);
     }
 
     /**

--- a/app/Model/Log.php
+++ b/app/Model/Log.php
@@ -199,7 +199,7 @@ class Log extends AppModel
      * @param int $modelId
      * @param string $title
      * @param string|array $change
-     * @return array
+     * @return array|null
      * @throws Exception
      * @throws InvalidArgumentException
      */
@@ -238,6 +238,10 @@ class Log extends AppModel
         ));
 
         if (!$result) {
+            if ($action === 'request' && !empty(Configure::read('MISP.log_paranoid_skip_db'))) {
+                return null;
+            }
+
             throw new Exception("Cannot save log because of validation errors: " . json_encode($this->validationErrors));
         }
 

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -1106,7 +1106,7 @@ class User extends AppModel
         return $results;
     }
 
-    public function resetauthkey($user, $id, $alert = false)
+    public function resetauthkey($user, $id, $alert = false, $keyId = null)
     {
         $this->id = $id;
         if (!$id || !$this->exists($id)) {
@@ -1123,8 +1123,7 @@ class User extends AppModel
             $this->extralog(
                     $user,
                     'reset_auth_key',
-                    sprintf(
-                        __('Authentication key for user %s (%s) updated.'),
+                    __('Authentication key for user %s (%s) updated.',
                         $updatedUser['User']['id'],
                         $updatedUser['User']['email']
                     ),
@@ -1133,7 +1132,7 @@ class User extends AppModel
             );
         } else {
             $this->AuthKey = ClassRegistry::init('AuthKey');
-            $newkey = $this->AuthKey->resetauthkey($id);
+            $newkey = $this->AuthKey->resetAuthKey($id, $keyId);
         }
         if ($alert) {
             $baseurl = Configure::read('MISP.external_baseurl');

--- a/app/View/AuthKeys/add.ctp
+++ b/app/View/AuthKeys/add.ctp
@@ -1,7 +1,7 @@
 <?php
 echo $this->element('genericElements/Form/genericForm', [
     'data' => [
-        'title' => __('Add auth key'),
+        'title' => isset($edit) ? __('Edit auth key') : __('Add auth key'),
         'description' => __('Auth keys are used for API access. A user can have more than one authkey, so if you would like to use separate keys per tool that queries MISP, add additional keys. Use the comment field to make identifying your keys easier.'),
         'fields' => [
             [
@@ -13,7 +13,14 @@ echo $this->element('genericElements/Form/genericForm', [
             [
                 'field' => 'comment',
                 'label' => __('Comment'),
-                'class' => 'span6'
+                'class' => 'span6',
+                'rows' => 4,
+            ],
+            [
+                'field' => 'allowed_ips',
+                'label' => __('Allowed IPs'),
+                'class' => 'span6',
+                'rows' => 4,
             ],
             [
                 'field' => 'expiration',

--- a/app/View/AuthKeys/index.ctp
+++ b/app/View/AuthKeys/index.ctp
@@ -63,11 +63,16 @@
                     'data_path' => 'AuthKey.last_used',
                     'element' => 'datetime',
                     'requirements' => $keyUsageEnabled,
+                    'empty' => __('Never'),
                 ],
                 [
                     'name' => __('Comment'),
                     'sort' => 'AuthKey.comment',
                     'data_path' => 'AuthKey.comment',
+                ],
+                [
+                    'name' => __('Allowed IPs'),
+                    'data_path' => 'AuthKey.allowed_ips',
                 ],
             ],
             'title' => empty($ajax) ? __('Authentication key Index') : false,
@@ -80,7 +85,16 @@
                         'AuthKey.id'
                     ),
                     'icon' => 'eye',
-                    'dbclickAction' => true
+                    'dbclickAction' => true,
+                    'title' => 'View auth key',
+                ],
+                [
+                    'url' => $baseurl . '/auth_keys/edit',
+                    'url_params_data_paths' => array(
+                        'AuthKey.id'
+                    ),
+                    'icon' => 'edit',
+                    'title' => 'Edit auth key',
                 ],
                 [
                     'onclick' => sprintf(

--- a/app/View/AuthKeys/view.ctp
+++ b/app/View/AuthKeys/view.ctp
@@ -15,65 +15,72 @@ if (isset($keyUsage)) {
     $uniqueIps = null;
 }
 
-echo $this->element(
-    'genericElements/SingleViews/single_view',
-    [
-        'title' => 'Auth key view',
-        'data' => $data,
-        'fields' => [
-            [
-                'key' => __('ID'),
-                'path' => 'AuthKey.id'
-            ],
-            [
-                'key' => __('UUID'),
-                'path' => 'AuthKey.uuid',
-            ],
-            [
-                'key' => __('Auth Key'),
-                'path' => 'AuthKey',
-                'type' => 'authkey'
-            ],
-            [
-                'key' => __('User'),
-                'path' => 'User.id',
-                'pathName' => 'User.email',
-                'model' => 'users',
-                'type' => 'model'
-            ],
-            [
-                'key' => __('Comment'),
-                'path' => 'AuthKey.comment'
-            ],
-            [
-                'key' => __('Created'),
-                'path' => 'AuthKey.created',
-                'type' => 'datetime'
-            ],
-            [
-                'key' => __('Expiration'),
-                'path' => 'AuthKey.expiration',
-                'type' => 'expiration'
-            ],
-            [
-                'key' => __('Key usage'),
-                'type' => 'sparkline',
-                'path' => 'AuthKey.id',
-                'csv' => [
-                    'data' => $keyUsageCsv,
-                ],
-                'requirement' => isset($keyUsage),
-            ],
-            [
-                'key' => __('Last used'),
-                'raw' => $lastUsed ? $this->Time->time($lastUsed) : __('Not used yet'),
-                'requirement' => isset($keyUsage),
-            ],
-            [
-                'key' => __('Unique IPs'),
-                'raw' => $uniqueIps,
-                'requirement' => isset($keyUsage),
-            ]
+echo $this->element('genericElements/SingleViews/single_view', [
+    'title' => 'Auth key view',
+    'data' => $data,
+    'fields' => [
+        [
+            'key' => __('ID'),
+            'path' => 'AuthKey.id'
         ],
-    ]
-);
+        [
+            'key' => __('UUID'),
+            'path' => 'AuthKey.uuid',
+        ],
+        [
+            'key' => __('Auth Key'),
+            'path' => 'AuthKey',
+            'type' => 'authkey'
+        ],
+        [
+            'key' => __('User'),
+            'path' => 'User.id',
+            'pathName' => 'User.email',
+            'model' => 'users',
+            'type' => 'model'
+        ],
+        [
+            'key' => __('Comment'),
+            'path' => 'AuthKey.comment'
+        ],
+        [
+            'key' => __('Allowed IPs'),
+            'type' => 'custom',
+            'function' => function (array $data) {
+                if (is_array($data['AuthKey']['allowed_ips'])) {
+                    return implode("<br>", array_map('h', $data['AuthKey']['allowed_ips']));
+                }
+                return __('All');
+            }
+        ],
+        [
+            'key' => __('Created'),
+            'path' => 'AuthKey.created',
+            'type' => 'datetime'
+        ],
+        [
+            'key' => __('Expiration'),
+            'path' => 'AuthKey.expiration',
+            'type' => 'expiration'
+        ],
+        [
+            'key' => __('Key usage'),
+            'type' => 'sparkline',
+            'path' => 'AuthKey.id',
+            'csv' => [
+                'data' => $keyUsageCsv,
+            ],
+            'requirement' => isset($keyUsage),
+        ],
+        [
+            'key' => __('Last used'),
+            'raw' => $lastUsed ? $this->Time->time($lastUsed) : __('Not used yet'),
+            'requirement' => isset($keyUsage),
+        ],
+        [
+            'key' => __('Unique IPs'),
+            'raw' => $uniqueIps,
+            'requirement' => isset($keyUsage),
+        ]
+    ],
+]);

--- a/app/View/Elements/genericElements/IndexTable/Fields/datetime.ctp
+++ b/app/View/Elements/genericElements/IndexTable/Fields/datetime.ctp
@@ -1,26 +1,27 @@
 <?php
-    $data = Hash::extract($row, $field['data_path']);
-    if (is_array($data)) {
-        if (count($data) > 1) {
-            $data = implode(', ', $data);
+$data = Hash::extract($row, $field['data_path']);
+if (is_array($data)) {
+    if (count($data) > 1) {
+        $data = implode(', ', $data);
+    } else {
+        if (count($data) > 0) {
+            $data = $data[0];
         } else {
-            if (count($data) > 0) {
-                $data = $data[0];
-            } else {
-                $data = '';
-            }
+            $data = '';
         }
     }
-    if (empty($data) && !empty($field['empty'])) {
-        $data = $field['empty'];
-    }
+}
+if (empty($data) && !empty($field['empty'])) {
+    $data = $field['empty'];
+} else {
     $data = $this->Time->time($data);
-    if (!empty($field['onClick'])) {
-        $data = sprintf(
-            '<span onClick="%s">%s</span>',
-            $field['onClick'],
-            $data
-        );
-    }
-    echo $data;
+}
+if (!empty($field['onClick'])) {
+    $data = sprintf(
+        '<span onClick="%s">%s</span>',
+        $field['onClick'],
+        $data
+    );
+}
+echo $data;
 

--- a/app/View/Elements/genericElements/SingleViews/Fields/customField.ctp
+++ b/app/View/Elements/genericElements/SingleViews/Fields/customField.ctp
@@ -1,0 +1,1 @@
+<?= $field['function']($data);

--- a/app/webroot/css/main.css
+++ b/app/webroot/css/main.css
@@ -174,12 +174,10 @@ td.searchLabelCancel{
 
 form .error-message {
     border-color: #b94a48;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-     -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-          box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
     background-color: #f2dede;
+    padding: 0 5px;
 }
-
 
 /* Form */
 div.form,

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -5298,7 +5298,8 @@ function submitGenericFormInPlace() {
             $('#genericModal').modal('hide').remove();
             $('body').append(data);
             $('#genericModal').modal();
-        }
+        },
+        error: xhrFailCallback,
     });
 }
 

--- a/db_schema.json
+++ b/db_schema.json
@@ -483,6 +483,17 @@
                 "column_type": "text",
                 "column_default": null,
                 "extra": ""
+            },
+            {
+                "column_name": "allowed_ips",
+                "is_nullable": "YES",
+                "data_type": "text",
+                "character_maximum_length": "65535",
+                "numeric_precision": null,
+                "collation_name": "utf8mb4_unicode_ci",
+                "column_type": "text",
+                "column_default": null,
+                "extra": ""
             }
         ],
         "bruteforces": [
@@ -7975,5 +7986,5 @@
             "id": true
         }
     },
-    "db_version": "65"
+    "db_version": "67"
 }

--- a/tests/testlive_security.py
+++ b/tests/testlive_security.py
@@ -562,6 +562,29 @@ class TestSecurity(unittest.TestCase):
 
             self.__delete_advanced_authkey(auth_key["id"])
 
+    def test_advanced_authkeys_invalid_ip(self):
+        with self.__setting("Security.advanced_authkeys", True):
+            auth_key = self.__create_advanced_authkey(self.test_usr.id, {
+                "allowed_ips": ["1.2.3.4"],
+            })
+
+            # Try to login
+            with self.assertRaises(PyMISPError):
+                PyMISP(url, auth_key["authkey_raw"])
+
+            self.__delete_advanced_authkey(auth_key["id"])
+
+    def test_advanced_authkeys_allow_all(self):
+        with self.__setting("Security.advanced_authkeys", True):
+            auth_key = self.__create_advanced_authkey(self.test_usr.id, {
+                "allowed_ips": ["0.0.0.0/0"],
+            })
+
+            # Try to login
+            PyMISP(url, auth_key["authkey_raw"])
+
+            self.__delete_advanced_authkey(auth_key["id"])
+
     def test_authkey_keep_session(self):
         with self.__setting( "Security.authkey_keep_session", True):
             logged_in = PyMISP(url, self.test_usr.authkey)


### PR DESCRIPTION
#### What does it do?

Allows to set list of IP ranges for advanced auth key. Specific key can be used just from these IP addresses. Solves second point from #7103.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
