### PR TITLE
new: [sync] Method for filtering out existing sightings

### DIFF
--- a/app/Controller/Component/ACLComponent.php
+++ b/app/Controller/Component/ACLComponent.php
@@ -571,6 +571,7 @@ class ACLComponent extends Component
                     'quickDelete' => array('perm_sighting'),
                     'viewSightings' => array('*'),
                     'bulkSaveSightings' => array('OR' => array('perm_sync', 'perm_sighting')),
+                    'filterSightingUuidsForPush' => ['perm_sync'],
                     'quickAdd' => array('perm_sighting')
             ),
             'sightingdb' => array(

--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -1788,6 +1788,7 @@ class ServersController extends AppController
             'perm_sighting' => $this->userRole['perm_sighting'],
             'perm_galaxy_editor' => $this->userRole['perm_galaxy_editor'],
             'request_encoding' => $this->CompressedRequestHandler->supportedEncodings(),
+            'filter_sightings' => true, // check if Sightings::filterSightingUuidsForPush method is supported
         ];
         return $this->RestResponse->viewData($response, $this->response->type());
     }

--- a/app/Controller/SightingsController.php
+++ b/app/Controller/SightingsController.php
@@ -353,4 +353,26 @@ class SightingsController extends AppController
             throw new MethodNotAllowedException($e->getMessage());
         }
     }
+
+    public function filterSightingUuidsForPush($eventId)
+    {
+        if (!$this->request->is('post')) {
+            throw new MethodNotAllowedException('This method is only accessible via POST requests.');
+        }
+
+        $event = $this->Sighting->Event->fetchSimpleEvent($this->Auth->user(), $eventId);
+        if (empty($event)) {
+            throw new NotFoundException("Event not found");
+        }
+
+        $incomingSightingUuids = $this->request->data;
+        $existingSightingUuids = $this->Sighting->find('column', [
+            'fields' => ['Sighting.uuid'],
+            'conditions' => [
+                'Sighting.uuid' => $incomingSightingUuids,
+                'Sighting.event_id' => $event['Event']['id']
+            ],
+        ]);
+        return $this->RestResponse->viewData($existingSightingUuids, $this->response->type());
+    }
 }

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -3042,12 +3042,12 @@ class AppModel extends Model
      * @param $query
      * @param array $results
      * @return array
-     * @throws Exception
+     * @throws InvalidArgumentException
      */
     protected function _findColumn($state, $query, $results = array())
     {
         if ($state === 'before') {
-            if (count($query['fields']) === 1) {
+            if (isset($query['fields']) && count($query['fields']) === 1) {
                 if (strpos($query['fields'][0], '.') === false) {
                     $query['fields'][0] = $this->alias . '.' . $query['fields'][0];
                 }
@@ -3058,8 +3058,10 @@ class AppModel extends Model
                 } else {
                     $query['fields'] = array($query['fields'][0]);
                 }
+            } else if (!isset($query['fields'])) {
+                throw new InvalidArgumentException("This method requires `fields` option defined.");
             } else {
-                throw new Exception("Invalid number of column, expected one, " . count($query['fields']) . " given");
+                throw new InvalidArgumentException("Invalid number of column, expected one, " . count($query['fields']) . " given");
             }
 
             if (!isset($query['recursive'])) {


### PR DESCRIPTION
#### What does it do?

New method that can be used for filtering out sightings that already exists on remote side when pushing sightings since sightings are immutable.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
