### PR TITLE
new: [internal] Store MISP live status also in Redis

### DIFF
--- a/app/Console/Command/AppShell.php
+++ b/app/Console/Command/AppShell.php
@@ -50,4 +50,23 @@ class AppShell extends Shell
     {
         return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
     }
+
+    /**
+     * @param mixed $value
+     * @return bool
+     */
+    protected function toBoolean($value)
+    {
+        $value = strtolower($value);
+        switch ($value) {
+            case 'true':
+            case '1':
+                return true;
+            case 'false':
+            case '0':
+                return false;
+            default:
+                $this->error("Invalid state value `$value`, it must be `true`, `false`, `1`, or `0`.");
+        }
+    }
 }

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -13,6 +13,7 @@ App::uses('BlowfishConstantPasswordHasher', 'Controller/Component/Auth');
  * @property UserSetting $UserSetting
  * @property Event $Event
  * @property AuthKey $AuthKey
+ * @property Server $Server
  */
 class User extends AppModel
 {


### PR DESCRIPTION
#### What does it do?

This is useful if organisation has multiple MISP frontend or immutable filesystem. Fixes #5543

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
