### PR TITLE
chg: [tags] possibility to define local_only tags and galaxies

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -3496,7 +3496,7 @@ class EventsController extends AppController
                 $tag = $this->Event->EventTag->Tag->find('first', array(
                     'conditions' => $conditions,
                     'recursive' => -1,
-                    'fields' => array('Tag.name')
+                    'fields' => array('Tag.name', 'Tag.local_only')
                 ));
                 if (!$tag) {
                     $fails[$tag_id] = __('Tag not found.');
@@ -3525,6 +3525,10 @@ class EventsController extends AppController
                 $exclusiveTestPassed = $this->Taxonomy->checkIfNewTagIsAllowedByTaxonomy($tag['Tag']['name'], Hash::extract($tagsOnEvent, '{n}.Tag.name'));
                 if (!$exclusiveTestPassed) {
                     $fails[$tag_id] = __('Tag is not allowed due to taxonomy exclusivity settings');
+                    continue;
+                }
+                if ($tag['Tag']['local_only'] && !$local) {
+                    $fails[$tag_id] = __('Invalid Tag. This tag can only be set as a local tag.');
                     continue;
                 }
                 $this->Event->EventTag->create();

--- a/app/Controller/GalaxiesController.php
+++ b/app/Controller/GalaxiesController.php
@@ -533,8 +533,9 @@ class GalaxiesController extends AppController
 
     public function attachCluster($target_id, $target_type = 'event')
     {
+        $local = !empty($this->params['named']['local']);
         $cluster_id = $this->request->data['Galaxy']['target_id'];
-        $result = $this->Galaxy->attachCluster($this->Auth->user(), $target_type, $target_id, $cluster_id);
+        $result = $this->Galaxy->attachCluster($this->Auth->user(), $target_type, $target_id, $cluster_id, $local);
         return new CakeResponse(array('body'=> json_encode(array('saved' => true, 'success' => $result, 'check_publish' => true)), 'status'=>200, 'type' => 'json'));
     }
 

--- a/app/Controller/GalaxiesController.php
+++ b/app/Controller/GalaxiesController.php
@@ -339,6 +339,11 @@ class GalaxiesController extends AppController
         $conditions[] = [
             'enabled' => true
         ];
+        if(!$local) {
+            $conditions[] = [
+                'local_only' => 0
+            ];
+        }
         $galaxies = $this->Galaxy->find('all', array(
             'recursive' => -1,
             'fields' => array('MAX(Galaxy.version) as latest_version', 'id', 'kill_chain_order', 'name', 'icon', 'description'),

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -83,7 +83,7 @@ class AppModel extends Model
         51 => false, 52 => false, 53 => false, 54 => false, 55 => false, 56 => false,
         57 => false, 58 => false, 59 => false, 60 => false, 61 => false, 62 => false,
         63 => true, 64 => false, 65 => false, 66 => false, 67 => false, 68 => false,
-        69 => false, 70 => false, 71 => true, 72 => true,
+        69 => false, 70 => false, 71 => true, 72 => true, 73 => true,
     );
 
     public $advanced_updates_description = array(
@@ -1577,6 +1577,10 @@ class AppModel extends Model
                 break;
             case 72:
                 $sqlArray[] = "ALTER TABLE `auth_keys` ADD `read_only` tinyint(1) NOT NULL DEFAULT 0 AFTER `expiration`;";
+                break;
+            case 73:
+                $sqlArray[] = "ALTER TABLE `tags` ADD `local_only` tinyint(1) NOT NULL DEFAULT 0 AFTER `is_custom_galaxy`;";
+                $sqlArray[] = "ALTER TABLE `galaxies` ADD `local_only` tinyint(1) NOT NULL DEFAULT 0 AFTER `enabled`;";
                 break;
             case 'fixNonEmptySharingGroupID':
                 $sqlArray[] = 'UPDATE `events` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';

--- a/app/Model/Galaxy.php
+++ b/app/Model/Galaxy.php
@@ -353,6 +353,7 @@ class Galaxy extends AppModel
             'conditions' => array('id' => $cluster_id),
             'fields' => array('tag_name', 'id', 'value'),
         ), $full=false);
+
         if (empty($cluster)) {
             throw new NotFoundException(__('Invalid Galaxy cluster'));
         }
@@ -368,7 +369,11 @@ class Galaxy extends AppModel
             throw new NotFoundException(__('Invalid %s.', $target_type));
         }
         $target = $target[0];
-        $tag_id = $this->Tag->captureTag(array('name' => $cluster['GalaxyCluster']['tag_name'], 'colour' => '#0088cc', 'exportable' => 1), $user, true);
+        $local_only = $cluster['GalaxyCluster']['Galaxy']['local_only'];
+        if ($local_only && !$local) {
+           return __("This Cluster can only be attached in a local scope");
+        }
+        $tag_id = $this->Tag->captureTag(array('name' => $cluster['GalaxyCluster']['tag_name'], 'colour' => '#0088cc', 'exportable' => 1, 'local_only' => $local_only), $user, true);
         $existingTag = $this->Tag->$connectorModel->find('first', array('conditions' => array($target_type . '_id' => $target_id, 'tag_id' => $tag_id)));
         if (!empty($existingTag)) {
             return 'Cluster already attached.';

--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -96,6 +96,9 @@ class Tag extends AppModel
         if (!isset($this->data['Tag']['exportable'])) {
             $this->data['Tag']['exportable'] = 1;
         }
+        if (!isset($this->data['Tag']['local_only'])) {
+            $this->data['Tag']['local_only'] = 0;
+        }
         if (isset($this->data['Tag']['name']) && strlen($this->data['Tag']['name']) >= 255) {
             $this->data['Tag']['name'] = substr($this->data['Tag']['name'], 0, 255);
         }
@@ -354,6 +357,7 @@ class Tag extends AppModel
                     'name' => $tag['name'],
                     'colour' => $tag['colour'],
                     'exportable' => isset($tag['exportable']) ? $tag['exportable'] : 1,
+                    'local_only' => $tag['local_only'] ?? 0,
                     'org_id' => 0,
                     'user_id' => 0,
                     'hide_tag' => Configure::read('MISP.incoming_tags_disabled_by_default') ? 1 : 0
@@ -409,11 +413,14 @@ class Tag extends AppModel
         return ($this->save($data));
     }
 
-    public function quickEdit($tag, $name, $colour, $hide = false, $numerical_value = null)
+    public function quickEdit($tag, $name, $colour, $hide = false, $numerical_value = null, $local_only = -1)
     {
-        if ($tag['Tag']['colour'] !== $colour || $tag['Tag']['name'] !== $name || $hide !== false || $tag['Tag']['numerical_value'] !== $numerical_value) {
+        if ($tag['Tag']['colour'] !== $colour || $tag['Tag']['name'] !== $name || $hide !== false || $tag['Tag']['numerical_value'] !== $numerical_value || ($tag['Tag']['local_only'] !== $local_only && $local_only !== -1)) {
             $tag['Tag']['name'] = $name;
             $tag['Tag']['colour'] = $colour;
+            if ($tag['Tag']['local_only'] !== -1) {
+                $tag['Tag']['local_only'] = $local_only;
+            }
             if ($hide !== false) {
                 $tag['Tag']['hide_tag'] = $hide;
             }

--- a/app/Model/Taxonomy.php
+++ b/app/Model/Taxonomy.php
@@ -242,7 +242,7 @@ class Taxonomy extends AppModel
 
     // returns all tags associated to a taxonomy
     // returns all tags not associated to a taxonomy if $inverse is true
-    public function getAllTaxonomyTags($inverse = false, $user = false, $full = false, $hideUnselectable = true)
+    public function getAllTaxonomyTags($inverse = false, $user = false, $full = false, $hideUnselectable = true, $local_tag = false)
     {
         $this->Tag = ClassRegistry::init('Tag');
         $taxonomyIdList = $this->find('column', array('fields' => array('Taxonomy.id')));
@@ -259,6 +259,10 @@ class Taxonomy extends AppModel
         }
         if (Configure::read('MISP.incoming_tags_disabled_by_default') || $hideUnselectable) {
             $conditions['Tag.hide_tag'] = 0;
+        }
+        // If the tag is to be added as global, we filter out the local_only tags
+        if (!$local_tag) {
+            $conditions['Tag.local_only'] = 0;
         }
         if ($full) {
             $allTags = $this->Tag->find(

--- a/app/View/Galaxies/index.ctp
+++ b/app/View/Galaxies/index.ctp
@@ -80,6 +80,13 @@
                     'class' => 'short',
                     'data_path' => 'Galaxy.enabled',
                 ),
+                array(
+                    'name' => __('Local Only'),
+                    'element' => 'boolean',
+                    'sort' => 'local_only',
+                    'class' => 'short',
+                    'data_path' => 'Galaxy.local_only',
+                ),
             ),
             'title' => __('Galaxy index'),
             'actions' => array(

--- a/app/View/Galaxies/view.ctp
+++ b/app/View/Galaxies/view.ctp
@@ -8,6 +8,7 @@
     $table_data[] = array('key' => __('UUID'), 'value' => $galaxy['Galaxy']['uuid']);
     $table_data[] = array('key' => __('Description'), 'value' => $galaxy['Galaxy']['description']);
     $table_data[] = array('key' => __('Version'), 'value' => $galaxy['Galaxy']['version']);
+    $table_data[] = array('key' => __('Local Only'), 'value' => ($galaxy['Galaxy']['local_only'] ? __("Yes. It can only be added in the local context.") : __("No")));
     $kco = '';
     if (isset($galaxy['Galaxy']['kill_chain_order'])) {
         $kco = '<strong>' . __('Kill chain order') . '</strong> <span class="useCursorPointer fa fa-expand" onclick="$(\'#killChainOrder\').toggle(\'blind\')"></span>';

--- a/app/View/Tags/add.ctp
+++ b/app/View/Tags/add.ctp
@@ -33,6 +33,11 @@ echo $this->element('genericElements/Form/genericForm', [
             [
                 'field' => 'hide_tag',
                 'type' => 'checkbox'
+            ],
+            [
+                'field' => 'local_only',
+                'label' => __('Enforce this tag to be used as local only'),
+                'type' => 'checkbox'
             ]
         ],
         'submit' => [

--- a/app/View/Tags/index.ctp
+++ b/app/View/Tags/index.ctp
@@ -51,6 +51,13 @@
                     'data_path' => 'Tag.hide_tag',
                 ],
                 [
+                    'name' => __('Local Only'),
+                    'sort' => 'Tag.local_only',
+                    'element' => 'boolean',
+                    'class' => 'short',
+                    'data_path' => 'Tag.local_only',
+                ],
+                [
                     'name' => __('Name'),
                     'sort' => 'Tag.name',
                     'class' => 'short',

--- a/app/webroot/doc/openapi.yaml
+++ b/app/webroot/doc/openapi.yaml
@@ -212,7 +212,7 @@ paths:
         default:
           $ref: "#/components/responses/ApiErrorResponse"
 
-  /attributes/addTag/{attributeId}/{tagId}:
+  /attributes/addTag/{attributeId}/{tagId}/local:{local}:
     post:
       summary: "Add a tag to an attribute"
       operationId: tagAttribute
@@ -221,6 +221,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/attributeIdParameter"
         - $ref: "#/components/parameters/tagIdParameter"
+        - $ref: "#/components/parameters/localParameter"
       responses:
         "200":
           $ref: "#/components/responses/AddAttributeTagResponse"
@@ -457,7 +458,7 @@ paths:
         default:
           $ref: "#/components/responses/ApiErrorResponse"
 
-  /events/addTag/{eventId}/{tagId}:
+  /events/addTag/{eventId}/{tagId}/local:{local}:
     post:
       summary: "Add event tag"
       operationId: tagEvent
@@ -466,6 +467,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/eventIdParameter"
         - $ref: "#/components/parameters/tagIdParameter"
+        - $ref: "#/components/parameters/localParameter"
       responses:
         "200":
           $ref: "#/components/responses/AddEventTagResponse"
@@ -607,7 +609,7 @@ paths:
         default:
           $ref: "#/components/responses/ApiErrorResponse"
 
-  /galaxies/attachCluster/{attachTargetId}/{attachTargetType}:
+  /galaxies/attachCluster/{attachTargetId}/{attachTargetType}/local:{local}:
     post:
       summary: "Attach the galaxy cluster tag a given entity"
       operationId: attachGalaxyCluster
@@ -616,6 +618,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/attachTargetIdParameter"
         - $ref: "#/components/parameters/attachTargetTypeParameter"
+        - $ref: "#/components/parameters/localParameter"
       requestBody:
         $ref: "#/components/requestBodies/AttachGalaxyClusterRequest"
       responses:
@@ -5302,6 +5305,16 @@ components:
     IsLocal:
       type: boolean
 
+    Local:
+      type: integer
+      format: int32
+      maxLength: 1
+      default: 0
+      nullable: false
+      enum:
+        - 0
+        - 1
+
     IsReadOnly:
       type: boolean
 
@@ -5691,6 +5704,14 @@ components:
       required: true
       schema:
         $ref: "#/components/schemas/TagId"
+
+    localParameter:
+      name: local
+      in: path
+      description: "Whether the object should be attached locally or not to the target"
+      required: false
+      schema:
+        $ref: "#/components/schemas/Local"
 
     tagSearchTermParameter:
       name: tagSearchTerm

--- a/db_schema.json
+++ b/db_schema.json
@@ -2461,6 +2461,17 @@
                 "extra": ""
             },
             {
+                "column_name": "local_only",
+                "is_nullable": "NO",
+                "data_type": "tinyint",
+                "character_maximum_length": null,
+                "numeric_precision": "3",
+                "collation_name": null,
+                "column_type": "tinyint(1)",
+                "column_default": "0",
+                "extra": ""
+            },
+            {
                 "column_name": "kill_chain_order",
                 "is_nullable": "YES",
                 "data_type": "text",
@@ -6246,6 +6257,17 @@
             },
             {
                 "column_name": "is_custom_galaxy",
+                "is_nullable": "NO",
+                "data_type": "tinyint",
+                "character_maximum_length": null,
+                "numeric_precision": "3",
+                "collation_name": null,
+                "column_type": "tinyint(1)",
+                "column_default": "0",
+                "extra": ""
+            },
+            {
+                "column_name": "local_only",
                 "is_nullable": "NO",
                 "data_type": "tinyint",
                 "character_maximum_length": null,

--- a/db_schema.json
+++ b/db_schema.json
@@ -8201,5 +8201,5 @@
             "id": true
         }
     },
-    "db_version": "75"
+    "db_version": "76"
 }


### PR DESCRIPTION
#### What does it do?

Fix #7876 .
Add local only options for tags and galaxies that shouldn't be put as global by the user.

Open for review

#### Questions

- [x] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
