### PR TITLE
chg: [csp] Report only by default

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -729,7 +729,8 @@ class AppController extends Controller
                 }
             }
         }
-        $this->response->header('Content-Security-Policy', implode('; ', $header));
+        $header = Configure::read('Security.csp_enforce') ? 'Content-Security-Policy' : 'Content-Security-Policy-Report-Only';
+        $this->response->header($header, implode('; ', $header));
     }
 
     private function __rateLimitCheck()

--- a/app/Lib/Tools/SecurityAudit.php
+++ b/app/Lib/Tools/SecurityAudit.php
@@ -61,13 +61,20 @@ class SecurityAudit
         if (empty(Configure::read('Security.disable_browser_cache'))) {
             $output['Browser'][] = [
                 'warning',
-                __('Browser cache is enabled. Attacker can obtain sensitive data from user cache. You can disable cache by setting `Security.disable_browser_cache` to `false`.'),
+                __('Browser cache is enabled. Attacker can obtain sensitive data from user cache. You can disable cache by setting `Security.disable_browser_cache` to `true`.'),
             ];
         }
         if (empty(Configure::read('Security.check_sec_fetch_site_header'))) {
             $output['Browser'][] = [
                 'warning',
                 __('MISP server is not checking `Sec-Fetch` HTTP headers. This is protection against CSRF for moder browsers. You can enable this checks by setting `Security.check_sec_fetch_site_header` to `true`.'),
+            ];
+        }
+        if (empty(Configure::read('Security.csp_enforce'))) {
+            $output['Browser'][] = [
+                'warning',
+                __('Content security policies (CSP) are not enforced. Consider enabling them by setting `Security.csp_enforce` to `true`.'),
+                'https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP',
             ];
         }
         if (Configure::read('Security.disable_form_security')) {


### PR DESCRIPTION
#### What does it do?

Because some users uses MISP very weird way, by default set Content Security Policies just to report only.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
