### PR TITLE
new: [internal] Support Cake installation by composer

### DIFF
--- a/app/Console/cake.php
+++ b/app/Console/cake.php
@@ -17,16 +17,28 @@
  * @since         CakePHP(tm) v 2.0
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-$ds = DIRECTORY_SEPARATOR;
-$dispatcher = dirname(__DIR__) . $ds . 'Lib' . $ds . 'cakephp' . $ds . 'lib' . $ds . 'Cake' . $ds . 'Console' . $ds . 'ShellDispatcher.php';
+if (!defined('DS')) {
+    define('DS', DIRECTORY_SEPARATOR);
+}
+$dispatcher = 'Cake' . DS . 'Console' . DS . 'ShellDispatcher.php';
+
 if (function_exists('ini_set')) {
-	$root = dirname(dirname(dirname(__FILE__)));
-	ini_set('include_path', $root . $ds . 'lib' . PATH_SEPARATOR . ini_get('include_path'));
+    $root = dirname(dirname(dirname(__FILE__)));
+    $appDir = basename(dirname(dirname(__FILE__)));
+    $install = $root . DS . $appDir . DS . 'Lib' . DS . 'cakephp' . DS . 'lib';
+    $composerInstall = $root . DS . $appDir . DS . 'Vendor' . DS . 'cakephp' . DS . 'cakephp' . DS . 'lib';
+
+    if (file_exists($composerInstall . DS . $dispatcher)) {
+        $install = $composerInstall; // prefer compose install
+    }
+
+    ini_set('include_path', $install . PATH_SEPARATOR . ini_get('include_path'));
+    unset($root, $appDir, $install, $composerInstall);
 }
 
-if (!include ($dispatcher)) {
-	trigger_error('Could not locate CakePHP core files.', E_USER_ERROR);
+if (!include $dispatcher) {
+    trigger_error('Could not locate CakePHP core files.', E_USER_ERROR);
 }
-unset($paths, $path, $dispatcher, $root, $ds);
+unset($dispatcher);
 
 return ShellDispatcher::run($argv);

--- a/app/webroot/index.php
+++ b/app/webroot/index.php
@@ -46,22 +46,31 @@ if (!defined('APP_DIR')) {
 }
 
 /**
- * The absolute path to the "cake" directory, WITHOUT a trailing DS.
- *
- * Un-comment this line to specify a fixed path to CakePHP.
- * This should point at the directory containing `Cake`.
- *
- * For ease of development CakePHP uses PHP's include_path.  If you
- * cannot modify your include_path set this value.
- *
- * Leaving this constant undefined will result in it being defined in Cake/bootstrap.php
+ * This auto-detects CakePHP as a composer installed library.
+ * You may remove this if you are not planning to use composer (not recommended, though).
  */
-	define('CAKE_CORE_INCLUDE_PATH', ROOT . DS . APP_DIR . DS .'Lib' . DS . 'cakephp' . DS . 'lib');
+$vendorPath = ROOT . DS . APP_DIR . DS . 'Vendor' . DS . 'cakephp' . DS . 'cakephp' . DS . 'lib';
+$dispatcher = 'Cake' . DS . 'Console' . DS . 'ShellDispatcher.php';
+if (!defined('CAKE_CORE_INCLUDE_PATH') && file_exists($vendorPath . DS . $dispatcher)) {
+    define('CAKE_CORE_INCLUDE_PATH', $vendorPath);
+} else {
+    /**
+     * The absolute path to the "cake" directory, WITHOUT a trailing DS.
+     *
+     * Un-comment this line to specify a fixed path to CakePHP.
+     * This should point at the directory containing `Cake`.
+     *
+     * For ease of development CakePHP uses PHP's include_path.  If you
+     * cannot modify your include_path set this value.
+     *
+     * Leaving this constant undefined will result in it being defined in Cake/bootstrap.php
+     */
+    define('CAKE_CORE_INCLUDE_PATH', ROOT . DS . APP_DIR . DS . 'Lib' . DS . 'cakephp' . DS . 'lib');
+}
 
 /**
  * Editing below this line should NOT be necessary.
  * Change at your own risk.
- *
  */
 if (!defined('WEBROOT_DIR')) {
 	define('WEBROOT_DIR', basename(dirname(__FILE__)));
@@ -83,7 +92,7 @@ if (!defined('CAKE_CORE_INCLUDE_PATH')) {
 	}
 }
 if (!empty($failed)) {
-	trigger_error("CakePHP core could not be found.  Check the value of CAKE_CORE_INCLUDE_PATH in APP/webroot/index.php.  It should point to the directory containing your " . DS . "cake core directory and your " . DS . "vendors root directory.", E_USER_ERROR);
+    trigger_error("CakePHP core could not be found. Check the value of CAKE_CORE_INCLUDE_PATH in APP/webroot/index.php. It should point to the directory containing your " . DS . "cake core directory and your " . DS . "vendors root directory.", E_USER_ERROR);
 }
 
 App::uses('Dispatcher', 'Routing');


### PR DESCRIPTION
#### What does it do?

This don't change how CakePHP is installed (it is still a git submodule), but it allows to install CakePHP by composer.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
