### PR TITLE
Include triggerData in downloadMarkdownFromURL

### DIFF
--- a/app/Model/EventReport.php
+++ b/app/Model/EventReport.php
@@ -916,7 +916,7 @@ class EventReport extends AppModel
             'url' => $url
         ];
         if (!empty($module)) {
-            $result = $this->Module->queryModuleServer($modulePayload, false);
+            $result = $this->Module->queryModuleServer($modulePayload, false, 'Enrichment', false, $modulePayload);
             if (empty($result['results'][0]['values'][0])) {
                 return '';
             }


### PR DESCRIPTION
Possible fix for https://github.com/MISP/MISP/issues/8531 ?  Having to include twice the $modulePayload doesn't seem quite OK though.

## Generic requirements in order to contribute to MISP:

#### What does it do?

Fixes https://github.com/MISP/MISP/issues/8531 #8531

#### Questions

- [No] Does it require a DB change? 
- [Yes] Are you using it in production? 
- [No] Does it require a change in the API (PyMISP for example)? 
