### PR TITLE
fix: [db] rename org_blacklists to org_blocklists everywhere

### DIFF
--- a/INSTALL/MYSQL.sql
+++ b/INSTALL/MYSQL.sql
@@ -637,21 +637,6 @@ KEY `type` (`type`)
 -- -------------------------------------------------------
 
 --
--- Table structure for `org_blacklists`
---
-
-CREATE TABLE IF NOT EXISTS `org_blocklists` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `org_uuid` varchar(40) COLLATE utf8_bin NOT NULL,
-  `created` datetime NOT NULL,
-  PRIMARY KEY (`id`),
-  `org_name` varchar(255) COLLATE utf8_bin NOT NULL,
-  `comment` TEXT CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
-
--- --------------------------------------------------------
-
---
 -- Table structure for table `objects`
 --
 
@@ -804,7 +789,7 @@ CREATE TABLE IF NOT EXISTS `organisations` (
   INDEX `name` (`name`(255))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
-CREATE TABLE IF NOT EXISTS `org_blacklists` (
+CREATE TABLE IF NOT EXISTS `org_blocklists` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `org_uuid` varchar(40) COLLATE utf8_bin NOT NULL,
   `created` datetime NOT NULL,
@@ -1670,7 +1655,7 @@ INSERT IGNORE INTO `template_element_texts` (`id`, `name`, `template_element_id`
 (11, 'Persistence mechanism', 41, 'The following fields allow you to describe the persistence mechanism used by the malware'),
 (12, 'Indicators', 45, 'Just paste your list of indicators based on type into the appropriate field. All of the fields are optional, so inputting a list of IP addresses into the Network indicator field for example is sufficient to complete this template.');
 
-INSERT IGNORE INTO `org_blacklists` (`org_uuid`, `created`, `org_name`, `comment`) VALUES
+INSERT IGNORE INTO `org_blocklists` (`org_uuid`, `created`, `org_name`, `comment`) VALUES
 ('58d38339-7b24-4386-b4b4-4c0f950d210f', NOW(), 'Setec Astrononomy', 'default example'),
 ('58d38326-eda8-443a-9fa8-4e12950d210f', NOW(), 'Acme Finance', 'default example');
 

--- a/INSTALL/POSTGRESQL-data-initial.sql
+++ b/INSTALL/POSTGRESQL-data-initial.sql
@@ -243,10 +243,10 @@ COPY public.objects (id, name, "meta-category", description, template_uuid, temp
 
 
 --
--- Data for Name: org_blacklists; Type: TABLE DATA; Schema: public; Owner: -
+-- Data for Name: org_blocklists; Type: TABLE DATA; Schema: public; Owner: -
 --
 
-COPY public.org_blacklists (id, org_uuid, created, org_name, comment) FROM stdin;
+COPY public.org_blocklists (id, org_uuid, created, org_name, comment) FROM stdin;
 1	58d38339-7b24-4386-b4b4-4c0f950d210f	2018-11-27 06:22:00+00	Setec Astrononomy	default example
 2	58d38326-eda8-443a-9fa8-4e12950d210f	2018-11-27 06:22:00+00	Acme Finance	default example
 \.
@@ -800,10 +800,10 @@ SELECT pg_catalog.setval('public.objects_id_seq', 1, true);
 
 
 --
--- Name: org_blacklists_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+-- Name: org_blocklists_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public.org_blacklists_id_seq', 2, true);
+SELECT pg_catalog.setval('public.org_blocklists_id_seq', 2, true);
 
 
 --

--- a/INSTALL/POSTGRESQL-structure.sql
+++ b/INSTALL/POSTGRESQL-structure.sql
@@ -967,10 +967,10 @@ ALTER SEQUENCE public.objects_id_seq OWNED BY public.objects.id;
 
 
 --
--- Name: org_blacklists; Type: TABLE; Schema: public; Owner: -
+-- Name: org_blocklists; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.org_blacklists (
+CREATE TABLE public.org_blocklists (
     id bigint NOT NULL,
     org_uuid character varying(40) NOT NULL,
     created timestamp with time zone NOT NULL,
@@ -980,10 +980,10 @@ CREATE TABLE public.org_blacklists (
 
 
 --
--- Name: org_blacklists_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: org_blocklists_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.org_blacklists_id_seq
+CREATE SEQUENCE public.org_blocklists_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -992,10 +992,10 @@ CREATE SEQUENCE public.org_blacklists_id_seq
 
 
 --
--- Name: org_blacklists_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+-- Name: org_blocklists_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.org_blacklists_id_seq OWNED BY public.org_blacklists.id;
+ALTER SEQUENCE public.org_blocklists_id_seq OWNED BY public.org_blocklists.id;
 
 
 --
@@ -2213,10 +2213,10 @@ ALTER TABLE ONLY public.objects ALTER COLUMN id SET DEFAULT nextval('public.obje
 
 
 --
--- Name: org_blacklists id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: org_blocklists id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.org_blacklists ALTER COLUMN id SET DEFAULT nextval('public.org_blacklists_id_seq'::regclass);
+ALTER TABLE ONLY public.org_blocklists ALTER COLUMN id SET DEFAULT nextval('public.org_blocklists_id_seq'::regclass);
 
 
 --
@@ -2647,10 +2647,10 @@ ALTER TABLE ONLY public.organisations
 
 
 --
--- Name: org_blacklists idx_20940_primary; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: org_blocklists idx_20940_primary; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.org_blacklists
+ALTER TABLE ONLY public.org_blocklists
     ADD CONSTRAINT idx_20940_primary PRIMARY KEY (id);
 
 


### PR DESCRIPTION
The old name `org_blacklists` was still present in several install files.