### PR TITLE
LinOTP minor fixes

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1388,6 +1388,7 @@ class Server extends AppModel
             'misc' => 'Security',
             'Security' => 'Security',
             'Session' => 'Security',
+            'LinOTPAuth' => 'Security',
             'SimpleBackgroundJobs' => 'SimpleBackgroundJobs'
         );
 
@@ -7134,6 +7135,37 @@ class Server extends AppModel
                 'test' => 'testDebugAdmin',
                 'type' => 'boolean',
                 'null' => true
+            ),
+            'LinOTPAuth' => array(
+                'branch' => 1,
+                'baseUrl' => array(
+                    'level' => 2,
+                    'description' => __('The default LinOTP URL.'),
+                    'value' => 'https://linotp',
+                    'test' => 'testForEmpty',
+                    'type' => 'string',
+                ),
+                'realm' => array(
+                    'level' => 2,
+                    'description' => __('The LinOTP realm to authenticate against.'),
+                    'value' => 'lino',
+                    'test' => 'testForEmpty',
+                    'type' => 'string',
+                ),
+                'verifyssl' => array(
+                    'level' => 2,
+                    'description' => __('Set to false to skip SSL/TLS verify'),
+                    'value' => true,
+                    'test' => 'testBoolTrue',
+                    'type' => 'boolean',
+                ),
+                'mixedauth' => array(
+                    'level' => 2,
+                    'description' => __('Set to true to enforce OTP usage'),
+                    'value' => false,
+                    'test' => 'testBoolFalse',
+                    'type' => 'boolean',
+                ),
             ),
         );
     }

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -7141,7 +7141,7 @@ class Server extends AppModel
                 'baseUrl' => array(
                     'level' => 2,
                     'description' => __('The default LinOTP URL.'),
-                    'value' => 'https://linotp',
+                    'value' => 'https://<your-linotp-baseUrl>',
                     'test' => 'testForEmpty',
                     'type' => 'string',
                 ),

--- a/app/Plugin/LinOTPAuth/Controller/Component/Auth/LinOTPAuthenticate.php
+++ b/app/Plugin/LinOTPAuth/Controller/Component/Auth/LinOTPAuthenticate.php
@@ -50,7 +50,13 @@ class LinOTPAuthenticate extends BaseAuthenticate
         $url = "$baseUrl/validate/check";
 
         CakeLog::debug( "Sending POST request to ${url}");
-        $results = $HttpSocket->post($url, $data);
+        try {
+            $results = $HttpSocket->post($url, $data);
+        }
+        catch (SocketException $ex) {
+            CakeLog::error("LinOTP: {$ex->getMessage()}.");
+            return false;
+        }
         if ($results->code != "200") {
             return false;
         }

--- a/app/View/Users/login.ctp
+++ b/app/View/Users/login.ctp
@@ -41,6 +41,13 @@
             echo $this->Form->input('password', array('autocomplete' => 'off'));
             if (!empty(Configure::read('LinOTPAuth'))) {
                 echo $this->Form->input('otp', array('autocomplete' => 'off', 'type' => 'password', 'label' => 'OTP'));
+                echo "<div class=\"clear\">";
+                echo sprintf(
+                    '%s <a href="%s/selfservice" title="LinOTP Selfservice">LinOTP Selfservice</a> %s',
+                    __('Visit'),
+                    Configure::read('LinOTPAuth.baseUrl'),
+                    __('for the One-Time-Password selfservice.')
+                );
             }
         ?>
             <div class="clear">


### PR DESCRIPTION
#### What does it do?

1. Improved error handling/logging if SSL/TLS socket could not be established.
2. Added a link to login.ctp to visit the LinOTP Selfservice portal (if LinOTP is enabled).
3. Make LinOTP config via web-ui + cli interface.

#### Questions

- [ ] Does it require a DB change? - NO
- [x] Are you using it in production? - Yes
- [ ] Does it require a change in the API (PyMISP for example)? - NO
