### PR TITLE
fix: [internal] No exception when db logs are disabled

### DIFF
--- a/app/Model/Log.php
+++ b/app/Model/Log.php
@@ -240,6 +240,9 @@ class Log extends AppModel
             if ($action === 'request' && !empty(Configure::read('MISP.log_paranoid_skip_db'))) {
                 return null;
             }
+            if (!empty(Configure::read('MISP.log_skip_db_logs_completely'))) {
+                return null;
+            }
 
             throw new Exception("Cannot save log because of validation errors: " . json_encode($this->validationErrors));
         }


### PR DESCRIPTION
#### What does it do?

Fixes #7875.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
