### PR TITLE
fix: [internal] Remove unused MISP.cached_attachments setting

### DIFF
--- a/INSTALL/ansible/roles/misp/templates/misp/config/config.php
+++ b/INSTALL/ansible/roles/misp/templates/misp/config/config.php
@@ -16,7 +16,6 @@ $config = array (
 		'org' => '',
 		'showorg' => true,
 		'background_jobs' => true,
-		'cached_attachments' => true,
 		'email' => '',
 		'contact' => '',
 		'cveurl' => 'http://cve.circl.lu/cve/',

--- a/app/Config/config.default.php
+++ b/app/Config/config.default.php
@@ -32,7 +32,6 @@ $config = array(
         'email_subject_tag'              => 'tlp',
         'email_subject_include_tag_name' => true,
         'background_jobs'                => true,
-        'cached_attachments'             => true,
         'osuser'                         => 'www-data',
         'email'                          => 'email@example.com',
         'contact'                        => 'email@example.com',

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -4896,13 +4896,6 @@ class Server extends AppModel
                     'type' => 'string',
                     'cli_only' => 1
                 ),
-                'cached_attachments' => array(
-                    'level' => 1,
-                    'description' => __('Allow the XML caches to include the encoded attachments.'),
-                    'value' => '',
-                    'test' => 'testBool',
-                    'type' => 'boolean',
-                ),
                 'download_attachments_on_load' => array(
                     'level' => 2,
                     'description' => __('Always download attachments when loaded by a user in a browser'),

--- a/travis/config.php
+++ b/travis/config.php
@@ -16,7 +16,6 @@ $config = array (
 		'org' => 'ORGNAME',
 		'showorg' => true,
 		'background_jobs' => false,
-		'cached_attachments' => false,
 		'email' => 'email@address.com',
 		'contact' => 'email@address.com',
 		'cveurl' => 'http://web.nvd.nist.gov/view/vuln/detail?vulnId=',


### PR DESCRIPTION
#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
