### PR TITLE
Allow sightings to be pushed upstream

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -4313,12 +4313,12 @@ class Event extends AppModel
     public function checkDistributionForPush($object, $server, $context = 'Event')
     {
         if (empty(Configure::read('MISP.host_org_id')) || !$server['Server']['internal'] || Configure::read('MISP.host_org_id') != $server['Server']['remote_org_id']) {
-            if ($object[$context]['distribution'] < 2) {
+            if ($context != 'Sighting' && $object[$context]['distribution'] < 2) {
                 return false;
             }
         }
         if ($object[$context]['distribution'] == 4) {
-            if ($context === 'Event') {
+            if ($context === 'Event' || $context === 'Sighting') {
                 return $this->SharingGroup->checkIfServerInSG($object['SharingGroup'], $server);
             } else {
                 return $this->SharingGroup->checkIfServerInSG($object[$context]['SharingGroup'], $server);
@@ -4351,9 +4351,9 @@ class Event extends AppModel
         // TODO: This are new conditions, that was not used in old code
         // Filter out servers that do not match server conditions for event push
         $servers = $this->Server->eventFilterPushableServers($event, $servers);
-        // Filter out servers that do not match event distribution conditions for event push
+        // Filter out servers that do not match event sharing group distribution for event push
         $servers = array_filter($servers, function (array $server) use ($event) {
-            return $this->checkDistributionForPush($event, $server);
+            return $this->checkDistributionForPush($event, $server, 'Sighting');
         });
         if (empty($servers)) {
             return true;


### PR DESCRIPTION
The MISP event distribution level is decreased from 2 -> 1 -> 0 at each remote MISP server the event is passed on to:

4: Sharing group
3: All communities
2: Connected communities
1: This community
0: Your organisation only

Sightings however travel in both directions: upstream and downstream. Since 8830696c4db4a97bd6a7ea6a8f2a55cf0e018882 sightings are no longer pushed upstream. This patch makes that possible again.

The `push_sightings` flag for sync servers determines where to push sightings to. Only allowing sightings to be pushed to a remote server when the event distribution is set to "All communities" or "Connected communities" makes no sense.

Limiting sightings for "Sharing group" events to servers in the sharing group does make sense. This code is untouched.