### PR TITLE
chg: [tag] Use detailed message in tag return

### DIFF
--- a/app/Controller/TagsController.php
+++ b/app/Controller/TagsController.php
@@ -885,6 +885,9 @@ class TagsController extends AppController
             $failedMessage = __('Failed to attach %s tags. Reasons: %s', count($fails), json_encode($fails,  JSON_FORCE_OBJECT));
         }
         if ($successes > 0) {
+            if ($successes > 1) {
+                $message = __('Successfully attached %s tags to %s (%s)', $successes, $objectType, $object[$objectType]['id']);
+            }
             $message .= !empty($fails) ? PHP_EOL . $failedMessage : '';
             return $this->RestResponse->saveSuccessResponse('Tags', 'attachTagToObject', false, $this->response->type(), $message);
         } else {

--- a/app/Controller/TagsController.php
+++ b/app/Controller/TagsController.php
@@ -885,7 +885,6 @@ class TagsController extends AppController
             $failedMessage = __('Failed to attach %s tags. Reasons: %s', count($fails), json_encode($fails,  JSON_FORCE_OBJECT));
         }
         if ($successes > 0) {
-            $message = __('Successfully attached %s tags to %s (%s)', $successes, $objectType, $object[$objectType]['id']);
             $message .= !empty($fails) ? PHP_EOL . $failedMessage : '';
             return $this->RestResponse->saveSuccessResponse('Tags', 'attachTagToObject', false, $this->response->type(), $message);
         } else {


### PR DESCRIPTION
#### What does it do?
Gives a more detailed message response when 1 tag is added (similar to when a tag is deleted).

A detailed message is created on lines 870 (local) and 877 (global) when a tag is attached, however, these messages are never used in the response as it is overwritten by the generic message on line 888. The generic message, that includes count, would be better served only when more than one tag is attached.

#### Questions

- [x] Does it require a DB change? **No**
- [x] Are you using it in production? **Yes**
- [x] Does it require a change in the API (PyMISP for example)? **No**
