### PR TITLE
chg: [UI] fix keyboard shortcut manager popup triangle

### DIFF
--- a/app/View/Elements/footer.ctp
+++ b/app/View/Elements/footer.ctp
@@ -1,5 +1,5 @@
 <div class="footer <?php echo $debugMode;?>">
-    <div id="shortcutsListContainer" class="<?php echo $debugMode ? 'hidden': ''; ?>">
+    <div id="shortcutsListContainer" class="<?php echo $debugMode == 'debugOn' ? 'hidden': ''; ?>">
         <div id="triangle"></div>
         <div id="shortcutsList">
             <span> <?php echo __('Keyboard shortcuts for this page'); ?>:</span><br>

--- a/app/webroot/js/keyboard-shortcuts.js
+++ b/app/webroot/js/keyboard-shortcuts.js
@@ -111,9 +111,9 @@ let keyboardShortcutsManager = {
 	}
 }
 
-// Inits the keyboard shortcut manager's main routine.
-$(document).ready(() => keyboardShortcutsManager.init());
-
-// Inits the click event on the keyboard shortcut triangle at the bottom of the screen.
-$('#triangle').click(keyboardShortcutsManager.onTriangleClick);
+// Inits the keyboard shortcut manager's main routine and the click event on the keyboard shortcut triangle at the bottom of the screen.
+$(document).ready(function(){
+        keyboardShortcutsManager.init();
+        $('#triangle').click(keyboardShortcutsManager.onTriangleClick);
+});
 


### PR DESCRIPTION
#### What does it do?

fixes / brings back the shortcuts popup triangle above the footer (bottom right)
See https://github.com/MISP/misp-book/tree/main/shortcuts for the related documentation

Looks like https://github.com/MISP/MISP/commit/2c20b305330b3c85386ae5852428f0c59ec6e548 might have broken it / made it invisible. Even after fixing that the menu was still not popping out, hence the change to app/webroot/js/keyboard-shortcuts.js as well.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
