### PR TITLE
fix: Remove hardcoded background color

### DIFF
--- a/app/View/Elements/healthElements/diagnostics.ctp
+++ b/app/View/Elements/healthElements/diagnostics.ctp
@@ -8,7 +8,7 @@
 ?>
     <h3><?php echo __('MISP version');?></h3>
     <p><?php echo __('Every version of MISP includes a json file with the current version. This is checked against the latest tag on github, if there is a version mismatch the tool will warn you about it. Make sure that you update MISP regularly.');?></p>
-    <div style="background-color:#f7f7f9;width:100%;">
+    <div style="width:100%;">
         <span><?php echo __('Currently installed version…');?>
             <?php
                 $upToDate = isset($version['upToDate']) ? $version['upToDate'] : null;
@@ -64,7 +64,7 @@
     <h3><?php echo __('Submodules version');?>
         <it id="refreshSubmoduleStatus" class="fas fa-sync useCursorPointer" style="font-size: small; margin-left: 5px;" title="<?php echo __('Refresh submodules version.'); ?>"></it>
     </h3>
-    <div id="divSubmoduleVersions" style="background-color:#f7f7f9;"></div>
+    <div id="divSubmoduleVersions" ></div>
     <span id="updateAllJson" class="btn btn-inverse" title="<?php echo __('Load all JSON into the database.'); ?>">
         <it class="fas fa-file-upload"></it> <?php echo __("Load JSON into database"); ?>
     </span>


### PR DESCRIPTION
Section background from #f7f7f9 to #ffffff (almost no difference)
With a dark theme, it will prevent an hardcoded white background

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2020-05-05: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

If it fixes an existing issue, please use github syntax: `#<IssueID>`

#### Questions

- [NO ] Does it require a DB change?
- [ YES ] Are you using it in production?
- [ NO ] Does it require a change in the API (PyMISP for example)?
