### PR TITLE
new: Supports MinIO as alternative to AWS S3

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -6699,9 +6699,25 @@ class Server extends AppModel
                     'test' => 'testBool',
                     'type' => 'boolean'
                 ),
+                'S3_aws_ca' => array(
+                    'level' => 2,
+                    'description' => __('AWS TLS CA, set to empty to use CURL internal trusted certificates or path for custom trusted CA'),
+                    'value' => '',
+                    'errorMessage' => '',
+                    'test' => 'testForEmpty',
+                    'type' => 'string'
+                ),
+                'S3_aws_validate_ca' => array(
+                    'level' => 2,
+                    'description' => __('Validate CA'),
+                    'value' => true,
+                    'errorMessage' => '',
+                    'test' => 'testBool',
+                    'type' => 'boolean'
+                ),
                 'S3_aws_endpoint' => array(
                     'level' => 2,
-                    'description' => __('External AWS compatible endpoint such as MinIO'),
+                    'description' => __('Uses external AWS compatible endpoint such as MinIO'),
                     'value' => '',
                     'errorMessage' => '',
                     'test' => 'testForEmpty',

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -6691,9 +6691,25 @@ class Server extends AppModel
                     'test' => 'testBool',
                     'type' => 'boolean'
                 ),
+                'S3_aws_compatible' => array(
+                    'level' => 2,
+                    'description' => __('Use external AWS compatible system such as MinIO'),
+                    'value' => false,
+                    'errorMessage' => '',
+                    'test' => 'testBool',
+                    'type' => 'boolean'
+                ),
+                'S3_aws_endpoint' => array(
+                    'level' => 2,
+                    'description' => __('External AWS compatible endpoint such as MinIO'),
+                    'value' => '',
+                    'errorMessage' => '',
+                    'test' => 'testForEmpty',
+                    'type' => 'string'
+                ),
                 'S3_bucket_name' => array(
                     'level' => 2,
-                    'description' => __('Bucket name to upload to'),
+                    'description' => __('Bucket name to upload to, please make sure that the bucket exists. We will not create the bucket for you'),
                     'value' => '',
                     'errorMessage' => '',
                     'test' => 'testForEmpty',


### PR DESCRIPTION
Needs an alternative S3 compatible file storage as it is against their policy. The widely used S3 compatible system includes [MinIO](https://min.io/). MinIO uses PHP AWS S3 SDK as pointed in MISP Composer requirements and MinIO's documentation.

#### What does it do?

Supports MinIO as an alternative to AWS S3 for file storage #3560
Check file whether it is exists, if it is not exists it will throw exception that will notify upper layer code.

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
