### PR TITLE
fix: Removes debug print in AWS S3 Client

### DIFF
--- a/app/Lib/Tools/AWSS3Client.php
+++ b/app/Lib/Tools/AWSS3Client.php
@@ -83,10 +83,6 @@ class AWSS3Client
         } else {
             $s3Config['http']['verify'] = false;
         }
-        echo 'Settings=====';
-        var_dump($settings);
-        echo 'S3Config=====';
-        var_dump($s3Config);
         $s3Client = new Aws\S3\S3Client($s3Config);
         $this->__client = $s3Client;
         $this->__settings = $settings;


### PR DESCRIPTION
#### What does it do?

Removes debug print in AWS S3 client

#### Questions

- [X ] Does it require a DB change?
- [V] Are you using it in production?
- [X ] Does it require a change in the API (PyMISP for example)?
