### PR TITLE
Preserve Session.* configuration in serverSettingsSaveValue

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -2308,10 +2308,9 @@ class Server extends AppModel
 
         $settingsToSave = array(
             'debug', 'MISP', 'GnuPG', 'SMIME', 'Proxy', 'SecureAuth',
-            'Security', 'Session.defaults', 'Session.timeout', 'Session.cookieTimeout',
-            'Session.autoRegenerate', 'Session.checkAgent', 'site_admin_debug',
-            'Plugin', 'CertAuth', 'ApacheShibbAuth', 'ApacheSecureAuth', 'OidcAuth',
-            'AadAuth', 'SimpleBackgroundJobs', 'LinOTPAuth'
+            'Security', 'Session', 'site_admin_debug', 'Plugin', 'CertAuth',
+            'ApacheShibbAuth', 'ApacheSecureAuth', 'OidcAuth', 'AadAuth',
+            'SimpleBackgroundJobs', 'LinOTPAuth'
         );
         $settingsArray = array();
         foreach ($settingsToSave as $setting) {


### PR DESCRIPTION
#### What does it do?

Fixes an issue where running `/var/www/MISP/app/Console/cake live 1` would remove any configuration under `Session` from config.php.

Repro:

1) Set `Session.defaults = 'database'` by running `/var/www/MISP/app/Console/cake Admin setSetting "Session.defaults" "database"`
This correctly inserts the setting into config.php

2) Run `/var/www/MISP/app/Console/cake live 1`. This removes the setting from config.php as it checks to see if `Session.defaults` exists in a hash that has a `Session` as key.

Without this, logging into multi-node installation fails with `You have tripped the cross-site request forgery protection of MISP` as sessions are local instead of in the DB.

#### Questions

- [x] Does it require a DB change? No
- [x] Are you using it in production? Yes
- [x] Does it require a change in the API (PyMISP for example)? No
