### PR TITLE
chg: [MispObject] fix copy paste error in checkForDuplicateObjects

### DIFF
--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -317,7 +317,7 @@ class MispObject extends AppModel
             }
             $newObjectAttributes[] = hash(
                 'sha256',
-                $attribute['object_relation'] . $attribute['category'] . $attribute['type'] . $this->data['Attribute']['value'] = $this->Attribute->modifyBeforeValidation($attribute['type'], $attribute['value'])
+                $attribute['object_relation'] . $attribute['category'] . $attribute['type'] .  $this->Attribute->modifyBeforeValidation($attribute['type'], $attribute['value'])
             );
         }
         $newObjectAttributeCount = count($newObjectAttributes);


### PR DESCRIPTION
#### What does it do?

Fixes a copy paste error from commit https://github.com/MISP/MISP/commit/7493f9e8c3c6abcadd7d669a62c1170b20e71d64

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
