### PR TITLE
fix: [eventGraph] use requiredOneOf and required for object labeling …

### DIFF
--- a/app/webroot/js/event-graph.js
+++ b/app/webroot/js/event-graph.js
@@ -1394,12 +1394,15 @@ class DataHandler {
         if (template_req === undefined) { // template not known
             return label;
         }
+
         // search if this field exists in the object
-        for (var attr of obj.Attribute) { // for each field
-            var attr_rel = attr.object_relation;
-            if (template_req.indexOf(attr_rel) != -1) {
-                label += ": " + attr.value;
-                return label;
+        for (var req of template_req){ // for each requiredOff
+            for (var attr of obj.Attribute) { // for each field
+                var attr_rel = attr.object_relation;
+                if (attr_rel === req) {
+                    label += ": " + attr.value;
+                    return label;
+                }
             }
         }
         return label;


### PR DESCRIPTION
…priority

#### What does it do?

See https://gitter.im/MISP/MISP?at=618e90432197144e84bf89bd as well

'requiredOneOf' and 'required' of the object templates are used to determine how to label an object in the event graph, but there is no priority order at the moment. The first attribute that matches any of the fields is used. Leading to inconsistencies in the display of objects having values for the same attributes.

An example:
If you have a Person object for which you added first-name and last-name immediately, the last-name value is displayed as default for label in the event graph. If you create a Person object with only first-name, save. Then edit it and add a last-name, the first-name value is displayed in the event graph as label.

This change makes it so that if two objects have values for the same fields, the same field will be used for the label.

Current situation (as described earlier):
![Current-situation](https://user-images.githubusercontent.com/9868873/142656623-35295574-c97d-4228-bb17-df76d116c42b.png)
I believe that in practice, ui-priority plays a fairly big role in deciding which attribute ends up as the label at the moment.

New situation (first-name is used for all three object labels):
![New-situation](https://user-images.githubusercontent.com/9868873/142656685-1ff31861-e331-4b85-b355-fe2b8099fbee.png)

Comments:

- Note that this situation is still not ideal. For some reason requiredOneOf had / has priority over required. Giving required priority wouldn't always make sense either (for example in the case of https://github.com/MISP/misp-objects/blob/main/objects/authentication-failure-report/definition.json)
- I guess there will be a performance impact
- While a small change in terms of code, I believe there can be a big difference for some graphs so would like some practical validation by others

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
