### PR TITLE
new: add setting to disable feed correlations

### DIFF
--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -384,9 +384,6 @@ class Feed extends AppModel
         if (isset($feed['Feed']['settings'][$type])) {
             $settings = $feed['Feed']['settings'][$type];
         }
-        if (isset($feed['Feed']['settings']['disable_correlation'])) {
-            $settings['disable_correlation'] = (bool) $feed['Feed']['settings']['disable_correlation'];
-        }
         if (isset($feed['Feed']['settings']['common'])) {
             $settings = array_merge($settings, $feed['Feed']['settings']['common']);
         }

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -384,6 +384,9 @@ class Feed extends AppModel
         if (isset($feed['Feed']['settings'][$type])) {
             $settings = $feed['Feed']['settings'][$type];
         }
+        if (isset($feed['Feed']['settings']['disable_correlation'])) {
+            $settings['disable_correlation'] = (bool) $feed['Feed']['settings']['disable_correlation'];
+        }
         if (isset($feed['Feed']['settings']['common'])) {
             $settings = array_merge($settings, $feed['Feed']['settings']['common']);
         }
@@ -1025,6 +1028,11 @@ class Feed extends AppModel
         if (!$this->__checkIfEventBlockedByFilter($event, $filterRules)) {
             return 'blocked';
         }
+        if (!empty($feed['Feed']['settings'])) {
+            if (!empty($feed['Feed']['settings']['disable_correlation'])) {
+                $event['Event']['disable_correlation'] = (bool) $feed['Feed']['settings']['disable_correlation'];
+            }
+        }
         return $event;
     }
 
@@ -1225,6 +1233,10 @@ class Feed extends AppModel
             if (!empty($feed['Feed']['orgc_id'])) {
                 $orgc_id = $feed['Feed']['orgc_id'];
             }
+            $disableCorrelation = false;
+            if (!empty($feed['Feed']['settings'])) {
+                $disableCorrelation = (bool) $feed['Feed']['settings']['disable_correlation'] ?? false;
+            }
             $event = array(
                 'info' => $feed['Feed']['name'] . ' feed',
                 'analysis' => 2,
@@ -1234,7 +1246,8 @@ class Feed extends AppModel
                 'date' => date('Y-m-d'),
                 'distribution' => $feed['Feed']['distribution'],
                 'sharing_group_id' => $feed['Feed']['sharing_group_id'],
-                'user_id' => $user['id']
+                'user_id' => $user['id'],
+                'disable_correlation' => $disableCorrelation,
             );
             $result = $this->Event->save($event);
             if (!$result) {

--- a/app/View/Feeds/add.ctp
+++ b/app/View/Feeds/add.ctp
@@ -22,6 +22,11 @@ echo $this->element('genericElements/Form/genericForm', [
                 'type' => 'checkbox'
             ],
             [
+                'field' => 'Feed.settings.disable_correlation',
+                'label' => __('Disable correlation'),
+                'type' => 'checkbox'
+            ],
+            [
                 'field' => 'name',
                 'label' => __('Name'),
                 'placeholder' => __('Feed name'),

--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -3,7 +3,7 @@
     "Feed": {
       "name": "CIRCL OSINT Feed",
       "provider": "CIRCL",
-      "url": "https://www.circl.lu/doc/misp/feed-osint/",
+      "url": "https://www.circl.lu/doc/misp/feed-osint",
       "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]}}",
       "enabled": true,
       "distribution": "3",
@@ -981,7 +981,7 @@
       "delta_merge": false,
       "publish": false,
       "override_ids": false,
-      "settings": "{\"csv\":{\"value\":\"3\",\"delimiter\":\",\"},\"common\":{\"excluderegex\":\"\"}}",
+      "settings": "{\"csv\":{\"value\":\"3\",\"delimiter\":\",\"},\"common\":{\"excluderegex\":\"\"},\"disable_correlation\":\"1\"}",
       "input_source": "network",
       "delete_local_file": false,
       "lookup_visible": true
@@ -1582,7 +1582,7 @@
       "delta_merge": false,
       "publish": false,
       "override_ids": false,
-      "settings": "{\"csv\":{\"value\":\"\",\"delimiter\":\"\"},\"common\":{\"excluderegex\":\"\"}}",
+      "settings": "{\"csv\":{\"value\":\"\",\"delimiter\":\"\"},\"common\":{\"excluderegex\":\"\"},\"disable_correlation\":\"1\"}",
       "input_source": "network",
       "delete_local_file": false,
       "lookup_visible": false

--- a/app/webroot/doc/openapi.yaml
+++ b/app/webroot/doc/openapi.yaml
@@ -4569,7 +4569,7 @@ components:
     FeedSettings:
       type: string
       nullable: true
-      example: '{"csv":{"value":"","delimiter":""},"common":{"excluderegex":""}}'
+      example: '{"csv":{"value":"","delimiter":""},"common":{"excluderegex":""},"disable_correlation":"1"}'
 
     FeedRules:
       description: "Stringified JSON filter rules."


### PR DESCRIPTION
#### What does it do?
Add option to disable correlations at a `Feed` level when adding/editing a feed, it sets `disabled_correlation` at an `Event` level, works both for MISP and CSV/Freetext events.

#### Screenshot
![image](https://user-images.githubusercontent.com/1659902/165778583-9dca5814-a8f6-4af8-add1-4829cc72a890.png)

after merging it to main, update docs: https://github.com/MISP/misp-book/pull/275

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
