### PR TITLE
fix: wrong attribute value hash computed

### DIFF
--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -365,9 +365,13 @@ class MispObject extends AppModel
                     $attribute['value'] = $attribute['value'] . '|' . md5(base64_decode($attribute['data']));
                 }
             }
+
+            $attributeValueAfterModification = $this->Attribute->modifyBeforeValidation($attribute['type'], $attribute['value']);
+            $attributeValueAfterModification = $this->Attribute->runRegexp($attribute['type'], $attributeValueAfterModification);
+
             $newObjectAttributes[] = hash(
                 'sha256',
-                $attribute['object_relation'] . $attribute['category'] . $attribute['type'] .  $this->Attribute->modifyBeforeValidation($attribute['type'], $attribute['value'])
+                $attribute['object_relation'] . $attribute['category'] . $attribute['type'] .  $attributeValueAfterModification
             );
         }
         $newObjectAttributeCount = count($newObjectAttributes);


### PR DESCRIPTION
#### What does it do?

The problem that this proposed PR solves is the following. When trying to add a duplicated object that contains in one of its attributes a text that will be modified by the method `Attribute->runRegexp`, the duplication is not detected. This happens because inside the method `MispObject->checkForDuplicateObjects` the hash of the attribute value that has to be inserted gets computed **before** performing the regular expression substitution, while the hash of the pre-existing attribute gets computed **after** this substitution. Therefore, the 2 hashes would never match. Specifically, this substitution happens later on during validation inside the file `app/Model/Attribute.php#591`.

As an example, if the attribute value contains the string `Os: Windows`, one of the default MISP regex will modify it as `O%WINDIR%`. When trying to insert this attribute twice the method `MispObject->checkForDuplicateObjects` will erroneously compare the `sha256("Os: Windows")` with the `sha256("O%WINDIR%")` and the duplicate won't be found. During the save process the attribute will then be modified in `O%WINDIR%` resulting in having 2 attribute with the same value.

The proposed solution performs the substitution on the attribute before computing the hash.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

Signed-off-by: Sebastiano Mariani <smariani@vmware.com>