### PR TITLE
fix: install guide links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,14 +2,20 @@
 
 On the following pages you will find stock install instructions for getting a base MISP system running.
 
+- [INSTALL.ubuntu2204.md](https://github.com/MISP/MISP/blob/2.4/docs/xINSTALL.ubuntu2204.md)
+- [INSTALL.ubuntu2004.md](https://github.com/MISP/MISP/blob/2.4/docs/INSTALL.ubuntu2004.md)
+- [INSTALL.ubuntu1804.md](https://github.com/MISP/MISP/blob/2.4/docs/INSTALL.ubuntu1804.md)
+- [INSTALL.rhel8.md](https://github.com/MISP/MISP/blob/2.4/docs/INSTALL.rhel8.md)
+- [INSTALL.rhel7.md](https://github.com/MISP/MISP/blob/2.4/docs/INSTALL.rhel7.md)
+- [INSTALL.kali.md](https://github.com/MISP/MISP/blob/2.4/docs/INSTALL.kali.md)
+- [INSTALL.NetBSD.md](https://github.com/MISP/MISP/blob/2.4/docs/xINSTALL.NetBSD.md)
+- [INSTALL.OpenBSD.md](https://github.com/MISP/MISP/blob/2.4/docs/xINSTALL.OpenBSD.md)
+- [INSTALL.centos7.md](https://github.com/MISP/MISP/blob/2.4/docs/xINSTALL.centos7.md)
+- [INSTALL.debian10.md](https://github.com/MISP/MISP/blob/2.4/docs/xINSTALL.debian10.md)
+- [INSTALL.tsurugi.md](https://github.com/MISP/MISP/blob/2.4/docs/xINSTALL.tsurugi.md)
+
 For full documentation visit [misp-book](https://www.circl.lu/doc/misp/).
 
 [![Twitter URL](https://img.shields.io/twitter/url/https/twitter.com/fold_left.svg?style=social&label=Follow%20%40MISPProject)](https://twitter.com/MISPProject)
 
-!!! note
-    #### INSTALL Guides...
-    ##### ... are stable and tested INSTALL guides.
-    #### xINSTALL Guides...
-    ##### ... are eXperimental guides that might be tested or not.
-    #### Config Guides...
-    ##### ... are CONFIGuration guides and not full blown INSTALL guides.
+


### PR DESCRIPTION
#### What does it do?
Installation procedure are not included in the [guide](https://misp.github.io/MISP/) or [README](https://github.com/MISP/MISP/blob/2.4/README.md), making it difficult for first-time MISP users to find the installation procedure. So I added a link to the installation guide.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Current installation guide

If you search by Google, you will find an installation guide page,
<img width="1100" alt="スクリーンショット 2023-03-11 8 58 13" src="https://user-images.githubusercontent.com/41001169/224451057-d7c3a294-0a7f-4107-a7f1-c192f51cdb11.png">

but there is no installation document links now as follows.
<img width="1100" alt="スクリーンショット 2023-03-11 8 58 57" src="https://user-images.githubusercontent.com/41001169/224451114-a45b192e-0cc3-4e2c-9d84-6f2005eba9a1.png">

Thank you for maintaining such a wonderful tool :)
I would appreciate it if you could review.
