### PR TITLE
Stix to misp types path

### DIFF
--- a/app/files/scripts/stix2/stix2misp.py
+++ b/app/files/scripts/stix2/stix2misp.py
@@ -21,6 +21,7 @@ import json
 import os
 import time
 import io
+import pymisp
 import stix2
 import stix2misp_mapping
 from collections import defaultdict
@@ -28,9 +29,7 @@ from copy import deepcopy
 from pathlib import Path
 _misp_dir = Path(os.path.realpath(__file__)).parents[4]
 _misp_objects_path = _misp_dir / 'app' / 'files' / 'misp-objects' / 'objects'
-_pymisp_dir = _misp_dir / 'PyMISP'
-with open(_pymisp_dir / 'pymisp' / 'data' / 'describeTypes.json', 'r') as f:
-    _misp_types = json.loads(f.read())['result'].get('types')
+_misp_types = pymisp.AbstractMISP().describe_types.get('types')
 from pymisp import MISPEvent, MISPObject, MISPAttribute
 
 

--- a/app/files/scripts/stix2misp.py
+++ b/app/files/scripts/stix2misp.py
@@ -21,6 +21,7 @@ import os
 import time
 import uuid
 import base64
+import pymisp
 import stix2misp_mapping
 import stix.extensions.marking.ais
 from mixbox.namespaces import NamespaceNotFoundError
@@ -33,13 +34,12 @@ except ImportError:
     pass
 
 _MISP_dir = "/".join([p for p in os.path.dirname(os.path.realpath(__file__)).split('/')[:-3]])
-_PyMISP_dir = '{_MISP_dir}/PyMISP'.format(_MISP_dir=_MISP_dir)
 _MISP_objects_path = '{_MISP_dir}/app/files/misp-objects/objects'.format(_MISP_dir=_MISP_dir)
-sys.path.append(_PyMISP_dir)
+
 from pymisp.mispevent import MISPEvent, MISPObject, MISPAttribute
 
-with open("{_PyMISP_dir}/pymisp/data/describeTypes.json".format(_PyMISP_dir=_PyMISP_dir), 'r') as f:
-    categories = json.loads(f.read())['result'].get('categories')
+categories = pymisp.AbstractMISP().describe_types.get('categories')
+
 
 class StixParser():
     def __init__(self):


### PR DESCRIPTION
#### What does it do?

If PyMISP is not installed from Git modules, but from Python package, file `describeTypes.json` is not in expected location. This fix that and loads `describeTypes.json` directly from package.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
