### PR TITLE
Styx Import Error

### DIFF
--- a/app/files/scripts/stix2/stix2misp.py
+++ b/app/files/scripts/stix2/stix2misp.py
@@ -2135,7 +2135,7 @@ def from_misp(stix_objects):
 def main(args):
     filename = args[1] if args[1][0] == '/' else Path(os.path.dirname(args[0]), args[1])
     with open(filename, 'rt', encoding='utf-8') as f:
-        event = stix2.parse(f.read(), allow_custom=True, interoperability=True)
+        event = stix2.parse(f.read(), allow_custom=True)
     stix_parser = StixFromMISPParser() if from_misp(event.objects) else ExternalStixParser()
     stix_parser.handler(event, filename, args[2:])
     stix_parser.save_file()


### PR DESCRIPTION
Styx import internal error caused by argument used by old python version, causes script to exit with error code

#### What does it do?
Fixes an issue when importing styx files via ui.
currently has a statement not needed in modern versions of python, causes the script to exit with error
