### PR TITLE
fix: allow setting org_id=0 via cake console, add --force option

### DIFF
--- a/app/Console/Command/AdminShell.php
+++ b/app/Console/Command/AdminShell.php
@@ -346,7 +346,7 @@ class AdminShell extends AppShell
                 echo 'Invalid setting "' . $setting_name . '". Please make sure that the setting that you are attempting to change exists and if a module parameter, the modules are running.' . PHP_EOL;
                 exit(1);
             }
-            $result = $this->Server->serverSettingsEditValue($cli_user, $setting, $value);
+            $result = $this->Server->serverSettingsEditValue($cli_user, $setting, $value, $this->params['force']);
             if ($result === true) {
                 echo 'Setting "' . $setting_name . '" changed to ' . $value . PHP_EOL;
             } else {
@@ -490,6 +490,7 @@ class AdminShell extends AppShell
     {
         $this->ConfigLoad->execute();
         $parser = parent::getOptionParser();
+        
         $parser->addSubcommand('updateJSON', array(
             'help' => __('Update the JSON definitions of MISP.'),
             'parser' => array(
@@ -498,6 +499,14 @@ class AdminShell extends AppShell
                 )
             )
         ));
+
+        $parser->addOption('force', array(
+            'short' => 'f',
+            'help' => 'Force the command.',
+            'default' => false,
+            'boolean' => true
+        ));
+
         return $parser;
     }
 

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1450,14 +1450,19 @@ class Server extends AppModel
         return $options;
     }
 
-    private function loadLocalOrganisations()
+    private function loadLocalOrganisations($strict = false)
     {
         $localOrgs = $this->Organisation->find('list', array(
             'conditions' => array('local' => 1),
             'recursive' => -1,
             'fields' => array('Organisation.id', 'Organisation.name')
         ));
-        return array_replace(array(0 => __('No organisation selected.')), $localOrgs);
+
+        if(!$strict){
+            return array_replace(array(0 => __('No organisation selected.')), $localOrgs);
+        }
+
+        return $localOrgs;
     }
 
     public function testTagCollections($value)
@@ -1519,7 +1524,16 @@ class Server extends AppModel
         if ($value == 0) {
             return true; // `No organisation selected` option
         }
+
+        return $this->testLocalOrgStrict($value);
+    }
+
+    public function testLocalOrgStrict($value)
+    {
         $this->Organisation = ClassRegistry::init('Organisation');
+        if ($value == 0) {
+            return 'No organisation selected';
+        }
         $local_orgs = $this->Organisation->find('list', array(
             'conditions' => array('local' => 1),
             'recursive' => -1,
@@ -4752,10 +4766,10 @@ class Server extends AppModel
                     'description' => __('The hosting organisation of this instance. If this is not selected then replication instances cannot be added.'),
                     'value' => '0',
                     'errorMessage' => '',
-                    'test' => 'testLocalOrg',
+                    'test' => 'testLocalOrgStrict',
                     'type' => 'numeric',
                     'optionsSource' => function () {
-                        return $this->loadLocalOrganisations();
+                        return $this->loadLocalOrganisations(true);
                     },
                 ),
                 'uuid' => array(

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1516,10 +1516,10 @@ class Server extends AppModel
 
     public function testLocalOrg($value)
     {
-        $this->Organisation = ClassRegistry::init('Organisation');
         if ($value == 0) {
-            return 'No organisation selected';
+            return true; // `No organisation selected` option
         }
+        $this->Organisation = ClassRegistry::init('Organisation');
         $local_orgs = $this->Organisation->find('list', array(
             'conditions' => array('local' => 1),
             'recursive' => -1,


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2020-05-05: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

Fixes #7346, allows setting org_id=0 via Cake console and adds --force option to enforce commands.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
