### PR TITLE
new: [security] Allow to specify min_tls_version

### DIFF
--- a/app/Lib/Tools/HttpSocketExtended.php
+++ b/app/Lib/Tools/HttpSocketExtended.php
@@ -128,6 +128,9 @@ class HttpSocketExtended extends HttpSocket
 {
     public $responseClass = 'HttpSocketResponseExtended';
 
+    /** @var callable */
+    private $onConnect;
+
     public function __construct($config = array())
     {
         parent::__construct($config);
@@ -137,6 +140,26 @@ class HttpSocketExtended extends HttpSocket
                 $this->config['request']['header']['Accept-Encoding'] = implode(', ', $this->acceptedEncodings());
             }
         }
+    }
+
+    public function connect()
+    {
+        $connected = parent::connect();
+        if ($this->onConnect) {
+            $handler = $this->onConnect;
+            $handler($this);
+        }
+        return $connected;
+    }
+
+    /**
+     * Set callback method, that will be called after connection to remote server is established.
+     * @param callable $callback
+     * @return void
+     */
+    public function onConnectHandler(callable $callback)
+    {
+        $this->onConnect = $callback;
     }
 
     /**

--- a/app/Lib/Tools/SyncTool.php
+++ b/app/Lib/Tools/SyncTool.php
@@ -59,6 +59,28 @@ class SyncTool
             $params['ssl_cafile'] = $caPath;
         }
 
+        if ($minTlsVersion = Configure::read('Security.min_tls_version')) {
+            $version = 0;
+            switch ($minTlsVersion) {
+                case 'tlsv1_0':
+                    $version |= STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT;
+                case 'tlsv1_1':
+                    $version |= STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT;
+                case 'tlsv1_2':
+                    $version |= STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
+                case 'tlsv1_3':
+                    if (defined('STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT')) {
+                        $version |= STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT;
+                    } else if ($minTlsVersion === 'tlsv1_3') {
+                        throw new Exception("TLSv1.3 is not supported by PHP.");
+                    }
+                    break;
+                default:
+                    throw new InvalidArgumentException("Invalid `Security.min_tls_version` option $minTlsVersion");
+            }
+            $params['ssl_crypto_method'] = $version;
+        }
+
         App::uses('HttpSocketExtended', 'Tools');
         $HttpSocket = new HttpSocketExtended($params);
         $proxy = Configure::read('Proxy');

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -5097,7 +5097,12 @@ class Server extends AppModel
                     'value' => '',
                     'test' => 'testForEmpty',
                     'type' => 'string',
-                    'options' => array('0' => __('Your organisation only'), '1' => __('This community only'), '2' => __('Connected communities'), '3' => __('All communities')),
+                    'options' => [
+                        '0' => __('Your organisation only'),
+                        '1' => __('This community only'),
+                        '2' => __('Connected communities'),
+                        '3' => __('All communities')
+                    ],
                 ),
                 'default_attribute_distribution' => array(
                     'level' => 0,
@@ -6136,7 +6141,7 @@ class Server extends AppModel
                 ],
                 'encryption_key' => [
                     'level' => self::SETTING_OPTIONAL,
-                    'description' => __('Encryption key used to store sensitive data (like authkeys) in database encrypted. If empty, data are stored unecrypted. Required PHP 7.1 or newer.'),
+                    'description' => __('Encryption key used to store sensitive data (like authkeys) in database encrypted. If empty, data are stored unencrypted. Requires PHP 7.1 or newer.'),
                     'value' => '',
                     'test' => function ($value) {
                         if (strlen($value) < 32) {
@@ -6160,6 +6165,20 @@ class Server extends AppModel
                     'null' => true,
                     'cli_only' => true,
                     'redacted' => true,
+                ],
+                'min_tls_version' => [
+                    'level' => self::SETTING_OPTIONAL,
+                    'description' => __('Minimal required TLS version when connecting to external resources.'),
+                    'value' => '',
+                    'type' => 'string',
+                    'null' => true,
+                    'options' => [
+                        '' => __('All versions'),
+                        'tlsv1_0' => 'TLSv1.0',
+                        'tlsv1_1' => 'TLSv1.1',
+                        'tlsv1_2' => 'TLSv1.2',
+                        'tlsv1_3' => 'TLSv1.3',
+                    ],
                 ],
             ),
             'SecureAuth' => array(


### PR DESCRIPTION
#### What does it do?

Add new setting `Security.min_tls_version` that will specify minimal TLS version for outgoing connections.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
