### PR TITLE
chg: [internal] Remove AdminSetting from AuditLog

### DIFF
--- a/app/Controller/AuditLogsController.php
+++ b/app/Controller/AuditLogsController.php
@@ -497,7 +497,7 @@ class AuditLogsController extends AppController
             'Galaxy' => 'galaxies',
             'Organisation' => 'organisation',
             'Warninglist' => 'warninglists',
-            'User' => 'admin/user',
+            'User' => 'admin/users',
             'Role' => 'roles',
             'EventReport' => 'eventReports',
             'SharingGroup' => 'sharing_groups',

--- a/app/Controller/AuditLogsController.php
+++ b/app/Controller/AuditLogsController.php
@@ -17,7 +17,6 @@ class AuditLogsController extends AppController
 
     /** @var string[] */
     private $models = [
-        'AdminSetting',
         'Attribute',
         'Allowedlist',
         'AuthKey',

--- a/app/Model/AdminSetting.php
+++ b/app/Model/AdminSetting.php
@@ -6,7 +6,6 @@ class AdminSetting extends AppModel
     public $useTable = 'admin_settings';
 
     public $actsAs = array(
-        'AuditLog',
         'SysLogLogable.SysLogLogable' => array(
             'userModel' => 'User',
             'userKey' => 'user_id',


### PR DESCRIPTION
#### What does it do?

No need to log something that is not user editable.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
