### PR TITLE
fix: [UI] restore event link on attributes index

### DIFF
--- a/app/View/Attributes/index.ctp
+++ b/app/View/Attributes/index.ctp
@@ -19,7 +19,12 @@ echo $this->element('/genericElements/IndexTable/index_table', [
             [
                 'name' => __('Event'),
                 'sort' => 'Attribute.event_id',
-                'data_path' => 'Attribute.event_id'
+                'data_path' => 'Attribute.event_id',
+                'element' => 'links',
+                'url' => $baseurl . '/events',
+                'url_params_data_paths' => [
+                    'Attribute.event_id'
+                ]
             ],
             [
                 'name' => __('Org'),


### PR DESCRIPTION
#### What does it do?
With the refactoring of the attributes view code, it seems that the link to the event disappeared. It is really useful to have it, especially in the context of search results, to be able to navigate to the parent event.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
