### PR TITLE
new: Add events time filter

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -33,7 +33,7 @@ class AppController extends Controller
 
     public $helpers = array('OrgImg', 'FontAwesome', 'UserName');
 
-    private $__queryVersion = '132';
+    private $__queryVersion = '133';
     public $pyMispVersion = '2.4.151';
     public $phpmin = '7.2';
     public $phprec = '7.4';

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -364,10 +364,21 @@ class EventsController extends AppController
                     if ($v == "") {
                         continue 2;
                     }
-                    if (preg_match('/^[0-9]+[mhdw]$/i', $v)) {
-                        $v = $this->Event->resolveTimeDelta($v);
+                    if (is_array($v) && isset($v[0]) && isset($v[1])) {
+                        if (!is_int($v)) {
+                            $v[0] = $this->Event->resolveTimeDelta($v[0]);
+                        }
+                        if (!is_int($v)) {
+                            $v[1] = $this->Event->resolveTimeDelta($v[1]);
+                        }
+                        $this->paginate['conditions']['AND'][] = array('Event.timestamp >=' => $v[0]);
+                        $this->paginate['conditions']['AND'][] = array('Event.timestamp <=' => $v[1]);
+                    } else {
+                        if (!is_int($v)) {
+                            $v = $this->Event->resolveTimeDelta($v);
+                        }
+                        $this->paginate['conditions']['AND'][] = array('Event.timestamp >=' => $v);
                     }
-                    $this->paginate['conditions']['AND'][] = array('Event.timestamp >=' => $v);
                     break;
                 case 'publish_timestamp':
                 case 'publishtimestamp':
@@ -375,16 +386,16 @@ class EventsController extends AppController
                         continue 2;
                     }
                     if (is_array($v) && isset($v[0]) && isset($v[1])) {
-                        if (preg_match('/^[0-9]+[mhdw]$/i', $v[0])) {
+                        if (!is_int($v)) {
                             $v[0] = $this->Event->resolveTimeDelta($v[0]);
                         }
-                        if (preg_match('/^[0-9]+[mhdw]$/i', $v[1])) {
+                        if (!is_int($v)) {
                             $v[1] = $this->Event->resolveTimeDelta($v[1]);
                         }
                         $this->paginate['conditions']['AND'][] = array('Event.publish_timestamp >=' => $v[0]);
                         $this->paginate['conditions']['AND'][] = array('Event.publish_timestamp <=' => $v[1]);
                     } else {
-                        if (preg_match('/^[0-9]+[mhdw]$/i', $v)) {
+                        if (!is_int($v)) {
                             $v = $this->Event->resolveTimeDelta($v);
                         }
                         $this->paginate['conditions']['AND'][] = array('Event.publish_timestamp >=' => $v);
@@ -1052,8 +1063,8 @@ class EventsController extends AppController
             'analysis' => array('OR' => array(), 'NOT' => array()),
             'attribute' => array('OR' => array(), 'NOT' => array()),
             'hasproposal' => 2,
-            'timestamp' => "",
-            'publishtimestamp' => ""
+            'timestamp' => array('from' => "", 'until' => ""),
+            'publishtimestamp' => array('from' => "", 'until' => ""),
         );
 
         if ($this->_isSiteAdmin()) {

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -56,6 +56,12 @@ class EventsController extends AppController
         'warninglistId' => '',
     );
 
+    // private
+    const DEFAULT_HIDDEN_INDEX_COLUMNS = [
+        'timestmap',
+        'publish_timestamp'
+    ];
+
     public $paginationFunctions = array('index', 'proposalEventIndex');
 
     public function beforeFilter()
@@ -933,6 +939,8 @@ class EventsController extends AppController
         }
 
         $possibleColumns[] = 'attribute_count';
+        $possibleColumns[] = 'timestamp';
+        $possibleColumns[] = 'publish_timestamp';
 
         if (Configure::read('MISP.showCorrelationsOnIndex')) {
             $possibleColumns[] = 'correlations';
@@ -958,12 +966,12 @@ class EventsController extends AppController
             $possibleColumns[] = 'creator_user';
         }
 
-        $userEnabledColumns = $this->User->UserSetting->getValueForUser($this->Auth->user()['id'], 'event_index_hide_columns');
-        if ($userEnabledColumns === null) {
-            $userEnabledColumns = [];
+        $userDisabledColumns = $this->User->UserSetting->getValueForUser($this->Auth->user()['id'], 'event_index_hide_columns');
+        if ($userDisabledColumns === null) {
+            $userDisabledColumns = self::DEFAULT_HIDDEN_INDEX_COLUMNS;
         }
 
-        $enabledColumns = array_diff($possibleColumns, $userEnabledColumns);
+        $enabledColumns = array_diff($possibleColumns, $userDisabledColumns);
 
         return [$possibleColumns, $enabledColumns];
     }
@@ -1044,6 +1052,8 @@ class EventsController extends AppController
             'analysis' => array('OR' => array(), 'NOT' => array()),
             'attribute' => array('OR' => array(), 'NOT' => array()),
             'hasproposal' => 2,
+            'timestamp' => "",
+            'publishtimestamp' => ""
         );
 
         if ($this->_isSiteAdmin()) {
@@ -1112,6 +1122,8 @@ class EventsController extends AppController
             'analysis' => __('Analysis'),
             'attribute' => __('Attribute'),
             'hasproposal' => __('Has proposal'),
+            'timestamp' => __('Last change at'),
+            'publishtimestamp' => __('Published at'),
         ];
 
         if ($this->_isSiteAdmin()) {

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -365,10 +365,10 @@ class EventsController extends AppController
                         continue 2;
                     }
                     if (is_array($v) && isset($v[0]) && isset($v[1])) {
-                        if (!is_int($v)) {
+                        if (!is_int($v[0])) {
                             $v[0] = $this->Event->resolveTimeDelta($v[0]);
                         }
-                        if (!is_int($v)) {
+                        if (!is_int($v[1])) {
                             $v[1] = $this->Event->resolveTimeDelta($v[1]);
                         }
                         $this->paginate['conditions']['AND'][] = array('Event.timestamp >=' => $v[0]);
@@ -386,10 +386,10 @@ class EventsController extends AppController
                         continue 2;
                     }
                     if (is_array($v) && isset($v[0]) && isset($v[1])) {
-                        if (!is_int($v)) {
+                        if (!is_int($v[0])) {
                             $v[0] = $this->Event->resolveTimeDelta($v[0]);
                         }
-                        if (!is_int($v)) {
+                        if (!is_int($v[1])) {
                             $v[1] = $this->Event->resolveTimeDelta($v[1]);
                         }
                         $this->paginate['conditions']['AND'][] = array('Event.publish_timestamp >=' => $v[0]);

--- a/app/View/Elements/Events/eventIndexTable.ctp
+++ b/app/View/Elements/Events/eventIndexTable.ctp
@@ -13,19 +13,19 @@
         <?php
             if (Configure::read('MISP.showorgalternate') && Configure::read('MISP.showorg')):
         ?>
-            <th class="filter"><?php echo $this->Paginator->sort('Org', 'Source org'); ?></th>
-            <th class="filter"><?php echo $this->Paginator->sort('Org', 'Member org'); ?></th>
+            <th class="filter"><?php echo $this->Paginator->sort('Orgc.name', __('Source org')); ?></th>
+            <th class="filter"><?php echo $this->Paginator->sort('Orgc.name', __('Member org')); ?></th>
         <?php
             elseif (Configure::read('MISP.showorg') || $isAdmin):
         ?>
-            <th class="filter"><?php echo $this->Paginator->sort('Org', __('Creator org')); ?></th>
+            <th class="filter"><?php echo $this->Paginator->sort('Orgc.name', __('Creator org')); ?></th>
         <?php
                 endif;
             $date = time();
             $day = 86400;
         ?>
 
-        <?php if (in_array('owner_org', $columns, true)): ?><th class="filter"><?= $this->Paginator->sort('owner org', __('Owner org')) ?></th><?php endif; ?>
+        <?php if (in_array('owner_org', $columns, true)): ?><th class="filter"><?= $this->Paginator->sort('Org.name', __('Owner org')) ?></th><?php endif; ?>
         <th><?= $this->Paginator->sort('id', __('ID'), ['direction' => 'desc']) ?></th>
         <?php if (in_array('clusters', $columns, true)): ?><th><?= __('Clusters') ?></th><?php endif; ?>
         <?php if (in_array('tags', $columns, true)): ?><th><?= __('Tags') ?></th><?php endif; ?>
@@ -37,6 +37,8 @@
         <?php if (in_array('discussion', $columns, true)): ?><th title="<?= __('Post Count') ?>"><?= __('#Posts') ?></th><?php endif; ?>
         <?php if (in_array('creator_user', $columns, true)): ?><th><?= $this->Paginator->sort('user_id', __('Creator user')) ?></th><?php endif; ?>
         <th class="filter"><?= $this->Paginator->sort('date', null, array('direction' => 'desc'));?></th>
+        <?php if (in_array('timestamp', $columns, true)): ?><th title="<?= __('Last modified at') ?>"><?= $this->Paginator->sort('timestamp', __('Last modified at')) ?></th><?php endif; ?>
+        <?php if (in_array('publish_timestamp', $columns, true)): ?><th title="<?= __('Last modified at') ?>"><?= $this->Paginator->sort('publish_timestamp', __('Published at')) ?></th><?php endif; ?>
         <th class="filter"><?= $this->Paginator->sort('info');?></th>
         <th title="<?= $eventDescriptions['distribution']['desc'];?>">
             <?= $this->Paginator->sort('distribution');?>
@@ -167,6 +169,16 @@
         <td class="short dblclickElement">
             <?= $event['Event']['date'] ?>
         </td>
+        <?php if (in_array('timestamp', $columns, true)): ?>
+        <td class="short dblclickElement">
+            <?=  $this->Time->time($event['Event']['timestamp']) ?>
+        </td>
+        <?php endif; ?>
+        <?php if (in_array('publish_timestamp', $columns, true)): ?>
+        <td class="short dblclickElement">
+            <?=  $this->Time->time($event['Event']['publish_timestamp']) ?>
+        </td>
+        <?php endif; ?>
         <td class="dblclickElement">
             <?= nl2br(h($event['Event']['info']), false) ?>
         </td>

--- a/app/View/Events/filter_event_index.ctp
+++ b/app/View/Events/filter_event_index.ctp
@@ -87,6 +87,23 @@
                         'style' => 'display:none;width:236px;',
                         'div' => false
                 ));
+
+                echo $this->Form->input('searchtimestamp', array(
+                    'class' => 'input',
+                    'label' => false,
+                    'style' => 'display:none;width:424px;',
+                    'div' => false,
+                    'placeholder' => __("Time related filter: 7d, timestamps, [14d, 7d] for ranges")
+                ));
+
+                echo $this->Form->input('searchpublishtimestamp', array(
+                    'class' => 'input',
+                    'label' => false,
+                    'style' => 'display:none;width:424px;',
+                    'div' => false,
+                    'placeholder' => __("Time related filter: 7d, timestamps, [14d, 7d] for ranges")
+                ));
+
                 echo $this->Form->input('searcheventinfo', array(
                         'label' => false,
                         'class' => 'input-large',
@@ -134,7 +151,7 @@
                         <th style="width:10px;border:1px solid #cccccc;border-left:0px;text-align: left;"></th>
                     </tr>
                     <?php
-                        $fields = array('published', 'org', 'tag', 'date', 'eventinfo', 'eventid', 'threatlevel', 'analysis', 'distribution', 'sharinggroup', 'attribute', 'hasproposal');
+                        $fields = array('published', 'org', 'tag', 'date', 'eventinfo', 'eventid', 'threatlevel', 'analysis', 'distribution', 'sharinggroup', 'attribute', 'hasproposal', 'timestamp', 'publishtimestamp');
                         if ($isSiteAdmin) $fields[] = 'email';
                         foreach ($fields as $k => $field):
                     ?>
@@ -209,11 +226,11 @@ var filtering = <?php echo $filtering; ?>;
 
 var operators = ["<?php echo __('OR');?>", "<?php echo __('NOT');?>"];
 
-var allFields = ["published", "tag", "date", "eventinfo", "eventid", "threatlevel", "distribution", "sharinggroup", "analysis", "attribute", "hasproposal"];
+var allFields = ["published", "tag", "date", "eventinfo", "eventid", "threatlevel", "distribution", "sharinggroup", "analysis", "attribute", "hasproposal", "timestamp", "publishtimestamp"];
 
 var simpleFilters = ["tag", "eventinfo", "eventid", "threatlevel", "distribution", "sharinggroup", "analysis", "attribute"];
 
-var differentFilters = ["published", "date", "hasproposal"];
+var differentFilters = ["published", "date", "hasproposal", "timestamp", "publishtimestamp"];
 
 var typedFields = ["tag", "threatlevel", "distribution", "analysis"];
 

--- a/app/View/Events/filter_event_index.ctp
+++ b/app/View/Events/filter_event_index.ctp
@@ -10,7 +10,7 @@
                         'class' => 'input',
                         //'label' => 'Add Filtering Rule',
                         'onchange' => "indexRuleChange();",
-                        'style' => 'margin-right:3px;width:120px;',
+                        'style' => 'margin-right:3px;width:130px;',
                         'div' => false
                 ));
                 echo $this->Form->input('searchbool', array(
@@ -88,20 +88,36 @@
                         'div' => false
                 ));
 
-                echo $this->Form->input('searchtimestamp', array(
+                echo $this->Form->input('searchtimestampfrom', array(
                     'class' => 'input',
                     'label' => false,
-                    'style' => 'display:none;width:424px;',
+                    'style' => 'display:none;width:236px;margin-right:3px;',
                     'div' => false,
-                    'placeholder' => __("Time related filter: 7d, timestamps, [14d, 7d] for ranges")
+                    'placeholder' => __("YYYY:MM:DD HH:MM:SS")
                 ));
 
-                echo $this->Form->input('searchpublishtimestamp', array(
+                echo $this->Form->input('searchtimestampuntil', array(
                     'class' => 'input',
                     'label' => false,
-                    'style' => 'display:none;width:424px;',
+                    'style' => 'display:none;width:236px;margin-right:3px;',
                     'div' => false,
-                    'placeholder' => __("Time related filter: 7d, timestamps, [14d, 7d] for ranges")
+                    'placeholder' => __("YYYY:MM:DD HH:MM:SS")
+                ));
+
+                echo $this->Form->input('searchpublishtimestampfrom', array(
+                    'class' => 'input',
+                    'label' => false,
+                    'style' => 'display:none;width:236px;margin-right:3px;',
+                    'div' => false,
+                    'placeholder' => __("YYYY:MM:DD HH:MM:SS")
+                ));
+
+                echo $this->Form->input('searchpublishtimestampuntil', array(
+                    'class' => 'input',
+                    'label' => false,
+                    'style' => 'display:none;width:236px;margin-right:3px;',
+                    'div' => false,
+                    'placeholder' => __("YYYY:MM:DD HH:MM:SS")
                 ));
 
                 echo $this->Form->input('searcheventinfo', array(

--- a/app/View/Events/filter_event_index.ctp
+++ b/app/View/Events/filter_event_index.ctp
@@ -93,7 +93,7 @@
                     'label' => false,
                     'style' => 'display:none;width:236px;margin-right:3px;',
                     'div' => false,
-                    'placeholder' => __("YYYY-MM-DD HH:MM:SS")
+                    'placeholder' => __("YYYY-MM-DD HH:mm:ss")
                 ));
 
                 echo $this->Form->input('searchtimestampuntil', array(
@@ -101,7 +101,7 @@
                     'label' => false,
                     'style' => 'display:none;width:236px;margin-right:3px;',
                     'div' => false,
-                    'placeholder' => __("YYYY-MM-DD HH:MM:SS")
+                    'placeholder' => __("YYYY-MM-DD HH:mm:ss")
                 ));
 
                 echo $this->Form->input('searchpublishtimestampfrom', array(

--- a/app/View/Events/filter_event_index.ctp
+++ b/app/View/Events/filter_event_index.ctp
@@ -93,7 +93,7 @@
                     'label' => false,
                     'style' => 'display:none;width:236px;margin-right:3px;',
                     'div' => false,
-                    'placeholder' => __("YYYY:MM:DD HH:MM:SS")
+                    'placeholder' => __("YYYY-MM-DD HH:MM:SS")
                 ));
 
                 echo $this->Form->input('searchtimestampuntil', array(
@@ -101,7 +101,7 @@
                     'label' => false,
                     'style' => 'display:none;width:236px;margin-right:3px;',
                     'div' => false,
-                    'placeholder' => __("YYYY:MM:DD HH:MM:SS")
+                    'placeholder' => __("YYYY-MM-DD HH:MM:SS")
                 ));
 
                 echo $this->Form->input('searchpublishtimestampfrom', array(

--- a/app/View/Events/index.ctp
+++ b/app/View/Events/index.ctp
@@ -16,7 +16,7 @@
             $filterParamsString[] = sprintf(
                 '%s: %s',
                 h(ucfirst($k)),
-                h(is_array($v) ? http_build_query($v) : h($v) )
+                h($v)
             );
         }
 

--- a/app/View/Events/index.ctp
+++ b/app/View/Events/index.ctp
@@ -16,7 +16,7 @@
             $filterParamsString[] = sprintf(
                 '%s: %s',
                 h(ucfirst($k)),
-                h($v)
+                h(is_array($v) ? http_build_query($v) : h($v) )
             );
         }
 

--- a/app/View/Events/index.ctp
+++ b/app/View/Events/index.ctp
@@ -30,7 +30,9 @@
             'sightings' => __('Sightings'),
             'proposals' => __('Proposals'),
             'discussion' => __('Posts'),
-            'report_count' => __('Report count')
+            'report_count' => __('Report count'),
+            'timestamp' => __('Last change at'),
+            'publish_timestamp' => __('Published at')
         ];
 
         $columnsMenu = [];

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -2500,7 +2500,8 @@ function indexFilterClearRow(field) {
         filtering.timestamp.from = "";
         filtering.timestamp.until = "";
     } else if (field == "publishtimestamp") {
-        filtering.timestamp = "";
+        filtering.publishtimestamp.from = "";
+        filtering.publishtimestamp.until = "";
     } else if (field == "published") {
         filtering.published = 2;
     } else if (field == "hasproposal") {

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -2095,15 +2095,23 @@ function indexEvaluateFiltering() {
         }
         $('#value_date').html(text);
 
-        if (filtering.timestamp != null) {
+        if (filtering.timestamp.from != null) {
             var text = "";
-            if (filtering.timestamp != "") text = "Last change at: " + $('<span>').text(filtering.timestamp).html();
+            if (filtering.timestamp.from != "") text = "From: " + $('<span>').text(filtering.timestamp.from).html();
+            if (filtering.timestamp.until != "") {
+                if (text != "") text += " ";
+                text += "Until: " + $('<span>').text(filtering.timestamp.until).html();
+            }
         }
         $('#value_timestamp').html(text);
 
-        if (filtering.publishtimestamp != null) {
+        if (filtering.publishtimestamp.from != null) {
             var text = "";
-            if (filtering.publishtimestamp != "") text = "Published at: " + $('<span>').text(filtering.publishtimestamp).html();
+            if (filtering.publishtimestamp.from != "") text = "From: " + $('<span>').text(filtering.publishtimestamp.from).html();
+            if (filtering.publishtimestamp.until != "") {
+                if (text != "") text += " ";
+                text += "Until: " + $('<span>').text(filtering.publishtimestamp.until).html();
+            }
         }
         $('#value_publishtimestamp').html(text);
 
@@ -2331,13 +2339,21 @@ function indexCreateFilters() {
             if (text != "") text += "/";
             text += "searchDateuntil:" + filtering.date.until;
         }
-        if (filtering.timestamp) {
+        if (filtering.timestamp.from) {
             if (text != "") text += "/";
-            text += "searchTimestamp:" + filtering.timestamp;
+            text += "searchTimestamp:" + filtering.timestamp.from;
         }
-        if (filtering.publishtimestamp) {
+        if (filtering.timestamp.until) {
             if (text != "") text += "/";
-            text += "searchPublishTimestamp:" + filtering.publishtimestamp;
+            text += "searchTimestamp:" + filtering.timestamp.until;
+        }
+        if (filtering.publishtimestamp.from) {
+            if (text != "") text += "/";
+            text += "searchPublishTimestamp:" + filtering.publishtimestamp.from;
+        }
+        if (filtering.publishtimestamp.until) {
+            if (text != "") text += "/";
+            text += "searchPublishTimestamp:" + filtering.publishtimestamp.until;
         }
         return baseurl + '/events/index/' + text;
     } else {
@@ -2414,23 +2430,17 @@ function indexEvaluateSimpleFiltering(field) {
 function indexAddRule(param) {
     var found = false;
     if (filterContext == 'event') {
-        if (param.data.param1 == "date") {
+        if (param.data.param1 == "date" || param.data.param1 == "timestamp" || param.data.param1 == "publishtimestamp") {
             var val1 = encodeURIComponent($('#EventSearch' + param.data.param1 + 'from').val());
             var val2 = encodeURIComponent($('#EventSearch' + param.data.param1 + 'until').val());
-            if (val1 != "") filtering.date.from = val1;
-            if (val2 != "") filtering.date.until = val2;
+            if (val1 != "") filtering[param.data.param1].from = val1;
+            if (val2 != "") filtering[param.data.param1].until = val2;
         } else if (param.data.param1 == "published") {
             var value = encodeURIComponent($('#EventSearchpublished').val());
             if (value != "") filtering.published = value;
         } else if (param.data.param1 == "hasproposal") {
             var value = encodeURIComponent($('#EventSearchhasproposal').val());
             if (value != "") filtering.hasproposal = value;
-        } else if (param.data.param1 == "timestamp") {
-            var value = encodeURIComponent($('#EventSearchtimestamp').val());
-            if (value != "") filtering.timestamp = value;
-        } else if (param.data.param1 == "publishtimestamp") {
-            var value = encodeURIComponent($('#EventSearchpublishtimestamp').val());
-            if (value != "") filtering.publishtimestamp = value;
         } else {
             var value = encodeURIComponent($('#EventSearch' + param.data.param1).val());
             var operator = operators[encodeURIComponent($('#EventSearchbool').val())];
@@ -2463,7 +2473,7 @@ function indexRuleChange() {
     $('[id^=' + context + 'Search]').hide();
     var rule = $('#' + context + 'Rule').val();
     var fieldName = '#' + context + 'Search' + rule;
-    if (fieldName === '#' + context + 'Searchdate') {
+    if (fieldName === '#' + context + 'Searchdate' || fieldName === '#' + context + 'Searchtimestamp' || fieldName === '#' + context + 'Searchpublishtimestamp') {
         $(fieldName + 'from').show();
         $(fieldName + 'until').show();
     } else {
@@ -2487,7 +2497,8 @@ function indexFilterClearRow(field) {
         filtering.date.from = "";
         filtering.date.until = "";
     } else if (field == "timestamp") {
-        filtering.timestamp = "";
+        filtering.timestamp.from = "";
+        filtering.timestamp.until = "";
     } else if (field == "publishtimestamp") {
         filtering.timestamp = "";
     } else if (field == "published") {

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -2094,6 +2094,19 @@ function indexEvaluateFiltering() {
             }
         }
         $('#value_date').html(text);
+
+        if (filtering.timestamp != null) {
+            var text = "";
+            if (filtering.timestamp != "") text = "Last change at: " + $('<span>').text(filtering.timestamp).html();
+        }
+        $('#value_timestamp').html(text);
+
+        if (filtering.publishtimestamp != null) {
+            var text = "";
+            if (filtering.publishtimestamp != "") text = "Published at: " + $('<span>').text(filtering.publishtimestamp).html();
+        }
+        $('#value_publishtimestamp').html(text);
+
         for (var i = 0; i < simpleFilters.length; i++) {
             indexEvaluateSimpleFiltering(simpleFilters[i]);
         }
@@ -2318,6 +2331,14 @@ function indexCreateFilters() {
             if (text != "") text += "/";
             text += "searchDateuntil:" + filtering.date.until;
         }
+        if (filtering.timestamp) {
+            if (text != "") text += "/";
+            text += "searchTimestamp:" + filtering.timestamp;
+        }
+        if (filtering.publishtimestamp) {
+            if (text != "") text += "/";
+            text += "searchPublishTimestamp:" + filtering.publishtimestamp;
+        }
         return baseurl + '/events/index/' + text;
     } else {
         return baseurl + '/admin/users/index/' + text;
@@ -2404,6 +2425,12 @@ function indexAddRule(param) {
         } else if (param.data.param1 == "hasproposal") {
             var value = encodeURIComponent($('#EventSearchhasproposal').val());
             if (value != "") filtering.hasproposal = value;
+        } else if (param.data.param1 == "timestamp") {
+            var value = encodeURIComponent($('#EventSearchtimestamp').val());
+            if (value != "") filtering.timestamp = value;
+        } else if (param.data.param1 == "publishtimestamp") {
+            var value = encodeURIComponent($('#EventSearchpublishtimestamp').val());
+            if (value != "") filtering.publishtimestamp = value;
         } else {
             var value = encodeURIComponent($('#EventSearch' + param.data.param1).val());
             var operator = operators[encodeURIComponent($('#EventSearchbool').val())];
@@ -2459,6 +2486,10 @@ function indexFilterClearRow(field) {
     if (field == "date") {
         filtering.date.from = "";
         filtering.date.until = "";
+    } else if (field == "timestamp") {
+        filtering.timestamp = "";
+    } else if (field == "publishtimestamp") {
+        filtering.timestamp = "";
     } else if (field == "published") {
         filtering.published = 2;
     } else if (field == "hasproposal") {


### PR DESCRIPTION
#### What does it do?
Implement feature request #8012:
* Adds new `Last change at` and `Published at` columns in Event Index view, by default hidden, to enable them click on the columns selector, both columns allow sorting.
![image](https://user-images.githubusercontent.com/1659902/144869468-5e0ac969-a714-4f1b-8cd5-543043a93912.png)
* Adds new `Last change at` (`Event.timestamp`) and `Published at` (`Event.publish_timestamp`) filter in the Filter Event Index dialog, filter accepts `YYYY-MM-DD HH:mm:ss`, `timestamp` and `X[mwhd]` expressions.
![image](https://user-images.githubusercontent.com/1659902/144870037-fa808628-83f4-4f21-8206-2be262807aa4.png)

* Fix Org sorting issues in Events Index (#8011)

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
