### PR TITLE
Improve compability with snuffleupagus sp.global_strict

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -957,7 +957,7 @@ class AppController extends Controller
         }
         foreach ($data as $k => $v) {
             if (!is_array($data[$k])) {
-                $data[$k] = trim($data[$k]);
+                $data[$k] = trim((string) $data[$k]);
                 if (strpos($data[$k], '||')) {
                     $data[$k] = explode('||', $data[$k]);
                 }

--- a/app/Controller/Component/RestResponseComponent.php
+++ b/app/Controller/Component/RestResponseComponent.php
@@ -491,7 +491,7 @@ class RestResponseComponent extends Component
      */
     private function __sendResponse($response, $code, $format = false, $raw = false, $download = false, $headers = array())
     {
-        $format = strtolower($format);
+        $format = strtolower((string) $format);
         if ($format === 'application/xml' || $format === 'xml') {
             if (!$raw) {
                 if (isset($response[0])) {

--- a/app/Lib/Tools/AttachmentTool.php
+++ b/app/Lib/Tools/AttachmentTool.php
@@ -425,7 +425,7 @@ class AttachmentTool
      */
     public function attachmentDirIsS3()
     {
-        return substr(Configure::read('MISP.attachments_dir'), 0, 2) === "s3";
+        return substr((string) Configure::read('MISP.attachments_dir'), 0, 2) === "s3";
     }
 
     /**

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -2492,7 +2492,7 @@ class AppModel extends Model
         $pass = Configure::read('MISP.redis_password');
 
         $redis = new Redis();
-        if (!$redis->connect($host, $port)) {
+        if (!$redis->connect($host, (int) $port)) {
             throw new Exception("Could not connect to Redis: {$redis->getLastError()}");
         }
         if (!empty($pass)) {

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -3403,7 +3403,7 @@ class Server extends AppModel
                 throw new MethodNotAllowedException('Non numeric PID found.');
             }
             if ($procAccessible) {
-                $alive = $correct_user ? (file_exists('/proc/' . addslashes($pid))) : false;
+                $alive = $correct_user ? (file_exists('/proc/' . addslashes((string) $pid))) : false;
             } else {
                 $alive = 'N/A';
             }


### PR DESCRIPTION
(https://github.com/nbs-system/snuffleupagus)

#### What does it do?

When using snuffleupagus for php hardening with global_strict enabled, some errors appears during ansible role testing https://github.com/juju4/ansible-MISP/
Below ensure tests are passed but likely more

#### Questions

- [ ] Does it require a DB change? No
- [ ] Are you using it in production? Github Action testing
- [ ] Does it require a change in the API (PyMISP for example)? No
