### PR TITLE
fix: [api] Fixes crash when a new indicator in existing event has a sighting

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -4076,10 +4076,6 @@ class Attribute extends AppModel
                 $attribute['distribution'] = 5;
             }
         }
-        if (isset($attribute['Sighting']) && !empty($attribute['Sighting'])) {
-            $this->Sighting = ClassRegistry::init('Sighting');
-            $this->Sighting->captureSightings($attribute['Sighting'], $attribute['id'], $eventId, $user);
-        }
         $fieldList = $this->editableFields;
         if (empty($existingAttribute)) {
             $addableFieldList = array('event_id', 'type', 'uuid');
@@ -4105,6 +4101,10 @@ class Attribute extends AppModel
             ));
             return $this->validationErrors;
         } else {
+            if (isset($attribute['Sighting']) && !empty($attribute['Sighting'])) {
+                $this->Sighting = ClassRegistry::init('Sighting');
+                $this->Sighting->captureSightings($attribute['Sighting'], $this->id, $eventId, $user);
+            }
             if ($user['Role']['perm_tagger']) {
                 /*
                     We should uncomment the line below in the future once we have tag soft-delete


### PR DESCRIPTION
#### What does it do?

When an existing event has a new indicator added, it goes to the 'editAttribute' function, which before expected an ID when creating a sighting. As a result, new indicators where there was no ID, this was not available until post-save. Moved the code further down following the save. Same code, but works better now :)

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
