### PR TITLE
fix: [internal] Tag `misp-galaxy:rsit="Information Gathering:Scanning…

### DIFF
--- a/app/Model/Taxonomy.php
+++ b/app/Model/Taxonomy.php
@@ -600,7 +600,6 @@ class Taxonomy extends AppModel
         RedisTool::deleteKeysByPattern(RedisTool::init(), "misp:taxonomies_cache:*");
     }
 
-
     /**
      * @param string $tagName
      * @param bool $fullTaxonomy
@@ -784,7 +783,7 @@ class Taxonomy extends AppModel
      */
     public function splitTagToComponents($tag)
     {
-        preg_match('/^([^:="]+):([^:="]+)(="([^:="]+)")?$/i', $tag, $matches);
+        preg_match('/^([^:="]+):([^:="]+)(="([^"]+)")?$/i', $tag, $matches);
         if (empty($matches)) {
             return null; // tag is not in taxonomy format
         }


### PR DESCRIPTION
…"` was considered as invalid

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
