### PR TITLE
new: [internal] Add option to log last API request

### DIFF
--- a/app/Config/config.default.php
+++ b/app/Config/config.default.php
@@ -71,6 +71,7 @@ $config = array(
         'enableOrgBlocklisting'          => true,
         'log_client_ip'                  => false,
         'log_auth'                       => false,
+        'store_api_access_time'          => false,
         'disableUserSelfManagement'      => false,
         'disable_user_login_change'      => false,
         'disable_user_password_change'   => false,

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -434,6 +434,10 @@ class AppController extends Controller
                         );
                         $this->Log->save($log);
                     }
+                    $storeAPITime = Configure::read('MISP.store_api_access_time');
+                    if (!empty($storeAPITime) && $storeAPITime) {
+                        $this->User->updateAPIAccessTime($user);
+                    }
                     $this->Session->renew();
                     $this->Session->write(AuthComponent::$sessionKey, $user);
                     $this->isApiAuthed = true;

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -427,6 +427,7 @@ class UsersController extends AppController
             'expiration',
             'current_login',
             'last_login',
+            'last_api_access',
             'force_logout',
             'date_created',
             'date_modified'

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -1683,7 +1683,7 @@ class AppModel extends Model
                 $this->__addIndex('cryptographic_keys', 'fingerprint');
                 break;
             case 86:
-                $sqlArray[] = sprintf("ALTER table users MODIFY description text;");
+                $this->__addIndex('attributes', 'timestamp');
                 break;
             case 87:
                 $sqlArray[] = "ALTER TABLE users ADD `last_api_access` INT(11) DEFAULT 0;";

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -1686,7 +1686,7 @@ class AppModel extends Model
                 $sqlArray[] = sprintf("ALTER table users MODIFY description text;");
                 break;
             case 87:
-                $sqlArray[] = "ALTER TABLE users ADD `last_login` INT(11) DEFAULT 0;";
+                $sqlArray[] = "ALTER TABLE users ADD `last_api_access` INT(11) DEFAULT 0;";
                 break;
             case 'fixNonEmptySharingGroupID':
                 $sqlArray[] = 'UPDATE `events` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -89,7 +89,8 @@ class AppModel extends Model
         63 => true, 64 => false, 65 => false, 66 => false, 67 => false, 68 => false,
         69 => false, 70 => false, 71 => true, 72 => true, 73 => false, 74 => false,
         75 => false, 76 => true, 77 => false, 78 => false, 79 => false, 80 => false,
-        81 => false, 82 => false, 83 => false, 84 => false, 85 => false, 86 => false
+        81 => false, 82 => false, 83 => false, 84 => false, 85 => false, 86 => false,
+        87 => false
     );
 
     public $advanced_updates_description = array(
@@ -1682,7 +1683,10 @@ class AppModel extends Model
                 $this->__addIndex('cryptographic_keys', 'fingerprint');
                 break;
             case 86:
-                $this->__addIndex('attributes', 'timestamp');
+                $sqlArray[] = sprintf("ALTER table users MODIFY description text;");
+                break;
+            case 87:
+                $sqlArray[] = "ALTER TABLE users ADD `last_login` INT(11) DEFAULT 0;";
                 break;
             case 'fixNonEmptySharingGroupID':
                 $sqlArray[] = 'UPDATE `events` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -5294,6 +5294,13 @@ class Server extends AppModel
                     'type' => 'string',
                     'null' => true,
                 ),
+                'store_api_access_time' => array(
+                    'level' => 1,
+                    'description' => __('If enabled, MISP will capture the last API access time following a successful authentication using API keys, stored against a user under the last_api_access field.'),
+                    'value' => false,
+                    'test' => 'testBool',
+                    'type' => 'boolean',
+                ),
                 'log_auth' => array(
                     'level' => 1,
                     'description' => __('If enabled, MISP will log all successful authentications using API keys. The requested URLs are also logged.'),

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -1367,6 +1367,22 @@ class User extends AppModel
     }
 
     /**
+     * Updates `last_api_access` time in database.
+     *
+     * @param array $user
+     * @return array|bool
+     * @throws Exception
+     */
+    public function updateAPIAccessTime(array $user)
+    {
+        if (!isset($user['id'])) {
+            throw new InvalidArgumentException("Invalid user object provided.");
+        }
+        $user['last_api_access'] = time();
+        return $this->save($user, true, array('id', 'last_api_access'));
+    }
+
+    /**
      * Update field in user model and also set `date_modified`
      *
      * @param array $user

--- a/app/View/Users/admin_index.ctp
+++ b/app/View/Users/admin_index.ctp
@@ -200,6 +200,14 @@
                         'data_path' => 'User.date_created'
                     ),
                     array(
+                        'name' => __('Last API Access'),
+                        'sort' => 'User.last_api_access',
+                        'element' => 'datetime',
+                        'class' => 'short',
+                        'data_path' => 'User.last_api_access',
+                        'requirement' => !empty(Configure::read('MISP.store_api_access_time')) && Configure::read('MISP.store_api_access_time', false)
+                    ),
+                    array(
                         'name' => (Configure::read('Plugin.CustomAuth_name') ? Configure::read('Plugin.CustomAuth_name') : __('External Auth')),
                         'sort' => 'User.external_auth_required',
                         'element' => 'boolean',

--- a/db_schema.json
+++ b/db_schema.json
@@ -7775,6 +7775,17 @@
                 "column_type": "varchar(255)",
                 "column_default": null,
                 "extra": ""
+            },
+            {
+                "column_name": "last_api_access",
+                "is_nullable": "YES",
+                "data_type": "int",
+                "character_maximum_length": null,
+                "numeric_precision": "10",
+                "collation_name": null,
+                "column_type": "int(11)",
+                "column_default": "0",
+                "extra": ""
             }
         ],
         "user_settings": [
@@ -8470,5 +8481,5 @@
             "id": true
         }
     },
-    "db_version": "86"
+    "db_version": "87"
 }


### PR DESCRIPTION
#### What does it do?

This PR adds in functionality to allow users to optionally turn on storing of the last time an API request was made against an account, similar to the last_login field.

This adds a new field under DB version 87 for `last_api_access`, updating each time a successful API authentication request occurs, and can be configured from within the MISP settings.

This is a useful change for us (and I assume others), as it allows you to get a better understanding of the activity of all user accounts, not just those that login on the web.

#### Questions

- [X] Does it require a DB change?
- [X] Are you using it in production? (Not yet - plan to!)
- [ ] Does it require a change in the API (PyMISP for example)?
