### PR TITLE
new: [security] Disable browser autocomplete for authkeys field

### DIFF
--- a/app/View/Cerebrates/add.ctp
+++ b/app/View/Cerebrates/add.ctp
@@ -12,7 +12,8 @@ $fields = [
     ],
     [
         'field' => 'authkey',
-        'class' => 'span6'
+        'class' => 'span6',
+        'autocomplete' => 'off',
     ],
     [
         'field' => 'org_id',

--- a/app/View/Elements/genericElements/Form/fieldScaffold.ctp
+++ b/app/View/Elements/genericElements/Form/fieldScaffold.ctp
@@ -47,7 +47,7 @@
         }
         //$params['class'] = sprintf('form-control %s', $params['class']);
         foreach ($fieldData as $k => $fd) {
-            if (!isset($simpleFieldAllowlist) || in_array($k, $simpleFieldAllowlist) || strpos($k, 'data-') === 0) {
+            if (!isset($simpleFieldAllowlist) || in_array($k, $simpleFieldAllowlist, true) || strpos($k, 'data-') === 0) {
                 $params[$k] = $fd;
             }
         }

--- a/app/View/Elements/genericElements/Form/genericForm.ctp
+++ b/app/View/Elements/genericElements/Form/genericForm.ctp
@@ -32,7 +32,8 @@ $simpleFieldAllowedlist = array(
     'selected',
     'legend',
     'disabled',
-    'description'
+    'description',
+    'autocomplete',
 );
 $fieldsArrayForPersistence = array();
 $formOptions = isset($formOptions) ? $formOptions : array();

--- a/app/View/Servers/edit.ctp
+++ b/app/View/Servers/edit.ctp
@@ -79,7 +79,10 @@
         echo sprintf(
             '<div id="AuthkeyContainer"><p class="red clear" style="width:50%%;">%s</p>%s</div>',
             __('Ask the owner of the remote instance for a sync account on their instance, log into their MISP using the sync user\'s credentials and retrieve your API key by navigating to Global actions -> My profile. This key is used to authenticate with the remote instance.'),
-            $this->Form->input('authkey', array('placeholder' => __('Leave empty to use current key')))
+            $this->Form->input('authkey', [
+                'placeholder' => __('Leave empty to use current key'),
+                'autocomplete' => 'off',
+            ])
         );
         echo '<div class = "input clear" style="width:100%;"><hr /></div>';
         echo '<h4 class="input clear">' . __('Enabled synchronisation methods') . '</h4>';


### PR DESCRIPTION
#### What does it do?

This will tell browsers to not store autkeys in autofill cache.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
