### PR TITLE
Allow new authentication keys to be replaced

### DIFF
--- a/app/Model/AuthKey.php
+++ b/app/Model/AuthKey.php
@@ -205,10 +205,11 @@ class AuthKey extends AppModel
     /**
      * @param int $userId
      * @param int|null $keyId
+     * @param string|null $authKey
      * @return false|string
      * @throws Exception
      */
-    public function resetAuthKey($userId, $keyId = null)
+    public function resetAuthKey($userId, $keyId = null, $authKey = null)
     {
         $time = time();
 
@@ -229,7 +230,7 @@ class AuthKey extends AppModel
             }
             $comment = __("Created by resetting auth key %s\n%s", $keyId, $currentAuthkey['AuthKey']['comment']);
             $allowedIps = isset($currentAuthkey['AuthKey']['allowed_ips']) ? $currentAuthkey['AuthKey']['allowed_ips'] : [];
-            return $this->createnewkey($userId, $comment, $allowedIps);
+            return $this->createnewkey($userId, $authKey, $comment, $allowedIps);
         } else {
             $existingAuthkeys = $this->find('all', [
                 'recursive' => -1,
@@ -245,21 +246,25 @@ class AuthKey extends AppModel
                 $key['AuthKey']['expiration'] = $time;
                 $this->save($key);
             }
-            return $this->createnewkey($userId);
+            return $this->createnewkey($userId, $authKey);
         }
     }
 
     /**
      * @param int $userId
+     * @param string|null $authKey
      * @param string $comment
      * @param array $allowedIps
      * @return false|string
      * @throws Exception
      */
-    public function createnewkey($userId, $comment = '', array $allowedIps = [])
+    public function createnewkey($userId, $authKey = null, $comment = '', array $allowedIps = [])
     {
+        if(empty($authKey)) {
+            $authKey = (new RandomTool())->random_str(true, 40);
+        }
         $newKey = [
-            'authkey' => (new RandomTool())->random_str(true, 40),
+            'authkey' => $authKey,
             'user_id' => $userId,
             'comment' => $comment,
             'allowed_ips' => empty($allowedIps) ? null : $allowedIps,


### PR DESCRIPTION
#### What does it do?

Allow new authentication keys to be replaced rather than just reset.
This means that it is now possible to run the following command:
```
cake user change_authkey 1 <new auth_key>
```

#### Questions

- [ ] Does it require a DB change? No
- [ ] Are you using it in production? Yes
- [ ] Does it require a change in the API (PyMISP for example)? No
