### PR TITLE
chg: [API] Deprecate getPyMISPVersion

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -18,6 +18,7 @@ App::uses('RequestRearrangeTool', 'Tools');
  * @property CRUDComponent $CRUD
  * @property IndexFilterComponent $IndexFilter
  * @property RateLimitComponent $RateLimit
+ * @property CompressedRequestHandlerComponent $CompressedRequestHandler
  */
 class AppController extends Controller
 {

--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -1805,6 +1805,7 @@ class ServersController extends AppController
         $versionArray = $this->Server->checkMISPVersion();
         $response = [
             'version' => $versionArray['major'] . '.' . $versionArray['minor'] . '.' . $versionArray['hotfix'],
+            'pymisp_recommended_version' => $this->pyMispVersion,
             'perm_sync' => $this->userRole['perm_sync'],
             'perm_sighting' => $this->userRole['perm_sighting'],
             'perm_galaxy_editor' => $this->userRole['perm_galaxy_editor'],
@@ -1813,6 +1814,9 @@ class ServersController extends AppController
         return $this->RestResponse->viewData($response, $this->response->type());
     }
 
+    /**
+     * @deprecated Use field `pymisp_recommended_version` from getVersion instead
+     */
     public function getPyMISPVersion()
     {
         $this->set('response', array('version' => $this->pyMispVersion));


### PR DESCRIPTION
#### What does it do?

With this, we can speed up initializing PyMISP.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
