### PR TITLE
fix: /feeds/add endpoint returns empty 'name' error via api call

### DIFF
--- a/app/Controller/FeedsController.php
+++ b/app/Controller/FeedsController.php
@@ -202,9 +202,6 @@ class FeedsController extends AppController
         $tags = $this->Event->EventTag->Tag->find('list', array('fields' => array('Tag.name'), 'order' => array('lower(Tag.name) asc')));
         $tags[0] = 'None';
         $this->set('tags', $tags);
-        if (!isset($this->request->data['Feed']['fixed_event'])) {
-            $this->request->data['Feed']['fixed_event'] = 1;
-        }
         $this->set('orgs', $this->Event->Orgc->find('list', array(
             'fields' => array('id', 'name'),
             'order' => 'LOWER(name)'
@@ -220,6 +217,9 @@ class FeedsController extends AppController
                         $this->request->data['Feed']['source_format'] = 1;
                     }
                 }
+            }
+            if (!isset($this->request->data['Feed']['fixed_event'])) {
+                $this->request->data['Feed']['fixed_event'] = 1;
             }
             $error = false;
             if (isset($this->request->data['Feed']['pull_rules'])) {


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2020-05-05: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?
Fixes a bug when trying to create a feed via `[POST]/feeds/add` the following error occurs:
```
{
    "saved": false,
    "name": "Could not add Feed",
    "message": "Could not add Feed",
    "url": "/feeds/add",
    "errors": "Feed could not be added. Reason: {\"name\":[\"This field cannot be left blank\"]}"
}
```
Request payload:
```
{
    "name": "test",
    "provider": "CIRCL",
    "url": "https://www.circl.lu/doc/misp/feed-osint"
}
```

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
