### PR TITLE
fix: [sync] Better error handling when fetching IDs for push/pull

### DIFF
--- a/app/Lib/Tools/HttpSocketExtended.php
+++ b/app/Lib/Tools/HttpSocketExtended.php
@@ -2,9 +2,29 @@
 App::uses('HttpSocketResponse', 'Network/Http');
 App::uses('HttpSocket', 'Network/Http');
 
-class HttpClientJsonException extends Exception
+class HttpSocketHttpException extends Exception
 {
-    /** @var HttpSocketResponse */
+    /** @var HttpSocketResponseExtended */
+    private $response;
+
+    public function __construct(HttpSocketResponseExtended $response)
+    {
+        $this->response = $response;
+        parent::__construct("Remote server returns HTTP error code {$response->code}", (int)$response->code);
+    }
+
+    /**
+     * @return HttpSocketResponseExtended
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+}
+
+class HttpSocketJsonException extends Exception
+{
+    /** @var HttpSocketResponseExtended */
     private $response;
 
     public function __construct($message, HttpSocketResponseExtended $response, Throwable $previous = null)
@@ -14,7 +34,7 @@ class HttpClientJsonException extends Exception
     }
 
     /**
-     * @return HttpSocketResponse
+     * @return HttpSocketResponseExtended
      */
     public function getResponse()
     {
@@ -56,7 +76,7 @@ class HttpSocketResponseExtended extends HttpSocketResponse
      * Decodes JSON string and throws exception if string is not valid JSON.
      *
      * @return array
-     * @throws HttpClientJsonException
+     * @throws HttpSocketJsonException
      */
     public function json()
     {
@@ -72,7 +92,7 @@ class HttpSocketResponseExtended extends HttpSocketResponse
             }
             return $decoded;
         } catch (Exception $e) {
-            throw new HttpClientJsonException('Could not parse response as JSON.', $this, $e);
+            throw new HttpSocketJsonException('Could not parse response as JSON.', $this, $e);
         }
     }
 }

--- a/app/Model/GalaxyCluster.php
+++ b/app/Model/GalaxyCluster.php
@@ -1964,38 +1964,45 @@ class GalaxyCluster extends AppModel
     private function getClusterIdListBasedOnPullTechnique(array $user, $technique, array $server)
     {
         $this->Server = ClassRegistry::init('Server');
-        if ("update" === $technique) {
-            $localClustersToUpdate = $this->getElligibleLocalClustersToUpdate($user);
-            $clusterIds = $this->Server->getElligibleClusterIdsFromServerForPull($server, $HttpSocket=null, $onlyUpdateLocalCluster=true, $elligibleClusters=$localClustersToUpdate);
-        } elseif ("pull_relevant_clusters" === $technique) {
-            // Fetch all local custom cluster tags then fetch their corresponding clusters on the remote end
-            $tagNames = $this->Tag->find('column', array(
-                'conditions' => array(
-                    'Tag.is_custom_galaxy' => true
-                ),
-                'fields' => array('Tag.name'),
-            ));
-            $clusterUUIDs = array();
-            $re = '/^misp-galaxy:[^:="]+="(?<uuid>[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})"$/m';
-            foreach ($tagNames as $tagName) {
-                preg_match($re, $tagName, $matches);
-                if (isset($matches['uuid'])) {
-                    $clusterUUIDs[$matches['uuid']] = true;
+        try {
+            if ("update" === $technique) {
+                $localClustersToUpdate = $this->getElligibleLocalClustersToUpdate($user);
+                $clusterIds = $this->Server->getElligibleClusterIdsFromServerForPull($server, $HttpSocket = null, $onlyUpdateLocalCluster = true, $elligibleClusters = $localClustersToUpdate);
+            } elseif ("pull_relevant_clusters" === $technique) {
+                // Fetch all local custom cluster tags then fetch their corresponding clusters on the remote end
+                $tagNames = $this->Tag->find('column', array(
+                    'conditions' => array(
+                        'Tag.is_custom_galaxy' => true
+                    ),
+                    'fields' => array('Tag.name'),
+                ));
+                $clusterUUIDs = array();
+                $re = '/^misp-galaxy:[^:="]+="(?<uuid>[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})"$/m';
+                foreach ($tagNames as $tagName) {
+                    preg_match($re, $tagName, $matches);
+                    if (isset($matches['uuid'])) {
+                        $clusterUUIDs[$matches['uuid']] = true;
+                    }
                 }
+                $localClustersToUpdate = $this->getElligibleLocalClustersToUpdate($user);
+                $conditions = array('uuid' => array_keys($clusterUUIDs));
+                $clusterIds = $this->Server->getElligibleClusterIdsFromServerForPull($server, $HttpSocket = null, $onlyUpdateLocalCluster = false, $elligibleClusters = $localClustersToUpdate, $conditions = $conditions);
+            } elseif (is_numeric($technique)) {
+                $conditions = array('eventid' => $technique);
+                $clusterIds = $this->Server->getElligibleClusterIdsFromServerForPull($server, $HttpSocket = null, $onlyUpdateLocalCluster = false, $elligibleClusters = array(), $conditions = $conditions);
+            } else {
+                $clusterIds = $this->Server->getElligibleClusterIdsFromServerForPull($server, $HttpSocket = null, $onlyUpdateLocalCluster = false);
             }
-            $localClustersToUpdate = $this->getElligibleLocalClustersToUpdate($user);
-            $conditions = array('uuid' => array_keys($clusterUUIDs));
-            $clusterIds = $this->Server->getElligibleClusterIdsFromServerForPull($server, $HttpSocket=null, $onlyUpdateLocalCluster=false, $elligibleClusters=$localClustersToUpdate, $conditions=$conditions);
-        } elseif (is_numeric($technique)) {
-            $conditions = array('eventid' => $technique);
-            $clusterIds = $this->Server->getElligibleClusterIdsFromServerForPull($server, $HttpSocket=null, $onlyUpdateLocalCluster=false, $elligibleClusters=array(), $conditions=$conditions);
-        } else {
-            $clusterIds = $this->Server->getElligibleClusterIdsFromServerForPull($server, $HttpSocket=null, $onlyUpdateLocalCluster=false);
-        }
-        if ($clusterIds === 403) {
-            return array('error' => array(1, null));
-        } elseif (is_string($clusterIds)) {
-            return array('error' => array(2, $clusterIds));
+        } catch (HttpSocketHttpException $e) {
+            if ($e->getCode() === 403) {
+                return array('error' => array(1, null));
+            } else {
+                $this->logException("Could not get eligible cluster IDs from server {$server['Server']['id']} for pull.", $e);
+                return array('error' => array(2, $e->getMessage()));
+            }
+        } catch (Exception $e) {
+            $this->logException("Could not get eligible cluster IDs from server {$server['Server']['id']} for pull.", $e);
+            return array('error' => array(2, $e->getMessage()));
         }
         return $clusterIds;
     }


### PR DESCRIPTION
#### What does it do?

Correctly handle HTTP errors when fetching cluster IDs for push/pull. Should help with debugging problems like #7426.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
