### PR TITLE
fix: do not fetch tag related entities

### DIFF
--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -293,7 +293,7 @@ class Tag extends AppModel
                 $conditions[] = array('Tag.name LIKE' => $tagName);
             }
             $result = $this->find('column', array(
-                'recursive' => 1,
+                'recursive' => -1,
                 'conditions' => ['OR' => $conditions],
                 'fields' => array('Tag.id')
             ));


### PR DESCRIPTION
#### What does it do?

Do not fetch recursivly records related to Tags, in some scenarios the recursive query can return millions of related records, causing the script to run out of memory.

Thanks a lot @ag-michael for reporting and helping debug the issue.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
