### PR TITLE
new: add MysqlExtended DboSource to support index query hints

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -810,7 +810,7 @@ class AppController extends Controller
             ConnectionManager::create('default', $db->config);
         }
         $dataSource = $dataSourceConfig['datasource'];
-        if (!in_array($dataSource, ['Database/Mysql', 'Database/Postgres', 'Database/MysqlObserver'], true)) {
+        if (!in_array($dataSource, ['Database/Mysql', 'Database/Postgres', 'Database/MysqlObserver', 'Database/MysqlExtended'], true)) {
             throw new Exception('Datasource not supported: ' . $dataSource);
         }
     }

--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -1536,6 +1536,12 @@ class AttributesController extends AppController
             if (!isset($params['conditions']['Attribute.deleted'])) {
                 $params['conditions']['Attribute.deleted'] = 0;
             }
+
+            // Force index for performance reasons see #3321
+            if (isset($filters['value'])) {
+                $this->paginate['useIndexHint'] = '(value1, value2)';
+            }
+
             $this->paginate['conditions'] = $params['conditions'];
             $attributes = $this->paginate();
             $this->Attribute->attachTagsToAttributes($attributes, ['includeAllTags' => true]);

--- a/app/Lib/Tools/QueryTool.php
+++ b/app/Lib/Tools/QueryTool.php
@@ -14,7 +14,7 @@ class QueryTool
     {
         $db = $model->getDataSource();
         $connection = $db->getConnection();
-        if ($db->config['datasource'] === 'Database/Mysql' || $db->config['datasource'] === 'Database/MysqlObserver') {
+        if (in_array($db->config['datasource'], ['Database/Mysql', 'Database/MysqlObserver', 'Database/MysqlExtended'])) {
             $query = $connection->prepare('DELETE FROM ' . $table . ' WHERE ' . $field . ' = :value');
         } elseif ($db->config['datasource'] == 'Database/Postgres' ) {
             $query = $connection->prepare('DELETE FROM "' . $table . '" WHERE "' . $field . '" = :value');

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -3309,7 +3309,6 @@ class AppModel extends Model
     {
         $dataSource = ConnectionManager::getDataSource('default');
         $dataSourceName = $dataSource->config['datasource'];
-        return $dataSourceName === 'Database/Mysql' || $dataSourceName === 'Database/MysqlObserver' || $dataSource instanceof Mysql;
-
+        return $dataSourceName === 'Database/Mysql' || $dataSourceName === 'Database/MysqlObserver' || $dataSourceName === 'Database/MysqlExtended' || $dataSource instanceof Mysql;
     }
 }

--- a/app/Model/Datasource/Database/MysqlExtended.php
+++ b/app/Model/Datasource/Database/MysqlExtended.php
@@ -105,7 +105,7 @@ class MysqlExtended extends Mysql
      * @param string|null $useIndexHint USE INDEX hint
      * @return string
      */
-    private function __buildIndexHint(?string $useIndexHint = null): string
+    private function __buildIndexHint($useIndexHint = null): string
     {
         $index = '';
         if (isset($useIndexHint)) {

--- a/app/Model/Datasource/Database/MysqlExtended.php
+++ b/app/Model/Datasource/Database/MysqlExtended.php
@@ -109,7 +109,7 @@ class MysqlExtended extends Mysql
     {
         $index = '';
         if (isset($useIndexHint)) {
-            $index = 'USE INDEX ' . $this->value($useIndexHint);
+            $index = 'USE INDEX ' . $useIndexHint;
         }
         return $index;
     }

--- a/app/Model/Datasource/Database/MysqlExtended.php
+++ b/app/Model/Datasource/Database/MysqlExtended.php
@@ -1,0 +1,117 @@
+<?php
+App::uses('Mysql', 'Model/Datasource/Database');
+
+/**
+ * Overrides the default MySQL database implementation to support the following features:
+ * - Set query hints to optimize queries
+ */
+class MysqlExtended extends Mysql
+{
+    /**
+     * Builds and generates an SQL statement from an array. Handles final clean-up before conversion.
+     *
+     * @param array $query An array defining an SQL query.
+     * @param Model $Model The model object which initiated the query.
+     * @return string An executable SQL statement.
+     * @see DboSource::renderStatement()
+     */
+    public function buildStatement($query, Model $Model)
+    {
+        $query = array_merge($this->_queryDefaults, $query);
+
+        if (!empty($query['joins'])) {
+            $count = count($query['joins']);
+            for ($i = 0; $i < $count; $i++) {
+                if (is_array($query['joins'][$i])) {
+                    $query['joins'][$i] = $this->buildJoinStatement($query['joins'][$i]);
+                }
+            }
+        }
+
+        return $this->renderStatement('select', array(
+            'conditions' => $this->conditions($query['conditions'], true, true, $Model),
+            'fields' => implode(', ', $query['fields']),
+            'table' => $query['table'],
+            'alias' => $this->alias . $this->name($query['alias']),
+            'order' => $this->order($query['order'], 'ASC', $Model),
+            'limit' => $this->limit($query['limit'], $query['offset']),
+            'joins' => implode(' ', $query['joins']),
+            'group' => $this->group($query['group'], $Model),
+            'having' => $this->having($query['having'], true, $Model),
+            'lock' => $this->getLockingHint($query['lock']),
+            'indexHint' => $this->__buildIndexHint($query['useIndexHint'] ?? null),
+        ));
+    }
+
+    /**
+     * Builds an SQL statement.
+     *
+     * This is merely a convenient wrapper to DboSource::buildStatement().
+     *
+     * @param Model $Model The model to build an association query for.
+     * @param array $queryData An array of queryData information containing keys similar to Model::find().
+     * @return string String containing an SQL statement.
+     * @see DboSource::buildStatement()
+     * @see DboSource::buildAssociationQuery()
+     */
+    public function buildAssociationQuery(Model $Model, $queryData)
+    {
+        $queryData = $this->_scrubQueryData($queryData);
+
+        return $this->buildStatement(
+            array(
+                'fields' => $this->prepareFields($Model, $queryData),
+                'table' => $this->fullTableName($Model),
+                'alias' => $Model->alias,
+                'limit' => $queryData['limit'],
+                'offset' => $queryData['offset'],
+                'joins' => $queryData['joins'],
+                'conditions' => $queryData['conditions'],
+                'order' => $queryData['order'],
+                'group' => $queryData['group'],
+                'having' => $queryData['having'],
+                'lock' => $queryData['lock'],
+                'useIndexHint' => $queryData['useIndexHint'] ?? null,
+            ),
+            $Model
+        );
+    }
+
+    /**
+     * Renders a final SQL statement by putting together the component parts in the correct order
+     * 
+     * Edit: Added support for query hints
+     *
+     * @param string $type type of query being run. e.g select, create, update, delete, schema, alter.
+     * @param array $data Array of data to insert into the query.
+     * @return string|null Rendered SQL expression to be run, otherwise null.\
+     * @see DboSource::renderStatement()
+     */
+
+    public function renderStatement($type, $data)
+    {
+        if ($type === 'select' && $data['indexHint'] != null) {
+            extract($data);
+            $having = !empty($having) ? " $having" : '';
+            return trim("SELECT {$fields} FROM {$table} {$alias} {$indexHint} {$joins} {$conditions} {$group}{$having} {$order} {$limit}{$lock}");
+        } else {
+            return parent::renderStatement($type, $data);
+        }
+    }
+
+    /**
+     * Builds the index hint for the query
+     * 
+     * @param string|null $useIndexHint USE INDEX hint
+     * @return string
+     */
+    private function __buildIndexHint(?string $useIndexHint = null): string
+    {
+        // TODO: support force and ignore indexes
+        $index = '';
+        if (isset($useIndexHint)) {
+            $index = 'USE INDEX ' . $this->value($useIndexHint);
+        }
+        return $index;
+    }
+}

--- a/app/Model/Datasource/Database/MysqlExtended.php
+++ b/app/Model/Datasource/Database/MysqlExtended.php
@@ -107,7 +107,6 @@ class MysqlExtended extends Mysql
      */
     private function __buildIndexHint(?string $useIndexHint = null): string
     {
-        // TODO: support force and ignore indexes
         $index = '';
         if (isset($useIndexHint)) {
             $index = 'USE INDEX ' . $this->value($useIndexHint);


### PR DESCRIPTION
#### What does it do?

* Implements #3321, should fix the issue described here: https://github.com/MISP/MISP/issues/3321#issuecomment-1115137925
* Adds support for `useIndexHint` option for CakePHP ORM query parameters.
* Requires to change default datasource in `/var/www/MISP/app/Config/database.php` config:
```php
<?php
  class DATABASE_CONFIG {
          public $default = array(
                  'datasource' => 'Database/MysqlExtended',
                  ...
```

* Sample usage:

```php
public $paginate = [
    'limit' => 10,
    'maxLimit' => 1000,
    'useIndexHint' => '(value1, value2)'
];
```
or:
```php
$event_ids = $this->Attribute->find('column', array(
  'recursive' => -1,
  'contain' => ['Event'],
  'useIndexHint' => "(value1, value2)",
  'conditions' => [
      'AND' => [
          'Event.id' => [1, 2, 3, 4, 5, 6, 7]
      ],
      'OR' => [
          'AND' => [
              'LOWER(Attribute.value1) LIKE' => strtolower($value),
              'Attribute.value2' => '',
          ],
          'LOWER(Attribute.value2) LIKE' => strtolower($value)
      ]
  ]
));
```

Related:
* https://github.com/cakephp/cakephp/issues/1847
* https://github.com/cakephp/cakephp/issues/9313

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
