### PR TITLE
chg: allow to restsearch attributes by value1 and value2

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -3128,6 +3128,8 @@ class Attribute extends AppModel
                 'Attribute' => array(
                     'sharinggroup' => array('function' => 'set_filter_sharing_group'),
                     'value' => array('function' => 'set_filter_value'),
+                    'value1' => array('function' => 'set_filter_simple_attribute'),
+                    'value2' => array('function' => 'set_filter_simple_attribute'),
                     'category' => array('function' => 'set_filter_simple_attribute'),
                     'type' => array('function' => 'set_filter_type'),
                     'object_relation' => array('function' => 'set_filter_simple_attribute'),

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -2710,17 +2710,8 @@ class Event extends AppModel
     public function set_filter_value(&$params, $conditions, $options)
     {
         if (!empty($params['value'])) {
-            $params[$options['filter']] = $this->convert_filters($params[$options['filter']]);
-            $conditions = $this->generic_add_filter($conditions, $params[$options['filter']], ['Attribute.value1', 'Attribute.value2']);
-            // Allows searching for ['value1' => [full, part1], 'value2' => [full, part2]]
-            if (is_string($params['value']) && strpos('|', $params['value']) !== false) {
-                $valueParts = explode('|', $params['value'], 2);
-                $convertedFilterVal1 = $this->convert_filters($valueParts[0]);
-                $convertedFilterVal2 = $this->convert_filters($valueParts[1]);
-                $conditionVal1 = $this->generic_add_filter([], $convertedFilterVal1, ['Attribute.value1'])['AND'][0]['OR'];
-                $conditionVal2 = $this->generic_add_filter([], $convertedFilterVal2, ['Attribute.value2'])['AND'][0]['OR'];
-                $conditions['AND'][0]['OR']['OR']['AND'] = [$conditionVal1, $conditionVal2];
-            }
+            $params[$options['filter']] = $this->convert_filters($params['value']);
+            $conditions = $this->generic_add_filter($conditions, $params['value'], ['Attribute.value1', 'Attribute.value2']);
         }
 
         return $conditions;

--- a/app/webroot/doc/openapi.yaml
+++ b/app/webroot/doc/openapi.yaml
@@ -2822,6 +2822,10 @@ components:
           $ref: "#/components/schemas/LimitSearchFilter"
         value:
           $ref: "#/components/schemas/AttributeValue"
+        value1:
+          $ref: "#/components/schemas/AttributeValue"
+        value2:
+          $ref: "#/components/schemas/AttributeValue"
         type:
           $ref: "#/components/schemas/AttributeType"
         category:

--- a/tests/testlive_comprehensive_local.py
+++ b/tests/testlive_comprehensive_local.py
@@ -823,30 +823,28 @@ class TestComprehensive(unittest.TestCase):
         event = self.user_misp_connector.add_event(event)
         check_response(event)
 
-        self.admin_misp_connector.publish(event, alert=False)
-        time.sleep(6)
-
         search_result = self._search_attribute({'value': '10.0.0.1', 'eventid': event.id})
-        self.assertEqual(search_result[0].id, attribute_1.id)
-        self.assertEqual(len(search_result), 1)
+        print(attribute_1.uuid)
+        self.assertEqual(search_result['Attribute'][0]['uuid'], attribute_1.uuid)
+        self.assertEqual(len(search_result['Attribute']), 1)
 
         search_result = self._search_attribute({'value': '8080', 'eventid': event.id})
-        self.assertEqual(len(search_result), 2)
+        self.assertEqual(len(search_result['Attribute']), 2)
 
         search_result = self._search_attribute({'value1': '10.0.0.1', 'eventid': event.id})
-        self.assertEqual(len(search_result), 1)
-        self.assertEqual(search_result[0].id, attribute_1.id)
+        self.assertEqual(len(search_result['Attribute']), 1)
+        self.assertEqual(search_result['Attribute'][0]['uuid'], attribute_1.uuid)
 
         search_result = self._search_attribute({'value1': '10.0.0.2', 'eventid': event.id})
-        self.assertEqual(len(search_result), 1)
-        self.assertEqual(search_result[0].id, attribute_2.id)
+        self.assertEqual(len(search_result['Attribute']), 1)
+        self.assertEqual(search_result['Attribute'][0]['uuid'], attribute_2.uuid)
 
         search_result = self._search_attribute({'value2': '8080', 'eventid': event.id})
-        self.assertEqual(len(search_result), 2)
+        self.assertEqual(len(search_result['Attribute']), 2)
 
         search_result = self._search_attribute({'value1': '10.0.0.1', 'value2': '8080', 'eventid': event.id})
-        self.assertEqual(len(search_result), 1)
-        self.assertEqual(search_result[0].id, attribute_1.id)
+        self.assertEqual(len(search_result['Attribute']), 1)
+        self.assertEqual(search_result['Attribute'][0]['uuid'], attribute_1.uuid)
 
         self.admin_misp_connector.delete_event(event)
 

--- a/tests/testlive_comprehensive_local.py
+++ b/tests/testlive_comprehensive_local.py
@@ -816,12 +816,49 @@ class TestComprehensive(unittest.TestCase):
 
         self.admin_misp_connector.delete_event(event)
 
+    def test_restsearch_composite_attribute(self):
+        event = create_simple_event()
+        event.add_attribute('ip-src|port', '10.0.0.1|8080')
+        event = self.user_misp_connector.add_event(event)
+        check_response(event)
+
+        self.admin_misp_connector.publish(event, alert=False)
+        time.sleep(6)
+
+        attribute = self._search({'value': '10.0.0.1', 'eventid': event.id})
+        self.assertIsInstance(attribute, str)
+        self.assertIn('10.0.0.1|8080', attribute)
+
+        attribute = self._search({'value': '8080', 'eventid': event.id})
+        self.assertIsInstance(attribute, str)
+        self.assertIn('10.0.0.1|8080', attribute)
+
+        attribute = self._search({'value1': '10.0.0.1', 'eventid': event.id})
+        self.assertIsInstance(attribute, str)
+        self.assertIn('10.0.0.1|8080', attribute)
+
+        attribute = self._search({'value2': '8080', 'eventid': event.id})
+        self.assertIsInstance(attribute, str)
+        self.assertIn('10.0.0.1|8080', attribute)
+
+        attribute = self._search({'value1': '10.0.0.1', 'value2': '8080', 'eventid': event.id})
+        self.assertIsInstance(attribute, str)
+        self.assertIn('10.0.0.1|8080', attribute)
+
+        self.admin_misp_connector.delete_event(event)
+
+
     def _search(self, query: dict):
         response = self.admin_misp_connector._prepare_request('POST', 'events/restSearch', data=query)
         response = self.admin_misp_connector._check_response(response)
         check_response(response)
         return response
 
+    def _search_attribute(self, query: dict):
+        response = self.admin_misp_connector._prepare_request('POST', 'attributes/restSearch', data=query)
+        response = self.admin_misp_connector._check_response(response)
+        check_response(response)
+        return response
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/testlive_comprehensive_local.py
+++ b/tests/testlive_comprehensive_local.py
@@ -824,7 +824,6 @@ class TestComprehensive(unittest.TestCase):
         check_response(event)
 
         search_result = self._search_attribute({'value': '10.0.0.1', 'eventid': event.id})
-        print(attribute_1.uuid)
         self.assertEqual(search_result['Attribute'][0]['uuid'], attribute_1.uuid)
         self.assertEqual(len(search_result['Attribute']), 1)
 

--- a/tests/testlive_comprehensive_local.py
+++ b/tests/testlive_comprehensive_local.py
@@ -818,32 +818,35 @@ class TestComprehensive(unittest.TestCase):
 
     def test_restsearch_composite_attribute(self):
         event = create_simple_event()
-        event.add_attribute('ip-src|port', '10.0.0.1|8080')
+        attribute_1 = event.add_attribute('ip-src|port', '10.0.0.1|8080')
+        attribute_2 = event.add_attribute('ip-src|port', '10.0.0.2|8080')
         event = self.user_misp_connector.add_event(event)
         check_response(event)
 
         self.admin_misp_connector.publish(event, alert=False)
         time.sleep(6)
 
-        attribute = self._search({'value': '10.0.0.1', 'eventid': event.id})
-        self.assertIsInstance(attribute, str)
-        self.assertIn('10.0.0.1|8080', attribute)
+        search_result = self._search_attribute({'value': '10.0.0.1', 'eventid': event.id})
+        self.assertEqual(search_result[0].id, attribute_1.id)
+        self.assertEqual(len(search_result), 1)
 
-        attribute = self._search({'value': '8080', 'eventid': event.id})
-        self.assertIsInstance(attribute, str)
-        self.assertIn('10.0.0.1|8080', attribute)
+        search_result = self._search_attribute({'value': '8080', 'eventid': event.id})
+        self.assertEqual(len(search_result), 2)
 
-        attribute = self._search({'value1': '10.0.0.1', 'eventid': event.id})
-        self.assertIsInstance(attribute, str)
-        self.assertIn('10.0.0.1|8080', attribute)
+        search_result = self._search_attribute({'value1': '10.0.0.1', 'eventid': event.id})
+        self.assertEqual(len(search_result), 1)
+        self.assertEqual(search_result[0].id, attribute_1.id)
 
-        attribute = self._search({'value2': '8080', 'eventid': event.id})
-        self.assertIsInstance(attribute, str)
-        self.assertIn('10.0.0.1|8080', attribute)
+        search_result = self._search_attribute({'value1': '10.0.0.2', 'eventid': event.id})
+        self.assertEqual(len(search_result), 1)
+        self.assertEqual(search_result[0].id, attribute_2.id)
 
-        attribute = self._search({'value1': '10.0.0.1', 'value2': '8080', 'eventid': event.id})
-        self.assertIsInstance(attribute, str)
-        self.assertIn('10.0.0.1|8080', attribute)
+        search_result = self._search_attribute({'value2': '8080', 'eventid': event.id})
+        self.assertEqual(len(search_result), 2)
+
+        search_result = self._search_attribute({'value1': '10.0.0.1', 'value2': '8080', 'eventid': event.id})
+        self.assertEqual(len(search_result), 1)
+        self.assertEqual(search_result[0].id, attribute_1.id)
 
         self.admin_misp_connector.delete_event(event)
 


### PR DESCRIPTION
#### What does it do?
Allows restSearch by attributes `value1` and ` value2`.

Fixes:
* https://github.com/MISP/MISP/issues/8527

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
