### PR TITLE
chg: [UI] correct edit org blocklist entries view

### DIFF
--- a/app/View/OrgBlocklists/edit.ctp
+++ b/app/View/OrgBlocklists/edit.ctp
@@ -1,8 +1,7 @@
 <div class="orgBlocklist form">
 <?php echo $this->Form->create('OrgBlocklist');?>
     <fieldset>
-        <legend><?php echo __('Edit Event Blocklist Entries');?></legend>
-        <p><?php echo __('List of all the event UUIDs that you wish to block from being entered.');?></p>
+        <legend><?php echo __('Edit Organisation Blocklist Entries');?></legend>
     <?php
         echo $this->Form->input('uuids', array(
                 'type' => 'textarea',


### PR DESCRIPTION
#### What does it do?

Corrects copypasta error ('Edit Event Blocklist Entries' legend for edit org blocklist entry view) and removes paragraph that doesn't really add value.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
