### PR TITLE
chg: [security] Mitigate timing attacks

### DIFF
--- a/app/Lib/Tools/BlowfishPasswordHasherConstant.php
+++ b/app/Lib/Tools/BlowfishPasswordHasherConstant.php
@@ -1,0 +1,12 @@
+<?php
+class BlowfishPasswordHasherConstant extends BlowfishPasswordHasher
+{
+    /**
+     * @param string $password
+     * @param string $hashedPassword
+     * @return bool
+     */
+    public function check($password, $hashedPassword) {
+        return hash_equals($hashedPassword, Security::hash($password, 'blowfish', $hashedPassword));
+    }
+}

--- a/app/Model/AuthKey.php
+++ b/app/Model/AuthKey.php
@@ -2,6 +2,7 @@
 App::uses('AppModel', 'Model');
 App::uses('RandomTool', 'Tools');
 App::uses('CidrTool', 'Tools');
+App::uses('BlowfishPasswordHasherConstant', 'Tools');
 
 /**
  * @property User $User
@@ -331,6 +332,6 @@ class AuthKey extends AppModel
      */
     private function getHasher()
     {
-        return new BlowfishPasswordHasher();
+        return new BlowfishPasswordHasherConstant();
     }
 }

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -4,6 +4,7 @@ App::uses('AuthComponent', 'Controller/Component');
 App::uses('RandomTool', 'Tools');
 App::uses('GpgTool', 'Tools');
 App::uses('SendEmail', 'Tools');
+App::uses('BlowfishPasswordHasherConstant', 'Tools');
 
 /**
  * @property Log $Log
@@ -1007,7 +1008,7 @@ class User extends AppModel
             App::uses('SimplePasswordHasher', 'Controller/Component/Auth');
             $passwordHasher = new SimplePasswordHasher();
         } else {
-            $passwordHasher = new BlowfishPasswordHasher();
+            $passwordHasher = new BlowfishPasswordHasherConstant();
         }
         $hashed = $passwordHasher->check($password, $currentUser['User']['password']);
         return $hashed;


### PR DESCRIPTION
#### What does it do?

Use PHP [hash_equals](https://www.php.net/manual/en/function.hash-equals.php), that should mitigate timing attacks.

Can be reverted after https://github.com/cakephp/cakephp/pull/15756 is merged and new CakePHP is released.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
