### PR TITLE
new: [internal] Store if MISP is live in Redis

### DIFF
--- a/INSTALL/MYSQL.sql
+++ b/INSTALL/MYSQL.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS `admin_settings` (
   `setting` varchar(255) COLLATE utf8_bin NOT NULL,
   `value` text COLLATE utf8_bin NOT NULL,
   PRIMARY KEY (`id`),
-  INDEX `setting` (`setting`)
+  UNIQUE INDEX `setting` (`setting`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `allowedlist` (

--- a/app/Console/Command/AdminShell.php
+++ b/app/Console/Command/AdminShell.php
@@ -642,11 +642,8 @@ class AdminShell extends AppShell
     public function dumpCurrentDatabaseSchema()
     {
         $dbActualSchema = $this->Server->getActualDBSchema();
-        $dbVersion = $this->AdminSetting->find('first', array(
-            'conditions' => array('setting' => 'db_version')
-        ));
+        $dbVersion = $this->AdminSetting->getSetting('db_version');
         if (!empty($dbVersion) && !empty($dbActualSchema['schema'])) {
-            $dbVersion = $dbVersion['AdminSetting']['value'];
             $data = array(
                 'schema' => $dbActualSchema['schema'],
                 'indexes' => $dbActualSchema['indexes'],

--- a/app/Console/Command/AdminShell.php
+++ b/app/Console/Command/AdminShell.php
@@ -3,6 +3,8 @@ App::uses('AppShell', 'Console/Command');
 
 /**
  * @property Server $Server
+ * @property User $User
+ * @property AdminSetting $AdminSetting
  */
 class AdminShell extends AppShell
 {
@@ -371,7 +373,6 @@ class AdminShell extends AppShell
 
     public function setSetting()
     {
-        $this->ConfigLoad->execute();
         $setting_name = !isset($this->args[0]) ? null : $this->args[0];
         $value = !isset($this->args[1]) ? null : $this->args[1];
         if ($value === 'false') {
@@ -434,7 +435,9 @@ class AdminShell extends AppShell
 
     public function getAuthkey()
     {
-        $this->ConfigLoad->execute();
+        if (Configure::read("Security.advanced_authkeys")) {
+            $this->error('Advanced autkeys enabled, it is not possible to get user authkey.');
+        }
         if (empty($this->args[0])) {
             echo 'Invalid parameters. Usage: ' . APP . 'Console/cake Admin getAuthkey [user_email]' . PHP_EOL;
         } else {
@@ -464,7 +467,6 @@ class AdminShell extends AppShell
 
     public function clearBruteforce()
     {
-        $this->ConfigLoad->execute();
         $conditions = array('Bruteforce.username !=' => '');
         if (!empty($this->args[0])) {
             $conditions = array('Bruteforce.username' => $this->args[0]);
@@ -511,7 +513,7 @@ class AdminShell extends AppShell
     }
 
     /**
-     * @deprecated Use UserShell instead
+     * @deprecated Use UserShell::change_authkey instead
      */
     public function change_authkey()
     {
@@ -639,7 +641,6 @@ class AdminShell extends AppShell
 
     public function dumpCurrentDatabaseSchema()
     {
-        $this->ConfigLoad->execute();
         $dbActualSchema = $this->Server->getActualDBSchema();
         $dbVersion = $this->AdminSetting->find('first', array(
             'conditions' => array('setting' => 'db_version')
@@ -688,6 +689,9 @@ class AdminShell extends AppShell
         );
     }
 
+    /**
+     * @deprecated Use UserShell instead
+     */
     public function IPUser()
     {
         $this->ConfigLoad->execute();
@@ -755,7 +759,6 @@ class AdminShell extends AppShell
 
     public function updateToAdvancedAuthKeys()
     {
-        $this->loadModel('User');
         $updated = $this->User->updateToAdvancedAuthKeys();
         $message = __('The upgrade process is complete, %s authkey(s) generated.', $updated);
         $this->out($message);

--- a/app/Console/Command/LiveShell.php
+++ b/app/Console/Command/LiveShell.php
@@ -1,8 +1,9 @@
 <?php
-/*
+/**
  * Enable/disable misp
  *
  * arg0 = [0|1]
+ * @deprecated Use AdminShell::live instead
  */
 class LiveShell extends AppShell {
 

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -1383,7 +1383,7 @@ class AppController extends Controller
     }
 
     /**
-     * @return bool True if MISP instance is livve
+     * @return bool True if MISP instance is live
      */
     protected function _isLive()
     {

--- a/app/Model/AdminSetting.php
+++ b/app/Model/AdminSetting.php
@@ -31,11 +31,11 @@ class AdminSetting extends AppModel
         }
     }
 
-
     public function getSetting($setting)
     {
         $setting_object = $this->find('first', array(
-                'conditions' => array('setting' => $setting)
+            'conditions' => array('setting' => $setting),
+            'fields' => ['value'],
         ));
         if (!empty($setting_object)) {
             return $setting_object['AdminSetting']['value'];
@@ -44,20 +44,20 @@ class AdminSetting extends AppModel
         }
     }
 
-
-
     public function updatesDone($blocking = false)
     {
         if ($blocking) {
-            $continue = false;
-            while ($continue == false) {
-                $db_version = $this->find('first', array('conditions' => array('setting' => 'db_version')));
-                $continue = empty($this->findUpgrades($db_version['AdminSetting']['value']));
+            while (true) {
+                $db_version = $this->getSetting('db_version');
+                $continue = empty($this->findUpgrades($db_version));
+                if (!$continue) {
+                    return true;
+                }
+                usleep(200000);
             }
-            return true;
         } else {
-            $db_version = $this->find('first', array('conditions' => array('setting' => 'db_version')));
-            return empty($this->findUpgrades($db_version['AdminSetting']['value']));
+            $db_version = $this->getSetting('db_version');
+            return empty($this->findUpgrades($db_version));
         }
     }
 }

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -3532,15 +3532,14 @@ class Event extends AppModel
 
     public function checkEventBlockRules($event)
     {
-        $this->AdminSetting = ClassRegistry::init('AdminSetting');
-        $setting = $this->AdminSetting->find('first', [
-            'conditions' => ['setting' => 'eventBlockRule'],
-            'recursive' => -1
-        ]);
-        if (empty($setting) || empty($setting['AdminSetting']['value'])) {
+        if (!isset($this->AdminSetting)) {
+            $this->AdminSetting = ClassRegistry::init('AdminSetting');
+        }
+        $setting = $this->AdminSetting->getSetting('eventBlockRule');
+        if (empty($setting)) {
             return true;
         }
-        $rules = json_decode($setting['AdminSetting']['value'], true);
+        $rules = json_decode($setting, true);
         if (empty($rules)) {
             return true;
         }

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -2806,9 +2806,7 @@ class Server extends AppModel
     public function dbSchemaDiagnostic()
     {
         $this->AdminSetting = ClassRegistry::init('AdminSetting');
-        $actualDbVersion = $this->AdminSetting->find('first', array(
-            'conditions' => array('setting' => 'db_version')
-        ))['AdminSetting']['value'];
+        $actualDbVersion = $this->AdminSetting->getSetting('db_version');
         $dataSource = $this->getDataSource()->config['datasource'];
         $schemaDiagnostic = array(
             'dataSource' => $dataSource,

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -2292,6 +2292,10 @@ class Server extends AppModel
      */
     public function serverSettingsSaveValue($setting, $value)
     {
+        if (!is_writable(APP . 'Config' . DS . 'config.php')) {
+            return false;
+        }
+
         // validate if current config.php is intact:
         $current = file_get_contents(APP . 'Config' . DS . 'config.php');
         $current = trim($current);

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -231,12 +231,8 @@ class User extends AppModel
     {
         parent::__construct($id, $table, $ds);
         $this->AdminSetting = ClassRegistry::init('AdminSetting');
-        $db_version = $this->AdminSetting->find('first', [
-            'recursive' => -1,
-            'conditions' => ['setting' => 'db_version'],
-            'fields' => ['value']
-        ]);
-        if ($db_version['AdminSetting']['value'] >= 62) {
+        $db_version = $this->AdminSetting->getSetting('db_version');
+        if ($db_version >= 62) {
             $this->bindModel([
                 'hasMany' => ['AuthKey']
             ], false);

--- a/db_schema.json
+++ b/db_schema.json
@@ -7739,7 +7739,7 @@
     "indexes": {
         "admin_settings": {
             "id": true,
-            "setting": false
+            "setting": true
         },
         "allowedlist": {
             "id": true


### PR DESCRIPTION
#### What does it do?

This is useful if organisation has multiple MISP frontend or immutable filesystem. Fixes #5543

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
