### PR TITLE
fix: [UI] Do not show publish checkbox when importing MISP event for user without permission

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -2359,8 +2359,10 @@ class EventsController extends AppController
                 $takeOwnership = Configure::read('MISP.take_ownership_xml_import')
                     && (isset($this->request->data['Event']['takeownership']) && $this->request->data['Event']['takeownership'] == 1);
 
+                $publish = $this->request->data['Event']['publish'] ?? false;
+
                 try {
-                    $results = $this->Event->addMISPExportFile($this->Auth->user(), $data, $isXml, $takeOwnership, $this->request->data['Event']['publish']);
+                    $results = $this->Event->addMISPExportFile($this->Auth->user(), $data, $isXml, $takeOwnership, $publish);
                 } catch (Exception $e) {
                     $this->log("Exception during processing MISP file import: {$e->getMessage()}");
                     $this->Flash->error(__('Could not process MISP export file. Probably file content is invalid.'));

--- a/app/View/Events/add_misp_export.ctp
+++ b/app/View/Events/add_misp_export.ctp
@@ -16,17 +16,19 @@
     ?>
         <div class="input clear"></div>
     <?php
-    if (Configure::read('MISP.take_ownership_xml_import')):
-    echo $this->Form->input('Event.takeownership', array(
-        'checked' => false,
-        'label' => __('Take ownership of the event'),
-        'title' => __('Warning: This will change the creator organisation of the event, tampering with the event\'s ownership and releasability and can lead to unexpected behaviour when synchronising the event with instances that have another creator for the same event.)'
-    )));
-    endif;
-    echo $this->Form->input('publish', array(
-        'checked' => false,
-        'label' => __('Publish imported events'),
-    ));
+    if (Configure::read('MISP.take_ownership_xml_import')) {
+        echo $this->Form->input('Event.takeownership', array(
+            'checked' => false,
+            'label' => __('Take ownership of the event'),
+            'title' => __('Warning: This will change the creator organisation of the event, tampering with the event\'s ownership and releasability and can lead to unexpected behaviour when synchronising the event with instances that have another creator for the same event.')
+        ));
+    }
+    if ($isAclPublish) {
+        echo $this->Form->input('publish', array(
+            'checked' => false,
+            'label' => __('Publish imported events'),
+        ));
+    }
 ?>
     </fieldset>
 <?php


### PR DESCRIPTION
#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
