### PR TITLE
new: [cerebrate:pull_sg] Pull sharing groups from a cerebrate instance

### DIFF
--- a/app/Controller/Component/ACLComponent.php
+++ b/app/Controller/Component/ACLComponent.php
@@ -81,10 +81,13 @@ class ACLComponent extends Component
                 'add' => [],
                 'delete' => [],
                 'download_org' => [],
+                'download_sg' => [],
                 'edit' => [],
                 'index' => [],
                 'preview_orgs' => [],
+                'preview_sharing_groups' => [],
                 'pull_orgs' => [],
+                'pull_sgs' => [],
                 'view' => []
             ],
             'correlationExclusions' => [

--- a/app/Model/Cerebrate.php
+++ b/app/Model/Cerebrate.php
@@ -109,6 +109,32 @@ class Cerebrate extends AppModel
         return $outcome;
     }
 
+    public function saveRemoteSgs($sgs, $user)
+    {
+        $outcome = [
+            'add' => 0,
+            'edit' => 0,
+            'fails' => 0
+        ];
+        foreach ($sgs as $sg) {
+            $isEdit = false;
+            $noChange = false;
+            $result = $this->captureSg($sg, $user, $isEdit, $noChange);
+            if (!is_array($result)) {
+                $outcome['fails'] += 1;
+            } else {
+                if ($isEdit) {
+                    if (!$noChange) {
+                        $outcome['edit'] += 1;
+                    }
+                } else {
+                    $outcome['add'] += 1;
+                }
+            }
+        }
+        return $outcome;
+    }
+
     public function captureOrg($org_data, &$edit=false, &$noChange=false) {
         $org = $this->convertOrg($org_data);
         if ($org) {
@@ -226,6 +252,165 @@ class Cerebrate extends AppModel
         }
         return false;
     }
-}
 
-?>
+    private function __compareMembers($existingMembers, $remoteMembers)
+    {
+        $memberFound = [];
+        $memberNotFound = [];
+        foreach ($remoteMembers as $remoteMember) {
+            $found = false;
+            foreach ($existingMembers as $existingMember) {
+                if ($existingMember['uuid'] == $remoteMember['uuid']) {
+                    $found = true;
+                    $memberFound[] = $remoteMember['uuid'];
+                    break;
+                }
+            }
+            if (!$found) {
+                $memberNotFound[] = $remoteMember['uuid'];
+            }
+        }
+        return empty($memberNotFound);
+    }
+
+    /*
+     *  Checks remote for the current status of each sharing groups
+     *  Adds the exists_locally field with a boolean status
+     *  If exists_loally is true, adds a list with the differences (keynames)
+     */
+    public function checkRemoteSharingGroups($sgs)
+    {
+        $this->SharingGroup = ClassRegistry::init('SharingGroup');
+        $uuids = Hash::extract($sgs, '{n}.uuid');
+        $existingSgs = $this->SharingGroup->find('all', [
+            'recursive' => -1,
+            'contain' => [
+                'SharingGroupOrg' => ['Organisation'],
+                'Organisation',
+            ],
+            'conditions' => [
+                'SharingGroup.uuid' => $uuids
+            ],
+        ]);
+        $rearranged = [];
+        foreach ($existingSgs as $existingSg) {
+            $existingSg['SharingGroup']['SharingGroupOrg'] = $existingSg['SharingGroupOrg'];
+            $existingSg['SharingGroup']['Organisation'] = $existingSg['Organisation'];
+            $rearranged[$existingSg['SharingGroup']['uuid']] = $existingSg['SharingGroup'];
+        }
+        unset($existingSgs);
+        $fieldsToCheck = ['name', 'releasability', 'description'];
+        foreach ($sgs as $k => $sg) {
+            $sgs[$k]['exists_locally'] = false;
+            if (isset($rearranged[$sg['uuid']])) {
+                $sgs[$k]['exists_locally'] = true;
+                $sgs[$k]['differences'] = $this->compareSgs($rearranged[$sg['uuid']], $sgs[$k]);
+            }
+        }
+        return $sgs;
+    }
+
+    private function compareSgs($existingSg, $remoteSg)
+    {
+        $differences = [];
+        $fieldsToCheck = ['name', 'releasability', 'description'];
+
+        foreach ($fieldsToCheck as $fieldToCheck) {
+            if (
+                !(empty($remoteSg[$fieldToCheck]) && empty($existingSg[$fieldToCheck])) &&
+                $remoteSg[$fieldToCheck] !== $existingSg[$fieldToCheck]
+            ) {
+                if ($fieldToCheck === 'name') {
+                    if ($this->__compareNames($existingSg[$fieldToCheck], $remoteSg[$fieldToCheck])) {
+                        continue;
+                    }
+                }
+                $differences[] = $fieldToCheck;
+            }
+        }
+        if (!$this->__compareMembers(Hash::extract($existingSg['SharingGroupOrg'], '{n}.Organisation'), $remoteSg['sharing_group_orgs'])) {
+            $differences[] = 'members';
+        }
+        return $differences;
+    }
+
+    private function convertSg($sg_data)
+    {
+        $mapping = [
+            'name' => [
+                'field' => 'name',
+                'required' => 1
+            ],
+            'uuid' => [
+                'field' => 'uuid',
+                'required' => 1
+            ],
+            'releasability' => [
+                'field' => 'releasability'
+            ],
+            'description' => [
+                'field' => 'description'
+            ],
+        ];
+        $sg = [];
+        foreach ($mapping as $cerebrate_field => $field_data) {
+            if (empty($sg_data[$cerebrate_field])) {
+                if (!empty($field_data['required'])) {
+                    return false;
+                } else {
+                    continue;
+                }
+            }
+            $sg[$field_data['field']] = $sg_data[$cerebrate_field];
+        }
+        $sg['SharingGroupOrg'] = [];
+        if (!empty($sg_data['sharing_group_orgs'])) {
+            $sg['SharingGroupOrg'] = $sg_data['sharing_group_orgs'];
+            foreach ($sg['SharingGroupOrg'] as $k => $org) {
+                if (isset($org['_joinData'])) {
+                    unset($sg['SharingGroupOrg'][$k]['_joinData']);
+                }
+                if (!isset($org['extend'])) {
+                    $sg['SharingGroupOrg'][$k]['extend'] = false;
+                }
+            }
+        }
+        return $sg;
+    }
+
+    public function captureSg($sg_data, $user, &$edit=false, &$noChange=false) {
+        $this->SharingGroup = ClassRegistry::init('SharingGroup');
+        $sg = $this->convertSg($sg_data);
+        if ($sg) {
+            $existingSg = $this->SharingGroup->find('first', [
+                'recursive' => -1,
+                'contain' => [
+                    'SharingGroupOrg' => ['Organisation'],
+                    'Organisation',
+                ],
+                'conditions' => [
+                    'SharingGroup.uuid' => $sg_data['uuid']
+                ],
+            ]);
+            if (!empty($existingSg)) {
+                $edit = true;
+            }
+            $captureResult = $this->SharingGroup->captureSG($sg, $user, false);
+            if (!empty($captureResult)) {
+                $savedSg = $this->SharingGroup->find('first', [
+                    'recursive' => -1,
+                    'contain' => [
+                        'SharingGroupOrg' => ['Organisation'],
+                        'Organisation',
+                    ],
+                    'conditions' => [
+                        'SharingGroup.id' => $captureResult
+                    ],
+                ]);
+                return $savedSg;
+            }
+            return __('The organisation could not be saved.');
+        }
+        return __('The retrieved data isn\'t a valid sharing group.');
+    }
+}

--- a/app/View/Cerebrates/index.ctp
+++ b/app/View/Cerebrates/index.ctp
@@ -93,6 +93,15 @@
                         'icon' => 'arrow-circle-down'
                     ],
                     [
+                        'onclick' => sprintf(
+                            'openGenericModal(\'%s/cerebrates/pull_sgs/[onclick_params_data_path]\');',
+                            $baseurl
+                        ),
+                        'onclick_params_data_path' => 'Cerebrate.id',
+                        'title' => __('Pull all sharing groups'),
+                        'icon' => 'arrow-circle-down'
+                    ],
+                    [
                         'url' => $baseurl . '/cerebrates/edit',
                         'url_params_data_paths' => ['Cerebrate.id'],
                         'icon' => 'edit'

--- a/app/View/Cerebrates/preview_sharing_groups.ctp
+++ b/app/View/Cerebrates/preview_sharing_groups.ctp
@@ -1,0 +1,90 @@
+<?php
+    $fields = [
+        [
+            'name' => __('Id'),
+            'sort' => 'id',
+            'data_path' => 'id'
+        ],
+        [
+            'name' => __('Status'),
+            'sort' => 'exists_locally',
+            'element' => 'remote_status',
+            'data_path' => ''
+        ],
+        [
+            'name' => __('UUID'),
+            'sort' => 'uuid',
+            'data_path' => 'uuid'
+        ],
+        [
+            'name' => __('Name'),
+            'sort' => 'name',
+            'data_path' => 'name'
+        ],
+        [
+            'name' => __('Releasability'),
+            'sort' => 'releasability',
+            'data_path' => 'releasability'
+        ],
+        [
+            'name' => __('Description'),
+            'sort' => 'description',
+            'data_path' => 'description'
+        ],
+        [
+            'name' => __('# Member'),
+            'element' => 'custom',
+            'function' => function($row) {
+                return count($row['sharing_group_orgs']);
+            }
+        ],
+    ];
+
+    echo $this->element('genericElements/IndexTable/scaffold', [
+        'scaffold_data' => [
+            'data' => [
+                'data' => $data,
+                'top_bar' => [
+                    'pull' => 'right',
+                    'children' => [
+                        [
+                            'type' => 'search',
+                            'button' => __('Filter'),
+                            'placeholder' => __('Enter value to search'),
+                            'data' => '',
+                            'preserve_url_params' => [$cerebrate['Cerebrate']['id']],
+                            'searchKey' => 'quickFilter'
+                        ]
+                    ]
+                ],
+                'fields' => $fields,
+                'title' => empty($ajax) ? __(
+                        'Sharing group list via Cerebrate %s (%s)',
+                        h($cerebrate['Cerebrate']['id']),
+                        h($cerebrate['Cerebrate']['name'])
+                    ) : false,
+                'description' => empty($ajax) ? __('Preview of the sharing group known to the remote Cerebrate instance.') : false,
+                'actions' => [
+                    [
+                        'onclick' => sprintf(
+                            'openGenericModal(\'%s/cerebrates/download_sg/%s/[onclick_params_data_path]\');',
+                            $baseurl,
+                            h($cerebrate['Cerebrate']['id'])
+                        ),
+                        'onclick_params_data_path' => 'id',
+                        'icon' => 'download',
+                        'title' => __('Fetch sharing group object')
+                    ]
+                ],
+                'paginatorOptions' => [
+                    'url' => [$cerebrate['Cerebrate']['id']]
+                ],
+                'persistUrlParams' => [0, 'quickFilter']
+            ],
+            'containerId' => 'preview_sgs_container'
+        ]
+    ]);
+?>
+<script type="text/javascript">
+    var passedArgsArray = <?= json_encode([h($cerebrate['Cerebrate']['id'])]) ?>;
+</script>

--- a/app/View/Cerebrates/view.ctp
+++ b/app/View/Cerebrates/view.ctp
@@ -56,7 +56,13 @@ echo $this->element(
                 'url_params' => ['Cerebrate.id'],
                 'title' => __('Organisations'),
                 'elementId' => 'preview_orgs_container'
-            ]
+            ],
+            [
+                'url' => '/cerebrates/preview_sharing_groups/{{0}}/',
+                'url_params' => ['Cerebrate.id'],
+                'title' => __('Sharing Groups'),
+                'elementId' => 'preview_sgs_container'
+            ],
         ]
     ]
 );


### PR DESCRIPTION
### Allow to pull sharing groups from a cerebrate instance.
As cerebrate does not support the organisation's `extend` flag. It's defaulted to `false` when pulling.download