### PR TITLE
Block org modification option for shibb auth.

### DIFF
--- a/app/Plugin/ShibbAuth/Controller/Component/Auth/ApacheShibbAuthenticate.php
+++ b/app/Plugin/ShibbAuth/Controller/Component/Auth/ApacheShibbAuthenticate.php
@@ -41,6 +41,7 @@ class ApacheShibbAuthenticate extends BaseAuthenticate
      *      'DefaultOrg' => 'MY_ORG',
      *      'DefaultRole' => false                   // set to a specific value if you wish to hard-set users created via ApacheShibbAuth
      *      'BlockRoleModifications' => false        // set to true if you wish for the roles never to be updated during login. Especially *                                               // useful if you manually change roles in MISP
+     *      'BlockOrgModifications' => false        // set to true if you wish for the organizations never to be updated during login. Especially *                                        // useful if you manually change orgs in MISP
      * ),
      * @param CakeRequest $request The request that contains login information.
      * @param CakeResponse $response Unused response object.
@@ -75,6 +76,7 @@ class ApacheShibbAuthenticate extends BaseAuthenticate
         $groupTag = Configure::read('ApacheShibbAuth.GroupTag');
         $groupRoleMatching = Configure::read('ApacheShibbAuth.GroupRoleMatching');
         $blockRoleModifications = Configure::check('ApacheShibbAuth.BlockRoleModifications') ? Configure::read('ApacheShibbAuth.BlockRoleModifications') : false;
+        $blockOrgModifications = Configure::check('ApacheShibbAuth.BlockOrgModifications') ? Configure::read('ApacheShibbAuth.BlockOrgModifications') : false;
 
         // Get user values
         if (!isset($_SERVER[$mailTag])) {
@@ -126,7 +128,9 @@ class ApacheShibbAuthenticate extends BaseAuthenticate
             if (!$blockRoleModifications) {
                 $user = $this->updateUserRole($roleChanged, $user, $roleId, $userModel);
             }
-            $user = $this->updateUserOrg($org, $user, $userModel);
+            if (!$blockOrgModifications) {
+                $user = $this->updateUserOrg($org, $user, $userModel);
+            }
             $userModel->extralog($user, 'login');
             return $user;
         }


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2020-05-05: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

Added `BlockOrgModifications` option for Shibboleth auth plugin. Analogical to already existing `BlockRoleModifications`.


#### Questions

- [ ] Does it require a DB change? 
- [x] Are you using it in production? 
- [ ] Does it require a change in the API (PyMISP for example)?
