### PR TITLE
fix: return api error when fetch from feed fails

### DIFF
--- a/app/Controller/FeedsController.php
+++ b/app/Controller/FeedsController.php
@@ -459,8 +459,15 @@ class FeedsController extends AppController
             $this->Feed->data['Feed']['settings'] = json_decode($this->Feed->data['Feed']['settings'], true);
         }
         if (!$this->Feed->data['Feed']['enabled']) {
-            $this->Flash->error(__('Feed is currently not enabled. Make sure you enable it.'));
-            $this->redirect(array('action' => 'index'));
+            if ($this->_isRest()) {
+                return $this->RestResponse->viewData(
+                    array('result' => __('Feed is currently not enabled. Make sure you enable it.')),
+                    $this->response->type()
+                );
+            } else {
+                $this->Flash->error(__('Feed is currently not enabled. Make sure you enable it.'));
+                $this->redirect(array('action' => 'index'));
+            }
         }
         if (Configure::read('MISP.background_jobs')) {
             $this->loadModel('Job');


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2020-05-05: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?
Fix bug when calling /feeds/fetchFromFeed/[feed_id] via API returns /feeds/index when feed is not enabled, return error message instead.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
