### PR TITLE
fix: do not show incorrect worker user when worker owner cannot be re…

### DIFF
--- a/app/Lib/Tools/BackgroundJobsTool.php
+++ b/app/Lib/Tools/BackgroundJobsTool.php
@@ -693,16 +693,19 @@ class BackgroundJobsTool
     /**
      * Get effective user name
      * @param int $pid
-     * @return string
+     * @return string|null
      */
     private function processUser(int $pid)
     {
+        $user = null;
         if (function_exists('posix_getpwuid') && file_exists("/proc/$pid/status")) {
             $content = file_get_contents("/proc/$pid/status");
             preg_match("/Uid:\t([0-9]+)\t([0-9]+)/", $content, $matches);
-            return posix_getpwuid((int)$matches[2])['name'];
+            $user = posix_getpwuid((int)$matches[2])['name'];
         } else {
-            return trim(shell_exec(sprintf("ps -o uname='' -p %s", $pid)) ?? '');
+            $user = trim(shell_exec(sprintf("ps -o uname='' -p %s", $pid)) ?? '');
         }
+
+        return $user;
     }
 }

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -3450,7 +3450,7 @@ class Server extends AppModel
         $procAccessible = file_exists('/proc');
         foreach ($workers as $pid => $worker) {
             $entry = ($worker['type'] == 'regular') ? $worker['queue'] : $worker['type'];
-            $correct_user = ($currentUser === $worker['user']);
+            $correct_user = ($currentUser === $worker['user'] || empty($worker['user']));
             if (!is_numeric($pid)) {
                 throw new MethodNotAllowedException('Non numeric PID found.');
             }

--- a/app/View/Elements/healthElements/workers.ctp
+++ b/app/View/Elements/healthElements/workers.ctp
@@ -104,7 +104,7 @@
     ?>
         <tr>
             <td class="shortish" style="<?php echo $style; ?>"><?php echo h($worker['pid']);?></td>
-            <td class="short" style="<?php echo $style; ?>"><?php echo h($worker['user']); ?></td>
+            <td class="short" style="<?php echo $style; ?>"><?php echo h($worker['user'] ?? __('Unknown')); ?></td>
             <td class="short" style="<?php echo $style; ?>"><?php echo $process; ?></td>
             <td style="<?php echo $style; ?>"><?php echo $message; ?></td>
             <td class="actions short" style="<?php echo $style; ?>">


### PR DESCRIPTION
#### What does it do?

Fixes incorrect error reporting when PHP fails to get the owner of a process by PID in more restrictive environments such as RHEL with SELinux enabled.
Fixes issue #8054 

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
