### PR TITLE
chg: [UI] Add small description of what event block rules do

### DIFF
--- a/app/View/Servers/event_block_rule.ctp
+++ b/app/View/Servers/event_block_rule.ctp
@@ -5,6 +5,7 @@
         'form' => $this->Form,
         'data' => array(
             'title' => __('Set event block rules'),
+            'description' => __('Event block rules allow you to add a simple tag filter to block events from being added or synced. Events with a tag that matches any of the tags in the rule list will be blocked. It is not possible to add more complex rules with boolean logic (NOT, AND).'),
             'model' => $modelForForm,
             'fields' => array(
                 array(


### PR DESCRIPTION
#### What does it do?

Adds small description of what event block rules do to the set event block rules page.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
