### PR TITLE
chg: [sync] unpublish event on pull sync if unpublish_event is set. f…

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -360,6 +360,10 @@ class Server extends AppModel
                 }
             }
         }
+	// Set published to false if unpublish_event is set for the server
+        if (!empty($server['Server']['unpublish_event'])) {
+            $event['Event']['published'] = 0;
+        }
 
         // Distribution, set reporter of the event, being the admin that initiated the pull
         $event['Event']['user_id'] = $user['id'];


### PR DESCRIPTION
…ix #7197

#### What does it do?

would fix #7197 (which is duplicate of #7139). Although from the comment on the latter it seems like the unpublish event would be removed altogether so if that is the case then this PR doesn't make a lot of sense anymore :D.

tested that both scenarios work (pull with and without the flag set) after this change, but please double check of course :)

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
