### PR TITLE
fix: [sync] Crash when attempting to sync with 'Pull Galaxy Clusters' enabled

### DIFF
--- a/app/Model/GalaxyCluster.php
+++ b/app/Model/GalaxyCluster.php
@@ -818,7 +818,7 @@ class GalaxyCluster extends AppModel
     {
         $this->Event = ClassRegistry::init('Event');
         if (isset($element[$model]['distribution']) && $element[$model]['distribution'] == 4) {
-            $element[$model] = $this->Event->__captureSGForElement($element[$model], $user);
+            $element[$model] = $this->Event->captureSGForElement($element[$model], $user);
         }
         // first we want to see how the creator organisation is encoded
         // The options here are either by passing an organisation object along or simply passing a string along

--- a/app/Model/GalaxyClusterRelation.php
+++ b/app/Model/GalaxyClusterRelation.php
@@ -475,7 +475,7 @@ class GalaxyClusterRelation extends AppModel
 
             $this->Event = ClassRegistry::init('Event');
             if (isset($relation['GalaxyClusterRelation']['distribution']) && $relation['GalaxyClusterRelation']['distribution'] == 4) {
-                $relation['GalaxyClusterRelation'] = $this->Event->__captureSGForElement($relation['GalaxyClusterRelation'], $user);
+                $relation['GalaxyClusterRelation'] = $this->Event->captureSGForElement($relation['GalaxyClusterRelation'], $user);
             }
 
             $saveSuccess = $this->save($relation);


### PR DESCRIPTION
#### What does it do?

Discovered that when 'Pull Galaxy Clusters' is checked against a sync server, when it comes to syncing it would crash with the error:

```
ERROR: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; 
check the manual that corresponds to your MariaDB server version for the right syntax to use
near '__captureSGForElement' at line 1
```

This is due to a function that was renamed from `__captureSGForElement` to `captureSGForElement` in commit https://github.com/MISP/MISP/commit/d24e2a085aeddb0b444e801f72f20f08889f3079 but wasn't updated in these two files.

Simple rename to the correct function allows this to carry on as expected.

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
