### PR TITLE
fix: typo in exists (does not exists => does not exist)

### DIFF
--- a/app/Console/Command/EventShell.php
+++ b/app/Console/Command/EventShell.php
@@ -68,7 +68,7 @@ class EventShell extends AppShell
         $user = $this->getUser($userId);
 
         if (!file_exists($path)) {
-            $this->error("File '$path' does not exists.");
+            $this->error("File '$path' does not exist.");
         }
         if (!is_readable($path)) {
             $this->error("File '$path' is not readable.");
@@ -637,7 +637,7 @@ class EventShell extends AppShell
     {
         $user = $this->User->getAuthUser($userId, true);
         if (empty($user)) {
-            $this->error("User with ID $userId does not exists.");
+            $this->error("User with ID $userId does not exist.");
         }
         Configure::write('CurrentUserId', $user['id']); // for audit logging purposes
         return $user;

--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -299,7 +299,7 @@ class AttributesController extends AppController
         $conditions['Attribute.type'] = array('attachment', 'malware-sample');
         $attributes = $this->Attribute->fetchAttributes($this->Auth->user(), array('conditions' => $conditions, 'flatten' => true));
         if (empty($attributes)) {
-            throw new UnauthorizedException(__('Attribute does not exists or you do not have the permission to download this attribute.'));
+            throw new UnauthorizedException(__('Attribute does not exist or you do not have the permission to download this attribute.'));
         }
         return $this->__downloadAttachment($attributes[0]['Attribute']);
     }
@@ -1770,7 +1770,7 @@ class AttributesController extends AppController
         $conditions['Attribute.type'] = array('attachment', 'malware-sample');
         $attributes = $this->Attribute->fetchAttributes($user, array('conditions' => $conditions, 'flatten' => true));
         if (empty($attributes)) {
-            throw new UnauthorizedException(__('Attribute does not exists or you do not have the permission to download this attribute.'));
+            throw new UnauthorizedException(__('Attribute does not exist or you do not have the permission to download this attribute.'));
         }
         return $this->__downloadAttachment($attributes[0]['Attribute']);
     }

--- a/app/Lib/Tools/AttachmentTool.php
+++ b/app/Lib/Tools/AttachmentTool.php
@@ -157,7 +157,7 @@ class AttachmentTool
             $filepath = $this->attachmentDir() . DS . $path;
             $file = new File($filepath);
             if (!is_file($file->path)) {
-                throw new NotFoundException("File '$filepath' does not exists.");
+                throw new NotFoundException("File '$filepath' does not exist.");
             }
         }
 

--- a/app/Locale/ara/LC_MESSAGES/default.po
+++ b/app/Locale/ara/LC_MESSAGES/default.po
@@ -725,7 +725,7 @@ msgid "Invalid Sharing Group or not authorised."
 msgstr ""
 
 #: Controller/AttributesController.php:316;1772
-msgid "Attribute does not exists or you do not have the permission to download this attribute."
+msgid "Attribute does not exist or you do not have the permission to download this attribute."
 msgstr ""
 
 #: Controller/AttributesController.php:334

--- a/app/Locale/cake_resque.pot
+++ b/app/Locale/cake_resque.pot
@@ -578,7 +578,7 @@ msgid "Workers number [%s] is not valid. Please enter a valid number"
 msgstr ""
 
 #: Plugin/CakeResque/Console/Command/CakeResqueShell.php:1282
-msgid "User [%s] does not exists. Please enter a valid system user"
+msgid "User [%s] does not exist. Please enter a valid system user"
 msgstr ""
 
 #: Plugin/CakeResque/Console/Command/CakeResqueShell.php:1304

--- a/app/Locale/cze/LC_MESSAGES/default.po
+++ b/app/Locale/cze/LC_MESSAGES/default.po
@@ -723,7 +723,7 @@ msgid "Invalid Sharing Group or not authorised."
 msgstr "Neplatná Skupina sdílení nebo není autorizovaná."
 
 #: Controller/AttributesController.php:316;1772
-msgid "Attribute does not exists or you do not have the permission to download this attribute."
+msgid "Attribute does not exist or you do not have the permission to download this attribute."
 msgstr ""
 
 #: Controller/AttributesController.php:334

--- a/app/Locale/dan/LC_MESSAGES/default.po
+++ b/app/Locale/dan/LC_MESSAGES/default.po
@@ -720,7 +720,7 @@ msgid "Invalid Sharing Group or not authorised."
 msgstr "Ugyldig Delingsgruppe, eller ingen godkendelse."
 
 #: Controller/AttributesController.php:316;1772
-msgid "Attribute does not exists or you do not have the permission to download this attribute."
+msgid "Attribute does not exist or you do not have the permission to download this attribute."
 msgstr ""
 
 #: Controller/AttributesController.php:334

--- a/app/Locale/default.pot
+++ b/app/Locale/default.pot
@@ -848,7 +848,7 @@ msgid "Add attribute"
 msgstr ""
 
 #: Controller/AttributesController.php:287;1725
-msgid "Attribute does not exists or you do not have the permission to download this attribute."
+msgid "Attribute does not exist or you do not have the permission to download this attribute."
 msgstr ""
 
 #: Controller/AttributesController.php:305

--- a/app/Locale/deu/LC_MESSAGES/default.po
+++ b/app/Locale/deu/LC_MESSAGES/default.po
@@ -720,7 +720,7 @@ msgid "Invalid Sharing Group or not authorised."
 msgstr "Ungültige Freigabegruppe oder nicht berechtigt."
 
 #: Controller/AttributesController.php:316;1772
-msgid "Attribute does not exists or you do not have the permission to download this attribute."
+msgid "Attribute does not exist or you do not have the permission to download this attribute."
 msgstr ""
 
 #: Controller/AttributesController.php:334

--- a/app/Locale/fra/LC_MESSAGES/default.po
+++ b/app/Locale/fra/LC_MESSAGES/default.po
@@ -723,7 +723,7 @@ msgid "Invalid Sharing Group or not authorised."
 msgstr "Groupe de partage invalide ou non autorisé."
 
 #: Controller/AttributesController.php:316;1772
-msgid "Attribute does not exists or you do not have the permission to download this attribute."
+msgid "Attribute does not exist or you do not have the permission to download this attribute."
 msgstr ""
 
 #: Controller/AttributesController.php:334

--- a/app/Locale/hun/LC_MESSAGES/default.po
+++ b/app/Locale/hun/LC_MESSAGES/default.po
@@ -720,7 +720,7 @@ msgid "Invalid Sharing Group or not authorised."
 msgstr ""
 
 #: Controller/AttributesController.php:316;1772
-msgid "Attribute does not exists or you do not have the permission to download this attribute."
+msgid "Attribute does not exist or you do not have the permission to download this attribute."
 msgstr ""
 
 #: Controller/AttributesController.php:334

--- a/app/Locale/ita/LC_MESSAGES/default.po
+++ b/app/Locale/ita/LC_MESSAGES/default.po
@@ -721,7 +721,7 @@ msgid "Invalid Sharing Group or not authorised."
 msgstr "Sharing Group non valido o non autorizzato."
 
 #: Controller/AttributesController.php:316;1772
-msgid "Attribute does not exists or you do not have the permission to download this attribute."
+msgid "Attribute does not exist or you do not have the permission to download this attribute."
 msgstr ""
 
 #: Controller/AttributesController.php:334

--- a/app/Locale/jpn/LC_MESSAGES/default.po
+++ b/app/Locale/jpn/LC_MESSAGES/default.po
@@ -719,7 +719,7 @@ msgid "Invalid Sharing Group or not authorised."
 msgstr "無効な共有グループ、もしくは権限がありません。"
 
 #: Controller/AttributesController.php:316;1772
-msgid "Attribute does not exists or you do not have the permission to download this attribute."
+msgid "Attribute does not exist or you do not have the permission to download this attribute."
 msgstr ""
 
 #: Controller/AttributesController.php:334

--- a/app/Locale/kor/LC_MESSAGES/default.po
+++ b/app/Locale/kor/LC_MESSAGES/default.po
@@ -720,7 +720,7 @@ msgid "Invalid Sharing Group or not authorised."
 msgstr "잘못된 공유 그룹이거나 권한이 없습니다"
 
 #: Controller/AttributesController.php:316;1772
-msgid "Attribute does not exists or you do not have the permission to download this attribute."
+msgid "Attribute does not exist or you do not have the permission to download this attribute."
 msgstr ""
 
 #: Controller/AttributesController.php:334

--- a/app/Locale/no/LC_MESSAGES/default.po
+++ b/app/Locale/no/LC_MESSAGES/default.po
@@ -720,7 +720,7 @@ msgid "Invalid Sharing Group or not authorised."
 msgstr "Ugyldig delingsgruppe eller ikke autorisert."
 
 #: Controller/AttributesController.php:316;1772
-msgid "Attribute does not exists or you do not have the permission to download this attribute."
+msgid "Attribute does not exist or you do not have the permission to download this attribute."
 msgstr ""
 
 #: Controller/AttributesController.php:334

--- a/app/Locale/pol/LC_MESSAGES/default.po
+++ b/app/Locale/pol/LC_MESSAGES/default.po
@@ -723,7 +723,7 @@ msgid "Invalid Sharing Group or not authorised."
 msgstr ""
 
 #: Controller/AttributesController.php:316;1772
-msgid "Attribute does not exists or you do not have the permission to download this attribute."
+msgid "Attribute does not exist or you do not have the permission to download this attribute."
 msgstr ""
 
 #: Controller/AttributesController.php:334

--- a/app/Locale/pt_BR/LC_MESSAGES/default.po
+++ b/app/Locale/pt_BR/LC_MESSAGES/default.po
@@ -721,7 +721,7 @@ msgid "Invalid Sharing Group or not authorised."
 msgstr "Grupo de compartilhamento inválido ou não autorizado."
 
 #: Controller/AttributesController.php:316;1772
-msgid "Attribute does not exists or you do not have the permission to download this attribute."
+msgid "Attribute does not exist or you do not have the permission to download this attribute."
 msgstr ""
 
 #: Controller/AttributesController.php:334

--- a/app/Locale/ro/LC_MESSAGES/default.po
+++ b/app/Locale/ro/LC_MESSAGES/default.po
@@ -721,7 +721,7 @@ msgid "Invalid Sharing Group or not authorised."
 msgstr ""
 
 #: Controller/AttributesController.php:316;1772
-msgid "Attribute does not exists or you do not have the permission to download this attribute."
+msgid "Attribute does not exist or you do not have the permission to download this attribute."
 msgstr ""
 
 #: Controller/AttributesController.php:334

--- a/app/Locale/rus/LC_MESSAGES/default.po
+++ b/app/Locale/rus/LC_MESSAGES/default.po
@@ -722,7 +722,7 @@ msgid "Invalid Sharing Group or not authorised."
 msgstr ""
 
 #: Controller/AttributesController.php:316;1772
-msgid "Attribute does not exists or you do not have the permission to download this attribute."
+msgid "Attribute does not exist or you do not have the permission to download this attribute."
 msgstr ""
 
 #: Controller/AttributesController.php:334

--- a/app/Locale/si-LK/LC_MESSAGES/default.po
+++ b/app/Locale/si-LK/LC_MESSAGES/default.po
@@ -723,7 +723,7 @@ msgid "Invalid Sharing Group or not authorised."
 msgstr "වලංගු නොවන බෙදාගැනීමේ කණ්ඩායමක් හෝ අවසරයක් නැත."
 
 #: Controller/AttributesController.php:316;1772
-msgid "Attribute does not exists or you do not have the permission to download this attribute."
+msgid "Attribute does not exist or you do not have the permission to download this attribute."
 msgstr "උපලක්ෂණයක් නොපවතී හෝ ඔබට මෙම උපලක්ෂණ බාගැනීමට අවසර නැත."
 
 #: Controller/AttributesController.php:334

--- a/app/Locale/spa/LC_MESSAGES/default.po
+++ b/app/Locale/spa/LC_MESSAGES/default.po
@@ -722,7 +722,7 @@ msgid "Invalid Sharing Group or not authorised."
 msgstr "Grupo de uso no válido o no autorizado."
 
 #: Controller/AttributesController.php:316;1772
-msgid "Attribute does not exists or you do not have the permission to download this attribute."
+msgid "Attribute does not exist or you do not have the permission to download this attribute."
 msgstr ""
 
 #: Controller/AttributesController.php:334

--- a/app/Locale/th_TH/LC_MESSAGES/default.po
+++ b/app/Locale/th_TH/LC_MESSAGES/default.po
@@ -722,7 +722,7 @@ msgid "Invalid Sharing Group or not authorised."
 msgstr "กลุ่มการแบ่งปันไม่ถูกต้องหรือไม่ได้รับอนุญาต"
 
 #: Controller/AttributesController.php:316;1772
-msgid "Attribute does not exists or you do not have the permission to download this attribute."
+msgid "Attribute does not exist or you do not have the permission to download this attribute."
 msgstr "ไม่มีแอตทริบิวต์หรือคุณไม่ได้รับอนุญาตให้ดาวน์โหลดแอตทริบิวต์นี้"
 
 #: Controller/AttributesController.php:334

--- a/app/Locale/zh-s/LC_MESSAGES/default.po
+++ b/app/Locale/zh-s/LC_MESSAGES/default.po
@@ -719,7 +719,7 @@ msgid "Invalid Sharing Group or not authorised."
 msgstr "无效的共享组或未授权."
 
 #: Controller/AttributesController.php:316;1772
-msgid "Attribute does not exists or you do not have the permission to download this attribute."
+msgid "Attribute does not exist or you do not have the permission to download this attribute."
 msgstr ""
 
 #: Controller/AttributesController.php:334

--- a/app/Model/GalaxyClusterRelation.php
+++ b/app/Model/GalaxyClusterRelation.php
@@ -223,7 +223,7 @@ class GalaxyClusterRelation extends AppModel
             }
             if (!$force) {
                 $targetCluster = $this->TargetCluster->fetchIfAuthorized($user, $relation['GalaxyClusterRelation']['referenced_galaxy_cluster_uuid'], 'view', $throwErrors=false, $full=false);
-                if (isset($targetCluster['authorized']) && !$targetCluster['authorized']) { // do not save the relation if referenced cluster is not accessible by the user (or does not exists)
+                if (isset($targetCluster['authorized']) && !$targetCluster['authorized']) { // do not save the relation if referenced cluster is not accessible by the user (or does not exist)
                     $errors[] = array(__('Invalid referenced galaxy cluster'));
                     return $errors;
                 }
@@ -315,7 +315,7 @@ class GalaxyClusterRelation extends AppModel
                     return $errors;
                 }
                 $targetCluster = $this->TargetCluster->fetchIfAuthorized($user, $relation['GalaxyClusterRelation']['referenced_galaxy_cluster_uuid'], 'view', $throwErrors=false, $full=false);
-                if (isset($targetCluster['authorized']) && !$targetCluster['authorized']) { // do not save the relation if referenced cluster is not accessible by the user (or does not exists)
+                if (isset($targetCluster['authorized']) && !$targetCluster['authorized']) { // do not save the relation if referenced cluster is not accessible by the user (or does not exist)
                     $errors[] = array(__('Invalid referenced galaxy cluster'));
                     return $errors;
                 }

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -3182,7 +3182,7 @@ class Server extends AppModel
         $indexDiff = array();
         foreach ($expectedIndex as $tableName => $indexes) {
             if (!array_key_exists($tableName, $actualIndex)) {
-                continue; // If table does not exists, it is covered by the schema diagnostic
+                continue; // If table does not exist, it is covered by the schema diagnostic
             }
             $tableIndexDiff = array_diff(array_keys($indexes), array_keys($actualIndex[$tableName])); // check for missing indexes
             foreach ($tableIndexDiff as $columnDiff) {

--- a/app/Model/Workflow.php
+++ b/app/Model/Workflow.php
@@ -1008,7 +1008,7 @@ class Workflow extends AppModel
         $className = str_replace('.php', '', $className[count($className)-1]);
         try {
             if (!@include_once($filepath)) {
-                $message = __('Could not load module for path %s. File does not exists.', $filepath);
+                $message = __('Could not load module for path %s. File does not exist.', $filepath);
                 $this->log($message, LOG_ERR);
                 return $message;
             }

--- a/app/webroot/js/cal-heatmap.js
+++ b/app/webroot/js/cal-heatmap.js
@@ -1114,7 +1114,7 @@ CalHeatMap.prototype = {
 		}
 
 		if (d3.select(options.itemSelector)[0][0] === null) {
-			throw new Error("The node '" + options.itemSelector + "' specified in itemSelector does not exists");
+			throw new Error("The node '" + options.itemSelector + "' specified in itemSelector does not exist");
 		}
 
 		try {

--- a/app/webroot/js/markdownEditor/event-report.js
+++ b/app/webroot/js/markdownEditor/event-report.js
@@ -886,7 +886,7 @@ function markdownItToggleRenderingRule(rulename, event) {
         event.stopPropagation()
     }
     if (renderingRules[rulename] === undefined) {
-        console.log('Rule does not exists')
+        console.log('Rule does not exist')
         return
     }
     renderingRules[rulename] = !renderingRules[rulename]

--- a/app/webroot/js/taskScheduler.js
+++ b/app/webroot/js/taskScheduler.js
@@ -199,7 +199,7 @@
             var checked = this.taskScheduled;
             this.container = document.getElementById(this.config.container);
             if (this.container === undefined || this.container === null) {
-                throw "Cannot create switch. Container does not exists";
+                throw "Cannot create switch. Container does not exist";
             }
             var temp = document.createElement('div');
             this.config.checkboxLink = this.genRandom();

--- a/tools/misp-config
+++ b/tools/misp-config
@@ -164,7 +164,7 @@ if ($apply) {
     my $misp_config_path = "$misp_config_path/misp.conf.d";
 
     unless(-d $misp_config_path) {
-	die "MISP Configuration Path does not exists: $misp_config_path\n";
+	die "MISP Configuration Path does not exist: $misp_config_path\n";
     }
     
     foreach my $fp (glob("$misp_config_path/*.conf")) {


### PR DESCRIPTION
#### What does it do?

This fix corrects a spelling error throughout the code (commands, controllers, locales, etc.).

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
