### PR TITLE
Org name unique

### DIFF
--- a/INSTALL/MYSQL.sql
+++ b/INSTALL/MYSQL.sql
@@ -788,7 +788,7 @@ CREATE TABLE IF NOT EXISTS `organisations` (
   `landingpage` text CHARACTER SET utf8 COLLATE utf8_unicode_ci,
   PRIMARY KEY (`id`),
   UNIQUE INDEX `uuid` (`uuid`),
-  INDEX `name` (`name`(255))
+  UNIQUE INDEX `name` (`name`(255))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
 CREATE TABLE IF NOT EXISTS `org_blocklists` (

--- a/db_schema.json
+++ b/db_schema.json
@@ -8027,7 +8027,7 @@
         "organisations": {
             "id": true,
             "uuid": true,
-            "name": false
+            "name": true
         },
         "org_blocklists": {
             "id": true,


### PR DESCRIPTION
#### What does it do?

Mark org name as unique index for new MISP instances.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
