### PR TITLE
quick fix sticky buffers

### DIFF
--- a/app/Lib/Export/NidsSuricataExport.php
+++ b/app/Lib/Export/NidsSuricataExport.php
@@ -35,7 +35,7 @@ class NidsSuricataExport extends NidsExport
         $sid++;
         // also do http requests
         // warning: only suricata compatible
-        $content = 'flow:to_server,established; content: "Host|3a| ' . $attribute['value'] . '"; fast_pattern; nocase; http.header; pcre: "/(^|[^A-Za-z0-9-\.])' . preg_quote($attribute['value']) . '[^A-Za-z0-9-\.]/Hi";';
+        $content = 'flow:to_server,established; http.header; content: "Host|3a| ' . $attribute['value'] . '"; fast_pattern; nocase; pcre: "/(^|[^A-Za-z0-9-\.])' . preg_quote($attribute['value']) . '[^A-Za-z0-9-\.]/Hi";';
         $this->rules[] = sprintf(
             $ruleFormat,
                 ($overruled) ? '#OVERRULED BY WHITELIST# ' : '',
@@ -76,7 +76,7 @@ class NidsSuricataExport extends NidsExport
         $sid++;
         // also do http requests,
         // warning: only suricata compatible
-        $content = 'flow:to_server,established; content: "Host|3a|"; nocase; http.header; content:"' . $attribute['value'] . '"; fast_pattern; nocase; http.header; pcre: "/(^|[^A-Za-z0-9-])' . preg_quote($attribute['value']) . '[^A-Za-z0-9-\.]/Hi";';
+        $content = 'flow:to_server,established; http.header; content: "Host|3a|"; nocase; http.header; content:"' . $attribute['value'] . '"; fast_pattern; nocase; pcre: "/(^|[^A-Za-z0-9-])' . preg_quote($attribute['value']) . '[^A-Za-z0-9-\.]/Hi";';
         $this->rules[] = sprintf(
             $ruleFormat,
                 ($overruled) ? '#OVERRULED BY WHITELIST# ' : '',
@@ -121,9 +121,9 @@ class NidsSuricataExport extends NidsExport
                 $tag = 'tag:session,600,seconds;';
                 if (!array_key_exists('path', $data)) {
                     $data['path'] = NidsExport::replaceIllegalChars($data['host']);
-                    $content = 'flow:to_server,established; content:"' . $data['host'] . '"; nocase; http.header;';
+                    $content = 'flow:to_server,established; http.header; content:"' . $data['host'] . '"; nocase;';
                 } else {
-                    $content = 'flow:to_server,established; content:"' . $data['host'] . '"; fast_pattern; nocase; http.header; content:"' . $data['path'] . '"; nocase; http.uri;';
+                    $content = 'flow:to_server,established; http.header; content:"' . $data['host'] . '"; fast_pattern; nocase; http.uri; content:"' . $data['path'] . '"; nocase;';
                 }
                 break;
 
@@ -182,7 +182,7 @@ class NidsSuricataExport extends NidsExport
                 $suricata_dst_port = 'any';
 
                 $url = NidsExport::replaceIllegalChars($attribute['value']);  // substitute chars not allowed in rule
-                $content = 'flow:to_server,established; content:"' . $url . '"; fast_pattern; nocase; http.uri;';
+                $content = 'flow:to_server,established; http.uri; content:"' . $url . '"; fast_pattern; nocase;';
                 $tag = 'tag:session,600,seconds;';
 
                 break;


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2020-05-05: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

According to documentation (https://suricata.readthedocs.io/en/suricata-6.0.3/rules/http-keywords.html#http-keywords) sticky buffers should be before content, http.header and http.uri isn't marked as sticky buffers, but rules are wrongly generated and reported to logs. Tested on stable Suricata v6.0.1+

#### Questions

- [ ] Does it require a DB change?
- [ x ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
