### PR TITLE
fix: [export] Create unique SIDs for email attributes in NIDS export

### DIFF
--- a/app/Lib/Export/NidsExport.php
+++ b/app/Lib/Export/NidsExport.php
@@ -159,7 +159,7 @@ class NidsExport
                     $this->ipSrcRule($ruleFormat, $item['Attribute'], $sid);
                     break;
                 case 'email':
-                    $this->emailSrcRule($ruleFormat, $item['Attribute'], $sid);
+                    $this->emailSrcRule($ruleFormat, $item['Attribute'], $sid++);
                     $this->emailDstRule($ruleFormat, $item['Attribute'], $sid);
                     break;
                 case 'email-src':


### PR DESCRIPTION
The NIDS export creates two rules for attributes with type `email` (a *src* and *dst* rule). However, the same SID is used for both rules. Since SIDs must be unique for a ruleset, this will be logged as an error by Suricata and the rule is not loaded (see issue #6379).

This fixes the issue by incrementing the SID before creating the second email rule.

This pull request does not require a DB change or a change in API. I'm not using the fix in production, but successfully applied it to a test instance.

