### PR TITLE
Create unique SIDs for email attributes in NIDS export - Second Attempt

### DIFF
--- a/app/Lib/Export/NidsExport.php
+++ b/app/Lib/Export/NidsExport.php
@@ -204,6 +204,7 @@ class NidsExport
                         break;
                     case 'email':
                         $this->emailSrcRule($ruleFormat, $item['Attribute'], $sid);
+			$sid++;
                         $this->emailDstRule($ruleFormat, $item['Attribute'], $sid);
                         break;
                     case 'email-src':


### PR DESCRIPTION
The NIDS export creates two rules for attributes with type `email` (a *src* and *dst* rule). However, the same SID is used for both rules. Since SIDs must be unique for a ruleset, this will be logged as an error by Suricata and the rule is not loaded (see issue #6379).

This fixes the issue by incrementing the SID before creating the second email rule.

This pull request does not require a DB change or a change in API. I'm not using the fix in production, but successfully applied it to a test instance running 2.4.161.

A similar pull request had already been merged https://github.com/MISP/MISP/pull/8433, but a later overwritten by https://github.com/MISP/MISP/commit/4ab4121d053915fc32afd5585204b5e5a8a95074


