### PR TITLE
fix: [sync] galaxy clusters stopped being pushed to remote servers

### DIFF
--- a/app/Model/GalaxyCluster.php
+++ b/app/Model/GalaxyCluster.php
@@ -1667,7 +1667,7 @@ class GalaxyCluster extends AppModel
         }
 
         try {
-            if (!$serverSync->isSupported(ServerSyncTool::PERM_SYNC) || $serverSync->isSupported(ServerSyncTool::PERM_GALAXY_EDITOR)) {
+            if (!$serverSync->isSupported(ServerSyncTool::PERM_SYNC) || !$serverSync->isSupported(ServerSyncTool::PERM_GALAXY_EDITOR)) {
                 return __('The remote user does not have the permission to manipulate galaxies - the upload of the galaxy clusters has been blocked.');
             }
             $serverSync->pushGalaxyCluster($cluster)->json();


### PR DESCRIPTION
#### What does it do?

After moving away from v2.4.159 "Push Galaxy Clusters" stopped working. The created publish_galaxy_cluster jobs are completing successfully, but the galaxy on the receiving end is never updated.

I traced the issue back to this permission check:
https://github.com/MISP/MISP/blob/8a67843035ab40de253506664b3a085fd4675125/app/Model/GalaxyCluster.php#L1670-L1672

The logic of the PERM_GALAXY_EDITOR check needs to be reversed.

The returned reason for failing did not end up in any logs, which made finding the culprit difficult.

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
