### PR TITLE
fix: Autocrypt email header force RFC 5322 - 2.1.1 line length limits

### DIFF
--- a/app/Lib/Tools/SendEmail.php
+++ b/app/Lib/Tools/SendEmail.php
@@ -974,6 +974,7 @@ class SendEmail
             $parts[] = 'prefer-encrypt=mutual';
         }
         $parts[] = 'keydata=' . base64_encode($keyData);
-        return implode('; ', $parts);
+        // Use the PHP wordwrap function to wrap the Autocrypt header to 74 (+ CRLF) to meet RFC 5322 - 2.1.1 line length limits 
+        return wordwrap(implode('; ', $parts), 74, "\r\n\t", true);
     }
 }


### PR DESCRIPTION
#### Questions

- [N] Does it require a DB change?
- [Y] Are you using it in production?
- [N] Does it require a change in the API (PyMISP for example)?

This change uses the PHP wordwrap function to wrap the Autocrypt header to 74 (+ CRLF) to meet RFC 5322 - 2.1.1 line length limits. Here, we wrap the line with a PHP_EOL and `\t`.

We noticed this issue when some upstream email server started (incorrectly) enforcing RFC line wrapping, but broke the email. This caused the Subject and other headers to end up in the body of the email. Upon investigation, it was identified that the Autocrypt header was VERY long and didn't meet RFC. A better fix would be to upstream this fix into CakePHP-Email for all headers, however, this solves the underlying issue for MISP. 

```
There are two limits that this standard places on the number of characters in a line. Each line of 
characters MUST be no more than 998 characters, and SHOULD be no more than 78 characters, 
excluding the CRLF.
```
