### PR TITLE
new: [UI] Define custom right menu link

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -5530,7 +5530,21 @@ class Server extends AppModel
                     'type' => 'boolean',
                     'null' => true,
                     'cli_only' => true,
-                ]
+                ],
+                'menu_custom_right_link' => [
+                    'level' => self::SETTING_OPTIONAL,
+                    'description' => __('Custom right menu URL.'),
+                    'value' => null,
+                    'type' => 'string',
+                    'null' => true,
+                ],
+                'menu_custom_right_link_html' => [
+                    'level' => self::SETTING_OPTIONAL,
+                    'description' => __('Custom right menu text (it is possible to use HTML).'),
+                    'value' => null,
+                    'type' => 'string',
+                    'null' => true,
+                ],
             ),
             'GnuPG' => array(
                 'branch' => 1,

--- a/app/View/Elements/global_menu.ctp
+++ b/app/View/Elements/global_menu.ctp
@@ -495,8 +495,8 @@
                 'html' => sprintf(
                     '<span class="fas fa-star %s" id="setHomePage" title="%s" role="img" aria-label="%s" data-current-page="%s"></span>',
                     (!empty($homepage['path']) && $homepage['path'] === $this->here) ? 'orange' : '',
-		    __('Set the current page as your home page in MISP'),
-		    __('Set the current page as your home page in MISP'),
+		            __('Set the current page as your home page in MISP'),
+		            __('Set the current page as your home page in MISP'),
                     h($this->here)
                 )
             ),
@@ -505,6 +505,12 @@
                 'url' => empty($homepage['path']) ? $baseurl : $baseurl . h($homepage['path']),
                 'html' => '<span class="logoBlueStatic bold" id="smallLogo">MISP</span>'
             ),
+            [
+                'type' => 'root',
+                'url' => Configure::read('MISP.menu_custom_right_link'),
+                'html' => Configure::read('MISP.menu_custom_right_link_html'),
+                'requirement' => !empty(Configure::read('MISP.menu_custom_right_link')),
+            ],
             array(
                 'type' => 'root',
                 'url' => $baseurl . '/dashboards',
@@ -528,7 +534,7 @@
         );
     }
 ?>
-<div id="topBar" class="navbar navbar-inverse <?php echo $debugMode;?>">
+<div id="topBar" class="navbar navbar-inverse <?= $debugMode ?>">
   <div class="navbar-inner">
     <ul class="nav">
         <?php


### PR DESCRIPTION
#### What does it do?

New option to add custom link to menu. It can be useful if MISP is part of bigger project and you want for example to add link to project homepage.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
