### PR TITLE
chg: add index for attributes.timestamp, show index diagnostics in di…

### DIFF
--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -1686,6 +1686,7 @@ class AppModel extends Model
                 break;
             case 86:
                 $this->__addIndex('attributes', 'timestamp');
+                break;
             case 'fixNonEmptySharingGroupID':
                 $sqlArray[] = 'UPDATE `events` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';
                 $sqlArray[] = 'UPDATE `attributes` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -89,7 +89,7 @@ class AppModel extends Model
         63 => true, 64 => false, 65 => false, 66 => false, 67 => false, 68 => false,
         69 => false, 70 => false, 71 => true, 72 => true, 73 => false, 74 => false,
         75 => false, 76 => true, 77 => false, 78 => false, 79 => false, 80 => false,
-        81 => false, 82 => false, 83 => false, 84 => false, 85 => false,
+        81 => false, 82 => false, 83 => false, 84 => false, 85 => false, 86 => false
     );
 
     public $advanced_updates_description = array(
@@ -1684,6 +1684,8 @@ class AppModel extends Model
                 $this->__addIndex('cryptographic_keys', 'parent_type');
                 $this->__addIndex('cryptographic_keys', 'fingerprint');
                 break;
+            case 86:
+                $this->__addIndex('attributes', 'timestamp');
             case 'fixNonEmptySharingGroupID':
                 $sqlArray[] = 'UPDATE `events` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';
                 $sqlArray[] = 'UPDATE `attributes` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';

--- a/app/View/Elements/healthElements/db_schema_diagnostic.ctp
+++ b/app/View/Elements/healthElements/db_schema_diagnostic.ctp
@@ -178,11 +178,13 @@
         __('DataSource: ') . h($dataSource),
         $dataSource != 'Database/Mysql' ? 'times' : 'check'
     );
-    echo $this->element('/healthElements/db_indexes_diagnostic', array(
-        'columnPerTable' => $columnPerTable,
-        'diagnostic' => $dbIndexDiagnostics,
-        'indexes' => $indexes
-    ));
+    if ($expectedDbVersion == $actualDbVersion) {
+        echo $this->element('/healthElements/db_indexes_diagnostic', array(
+            'columnPerTable' => $columnPerTable,
+            'diagnostic' => $dbIndexDiagnostics,
+            'indexes' => $indexes
+        ));
+    }
 ?>
 <script>
 var dbSchemaDiagnostics = <?php echo json_encode($dbSchemaDiagnostics); ?>;

--- a/app/View/Elements/healthElements/db_schema_diagnostic.ctp
+++ b/app/View/Elements/healthElements/db_schema_diagnostic.ctp
@@ -178,13 +178,11 @@
         __('DataSource: ') . h($dataSource),
         $dataSource != 'Database/Mysql' ? 'times' : 'check'
     );
-    if ($expectedDbVersion == $actualDbVersion) {
-        echo $this->element('/healthElements/db_indexes_diagnostic', array(
-            'columnPerTable' => $columnPerTable,
-            'diagnostic' => $dbIndexDiagnostics,
-            'indexes' => $indexes
-        ));
-    }
+    echo $this->element('/healthElements/db_indexes_diagnostic', array(
+        'columnPerTable' => $columnPerTable,
+        'diagnostic' => $dbIndexDiagnostics,
+        'indexes' => $indexes
+    ));
 ?>
 <script>
 var dbSchemaDiagnostics = <?php echo json_encode($dbSchemaDiagnostics); ?>;

--- a/db_schema.json
+++ b/db_schema.json
@@ -8031,7 +8031,8 @@
             "category": false,
             "sharing_group_id": false,
             "first_seen": false,
-            "last_seen": false
+            "last_seen": false,
+            "timestamp": false
         },
         "attribute_tags": {
             "id": true,
@@ -8469,5 +8470,5 @@
             "id": true
         }
     },
-    "db_version": "85"
+    "db_version": "86"
 }


### PR DESCRIPTION
#### What does it do?

If it fixes an existing issue, please use github syntax: `#<IssueID>`
Add index for `attributes.timestamp` column, show index diagnostics on index diagnostics page when db versions mismatch.

fixes #8329

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
