### PR TITLE
fix: improve error handling when supervisor is not available or conne…

### DIFF
--- a/app/Lib/Tools/BackgroundJobsTool.php
+++ b/app/Lib/Tools/BackgroundJobsTool.php
@@ -281,12 +281,7 @@ class BackgroundJobsTool
         try {
             $procs = $this->getSupervisor()->getAllProcesses();
         } catch (\Exception $exception) {
-            CakeLog::error(
-                "An error occured when getting the workers statuses via Supervisor API: {$exception->getMessage()}",
-                0,
-                $exception
-            );
-
+            CakeLog::error("An error occured when getting the workers statuses via Supervisor API: {$exception->getMessage()}");
             return [];
         }
 

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -3443,6 +3443,16 @@ class Server extends AppModel
         if (Configure::check('MISP.manage_workers')) {
             $worker_array['controls'] = Configure::read('MISP.manage_workers');
         }
+
+        if (Configure::read('SimpleBackgroundJobs.enabled')) {
+            try {
+                $worker_array['supervisord_status'] = $this->getBackgroundJobsTool()->getSupervisorStatus();
+            } catch (Exception $exception) {
+                $this->logException('Error getting supervisor status.', $exception);
+                $worker_array['supervisord_status'] = false;
+            }
+        }
+
         return $worker_array;
     }
 

--- a/app/View/Elements/healthElements/workers.ctp
+++ b/app/View/Elements/healthElements/workers.ctp
@@ -1,10 +1,17 @@
 <div style="border:1px solid #dddddd; margin-top:1px; width:100%; padding:10px">
-    <?php
+<?php
         if (!$worker_array['proc_accessible']):
     ?>
     <div style="background-color:red !important;color:white;"><b><?php echo __('Warning');?></b>: <?php echo __('MISP cannot access your /proc directory to check the status of the worker processes, which means that dead workers will not be detected by the diagnostic tool. If you would like to regain this functionality, make sure that the open_basedir directive is not set, or that /proc is included in it.');?></div>
 <?php
     endif;
+
+    if(Configure::read('SimpleBackgroundJobs.enabled') && !$worker_array['supervisord_status']):
+    ?>
+        <div style="background-color:red !important;color:white;"><b><?php echo __('Warning');?></b>: <?php echo __('MISP cannot connect to the Supervisord API, check the following settings are correct: [`supervisor_host`, `supervisor_port`, `supervisor_user`, `supervisor_password`] and restart the service. For details check the MISP error logs.');?></div>
+    <?php
+    endif;
+
     if (!$worker_array['controls']):
 ?>
     <div><b><?php echo __('Note:');?></b>: <?php echo  __('You have set the "manage_workers" variable to "false", therefore worker controls have been disabled.');?></div>


### PR DESCRIPTION
#### What does it do?

If it fixes an existing issue, please use github syntax: `#<IssueID>`
* Fixes #7988 and provides better error handling when Supervisor is not available.
* Show a warning message in Server Settings -> Workers tab when connection to Supervisor failed, log errors.
![image](https://user-images.githubusercontent.com/1659902/143415839-7a66d990-8814-4136-8419-cc6c2f8a31e1.png)

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
