### PR TITLE
chg: [sync] Remove commit and MISP-version from HTTP header

### DIFF
--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -2748,13 +2748,9 @@ class AppModel extends Model
                 'Authorization' => $server[$model]['authkey'],
                 'Accept' => 'application/json',
                 'Content-Type' => 'application/json',
-                'MISP-version' => $version,
                 'User-Agent' => 'MISP ' . $version . (empty($commit) ? '' : ' - #' . $commit),
             )
         );
-        if ($commit) {
-            $request['header']['commit'] = $commit;
-        }
         return $request;
     }
 


### PR DESCRIPTION
#### What does it do?

Commit and MISP version is also part of User-Agent, to it doesn't make sense to have that information in three separate headers. Also `commit` and `MISP-version` headers is not allowed in HTTP protocol.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
