### PR TITLE
fix: [fetchFeed] Set CurrentUserId in fetchFeed

### DIFF
--- a/app/Console/Command/ServerShell.php
+++ b/app/Console/Command/ServerShell.php
@@ -216,6 +216,7 @@ class ServerShell extends AppShell
         $userId = $this->args[0];
         $user = $this->getUser($userId);
         $feedId = $this->args[1];
+        Configure::write('CurrentUserId', $userId);
         if (!empty($this->args[2])) {
             $jobId = $this->args[2];
         } else {


### PR DESCRIPTION
Currently the CurrentUserId is not set, when fetchFeed is called, which results in an exception in the Event->publish() function.

#### What does it do?

Fixes: #8549

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Comment

Please review the fix, I've implemented `Configure::write` as it is implemented in `EventShell.php`.
I hope this is ok for you.
