### PR TITLE
chg: fix findoriginaluuid typo

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -6753,7 +6753,7 @@ class Event extends AppModel
             )
         );
         if (!empty($original_uuid)) {
-            return ['Attribute']['uuid'];
+            return $original_uuid['Attribute']['uuid'];
         }
         $original_uuid = $this->Object->find(
             'first',


### PR DESCRIPTION
#### What does it do?

Fixes what I assume is a typo. I was getting notices in logs for this while debugging another issue.

Please note this typo is also in the 2.4 branch. I did not assess how/where this function is used etc.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
