### PR TITLE
chg: fix and fix default feed link

### DIFF
--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -1674,5 +1674,34 @@
       "exportable": true,
       "hide_tag": false
     }
+  },
+  {
+    "Feed": {
+        "name": "threatfox indicators of compromise",
+        "provider": "abuse.ch",
+        "url": "https://threatfox.abuse.ch/export/csv/recent/",
+        "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]}",
+        "enabled": false,
+        "distribution": "0",
+        "sharing_group_id": "0",
+        "default": false,
+        "source_format": "csv",
+        "fixed_event": true,
+        "delta_merge": false,
+        "publish": false,
+        "override_ids": false,
+        "settings": "{\"csv\":{\"value\":\"3\",\"delimiter\":\"\"},\"common\":{\"excluderegex\":\"\"}}",
+        "input_source": "network",
+        "delete_local_file": false,
+        "lookup_visible": true,
+        "caching_enabled": true,
+        "force_to_ids": false
+    },
+    "Tag": {
+        "name": "osint:source-type=\"block-or-filter-list\"",
+        "colour": "#004f89",
+        "exportable": true,
+        "hide_tag": false
+    }
   }
 ]

--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -970,8 +970,8 @@
   {
     "Feed": {
       "name": "URLHaus Malware URLs",
-      "provider": "Abuse.ch",
-      "url": "https://urlhaus.abuse.ch/downloads/csv/",
+      "provider": "abuse.ch",
+      "url": "https://urlhaus.abuse.ch/downloads/csv_recent/",
       "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]}}",
       "enabled": true,
       "distribution": "3",
@@ -1471,7 +1471,7 @@
     "Feed": {
       "name": "Malware Bazaar",
       "provider": "abuse.ch",
-      "url": "https://bazaar.abuse.ch/export/txt/md5/full/",
+      "url": "https://bazaar.abuse.ch/export/txt/md5/recent/",
       "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]},\"url_params\":\"\"}",
       "enabled": false,
       "distribution": "0",
@@ -1522,7 +1522,7 @@
   {
     "Feed": {
       "name": "Threatfox",
-      "provider": "Abuse.ch",
+      "provider": "abuse.ch",
       "url": "https://threatfox.abuse.ch/downloads/misp/",
       "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]},\"url_params\":\"\"}",
       "enabled": true,
@@ -1551,7 +1551,7 @@
   {
     "Feed": {
       "name": "MalwareBazaar",
-      "provider": "Abuse.ch",
+      "provider": "abuse.ch",
       "url": "https://bazaar.abuse.ch/downloads/misp/",
       "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]}}",
       "enabled": false,
@@ -1571,7 +1571,7 @@
   {
     "Feed": {
       "name": "URLhaus",
-      "provider": "Abuse.ch",
+      "provider": "abuse.ch",
       "url": "https://urlhaus.abuse.ch/downloads/misp/",
       "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]}}",
       "enabled": false,
@@ -1674,5 +1674,5 @@
       "exportable": true,
       "hide_tag": false
     }
-  } 
+  }
 ]

--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -1680,7 +1680,7 @@
         "name": "threatfox indicators of compromise",
         "provider": "abuse.ch",
         "url": "https://threatfox.abuse.ch/export/csv/recent/",
-        "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]}",
+        "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]}}",
         "enabled": false,
         "distribution": "0",
         "sharing_group_id": "0",


### PR DESCRIPTION
#### What does it do?

default feed metadata: 
- https://bazaar.abuse.ch/export/txt/md5/full/
- https://urlhaus.abuse.ch/downloads/csv/
The above two links will download zip files, not CVS files, resulting in not pulling feed data properly, I modified them to recent data links and added the recent data links for threatfox.

Also standardized the case of provider names.
