### PR TITLE
fix: [ACL] queryAvailableSyncFilteringRules is required just for site admins

### DIFF
--- a/app/Controller/Component/ACLComponent.php
+++ b/app/Controller/Component/ACLComponent.php
@@ -533,7 +533,7 @@ class ACLComponent extends Component
                     'pull' => array(),
                     'purgeSessions' => array(),
                     'push' => array(),
-                    'queryAvailableSyncFilteringRules' => array('*'),
+                    'queryAvailableSyncFilteringRules' => array(),
                     'releaseUpdateLock' => array(),
                     'resetRemoteAuthKey' => array(),
                     'removeOrphanedCorrelations' => array('perm_site_admin'),


### PR DESCRIPTION
#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
