### PR TITLE
Make `Event.locked` a boolean as per MISP RFC

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -3904,7 +3904,7 @@ class EventsController extends AppController
                     unset($incomingEvents[$event['Event']['uuid']]);
                     continue;
                 }
-                if ($event['Event']['locked'] == 0) {
+                if (!$event['Event']['locked']) {
                     unset($incomingEvents[$event['Event']['uuid']]);
                 }
             }

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -3623,7 +3623,7 @@ class Event extends AppModel
                 }
                 $event = array('Event' => $event);
                 $created_id = 0;
-                $event['Event']['locked'] = 1;
+                $event['Event']['locked'] = true;
                 $event['Event']['published'] = $publish;
                 $result['result'] = $this->_add($event, true, $user, '', null, false, null, $created_id, $validationIssues);
                 $result['id'] = $created_id;
@@ -3637,7 +3637,7 @@ class Event extends AppModel
                 unset($temp['Event']['Orgc']);
             }
             $created_id = 0;
-            $temp['Event']['locked'] = 1;
+            $temp['Event']['locked'] = true;
             $temp['Event']['published'] = $publish;
             $result = $this->_add($temp, true, $user, '', null, false, null, $created_id, $validationIssues);
             $results = array(array(
@@ -4451,7 +4451,7 @@ class Event extends AppModel
             return true;
         }
         $event = $event[0];
-        $event['Event']['locked'] = 1;
+        $event['Event']['locked'] = true;
         // get a list of the servers
         $this->Server = ClassRegistry::init('Server');
 
@@ -4501,7 +4501,7 @@ class Event extends AppModel
                 }
                 $event = $this->fetchEvent($elevatedUser, $params);
                 $event = $event[0];
-                $event['Event']['locked'] = 1;
+                $event['Event']['locked'] = true;
 
                 $fakeSyncUser = array(
                     'org_id' => $server['Server']['remote_org_id'],
@@ -4766,7 +4766,7 @@ class Event extends AppModel
                 'conditions' => $conditions
         ));
         $this->updateAll(
-                array('Event.locked' => 1),
+                array('Event.locked' => true),
                 $conditions
         );
         return $toBeUpdated;


### PR DESCRIPTION
#### What does it do?

Changes the `Event.locked` field from an `int` to a `bool` as per the MISP Core RFC.
Some locations already correctly used a `bool` as [/app/Model/Server.php#L247](https://github.com/MISP/MISP/blob/4b3626d000efe68b1aca73d53eba765ce7d6d1f9/app/Model/Server.php#L247).

The following is an event as pushed to the `/events/add/metadata:1` endpoint during a sync. The `locked` property is an `int` resulting in some JSON parsers not being able to parse the unexpected format.

```json
{
  "Event": {
    "id": "1",
    "date": "2022-02-03",
    "threat_level_id": "1",
    "info": "Test",
    "published": true,
    "uuid": "c2774569-e6a3-4bcc-b148-9536381eba0b",
    "attribute_count": "4",
    "analysis": "0",
    "timestamp": "1643972122",
    "distribution": "1",
    "user_id": "1",
    "locked": 1,
    "publish_timestamp": "1643972130",
    "sharing_group_id": "0",
    "disable_correlation": false,
    "extends_uuid": "",
    "event_creator_email": "admin@admin.test",
    "Attribute": [],
    "Object": [],
    "Orgc": {
      "id": "1",
      "name": "ORGNAME",
      "uuid": "f8a8705f-5c39-4966-b442-323fce208528",
      "local": true
    },
    "ShadowAttribute": []
  },
  "ThreatLevel": {
    "name": "High",
    "id": "1"
  },
  "Galaxy": [],
  "User": {
    "email": "admin@admin.test"
  },
  "RelatedEvent": []
}
```

#### Questions

- [ ] Does it require a DB change?
  Unsure, some other boolean values are also stored as `tinyint`.
- [ ] Are you using it in production?
  **No, changes have not been tested.**
- [ ] Does it require a change in the API (PyMISP for example)?
  Depends on the API language. Some type-safe languages implementing the MISP Core RFC will not be able to interpret the current representation as they expect a JSON `bool` and not a `number`.
