### PR TITLE
fix: supervisord_status showing as a worker when its not

### DIFF
--- a/app/Lib/Tools/BackgroundJobsTool.php
+++ b/app/Lib/Tools/BackgroundJobsTool.php
@@ -58,7 +58,8 @@ class BackgroundJobsTool
         EMAIL_QUEUE = 'email',
         CACHE_QUEUE = 'cache',
         PRIO_QUEUE = 'prio',
-        UPDATE_QUEUE = 'update';
+        UPDATE_QUEUE = 'update',
+        SCHEDULER_QUEUE = 'scheduler';
 
     const VALID_QUEUES = [
         self::DEFAULT_QUEUE,
@@ -66,6 +67,7 @@ class BackgroundJobsTool
         self::CACHE_QUEUE,
         self::PRIO_QUEUE,
         self::UPDATE_QUEUE,
+        self::SCHEDULER_QUEUE,
     ];
 
     const

--- a/app/View/Elements/healthElements/workers.ctp
+++ b/app/View/Elements/healthElements/workers.ctp
@@ -18,7 +18,7 @@
 <?php
         endif;
         foreach ($worker_array as $type => $data):
-        if ($type == 'proc_accessible' or $type == 'controls') continue;
+        if (!in_array($type, BackgroundJobsTool::VALID_QUEUES)) continue;
         $queueStatusMessage = __("Issues prevent jobs from being processed. Please resolve them below.");
         $queueStatus = false;
         if ($data['ok']) {


### PR DESCRIPTION
#### What does it do?
removes `supervisord_status` worker entry from workers diagnostics page as it's a auxiliary key to evaluate the status of `supervisord` and not a valid worker queue.

Fixes issue #8064

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
