### PR TITLE
chg: [ShibbAuth] Add login entry on logging in for audit

### DIFF
--- a/app/Plugin/ShibbAuth/Controller/Component/Auth/ApacheShibbAuthenticate.php
+++ b/app/Plugin/ShibbAuth/Controller/Component/Auth/ApacheShibbAuthenticate.php
@@ -127,7 +127,7 @@ class ApacheShibbAuthenticate extends BaseAuthenticate
                 $user = $this->updateUserRole($roleChanged, $user, $roleId, $userModel);
             }
             $user = $this->updateUserOrg($org, $user, $userModel);
-            CakeLog::info("User `$mispUsername` logged in.");
+            $userModel->extralog($user, 'login');
             return $user;
         }
 
@@ -145,8 +145,9 @@ class ApacheShibbAuthenticate extends BaseAuthenticate
         // save user
         $userModel->save($userData);
         CakeLog::info("User `$mispUsername` saved in database.");
-        CakeLog::info("User `$mispUsername` logged in.");
-        return $this->_findUser($mispUsername);
+        $user = $this->_findUser($mispUsername);
+        $userModel->extralog($user, 'login');
+        return $user;
     }
 
     /**


### PR DESCRIPTION
#### What does it do?

Adds a login entry that is visible in the audit logs when someone logs in with ShibbAuth.

Would still like to test this in production before it is merged but feedback is appreciated if this is not the best way to log login.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
