### PR TITLE
chg: [MispObject] fix copy paste error in editObject

### DIFF
--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -1056,8 +1056,8 @@ class MispObject extends AppModel
                 'email' => $user['email'],
                 'action' => 'edit',
                 'user_id' => $user['id'],
-                'title' => 'Attribute dropped due to validation for Event ' . $eventId . ' failed: ' . $object['name'],
-                'change' => 'Validation errors: ' . json_encode($this->validationErrors) . ' Full Object: ' . json_encode($attribute),
+                'title' => 'Object dropped due to validation for Event ' . $eventId . ' failed: ' . $object['name'],
+                'change' => 'Validation errors: ' . json_encode($this->validationErrors) . ' Full Object: ' . json_encode($object),
             ));
             return $this->validationErrors;
         }


### PR DESCRIPTION
#### What does it do?

Fixes some likely copy paste errors in editObject.  Considering the surrounding code and fact that IDE was complaining about $attribute not existing I assume this should be the correct version.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
