### PR TITLE
new: add setting for allowing svg org logos

### DIFF
--- a/app/Config/config.default.php
+++ b/app/Config/config.default.php
@@ -17,6 +17,7 @@ $config = array(
         'user_monitoring_enabled'           => false,
         'authkey_keep_session'              => false,
         'disable_local_feed_access'         => false,
+        'enable_svg_logos'                  => false,
         //'auth'                            => array('CertAuth.Certificate'), // additional authentication methods
         //'auth'                            => array('ShibbAuth.ApacheShibb'),
         //'auth'                            => array('AadAuth.AadAuthenticate'),

--- a/app/Controller/OrganisationsController.php
+++ b/app/Controller/OrganisationsController.php
@@ -483,6 +483,12 @@ class OrganisationsController extends AppController
         if ($logo['size'] > 0 && $logo['error'] == 0) {
             $extension = pathinfo($logo['name'], PATHINFO_EXTENSION);
             $filename = $orgId . '.' . ($extension === 'svg' ? 'svg' : 'png');
+
+            if ($extension === 'svg' && !Configure::read('Security.enable_svg_logos')) {
+                $this->Flash->error(__('Invalid file extension, SVG images are not allowed.'));
+                return false;
+            }
+
             if (!empty($logo['tmp_name']) && is_uploaded_file($logo['tmp_name'])) {
                 return move_uploaded_file($logo['tmp_name'], APP . 'webroot/img/orgs/' . $filename);
             }

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -6136,6 +6136,14 @@ class Server extends AppModel
                         'tlsv1_3' => 'TLSv1.3',
                     ],
                 ],
+                'enable_svg_logos' => [
+                    'level' => self::SETTING_OPTIONAL,
+                    'description' => __('When enabled, orgnisation logos in svg format are allowed.'),
+                    'value' => false,
+                    'test' => 'testBool',
+                    'type' => 'boolean',
+                    'null' => true
+                ]
             ),
             'SecureAuth' => array(
                 'branch' => 1,

--- a/app/View/Organisations/admin_add.ctp
+++ b/app/View/Organisations/admin_add.ctp
@@ -50,7 +50,7 @@ echo $this->element('genericElements/Form/genericForm', [
                 'type' => 'file',
                 'field' => 'logo',
                 'error' => array('escape' => false),
-                'label' => __('Logo (48×48 PNG or SVG)'),
+                'label' => __('Logo (48×48 %s)', Configure::read('Security.enable_svg_logos')? 'PNG or SVG' : 'PNG'),
             ],
             [
                 'field' => 'nationality',


### PR DESCRIPTION
#### What does it do?
add new security setting for allowing svg org logos

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
