### PR TITLE
Fix restricted to domain reset on org edit

### DIFF
--- a/app/Controller/OrganisationsController.php
+++ b/app/Controller/OrganisationsController.php
@@ -183,7 +183,7 @@ class OrganisationsController extends AppController
                     $this->request->data['Organisation'] = $this->request->data;
                 }
                 $existingOrg = $this->Organisation->find('first', array('conditions' => array('Organisation.id' => $id)));
-                $changeFields = array('name', 'type', 'nationality', 'sector', 'contacts', 'description', 'local', 'uuid');
+                $changeFields = array('name', 'type', 'nationality', 'sector', 'contacts', 'description', 'local', 'uuid', 'restricted_to_domain');
                 $temp = array('Organisation' => array());
                 foreach ($changeFields as $field) {
                     if (isset($this->request->data['Organisation'][$field])) {

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -248,9 +248,16 @@ class Attribute extends AppModel
             'message' => array('Invalid ISO 8601 format')
         ),
         'last_seen' => array(
-            'rule' => array('datetimeOrNull'),
-            'required' => false,
-            'message' => array('Invalid ISO 8601 format')
+            'datetimeOrNull' => array(
+                'rule' => array('datetimeOrNull'),
+                'required' => false,
+                'message' => array('Invalid ISO 8601 format')
+            ),
+            'validateLastSeenValue' => array(
+                'rule' => array('validateLastSeenValue'),
+                'required' => false,
+                'message' => array('Last seen value should be greater than first seen value')
+            ),
         )
     );
 
@@ -713,6 +720,22 @@ class Attribute extends AppModel
             $returnValue = false;
         }
         return $returnValue || is_null($seen);
+    }
+
+    public function validateLastSeenValue($fields)
+    {
+        $ls = $fields['last_seen'];
+        if (is_null($this->data['Attribute']['first_seen']) || is_null($ls)) {
+            return true;
+        }
+        $converted = $this->ISODatetimeToUTC(['Attribute' => [
+            'first_seen' => $this->data['Attribute']['first_seen'],
+            'last_seen' => $ls
+        ]], 'Attribute');
+        if ($converted['Attribute']['first_seen'] >= $converted['Attribute']['last_seen']) {
+            return false;
+        }
+        return true;
     }
 
     private $__hexHashLengths = array(

--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -75,9 +75,16 @@ class MispObject extends AppModel
             'message' => array('Invalid ISO 8601 format')
         ),
         'last_seen' => array(
-            'rule' => array('datetimeOrNull'),
-            'required' => false,
-            'message' => array('Invalid ISO 8601 format')
+            'datetimeOrNull' => array(
+                'rule' => array('datetimeOrNull'),
+                'required' => false,
+                'message' => array('Invalid ISO 8601 format')
+            ),
+            'validateLastSeenValue' => array(
+                'rule' => array('validateLastSeenValue'),
+                'required' => false,
+                'message' => array('Last seen value should be greater than first seen value')
+            ),
         )
     );
 
@@ -181,6 +188,22 @@ class MispObject extends AppModel
              $returnValue = false;
          }
          return $returnValue || is_null($seen);
+     }
+
+     public function validateLastSeenValue($fields)
+     {
+         $ls = $fields['last_seen'];
+         if (is_null($this->data['Object']['first_seen']) || is_null($ls)) {
+             return true;
+         }
+         $converted = $this->Attribute->ISODatetimeToUTC(['Object' => [
+             'first_seen' => $this->data['Object']['first_seen'],
+             'last_seen' => $ls
+         ]], 'Object');
+         if ($converted['Object']['first_seen'] >= $converted['Object']['last_seen']) {
+             return false;
+         }
+         return true;
      }
 
     public function afterFind($results, $primary = false)

--- a/app/Model/Organisation.php
+++ b/app/Model/Organisation.php
@@ -97,7 +97,7 @@ class Organisation extends AppModel
         'uuid' => '0',
         'contacts' => '',
         'local' => true,
-        'restricted_to_domain' => '',
+        'restricted_to_domain' => '[]',
         'landingpage' => null
     );
 
@@ -110,15 +110,19 @@ class Organisation extends AppModel
             $this->data['Organisation']['uuid'] = strtolower(trim($this->data['Organisation']['uuid']));
         }
         $date = date('Y-m-d H:i:s');
-        if (!empty($this->data['Organisation']['restricted_to_domain'])) {
-            $this->data['Organisation']['restricted_to_domain'] = str_replace("\r", '', $this->data['Organisation']['restricted_to_domain']);
-            $this->data['Organisation']['restricted_to_domain'] = explode("\n", $this->data['Organisation']['restricted_to_domain']);
-            foreach ($this->data['Organisation']['restricted_to_domain'] as $k => $v) {
-                $this->data['Organisation']['restricted_to_domain'][$k] = trim($v);
+        if (array_key_exists('restricted_to_domain', $this->data['Organisation'])) {
+            if (!is_array($this->data['Organisation']['restricted_to_domain'])) {
+                $this->data['Organisation']['restricted_to_domain'] = str_replace('\r', '', $this->data['Organisation']['restricted_to_domain']);
+                $this->data['Organisation']['restricted_to_domain'] = explode('\n', $this->data['Organisation']['restricted_to_domain']);
             }
+            
+            $this->data['Organisation']['restricted_to_domain'] = array_values(
+                array_filter(
+                    array_map('trim', $this->data['Organisation']['restricted_to_domain'])
+                )
+            );
+
             $this->data['Organisation']['restricted_to_domain'] = json_encode($this->data['Organisation']['restricted_to_domain']);
-        } else {
-            $this->data['Organisation']['restricted_to_domain'] = '';
         }
         if (!isset($this->data['Organisation']['id'])) {
             $this->data['Organisation']['date_created'] = $date;

--- a/app/Model/ShadowAttribute.php
+++ b/app/Model/ShadowAttribute.php
@@ -142,9 +142,16 @@ class ShadowAttribute extends AppModel
             'message' => array('Invalid ISO 8601 format')
         ),
         'last_seen' => array(
-            'rule' => array('datetimeOrNull'),
-            'required' => false,
-            'message' => array('Invalid ISO 8601 format')
+            'datetimeOrNull' => array(
+                'rule' => array('datetimeOrNull'),
+                'required' => false,
+                'message' => array('Invalid ISO 8601 format')
+            ),
+            'validateLastSeenValue' => array(
+                'rule' => array('validateLastSeenValue'),
+                'required' => false,
+                'message' => array('Last seen value should be greater than first seen value')
+            ),
         )
     );
 
@@ -449,6 +456,22 @@ class ShadowAttribute extends AppModel
     public function datetimeOrNull($fields)
     {
         return $this->Attribute->datetimeOrNull($fields);
+    }
+
+    public function validateLastSeenValue($fields)
+    {
+        $ls = $fields['last_seen'];
+        if (is_null($this->data['ShadowAttribute']['first_seen']) || is_null($ls)) {
+            return true;
+        }
+        $converted = $this->Attribute->ISODatetimeToUTC(['ShadowAttribute' => [
+            'first_seen' => $this->data['ShadowAttribute']['first_seen'],
+            'last_seen' => $ls
+        ]], 'ShadowAttribute');
+        if ($converted['ShadowAttribute']['first_seen'] >= $converted['ShadowAttribute']['last_seen']) {
+            return false;
+        }
+        return true;
     }
 
     public function setDeleted($id)


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2020-05-05: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?
* Fixes restricted_to_domain set to empty when updating organisation via [POST]/admin/organisations/[organisation_id] end point.
* Allow sending an array on top of brake line separated hostnames.
* Fixes `#<4928>`

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
