### PR TITLE
fix : Update Stix1Export.php to fix issue #8108

### DIFF
--- a/app/Lib/Export/Stix1Export.php
+++ b/app/Lib/Export/Stix1Export.php
@@ -16,7 +16,7 @@ class Stix1Export extends StixExport
             '-s', $this->__scope,
             '-v', $this->__version,
             '-n', Configure::read('MISP.baseurl'),
-            '-o', Configure::read('MISP.org'),
+            '-o', str_replace(' ', '_', Configure::read('MISP.org')),
             '-f', $this->__return_format,
         ];
     }


### PR DESCRIPTION
Not sure if this is the best solution to #8108, but replacing the whitespace in the orgname here fixed the double tag problem. It also eliminates the need to have several sections of code in the misp_stix_converter.py where you are doing  org = re.sub('[\W]+', '', org.replace(" ", "_"))

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2020-05-05: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

Fixes issue #8108

#### Questions

- [ ] Does it require a DB change?  no
- [x] Are you using it in production? yes
- [ ] Does it require a change in the API (PyMISP for example)? no
