### PR TITLE
fix: [UI] Restore notice list warnings when adding or editing attribute

### DIFF
--- a/app/View/Attributes/add.ctp
+++ b/app/View/Attributes/add.ctp
@@ -85,6 +85,7 @@
                 )
             ),
             'metaFields' => array(
+                '<div id="notice_message" style="display: none;></div>',
                 '<div id="bothSeenSliderContainer" style="height: 170px;"></div>'
             )
         )


### PR DESCRIPTION
Restore the notice_message div that vanished in commit 0d4df7c98b0fc67618b1c3c298e64efb668fc4fe.

#### Questions

- [X] Does it require a DB change?
- [Y] Are you using it in production?
- [X] Does it require a change in the API (PyMISP for example)?
