### PR TITLE
[chg] LinOTP error exceptions up to the ui

### DIFF
--- a/app/Plugin/LinOTPAuth/Controller/Component/Auth/LinOTPAuthenticate.php
+++ b/app/Plugin/LinOTPAuth/Controller/Component/Auth/LinOTPAuthenticate.php
@@ -131,7 +131,7 @@ class LinOTPAuthenticate extends BaseAuthenticate
         if (!$linOTP_baseUrl || $linOTP_baseUrl === "") {
             CakeLog::error("LinOTP: Please configure baseUrl.");
             if ($mixedauth) {
-                throw new CakeException(__d('cake_dev', 'LinOTP: Missing "baseUrl" configuration - access denied!', 'authenticate()'));
+                throw new ForbiddenException(__('LinOTP: Missing "baseUrl" configuration - access denied!'));
             } else {
                 return false;
             }
@@ -150,7 +150,7 @@ class LinOTPAuthenticate extends BaseAuthenticate
         } else {
             // Enforce OTP token by Authentication Form
             if (!$otp || $otp === "") {
-                throw new CakeException(__d('cake_dev', 'Missing OTP Token.', 'authenticate()'));
+                throw new ForbiddenException(__('Missing OTP Token.'));
             }
 
             $response = $this->_linotp_verify(
@@ -200,7 +200,7 @@ class LinOTPAuthenticate extends BaseAuthenticate
         // Don't fall back to FormAuthenticate in mixedauth mode.
         // This enforces the second factor.
         if ($mixedauth && !self::$user) {
-            throw new CakeException(__d('cake_dev', 'User could not be authenticated by LinOTP.', 'authenticate()'));
+            throw new UnauthorizedException(__('User could not be authenticated by LinOTP.'));
         }
         return self::$user;
     }


### PR DESCRIPTION
#### What does it do?

Current situation would only throw a common unspecified "Internal Error Message...." when something went wrong while authenticating against LinOTP.
With this PR it throws some more meaningful error messages back to the UI - regardless of debug enabled.  

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
