### PR TITLE
chg: [statistics:UsageData] fix active proposal count, exclude deleted entries

### DIFF
--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -1848,7 +1848,7 @@ class UsersController extends AppController
         $stats['correlation_count'] = $this->Correlation->find('count', array('recursive' => -1));
         $stats['correlation_count'] = $stats['correlation_count'] / 2;
 
-        $stats['proposal_count'] = $this->User->Event->ShadowAttribute->find('count', array('recursive' => -1));
+        $stats['proposal_count'] = $this->User->Event->ShadowAttribute->find('count', array('recursive' => -1, 'conditions' => array('deleted' => 0)));
 
         $stats['user_count'] = $this->User->find('count', array('recursive' => -1));
         $stats['user_count_pgp'] = $this->User->find('count', array('recursive' => -1, 'conditions' => array('User.gpgkey !=' => '')));

--- a/app/Lib/Dashboard/UsageDataWidget.php
+++ b/app/Lib/Dashboard/UsageDataWidget.php
@@ -30,7 +30,7 @@ class UsageDataWidget
         $this->Correlation = ClassRegistry::init('Correlation');
         $correlationsCount = $this->Correlation->find('count', array('recursive' => -1)) / 2;
 
-        $proposalsCount = $this->Event->ShadowAttribute->find('count', array('recursive' => -1));
+        $proposalsCount = $this->Event->ShadowAttribute->find('count', array('recursive' => -1, 'conditions' => array('deleted' => 0)));
 
         $usersCount = $this->User->find('count', array('recursive' => -1));
         $usersCountPgp = $this->User->find('count', array('recursive' => -1, 'conditions' => array('User.gpgkey !=' => '')));


### PR DESCRIPTION
#### What does it do?

Realized statistics usage data counts all proposals, even deleted ones. This shouldn't be the case I think as it's clearly marked as 'active proposals'. Since I copied this code for the related dashboard widget it needs to be fixed in two places.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
