### PR TITLE
chg: [internal] allow site admins ability to view event_creator_email for all events in export

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -2097,7 +2097,7 @@ class Event extends AppModel
             // Include information about event creator user email. This information is included for:
             // - users from event creator org
             // - site admins
-            // In export, this information will be included in `event_creator_email` field just for auditors of event creator org.
+            // In export, this information will be included in `event_creator_email` field for auditors of event creator org and site admins.
             $sameOrg = $event['Event']['orgc_id'] === $user['org_id'];
             if ($sameOrg || $user['Role']['perm_site_admin']) {
                 if (!isset($userEmails[$event['Event']['user_id']])) {
@@ -2105,7 +2105,7 @@ class Event extends AppModel
                 }
 
                 $userEmail = $userEmails[$event['Event']['user_id']];
-                if ($sameOrg && $user['Role']['perm_audit']) {
+                if ($sameOrg && $user['Role']['perm_audit'] || $user['Role']['perm_site_admin']) {
                     $event['Event']['event_creator_email'] = $userEmail;
                 }
                 $event['User']['email'] = $userEmail;


### PR DESCRIPTION
#### What does it do?

The comment on line 2097 states:

> Include information about event creator user email. This information is included for: 
>  - users from event creator org
>  - site admins
>  In export, this information will be included in `event_creator_email` field just for auditors of event creator org.

`$event['Event']['event_creator_email']` is not set for site admins, only for users from the same org that have a role assigned with audit permission. 

This change will allow a site admin the ability to gather more granular metrics on which users are actively sharing to a community MISP instance via the MISP API.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
