### PR TITLE
Redact sensitive settings

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -6038,6 +6038,7 @@ class Server extends AppModel
                     'value' => '',
                     'test' => 'testForEmpty',
                     'type' => 'string',
+                    'redacted' => true
                 ),
             ),
             'Security' => array(
@@ -6746,6 +6747,7 @@ class Server extends AppModel
                     'test' => 'testForEmpty',
                     'type' => 'string',
                     'afterHook' => 'zmqAfterHook',
+                    'redacted' => true
                 ),
                 'ZeroMQ_redis_host' => array(
                     'level' => 2,
@@ -6769,6 +6771,7 @@ class Server extends AppModel
                     'value' => '',
                     'type' => 'string',
                     'afterHook' => 'zmqAfterHook',
+                    'redacted' => true
                 ),
                 'ZeroMQ_redis_database' => array(
                     'level' => 2,


### PR DESCRIPTION
Proxy password, ZeroMQ password and ZeroMQ redis password were not redacted as all other password fields

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2020-05-05: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

Redacts password fields in the server settings, all other password fields seem to use this, these were somehow skipped

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
