### PR TITLE
fix: [selinux] allow log files rename

### DIFF
--- a/INSTALL/misplogrotate.te
+++ b/INSTALL/misplogrotate.te
@@ -7,10 +7,10 @@ require {
 	type httpd_sys_content_t;
 	type httpd_sys_rw_content_t;
 	class dir { ioctl read getattr lock search open remove_name };
-	class file { unlink write };
+	class file { unlink write rename };
 }
 #============= logrotate_t ==============
 allow logrotate_t httpd_sys_content_t:dir { ioctl read getattr lock search open };
 allow logrotate_t httpd_sys_rw_content_t:dir { ioctl read getattr lock search open };
 allow httpd_t httpd_log_t:dir remove_name;
-allow { httpd_t httpd_sys_script_t } httpd_log_t:file { unlink write };
+allow { httpd_t httpd_sys_script_t } httpd_log_t:file { unlink write rename };


### PR DESCRIPTION
SELinux was complaining in /var/opt/rh/rh-php72/log/php-fpm/www-error.log
```
[21-Mar-2021 03:36:51 Europe/Amsterdam] PHP Warning:  rename(/var/www/MISP/app/tmp/logs/debug.log,/var/www/MISP/app/tmp/logs/debug.log.1616294211) [<a href='http://php.net/function.rename'>function.rename</a>]: Permission denied in /var/www/MISP/app/Lib/cakephp/lib/Cake/Log/Engine/FileLog.php on line 205
```
This is a quick fix for this problem.