### PR TITLE
fix: [UI] Fixes bug that stops country flag being displayed alongside country

### DIFF
--- a/app/View/Elements/genericElements/IndexTable/Fields/galaxy_element_value.ctp
+++ b/app/View/Elements/genericElements/IndexTable/Fields/galaxy_element_value.ctp
@@ -7,7 +7,7 @@ if ($key === 'refs' &&
 ) {
     echo '<a href="' . h($value) . '" rel="noreferrer noopener">' . h($value) . '</a>';
 } else if ($key === 'country') {
-    echo $this->Icon->countryFlag($item['GalaxyElement']['value']) . ' ' . h($value);
+    echo $this->Icon->countryFlag($value) . ' ' . h($value);
 } else {
     echo h($value);
 }


### PR DESCRIPTION
Fixed a minor bug introduced when the galaxy cluster element view was changed to a generic factory and the path passed to the country flag was not updated. Caused no country flag to be shown and error to be thrown

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
