### PR TITLE
fix: [internal] withCredentials property was added into $.ajaxSetup()…

### DIFF
--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -5379,3 +5379,13 @@ $('td.rotate').hover(function() {
     var t = parseInt($(this).index()) + 1;
     $table.find('td:nth-child(' + t + ')').css('background-color', '');
 });
+
+$.ajaxSetup({
+    xhrFields: {
+        withCredentials: true
+    },
+    headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+    },
+});
+


### PR DESCRIPTION
… to get rid of 403 and 302 responses

#### What does it do?

It fixes missing cookies in AJAX requests like:
 - /events/checkLocks/<ID>/<TS>
 - /threads/view/<ID>/true
 - /eventReports/index/event_id:<ID>/index_for_event:1
 - ...
I've a new MISP installation and when go into event details - issues appear.
In some cases on the backend the ajax request doesn't determine as ajax - 'X-Requested-With' header fixes this.

#### Questions

- [NO] Does it require a DB change?
- [YES] Are you using it in production?
- [NO] Does it require a change in the API (PyMISP for example)?
