### PR TITLE
fix: Allow Tag_Editors to edit tags

### DIFF
--- a/app/Controller/Component/ACLComponent.php
+++ b/app/Controller/Component/ACLComponent.php
@@ -610,7 +610,7 @@ class ACLComponent extends Component
                     'add' => array('perm_tag_editor'),
                     'attachTagToObject' => array('perm_tagger'),
                     'delete' => array(),
-                    'edit' => array(),
+                    'edit' => array('perm_tag_editor'),
                     'index' => array('*'),
                     'quickAdd' => array('perm_tag_editor'),
                     'removeTagFromObject' => array('perm_tagger'),

--- a/app/View/Tags/index.ctp
+++ b/app/View/Tags/index.ctp
@@ -138,7 +138,7 @@
                     ],
                     'icon' => 'edit',
                     'title' => __('Edit'),
-                    'requirement' => $isSiteAdmin,
+                    'requirement' => $isAclTagEditor,
                 ],
                 [
                     'url' => $baseurl . '/tags/delete',


### PR DESCRIPTION
#### What does it do?
Allows users with permisssion Tag_Editor to not only create but also edit Tags.

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
