### PR TITLE
new: [cli] enable all tags for a taxonomy

### DIFF
--- a/app/Console/Command/AdminShell.php
+++ b/app/Console/Command/AdminShell.php
@@ -189,6 +189,20 @@ class AdminShell extends AppShell
         echo $message . PHP_EOL;
     }
 
+    public function enableTaxonomyTags()
+    {
+        if (empty($this->args[0]) || !is_numeric($this->args[0])) {
+            echo 'Usage: ' . APP . '/cake ' . 'Admin enableTaxonomyTags [taxonomy_id]' . PHP_EOL;
+	} else {
+            $result = $this->Taxonomy->addTags(intval($this->args[0]));
+	    if ($result) {
+                echo 'Taxonomy tags enabled' . PHP_EOL;
+	    } else {
+                echo 'Could not enable taxonomy tags' . PHP_EOL;
+            }
+        }
+    }
+
     public function updateWarningLists()
     {
         $this->ConfigLoad->execute();


### PR DESCRIPTION
#### What does it do?

adds a command enableTaxonomyTags to enable all tags of a particular taxonomy from command line. As discussed on gitter.
I'll do a PR for update documentation in misp-book in a sec.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
