### PR TITLE
chg: [shibbauth] added option to block organisation changes at login

### DIFF
--- a/app/Plugin/ShibbAuth/Controller/Component/Auth/ApacheShibbAuthenticate.php
+++ b/app/Plugin/ShibbAuth/Controller/Component/Auth/ApacheShibbAuthenticate.php
@@ -39,6 +39,7 @@ class ApacheShibbAuthenticate extends BaseAuthenticate
      *          'group_one' => 1,
      *       ),
      *      'DefaultOrg' => 'MY_ORG',
+     *      'BlockOrgModifications' => false         // set to true if you wish for the user's organisation never to be updated during login. Especially useful if you manually change organisations in MISP
      *      'DefaultRole' => false                   // set to a specific value if you wish to hard-set users created via ApacheShibbAuth
      *      'BlockRoleModifications' => false        // set to true if you wish for the roles never to be updated during login. Especially *                                               // useful if you manually change roles in MISP
      * ),
@@ -69,6 +70,7 @@ class ApacheShibbAuthenticate extends BaseAuthenticate
         $roleId = -1;
         $org = Configure::read('ApacheShibbAuth.DefaultOrg');
         $useDefaultOrg = Configure::read('ApacheShibbAuth.UseDefaultOrg');
+        $blockOrgModifications = Configure::check('ApacheShibbAuth.BlockOrgModifications') ? Configure::read('ApacheShibbAuth.BlockOrgModifications') : false;
         // Get tags from SSO config
         $mailTag = Configure::read('ApacheShibbAuth.MailTag');
         $orgTag = Configure::read('ApacheShibbAuth.OrgTag');
@@ -126,7 +128,9 @@ class ApacheShibbAuthenticate extends BaseAuthenticate
             if (!$blockRoleModifications) {
                 $user = $this->updateUserRole($roleChanged, $user, $roleId, $userModel);
             }
-            $user = $this->updateUserOrg($org, $user, $userModel);
+            if (!$blockOrgModifications) {
+                $user = $this->updateUserOrg($org, $user, $userModel);
+            }
             $userModel->extralog($user, 'login');
             return $user;
         }


### PR DESCRIPTION
#### What does it do?

New ApacheShibbAuth.BlockOrgModifications setting added, defaults to false, boolean. If set to true, will block updates to the organisation of existing users on authentication. This preserves any modifications made by a site admin in MISP and is similar to ApacheShibbauth.BlockRoleModifications (same logic applied to role modifications).

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
