### PR TITLE
Revert "chg: [sync] Use server sync when fetching galaxy clusters"

### DIFF
--- a/app/Lib/Tools/ServerSyncTool.php
+++ b/app/Lib/Tools/ServerSyncTool.php
@@ -9,8 +9,7 @@ class ServerSyncTool
         FEATURE_FILTER_SIGHTINGS = 'filter_sightings',
         FEATURE_PROPOSALS = 'proposals',
         FEATURE_POST_TEST = 'post_test',
-        FEATURE_PROTECTED_EVENT = 'protected_event',
-        FEATURE_GALAXY_CLUSTER_SYNC = 'galaxy_cluster_sync';
+        FEATURE_PROTECTED_EVENT = 'protected_event';
 
     /** @var array */
     private $server;
@@ -214,27 +213,6 @@ class ServerSyncTool
     }
 
     /**
-     * @param array $filterRules
-     * @return HttpSocketResponseExtended
-     * @throws HttpSocketHttpException
-     * @throws HttpSocketJsonException
-     */
-    public function galaxyClusterSearch(array $filterRules = [])
-    {
-        return $this->post('/galaxy_clusters/restSearch', $filterRules);
-    }
-
-    /**
-     * @param int|string $clusterId Cluster ID or UUID
-     * @return HttpSocketResponseExtended
-     * @throws HttpSocketHttpException
-     */
-    public function fetchGalaxyCluster($clusterId)
-    {
-        return $this->get('/galaxy_clusters/view/' . $clusterId);
-    }
-
-    /**
      * @return HttpSocketResponseExtended
      * @throws HttpSocketHttpException
      */
@@ -354,8 +332,6 @@ class ServerSyncTool
             case self::FEATURE_PROTECTED_EVENT:
                 $version = explode('.', $info['version']);
                 return $version[0] == 2 && $version[1] == 4 && $version[2] > 155;
-            case self::FEATURE_GALAXY_CLUSTER_SYNC:
-                return isset($version['perm_galaxy_editor']);
             default:
                 throw new InvalidArgumentException("Invalid flag `$flag` provided");
         }

--- a/app/Model/GalaxyCluster.php
+++ b/app/Model/GalaxyCluster.php
@@ -1943,7 +1943,7 @@ class GalaxyCluster extends AppModel
      * pullGalaxyClusters
      *
      * @param  array $user
-     * @param  ServerSyncTool $serverSync
+     * @param  array $server
      * @param  string|int $technique The technique startegy used for pulling
      *      allowed:
      *          - int <event id>                    event containing the clusters to pulled
@@ -1952,20 +1952,21 @@ class GalaxyCluster extends AppModel
      *          - string <pull_relevant_clusters>   pull clusters based on tags present locally
      * @return int The number of pulled clusters
      */
-    public function pullGalaxyClusters(array $user, ServerSyncTool $serverSync, $technique = 'full')
+    public function pullGalaxyClusters(array $user, array $server, $technique = 'full')
     {
-        if (!$serverSync->isSupported(ServerSyncTool::FEATURE_GALAXY_CLUSTER_SYNC)) {
+        $this->Server = ClassRegistry::init('Server');
+        $compatible = $this->Server->checkVersionCompatibility($server, $user)['supportEditOfGalaxyCluster'];
+        if (!$compatible) {
             return 0;
         }
-
-        $clusterIds = $this->getClusterIdListBasedOnPullTechnique($user, $technique, $serverSync);
+        $clusterIds = $this->getClusterIdListBasedOnPullTechnique($user, $technique, $server);
         $successes = array();
         $fails = array();
         // now process the $clusterIds to pull each of the events sequentially
         if (!empty($clusterIds)) {
             // download each cluster
-            foreach ($clusterIds as $clusterId) {
-                $this->__pullGalaxyCluster($clusterId, $successes, $fails, $serverSync, $user);
+            foreach ($clusterIds as $k => $clusterId) {
+                $this->__pullGalaxyCluster($clusterId, $successes, $fails, $server, $user);
             }
         }
         return count($successes);
@@ -1976,16 +1977,16 @@ class GalaxyCluster extends AppModel
      *
      * @param  array $user
      * @param  string|int $technique
-     * @param  ServerSyncTool $serverSync
+     * @param  array $server
      * @return array cluster ID list to be pulled
      */
-    private function getClusterIdListBasedOnPullTechnique(array $user, $technique, ServerSyncTool $serverSync)
+    private function getClusterIdListBasedOnPullTechnique(array $user, $technique, array $server)
     {
         $this->Server = ClassRegistry::init('Server');
         try {
             if ("update" === $technique) {
                 $localClustersToUpdate = $this->getElligibleLocalClustersToUpdate($user);
-                $clusterIds = $this->Server->getElligibleClusterIdsFromServerForPull($serverSync, $onlyUpdateLocalCluster = true, $elligibleClusters = $localClustersToUpdate);
+                $clusterIds = $this->Server->getElligibleClusterIdsFromServerForPull($server, $HttpSocket = null, $onlyUpdateLocalCluster = true, $elligibleClusters = $localClustersToUpdate);
             } elseif ("pull_relevant_clusters" === $technique) {
                 // Fetch all local custom cluster tags then fetch their corresponding clusters on the remote end
                 $tagNames = $this->Tag->find('column', array(
@@ -2004,53 +2005,55 @@ class GalaxyCluster extends AppModel
                 }
                 $localClustersToUpdate = $this->getElligibleLocalClustersToUpdate($user);
                 $conditions = array('uuid' => array_keys($clusterUUIDs));
-                $clusterIds = $this->Server->getElligibleClusterIdsFromServerForPull($serverSync, $onlyUpdateLocalCluster = false, $elligibleClusters = $localClustersToUpdate, $conditions = $conditions);
+                $clusterIds = $this->Server->getElligibleClusterIdsFromServerForPull($server, $HttpSocket = null, $onlyUpdateLocalCluster = false, $elligibleClusters = $localClustersToUpdate, $conditions = $conditions);
             } elseif (is_numeric($technique)) {
                 $conditions = array('eventid' => $technique);
-                $clusterIds = $this->Server->getElligibleClusterIdsFromServerForPull($serverSync, $onlyUpdateLocalCluster = false, $elligibleClusters = array(), $conditions = $conditions);
+                $clusterIds = $this->Server->getElligibleClusterIdsFromServerForPull($server, $HttpSocket = null, $onlyUpdateLocalCluster = false, $elligibleClusters = array(), $conditions = $conditions);
             } else {
-                $clusterIds = $this->Server->getElligibleClusterIdsFromServerForPull($serverSync, $onlyUpdateLocalCluster = false);
+                $clusterIds = $this->Server->getElligibleClusterIdsFromServerForPull($server, $HttpSocket = null, $onlyUpdateLocalCluster = false);
             }
         } catch (HttpSocketHttpException $e) {
             if ($e->getCode() === 403) {
                 return array('error' => array(1, null));
             } else {
-                $this->logException("Could not get eligible cluster IDs from server {$serverSync->serverId()} for pull.", $e);
+                $this->logException("Could not get eligible cluster IDs from server {$server['Server']['id']} for pull.", $e);
                 return array('error' => array(2, $e->getMessage()));
             }
         } catch (Exception $e) {
-            $this->logException("Could not get eligible cluster IDs from server {$serverSync->serverId()} for pull.", $e);
+            $this->logException("Could not get eligible cluster IDs from server {$server['Server']['id']} for pull.", $e);
             return array('error' => array(2, $e->getMessage()));
         }
         return $clusterIds;
     }
 
-    /**
-     * @param $clusterId
-     * @param array $successes
-     * @param array $fails
-     * @param ServerSyncTool $serverSync
-     * @param array $user
-     * @return bool
-     */
-    private function __pullGalaxyCluster($clusterId, array &$successes, array &$fails, ServerSyncTool $serverSync, array $user)
+    private function __pullGalaxyCluster($clusterId, &$successes, &$fails, $server, $user)
     {
-        try {
-            $cluster = $serverSync->fetchGalaxyCluster($clusterId)->json();
-        } catch (Exception $e)  {
-            $this->logException("Failed downloading the galaxy cluster $clusterId from server {$serverSync->serverId()}", $e);
-            $fails[$clusterId] = __('failed downloading the galaxy cluster');
-            return false;
-        }
-
-        $cluster = $this->updatePulledClusterBeforeInsert($cluster, $serverSync->server(), $user);
-        $result = $this->captureCluster($user, $cluster, $fromPull=true, $orgId=$serverSync->server()['Server']['org_id']);
-        if ($result['success']) {
-            $successes[] = $clusterId;
+        $cluster = $this->downloadGalaxyClusterFromServer($clusterId, $server);
+        if (!empty($cluster)) {
+            $cluster = $this->updatePulledClusterBeforeInsert($cluster, $server, $user);
+            $result = $this->captureCluster($user, $cluster, $fromPull=true, $orgId=$server['Server']['org_id']);
+            if ($result['success']) {
+                $successes[] = $clusterId;
+            } else {
+                $fails[$clusterId] = __('Failed because of errors: ') . json_encode($result['errors']);
+            }
         } else {
-            $fails[$clusterId] = __('Failed because of errors: ') . json_encode($result['errors']);
+            $fails[$clusterId] = __('failed downloading the galaxy cluster');
         }
         return true;
+    }
+
+    public function downloadGalaxyClusterFromServer($clusterId, $server, $HttpSocket=null)
+    {
+        $url = $server['Server']['url'];
+        $HttpSocket = $this->setupHttpSocket($server, $HttpSocket);
+        $request = $this->setupSyncRequest($server);
+        $uri = $url . '/galaxy_clusters/view/' . $clusterId;
+        $response = $HttpSocket->get($uri, $data = '', $request);
+        if ($response->isOk()) {
+            return json_decode($response->body, true);
+        }
+        return null;
     }
 
     private function updatePulledClusterBeforeInsert($cluster, $server, $user)


### PR DESCRIPTION
This reverts commit f887bb1a5b7147358e81b862dab40705cc329e41.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
