### PR TITLE
Fixed a logic error in Tag::quickEdit()

### DIFF
--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -399,7 +399,7 @@ class Tag extends AppModel
         if ($tag['Tag']['colour'] !== $colour || $tag['Tag']['name'] !== $name || $hide !== false || $tag['Tag']['numerical_value'] !== $numerical_value || ($tag['Tag']['local_only'] !== $local_only && $local_only !== -1)) {
             $tag['Tag']['name'] = $name;
             $tag['Tag']['colour'] = $colour;
-            if ($tag['Tag']['local_only'] !== -1) {
+            if ($local_only !== -1) {
                 $tag['Tag']['local_only'] = $local_only;
             }
             if ($hide !== false) {


### PR DESCRIPTION
Tag::quickEdit(): Fixed a logic error in this method that was causing tags to always be set to "local_only", wherever not intended.

I found this issue because after calling pymisp.enable_taxonomy_tags(), all my tags were systematically changed to local_only.
