### PR TITLE
chg: [installer] Added support for Ubuntu Jammy

### DIFF
--- a/INSTALL/INSTALL.tpl.sh
+++ b/INSTALL/INSTALL.tpl.sh
@@ -849,6 +849,7 @@ x86_64-debian-buster
 x86_64-ubuntu-bionic
 x86_64-ubuntu-focal
 x86_64-ubuntu-hirsute
+x86_64-ubuntu-jammy
 x86_64-kali-2021.4
 x86_64-kali-2022.1
 x86_64-kali-2022.2


### PR DESCRIPTION
Ubuntu 22.04 server is now detected correctly