### PR TITLE
chg: allow change disable_correlation in mass edit attributes

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -1397,7 +1397,7 @@ class AttributesController extends AppController
             || ($clusters_ids_remove === null || count($clusters_ids_remove) > 0)
             || ($clusters_ids_add === null || count($clusters_ids_add) > 0);
 
-        $changeInAttribute = ($this->request->data['Attribute']['to_ids'] != 2) || ($this->request->data['Attribute']['distribution'] != 6) || ($this->request->data['Attribute']['comment'] != null);
+        $changeInAttribute = ($this->request->data['Attribute']['to_ids'] != 2) || ($this->request->data['Attribute']['distribution'] != 6) || ($this->request->data['Attribute']['comment'] != null) || ($this->request->data['Attribute']['disable_correlation'] != 2);
 
         if (!$changeInAttribute && !$changeInTagOrCluster) {
             return new CakeResponse(array('body'=> json_encode(array('saved' => true)), 'status' => 200, 'type' => 'json'));
@@ -1432,6 +1432,12 @@ class AttributesController extends AppController
         if ($this->request->data['Attribute']['comment'] != null) {
             foreach ($attributes as $key => $attribute) {
                 $attributes[$key]['Attribute']['comment'] = $this->request->data['Attribute']['comment'];
+            }
+        }
+
+        if ($this->request->data['Attribute']['disable_correlation'] != 2) {
+            foreach ($attributes as $key => $attribute) {
+                $attributes[$key]['Attribute']['disable_correlation'] = $this->request->data['Attribute']['disable_correlation'] === '0' ? false : true;
             }
         }
 

--- a/app/View/Attributes/ajax/attributeEditMassForm.ctp
+++ b/app/View/Attributes/ajax/attributeEditMassForm.ctp
@@ -27,16 +27,28 @@
             ?>
                 </div>
             <?php
+            echo '<div class="input clear"></div>';
             echo $this->Form->input('to_ids', array(
-                    'options' => array(__('No'), __('Yes'), __('Do not alter current settings')),
-                    'data-content' => isset($attrDescriptions['signature']['formdesc']) ? $attrDescriptions['signature']['formdesc'] : $attrDescriptions['signature']['desc'],
-                    'label' => __('For Intrusion Detection System'),
-                    'selected' => 2,
+                'options' => array(__('No'), __('Yes'), __('Do not alter current settings')),
+                'data-content' => isset($attrDescriptions['signature']['formdesc']) ? $attrDescriptions['signature']['formdesc'] : $attrDescriptions['signature']['desc'],
+                'label' => __('For Intrusion Detection System'),
+                'selected' => 2
             ));
+            echo '<div class="input clear"></div>';
             echo $this->Form->input('is_proposal', array(
                 'type' => 'checkbox',
                 'label' => __('Create proposals'),
                 'checked' => false
+            ));
+            echo '<div class="input clear"></div>';
+            echo $this->Form->input('disable_correlation', array(
+                'label' => __('Correlations'),
+                'options' => [
+                    '2' => __('Do not alter current settings'),
+                    '0' => __('Enable correlations'),
+                    '1' => __('Disable correlations')
+                ],
+                'selected' => '2'
             ));
             ?>
                 <div class="input clear"></div>


### PR DESCRIPTION
#### What does it do?
Allow changing disable_correlation property in `Mass Edit Attributes` view. Fixes #7874

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
