### PR TITLE
Set max-height to allow generating scrollbars on overflow

### DIFF
--- a/app/webroot/css/main.css
+++ b/app/webroot/css/main.css
@@ -910,7 +910,10 @@ a.proposal_link_red:hover {
     width: 300px;
     top:calc(50% - 50px);
     left:calc(50% - 150px);
+    max-height:calc(50% + 50px);
     position: fixed;
+    overflow: auto;
+    overflow-x: hidden;
     background-color:#f4f4f4;
     border-radius: 5px;
     box-shadow: 4px 4px 4px #333;


### PR DESCRIPTION
With this the confirmation_box uses the whole available space for content if needed and generates scrollbar when exceeded (fixes #4307)

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2020-05-05: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

Fixes #4307

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
