### PR TITLE
Allow saving of OIDC plugin settings

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -2230,7 +2230,7 @@ class Server extends AppModel
             'debug', 'MISP', 'GnuPG', 'SMIME', 'Proxy', 'SecureAuth',
             'Security', 'Session.defaults', 'Session.timeout', 'Session.cookieTimeout',
             'Session.autoRegenerate', 'Session.checkAgent', 'site_admin_debug',
-            'Plugin', 'CertAuth', 'ApacheShibbAuth', 'ApacheSecureAuth'
+            'Plugin', 'CertAuth', 'ApacheShibbAuth', 'ApacheSecureAuth', 'OidcAuth'
         );
         $settingsArray = array();
         foreach ($settingsToSave as $setting) {


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2020-05-05: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

It allows for saving settings for the OIDCAuth plugin (https://github.com/MISP/MISP/tree/2.4/app/Plugin/OidcAuth) back into config.php so those settings do not get wiped on a restart.

#### Questions

- [ ] Does it require a DB change?
No
- [ ] Are you using it in production?
Yes
- [ ] Does it require a change in the API (PyMISP for example)?
No
