### PR TITLE
chg: [attributes] fix copypasta error leading to internal server erro…

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -2678,7 +2678,7 @@ class AttributesController extends AppController
                             }
                         }
                     } else {
-                        $tag = $this->Event->EventTag->Tag->find('first', array('recursive' => -1, 'conditions' => $conditions));
+                        $tag = $this->Attribute->AttributeTag->Tag->find('first', array('recursive' => -1, 'conditions' => $conditions));
                         if (empty($tag)) {
                             return new CakeResponse(array('body'=> json_encode(array('saved' => false, 'errors' => 'Invalid Tag.')), 'status'=>200, 'type' => 'json'));
                         }


### PR DESCRIPTION
…r on addtag with tag name

#### What does it do?

Fixes following issue:
Adding tag to attribute using /attributes/addTag gives internal server when trying to add with tag name.
Looks like line was not correctly modified after copying logic from /events/addTag to add tag collection

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
