### PR TITLE
Make supervisor connector work

### DIFF
--- a/app/Lib/Tools/BackgroundJobsTool.php
+++ b/app/Lib/Tools/BackgroundJobsTool.php
@@ -632,6 +632,12 @@ class BackgroundJobsTool
             )
         );
 
+        if (class_exists('Supervisor\Connector\XmlRpc')) {
+            // for compatibility with older versions of supervisor
+            $connector = new \Supervisor\Connector\XmlRpc($client);
+            return new \Supervisor\Supervisor($connector);
+        }
+
         return new \Supervisor\Supervisor($client);
     }
 


### PR DESCRIPTION
I just enabled SimpleBackgroundJobs on CentOS using the guide at https://gist.github.com/righel/8ebc6c84341f2aea7d0bfa124e535ef8
After fixing #8050 I was left with another error:
```
2021-12-23 13:52:58 Error: [TypeError] Argument 1 passed to Supervisor\Supervisor::__construct() must be an instance of Supervisor\Connector, instance of fXmlRpc\
Client given, called in /var/www/app/Lib/Tools/BackgroundJobsTool.php on line 635
Request URL: /jobs/index
Stack Trace:
#0 /var/www/app/Lib/Tools/BackgroundJobsTool.php(635): Supervisor\Supervisor->__construct(Object(fXmlRpc\Client))
#1 /var/www/app/Lib/Tools/BackgroundJobsTool.php(593): BackgroundJobsTool->createSupervisorConnection()
#2 /var/www/app/Lib/Tools/BackgroundJobsTool.php(282): BackgroundJobsTool->getSupervisor()
#3 /var/www/app/Model/Server.php(7257): BackgroundJobsTool->getWorkers()
#4 /var/www/app/Model/Server.php(3447): Server->getWorkers()
#5 /var/www/app/Controller/JobsController.php(26): Server->workerDiagnostics(0)
#6 [internal function]: JobsController->index()
#7 /var/www/app/Lib/cakephp/lib/Cake/Controller/Controller.php(499): ReflectionMethod->invokeArgs(Object(JobsController), Array)
#8 /var/www/app/Lib/cakephp/lib/Cake/Routing/Dispatcher.php(193): Controller->invokeAction(Object(CakeRequest))
#9 /var/www/app/Lib/cakephp/lib/Cake/Routing/Dispatcher.php(167): Dispatcher->_invoke(Object(JobsController), Object(CakeRequest))
#10 /var/www/app/webroot/index.php(99): Dispatcher->dispatch(Object(CakeRequest), Object(CakeResponse))
#11 {main}
```
I found the fix at https://github.com/supervisorphp/supervisor/issues/10 and now everything is fine.
My `app/composer.json` was updated with these libraries:
```
        "pear/crypt_gpg": "^1.6",
        "supervisorphp/supervisor": "^3.0",
        "guzzlehttp/guzzle": "^7.4",
        "php-http/message": "^1.12",
        "lstrojny/fxmlrpc": "^0.22.0"
```