### PR TITLE
new: [ApacheAuthenticate] Add STARTTLS support for LDAP connection

### DIFF
--- a/app/Config/config.default.php
+++ b/app/Config/config.default.php
@@ -213,12 +213,13 @@ $config = array(
     // Warning: The following is a 3rd party contribution and still untested (including security) by the MISP-project team.
     // Feel free to enable it and report back to us if you run into any issues.
     //
-    // Uncomment the following to enable Kerberos authentication
+    // Uncomment the following to enable Kerberos/LDAP authentication
     // needs PHP LDAP support enabled (e.g. compile flag --with-ldap or Debian package php5-ldap)
     /*
-    'ApacheSecureAuth' => array( // Configuration for kerberos authentication
+    'ApacheSecureAuth' => array( // Configuration for kerberos/LDAP authentication
         'apacheEnv'          => 'REMOTE_USER',           // If proxy variable = HTTP_REMOTE_USER, If BasicAuth ldap = PHP_AUTH_USER
-        'ldapServer'         => 'ldap://example.com',   // FQDN or IP
+        'ldapServer'         => 'ldap://example.com',   // FQDN or IP, ldap:// for LDAP or LDAP+STARTTLS, ldaps:// for LDAPS
+        'starttls'           => true, // true for STARTTLS, ignored for LDAPS
         'ldapProtocol'       => 3,
         'ldapNetworkTimeout' => -1,  // use -1 for unlimited network timeout
         'ldapReaderUser'     => 'cn=userWithReadAccess,ou=users,dc=example,dc=com', // DN ou RDN LDAP with reader user right

--- a/app/Controller/Component/Auth/ApacheAuthenticate.php
+++ b/app/Controller/Component/Auth/ApacheAuthenticate.php
@@ -38,10 +38,10 @@ class ApacheAuthenticate extends BaseAuthenticate
         }
         return $returnCode;
     }
-	
+
     private function getEmailAddress($ldapEmailField, $ldapUserData)
     {
-	// return the email address of an LDAP user if one of the fields in $ldapEmaiLField exists
+        // return the email address of an LDAP user if one of the fields in $ldapEmaiLField exists
         foreach($ldapEmailField as $field) {
             if (isset($ldapUserData[0][$field][0])) {
                 return $ldapUserData[0][$field][0];
@@ -72,6 +72,14 @@ class ApacheAuthenticate extends BaseAuthenticate
         // LDAP protocol configuration
         ldap_set_option($ldapconn, LDAP_OPT_PROTOCOL_VERSION, Configure::read('ApacheSecureAuth.ldapProtocol'));
         ldap_set_option($ldapconn, LDAP_OPT_REFERRALS, Configure::read('ApacheSecureAuth.ldapAllowReferrals', true));
+
+        if (Configure::read('ApacheSecureAuth.starttls', false) == true) {
+            # Default is false, sine STARTTLS support is a new feature
+            # Ignored on ldaps://, but can trigger problems for orgs
+            # using unencrypted LDAP. Loose comparison allows users to
+            # use # true / 1 / etc.
+            ldap_start_tls($ldapconn);
+        }
 
         if ($ldapconn) {
             // LDAP bind
@@ -105,7 +113,6 @@ class ApacheAuthenticate extends BaseAuthenticate
             } else {
                 die("User not found in LDAP");
             }
-		
             // close LDAP connection
             ldap_close($ldapconn);
         }


### PR DESCRIPTION
Controlled by setting `ApacheSecureAuth.starttls`. Default (`ApacheSecureAuth.starttls undefined`) is `false`, since it is a new feature.

config.default.php is updated with `ApacheSecureAuth.starttls = true` as default and extra explanations.

- [NO] Does it require a DB change?
- [YES] Are you using it in production?
- [NO] Does it require a change in the API (PyMISP for example)?
