### PR TITLE
fix: decode json ref and geographical_area properties in /noticelists…

### DIFF
--- a/app/Controller/NoticelistsController.php
+++ b/app/Controller/NoticelistsController.php
@@ -171,6 +171,10 @@ class NoticelistsController extends AppController
         if (empty($noticelist)) {
             throw new NotFoundException('Noticelist not found.');
         }
+        
+        $noticelist['Noticelist']['ref'] = json_decode($noticelist['Noticelist']['ref']);
+        $noticelist['Noticelist']['geographical_area'] = json_decode($noticelist['Noticelist']['geographical_area']);
+
         if ($this->_isRest()) {
             $noticelist['Noticelist']['NoticelistEntry'] = $noticelist['NoticelistEntry'];
             return $this->RestResponse->viewData($noticelist, $this->response->type());

--- a/app/View/Noticelists/view.ctp
+++ b/app/View/Noticelists/view.ctp
@@ -5,7 +5,7 @@
         $fields = array();
         foreach ($field_names as $field_name) {
             if ($field_name == 'ref' || $field_name == 'geographical_area') {
-                $value = json_decode($noticelist['Noticelist'][$field_name]);
+                $value = $noticelist['Noticelist'][$field_name];
                 foreach ($value as $k => $v) {
                     if ($field_name == 'ref') {
                         $value[$k] = '<a href="' . h($v) . '">' . h($v) . '</a>';


### PR DESCRIPTION
…/view/[noticelist_id] endpoint

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2020-05-05: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?
Return decoded json values for `ref` and `geographical_area` properties for /noticelists/view/[noticelist_id] endpoint.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
