### PR TITLE
[fix] fix installer pages

### DIFF
--- a/docs/INSTALL.rhel7.md
+++ b/docs/INSTALL.rhel7.md
@@ -7,16 +7,16 @@
     Tested fully working without SELinux by [@SteveClement](https://twitter.com/SteveClement) on 20210401
     TODO: Fix SELinux permissions, *pull-requests welcome*.
 
-{% generic/manual-install-notes.md %}
+{% include_relative generic/manual-install-notes.md %}
 
 !!! notice
     If the next line is `[!generic/community.md!]()` [click here](https://misp.github.io/MISP/INSTALL.rhel7).
 
-{% generic/community.md %}
+{% include_relative generic/community.md %}
 
 ### 0/ Overview and Assumptions
 
-{% generic/rhelVScentos.md %}
+{% include_relative generic/rhelVScentos.md %}
 
 !!! warning
     The core MISP team cannot easily verify if this guide is working or not. Please help us in keeping it up to date and accurate.
@@ -26,7 +26,7 @@
     Maintenance for CentOS 7 will end on: June 30th, 2024 [Source[0]](https://wiki.centos.org/About/Product) [Source[1]](https://linuxlifecycle.com/)
     CentOS 7-1908 [NetInstallURL](http://mirror.centos.org/centos/7/os/x86_64/)
 
-{% generic/manual-install-notes.md %}
+{% include_relative generic/manual-install-notes.md %}
 
 This document details the steps to install MISP on Red Hat Enterprise Linux 7.x (RHEL 7.x) and CentOS 7.x.
 This is a joint RHEL/CentOS install guide. The authors tried to make it contextually evident what applies to which flavor.
@@ -38,7 +38,7 @@ The following assumptions with regard to this installation have been made.
 - This system will have direct or proxy access to the Internet for updates. Or connected to a Red Hat Satellite Server
 - This document will bootstrap a MISP instance running over HTTPS. A full test of all features have yet to be done. [The following GitHub issue](https://github.com/MISP/MISP/issues/4084) details some shortcomings.
 
-{% generic/globalVariables.md %}
+{% include_relative generic/globalVariables.md %}
 
 !!! note
     For fresh installs the following tips might be handy.<br />
@@ -633,19 +633,19 @@ configWorkersRHEL () {
 # <snippet-end 3_configWorkers_RHEL.sh>
 ```
 
-{% generic/MISP_CAKE_init.md %}
+{% include_relative generic/MISP_CAKE_init.md %}
 
-{% generic/misp-modules-rhel.md %}
+{% include_relative generic/misp-modules-rhel.md %}
 
-{% generic/misp-modules-cake.md %}
+{% include_relative generic/misp-modules-cake.md %}
 
-{% generic/misp-dashboard-rhel.md %}
+{% include_relative generic/misp-dashboard-rhel.md %}
 
-{% generic/misp-dashboard-cake.md %}
+{% include_relative generic/misp-dashboard-cake.md %}
 
-{% generic/INSTALL.done.md %}
+{% include_relative generic/INSTALL.done.md %}
 
-{% generic/recommended.actions.md %}
+{% include_relative generic/recommended.actions.md %}
 
 ### 11/ Known Issues
 ## 11.01/ Workers cannot be started or restarted from the web page
@@ -658,4 +658,4 @@ systemctl restart misp-workers.service
     No other functions were tested after the conclusion of this install. There may be issue that aren't addressed<br />
     via this guide and will need additional investigation.
 
-{% generic/hardening.md %}
+{% include_relative generic/hardening.md %}

--- a/docs/INSTALL.rhel7.md
+++ b/docs/INSTALL.rhel7.md
@@ -7,16 +7,16 @@
     Tested fully working without SELinux by [@SteveClement](https://twitter.com/SteveClement) on 20210401
     TODO: Fix SELinux permissions, *pull-requests welcome*.
 
-{!generic/manual-install-notes.md!}
+{% generic/manual-install-notes.md %}
 
 !!! notice
     If the next line is `[!generic/community.md!]()` [click here](https://misp.github.io/MISP/INSTALL.rhel7).
 
-{!generic/community.md!}
+{% generic/community.md %}
 
 ### 0/ Overview and Assumptions
 
-{!generic/rhelVScentos.md!}
+{% generic/rhelVScentos.md %}
 
 !!! warning
     The core MISP team cannot easily verify if this guide is working or not. Please help us in keeping it up to date and accurate.
@@ -26,7 +26,7 @@
     Maintenance for CentOS 7 will end on: June 30th, 2024 [Source[0]](https://wiki.centos.org/About/Product) [Source[1]](https://linuxlifecycle.com/)
     CentOS 7-1908 [NetInstallURL](http://mirror.centos.org/centos/7/os/x86_64/)
 
-{!generic/manual-install-notes.md!}
+{% generic/manual-install-notes.md %}
 
 This document details the steps to install MISP on Red Hat Enterprise Linux 7.x (RHEL 7.x) and CentOS 7.x.
 This is a joint RHEL/CentOS install guide. The authors tried to make it contextually evident what applies to which flavor.
@@ -38,7 +38,7 @@ The following assumptions with regard to this installation have been made.
 - This system will have direct or proxy access to the Internet for updates. Or connected to a Red Hat Satellite Server
 - This document will bootstrap a MISP instance running over HTTPS. A full test of all features have yet to be done. [The following GitHub issue](https://github.com/MISP/MISP/issues/4084) details some shortcomings.
 
-{!generic/globalVariables.md!}
+{% generic/globalVariables.md %}
 
 !!! note
     For fresh installs the following tips might be handy.<br />
@@ -633,19 +633,19 @@ configWorkersRHEL () {
 # <snippet-end 3_configWorkers_RHEL.sh>
 ```
 
-{!generic/MISP_CAKE_init.md!}
+{% generic/MISP_CAKE_init.md %}
 
-{!generic/misp-modules-rhel.md!}
+{% generic/misp-modules-rhel.md %}
 
-{!generic/misp-modules-cake.md!}
+{% generic/misp-modules-cake.md %}
 
-{!generic/misp-dashboard-rhel.md!}
+{% generic/misp-dashboard-rhel.md %}
 
-{!generic/misp-dashboard-cake.md!}
+{% generic/misp-dashboard-cake.md %}
 
-{!generic/INSTALL.done.md!}
+{% generic/INSTALL.done.md %}
 
-{!generic/recommended.actions.md!}
+{% generic/recommended.actions.md %}
 
 ### 11/ Known Issues
 ## 11.01/ Workers cannot be started or restarted from the web page
@@ -658,4 +658,4 @@ systemctl restart misp-workers.service
     No other functions were tested after the conclusion of this install. There may be issue that aren't addressed<br />
     via this guide and will need additional investigation.
 
-{!generic/hardening.md!}
+{% generic/hardening.md %}

--- a/docs/INSTALL.rhel8.md
+++ b/docs/INSTALL.rhel8.md
@@ -9,12 +9,12 @@
 !!! notice
     TODO: Fix SELinux permissions, *pull-requests welcome*.
 
-{!generic/manual-install-notes.md!}
+{% generic/manual-install-notes.md %}
 
 !!! notice
     If the next line is `[!generic/community.md!]()` [click here](https://misp.github.io/MISP/INSTALL.rhel8).
 
-{!generic/community.md!}
+{% generic/community.md %}
 
 ### 0/ Overview and Assumptions
 
@@ -27,7 +27,7 @@
     Consider using [Rocky Linux](https://rockylinux.org/)
     CentOS 8 [NetInstallURL](http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=BaseOS)
 
-{!generic/manual-install-notes.md!}
+{% generic/manual-install-notes.md %}
 
 This document details the steps to install MISP on Red Hat Enterprise Linux 8.x (RHEL 8.x) and Rocky Linux 8.x.
 This is a joint RHEL/Rocky install guide. The authors tried to make it contextually evident what applies to which flavor.
@@ -39,7 +39,7 @@ The following assumptions with regard to this installation have been made.
 - This system will have direct or proxy access to the Internet for updates. Or connected to a Red Hat Satellite Server
 - This document will bootstrap a MISP instance running over HTTPS. A full test of all features have yet to be done. [The following GitHub issue](https://github.com/MISP/MISP/issues/4084) details some shortcomings.
 
-{!generic/globalVariables.md!}
+{% generic/globalVariables.md %}
 
 !!! note
     For fresh installs the following tips might be handy.<br />
@@ -676,19 +676,19 @@ configWorkersRHEL () {
 # <snippet-end 3_configWorkers_RHEL.sh>
 ```
 
-{!generic/MISP_CAKE_init.md!}
+{% generic/MISP_CAKE_init.md %}
 
-{!generic/misp-modules-rhel.md!}
+{% generic/misp-modules-rhel.md %}
 
-{!generic/misp-modules-cake.md!}
+{% generic/misp-modules-cake.md %}
 
-{!generic/misp-dashboard-rhel.md!}
+{% generic/misp-dashboard-rhel.md %}
 
-{!generic/misp-dashboard-cake.md!}
+{% generic/misp-dashboard-cake.md %}
 
-{!generic/INSTALL.done.md!}
+{% generic/INSTALL.done.md %}
 
-{!generic/recommended.actions.md!}
+{% generic/recommended.actions.md %}
 
 ### 11/ LIEF Installation
 *lief* is required for the Advanced Attachment Handler and requires manual compilation
@@ -706,4 +706,4 @@ systemctl restart misp-workers.service
     No other functions were tested after the conclusion of this install. There may be issue that aren't addressed<br />
     via this guide and will need additional investigation.
 
-{!generic/hardening.md!}
+{% generic/hardening.md %}

--- a/docs/INSTALL.rhel8.md
+++ b/docs/INSTALL.rhel8.md
@@ -9,12 +9,12 @@
 !!! notice
     TODO: Fix SELinux permissions, *pull-requests welcome*.
 
-{% generic/manual-install-notes.md %}
+{% include_relative generic/manual-install-notes.md %}
 
 !!! notice
     If the next line is `[!generic/community.md!]()` [click here](https://misp.github.io/MISP/INSTALL.rhel8).
 
-{% generic/community.md %}
+{% include_relative generic/community.md %}
 
 ### 0/ Overview and Assumptions
 
@@ -27,7 +27,7 @@
     Consider using [Rocky Linux](https://rockylinux.org/)
     CentOS 8 [NetInstallURL](http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=BaseOS)
 
-{% generic/manual-install-notes.md %}
+{% include_relative generic/manual-install-notes.md %}
 
 This document details the steps to install MISP on Red Hat Enterprise Linux 8.x (RHEL 8.x) and Rocky Linux 8.x.
 This is a joint RHEL/Rocky install guide. The authors tried to make it contextually evident what applies to which flavor.
@@ -39,7 +39,7 @@ The following assumptions with regard to this installation have been made.
 - This system will have direct or proxy access to the Internet for updates. Or connected to a Red Hat Satellite Server
 - This document will bootstrap a MISP instance running over HTTPS. A full test of all features have yet to be done. [The following GitHub issue](https://github.com/MISP/MISP/issues/4084) details some shortcomings.
 
-{% generic/globalVariables.md %}
+{% include_relative generic/globalVariables.md %}
 
 !!! note
     For fresh installs the following tips might be handy.<br />
@@ -676,19 +676,19 @@ configWorkersRHEL () {
 # <snippet-end 3_configWorkers_RHEL.sh>
 ```
 
-{% generic/MISP_CAKE_init.md %}
+{% include_relative generic/MISP_CAKE_init.md %}
 
-{% generic/misp-modules-rhel.md %}
+{% include_relative generic/misp-modules-rhel.md %}
 
-{% generic/misp-modules-cake.md %}
+{% include_relative generic/misp-modules-cake.md %}
 
-{% generic/misp-dashboard-rhel.md %}
+{% include_relative generic/misp-dashboard-rhel.md %}
 
-{% generic/misp-dashboard-cake.md %}
+{% include_relative generic/misp-dashboard-cake.md %}
 
-{% generic/INSTALL.done.md %}
+{% include_relative generic/INSTALL.done.md %}
 
-{% generic/recommended.actions.md %}
+{% include_relative generic/recommended.actions.md %}
 
 ### 11/ LIEF Installation
 *lief* is required for the Advanced Attachment Handler and requires manual compilation
@@ -706,4 +706,4 @@ systemctl restart misp-workers.service
     No other functions were tested after the conclusion of this install. There may be issue that aren't addressed<br />
     via this guide and will need additional investigation.
 
-{% generic/hardening.md %}
+{% include_relative generic/hardening.md %}

--- a/docs/INSTALL.ubuntu1804.md
+++ b/docs/INSTALL.ubuntu1804.md
@@ -1,7 +1,7 @@
 # INSTALLATION INSTRUCTIONS
 ## for Ubuntu 18.04.5-server
 
-{% generic/manual-install-notes.md %}
+{% include_relative generic/manual-install-notes.md %}
 
 Make sure you are reading the parsed version of this Document. When in doubt [click here](https://misp.github.io/MISP/INSTALL.ubuntu1804).
 
@@ -13,7 +13,7 @@ Make sure you are reading the parsed version of this Document. When in doubt [cl
 !!! notice
     If the next line is `[!generic/core.md!]()` [click here](https://misp.github.io/MISP/INSTALL.ubuntu1804).
 
-{% generic/core.md %}
+{% include_relative generic/core.md %}
 
 ### 1/ Minimal Ubuntu install
 -------------------------
@@ -42,9 +42,9 @@ aptUpgrade () {
 # <snippet-end 0_apt-upgrade.sh>
 ```
 
-{% generic/sudo_etckeeper.md %}
+{% include_relative generic/sudo_etckeeper.md %}
 
-{% generic/ethX.md %}
+{% include_relative generic/ethX.md %}
 
 #### install postfix, there will be some questions.
 ```bash
@@ -61,7 +61,7 @@ sudo apt-get install postfix dialog -qy
     sudo postfix reload
     ```
 
-{% generic/globalVariables.md %}
+{% include_relative generic/globalVariables.md %}
 
 ### 2/ Install LAMP & dependencies
 ------------------------------
@@ -433,7 +433,7 @@ configMISP () {
 # <snippet-end 2_configMISP.sh>
 ```
 
-{% generic/gnupg.md %}
+{% include_relative generic/gnupg.md %}
 
 !!! notice
     If entropy is not high enough, you can install havegd and then start the service
@@ -487,15 +487,15 @@ echo "Admin (root) DB Password: $DBPASSWORD_ADMIN"
 echo "User  (misp) DB Password: $DBPASSWORD_MISP"
 ```
 
-{% generic/MISP_CAKE_init.md %}
+{% include_relative generic/MISP_CAKE_init.md %}
 
-{% generic/misp-modules-debian.md %}
+{% include_relative generic/misp-modules-debian.md %}
 
-{% generic/misp-modules-cake.md %}
+{% include_relative generic/misp-modules-cake.md %}
 
-{% generic/INSTALL.done.md %}
+{% include_relative generic/INSTALL.done.md %}
 
-{% generic/recommended.actions.md %}
+{% include_relative generic/recommended.actions.md %}
 
 ### Optional features
 -----------------
@@ -518,17 +518,17 @@ installKafka () {
 # <snippet-end 4_kafka.sh>
 ```
 
-{% generic/misp-dashboard-debian.md %}
+{% include_relative generic/misp-dashboard-debian.md %}
 
-{% generic/misp-dashboard-cake.md %}
+{% include_relative generic/misp-dashboard-cake.md %}
 
-{% generic/viper-debian.md %}
+{% include_relative generic/viper-debian.md %}
 
-{% generic/ssdeep-debian.md %}
+{% include_relative generic/ssdeep-debian.md %}
 
-{% generic/mail_to_misp-debian.md %}
+{% include_relative generic/mail_to_misp-debian.md %}
 
-{% generic/hardening.md %}
+{% include_relative generic/hardening.md %}
 
 # INSTALL.sh
 
@@ -536,4 +536,4 @@ installKafka () {
     The following section is an administrative section that is used by the "[INSTALL.sh](https://raw.githubusercontent.com/MISP/MISP/2.4/INSTALL/INSTALL.sh)" script.
     Please ignore.
 
-{% generic/supportFunctions.md %}
+{% include_relative generic/supportFunctions.md %}

--- a/docs/INSTALL.ubuntu1804.md
+++ b/docs/INSTALL.ubuntu1804.md
@@ -1,7 +1,7 @@
 # INSTALLATION INSTRUCTIONS
 ## for Ubuntu 18.04.5-server
 
-{!generic/manual-install-notes.md!}
+{% generic/manual-install-notes.md %}
 
 Make sure you are reading the parsed version of this Document. When in doubt [click here](https://misp.github.io/MISP/INSTALL.ubuntu1804).
 
@@ -13,7 +13,7 @@ Make sure you are reading the parsed version of this Document. When in doubt [cl
 !!! notice
     If the next line is `[!generic/core.md!]()` [click here](https://misp.github.io/MISP/INSTALL.ubuntu1804).
 
-{!generic/core.md!}
+{% generic/core.md %}
 
 ### 1/ Minimal Ubuntu install
 -------------------------
@@ -42,9 +42,9 @@ aptUpgrade () {
 # <snippet-end 0_apt-upgrade.sh>
 ```
 
-{!generic/sudo_etckeeper.md!}
+{% generic/sudo_etckeeper.md %}
 
-{!generic/ethX.md!}
+{% generic/ethX.md %}
 
 #### install postfix, there will be some questions.
 ```bash
@@ -61,7 +61,7 @@ sudo apt-get install postfix dialog -qy
     sudo postfix reload
     ```
 
-{!generic/globalVariables.md!}
+{% generic/globalVariables.md %}
 
 ### 2/ Install LAMP & dependencies
 ------------------------------
@@ -433,7 +433,7 @@ configMISP () {
 # <snippet-end 2_configMISP.sh>
 ```
 
-{!generic/gnupg.md!}
+{% generic/gnupg.md %}
 
 !!! notice
     If entropy is not high enough, you can install havegd and then start the service
@@ -487,15 +487,15 @@ echo "Admin (root) DB Password: $DBPASSWORD_ADMIN"
 echo "User  (misp) DB Password: $DBPASSWORD_MISP"
 ```
 
-{!generic/MISP_CAKE_init.md!}
+{% generic/MISP_CAKE_init.md %}
 
-{!generic/misp-modules-debian.md!}
+{% generic/misp-modules-debian.md %}
 
-{!generic/misp-modules-cake.md!}
+{% generic/misp-modules-cake.md %}
 
-{!generic/INSTALL.done.md!}
+{% generic/INSTALL.done.md %}
 
-{!generic/recommended.actions.md!}
+{% generic/recommended.actions.md %}
 
 ### Optional features
 -----------------
@@ -518,17 +518,17 @@ installKafka () {
 # <snippet-end 4_kafka.sh>
 ```
 
-{!generic/misp-dashboard-debian.md!}
+{% generic/misp-dashboard-debian.md %}
 
-{!generic/misp-dashboard-cake.md!}
+{% generic/misp-dashboard-cake.md %}
 
-{!generic/viper-debian.md!}
+{% generic/viper-debian.md %}
 
-{!generic/ssdeep-debian.md!}
+{% generic/ssdeep-debian.md %}
 
-{!generic/mail_to_misp-debian.md!}
+{% generic/mail_to_misp-debian.md %}
 
-{!generic/hardening.md!}
+{% generic/hardening.md %}
 
 # INSTALL.sh
 
@@ -536,4 +536,4 @@ installKafka () {
     The following section is an administrative section that is used by the "[INSTALL.sh](https://raw.githubusercontent.com/MISP/MISP/2.4/INSTALL/INSTALL.sh)" script.
     Please ignore.
 
-{!generic/supportFunctions.md!}
+{% generic/supportFunctions.md %}

--- a/docs/INSTALL.ubuntu2004.md
+++ b/docs/INSTALL.ubuntu2004.md
@@ -1,7 +1,7 @@
 # INSTALLATION INSTRUCTIONS
 ## for Ubuntu 20.04.2.0-server
 
-{% generic/manual-install-notes.md %}
+{% include_relative generic/manual-install-notes.md %}
 
 ### -1/ Installer and Manual install instructions
 
@@ -15,7 +15,7 @@ Make sure you are reading the parsed version of this Document. When in doubt [cl
 !!! notice
     If the next line is `[!generic/core.md!]()` [click here](https://misp.github.io/MISP/INSTALL.ubuntu2004).
 
-{% generic/core.md %}
+{% include_relative generic/core.md %}
 
 ### 1/ Minimal Ubuntu install
 -------------------------
@@ -44,9 +44,9 @@ aptUpgrade () {
 # <snippet-end 0_apt-upgrade.sh>
 ```
 
-{% generic/sudo_etckeeper.md %}
+{% include_relative generic/sudo_etckeeper.md %}
 
-{% generic/ethX.md %}
+{% include_relative generic/ethX.md %}
 
 #### install postfix, there will be some questions.
 ```bash
@@ -63,7 +63,7 @@ sudo apt-get install postfix dialog -qy
     sudo postfix reload
     ```
 
-{% generic/globalVariables.md %}
+{% include_relative generic/globalVariables.md %}
 
 ### 2/ Install LAMP & dependencies
 ------------------------------
@@ -423,7 +423,7 @@ configMISP () {
 # <snippet-end 2_configMISP.sh>
 ```
 
-{% generic/gnupg.md %}
+{% include_relative generic/gnupg.md %}
 
 !!! notice
     If entropy is not high enough, you can install havegd and then start the service
@@ -477,15 +477,15 @@ echo "Admin (root) DB Password: $DBPASSWORD_ADMIN"
 echo "User  (misp) DB Password: $DBPASSWORD_MISP"
 ```
 
-{% generic/MISP_CAKE_init.md %}
+{% include_relative generic/MISP_CAKE_init.md %}
 
-{% generic/misp-modules-debian.md %}
+{% include_relative generic/misp-modules-debian.md %}
 
-{% generic/misp-modules-cake.md %}
+{% include_relative generic/misp-modules-cake.md %}
 
-{% generic/INSTALL.done.md %}
+{% include_relative generic/INSTALL.done.md %}
 
-{% generic/recommended.actions.md %}
+{% include_relative generic/recommended.actions.md %}
 
 ### Optional features
 -----------------
@@ -508,17 +508,17 @@ installKafka () {
 # <snippet-end 4_kafka.sh>
 ```
 
-{% generic/misp-dashboard-debian.md %}
+{% include_relative generic/misp-dashboard-debian.md %}
 
-{% generic/misp-dashboard-cake.md %}
+{% include_relative generic/misp-dashboard-cake.md %}
 
-{% generic/viper-debian.md %}
+{% include_relative generic/viper-debian.md %}
 
-{% generic/ssdeep-debian.md %}
+{% include_relative generic/ssdeep-debian.md %}
 
-{% generic/mail_to_misp-debian.md %}
+{% include_relative generic/mail_to_misp-debian.md %}
 
-{% generic/hardening.md %}
+{% include_relative generic/hardening.md %}
 
 # INSTALL.sh
 
@@ -526,4 +526,4 @@ installKafka () {
     The following section is an administrative section that is used by the "[INSTALL.sh](https://raw.githubusercontent.com/MISP/MISP/2.4/INSTALL/INSTALL.sh)" script.
     Please ignore.
 
-{% generic/supportFunctions.md %}
+{% include_relative generic/supportFunctions.md %}

--- a/docs/INSTALL.ubuntu2004.md
+++ b/docs/INSTALL.ubuntu2004.md
@@ -1,7 +1,7 @@
 # INSTALLATION INSTRUCTIONS
 ## for Ubuntu 20.04.2.0-server
 
-{!generic/manual-install-notes.md!}
+{% generic/manual-install-notes.md %}
 
 ### -1/ Installer and Manual install instructions
 
@@ -15,7 +15,7 @@ Make sure you are reading the parsed version of this Document. When in doubt [cl
 !!! notice
     If the next line is `[!generic/core.md!]()` [click here](https://misp.github.io/MISP/INSTALL.ubuntu2004).
 
-{!generic/core.md!}
+{% generic/core.md %}
 
 ### 1/ Minimal Ubuntu install
 -------------------------
@@ -44,9 +44,9 @@ aptUpgrade () {
 # <snippet-end 0_apt-upgrade.sh>
 ```
 
-{!generic/sudo_etckeeper.md!}
+{% generic/sudo_etckeeper.md %}
 
-{!generic/ethX.md!}
+{% generic/ethX.md %}
 
 #### install postfix, there will be some questions.
 ```bash
@@ -63,7 +63,7 @@ sudo apt-get install postfix dialog -qy
     sudo postfix reload
     ```
 
-{!generic/globalVariables.md!}
+{% generic/globalVariables.md %}
 
 ### 2/ Install LAMP & dependencies
 ------------------------------
@@ -423,7 +423,7 @@ configMISP () {
 # <snippet-end 2_configMISP.sh>
 ```
 
-{!generic/gnupg.md!}
+{% generic/gnupg.md %}
 
 !!! notice
     If entropy is not high enough, you can install havegd and then start the service
@@ -477,15 +477,15 @@ echo "Admin (root) DB Password: $DBPASSWORD_ADMIN"
 echo "User  (misp) DB Password: $DBPASSWORD_MISP"
 ```
 
-{!generic/MISP_CAKE_init.md!}
+{% generic/MISP_CAKE_init.md %}
 
-{!generic/misp-modules-debian.md!}
+{% generic/misp-modules-debian.md %}
 
-{!generic/misp-modules-cake.md!}
+{% generic/misp-modules-cake.md %}
 
-{!generic/INSTALL.done.md!}
+{% generic/INSTALL.done.md %}
 
-{!generic/recommended.actions.md!}
+{% generic/recommended.actions.md %}
 
 ### Optional features
 -----------------
@@ -508,17 +508,17 @@ installKafka () {
 # <snippet-end 4_kafka.sh>
 ```
 
-{!generic/misp-dashboard-debian.md!}
+{% generic/misp-dashboard-debian.md %}
 
-{!generic/misp-dashboard-cake.md!}
+{% generic/misp-dashboard-cake.md %}
 
-{!generic/viper-debian.md!}
+{% generic/viper-debian.md %}
 
-{!generic/ssdeep-debian.md!}
+{% generic/ssdeep-debian.md %}
 
-{!generic/mail_to_misp-debian.md!}
+{% generic/mail_to_misp-debian.md %}
 
-{!generic/hardening.md!}
+{% generic/hardening.md %}
 
 # INSTALL.sh
 
@@ -526,4 +526,4 @@ installKafka () {
     The following section is an administrative section that is used by the "[INSTALL.sh](https://raw.githubusercontent.com/MISP/MISP/2.4/INSTALL/INSTALL.sh)" script.
     Please ignore.
 
-{!generic/supportFunctions.md!}
+{% generic/supportFunctions.md %}

--- a/docs/archive/xINSTALL.FreeBSD.md
+++ b/docs/archive/xINSTALL.FreeBSD.md
@@ -6,7 +6,7 @@
 !!! warning
     NOT working: pydeep, lief
 
-{% include_relative generic/globalVariables.md %}
+{% include_relative ../generic/globalVariables.md %}
 
 ```bash
 PHP_ETC_BASE=/usr/local/etc
@@ -434,7 +434,7 @@ then
 fi
 ```
 
-{% include_relative generic/MISP_CAKE_init.md %}
+{% include_relative ../generic/MISP_CAKE_init.md %}
 
 ```bash
 sudo gsed -i -e '$i \sudo -u www bash /usr/local/www/MISP/app/Console/worker/start.sh > /tmp/worker_start_rc.local.log\n' /etc/rc.local
@@ -461,9 +461,9 @@ sudo -H -u www ${PATH_TO_MISP}/venv/bin/pip install .
 sudo -H -u www ${PATH_TO_MISP}/venv/bin/pip install stix2
 ```
 
-{% include_relative generic/INSTALL.done.md %}
+{% include_relative ../generic/INSTALL.done.md %}
 
-{% include_relative generic/recommended.actions.md %}
+{% include_relative ../generic/recommended.actions.md %}
 
 ### Optional features
 -----------------

--- a/docs/archive/xINSTALL.FreeBSD.md
+++ b/docs/archive/xINSTALL.FreeBSD.md
@@ -6,7 +6,7 @@
 !!! warning
     NOT working: pydeep, lief
 
-{% generic/globalVariables.md %}
+{% include_relative generic/globalVariables.md %}
 
 ```bash
 PHP_ETC_BASE=/usr/local/etc
@@ -434,7 +434,7 @@ then
 fi
 ```
 
-{% generic/MISP_CAKE_init.md %}
+{% include_relative generic/MISP_CAKE_init.md %}
 
 ```bash
 sudo gsed -i -e '$i \sudo -u www bash /usr/local/www/MISP/app/Console/worker/start.sh > /tmp/worker_start_rc.local.log\n' /etc/rc.local
@@ -461,9 +461,9 @@ sudo -H -u www ${PATH_TO_MISP}/venv/bin/pip install .
 sudo -H -u www ${PATH_TO_MISP}/venv/bin/pip install stix2
 ```
 
-{% generic/INSTALL.done.md %}
+{% include_relative generic/INSTALL.done.md %}
 
-{% generic/recommended.actions.md %}
+{% include_relative generic/recommended.actions.md %}
 
 ### Optional features
 -----------------

--- a/docs/archive/xINSTALL.FreeBSD.md
+++ b/docs/archive/xINSTALL.FreeBSD.md
@@ -6,7 +6,9 @@
 !!! warning
     NOT working: pydeep, lief
 
-`{% include_relative generic/globalVariables.md %}`
+{% comment %}
+{% include_relative generic/globalVariables.md %}
+{% endcomment %}
 
 ```bash
 PHP_ETC_BASE=/usr/local/etc
@@ -434,7 +436,9 @@ then
 fi
 ```
 
-`{% include_relative generic/MISP_CAKE_init.md %}`
+{% comment %}
+{% include_relative generic/MISP_CAKE_init.md %}
+{% endcomment %}
 
 ```bash
 sudo gsed -i -e '$i \sudo -u www bash /usr/local/www/MISP/app/Console/worker/start.sh > /tmp/worker_start_rc.local.log\n' /etc/rc.local
@@ -461,9 +465,13 @@ sudo -H -u www ${PATH_TO_MISP}/venv/bin/pip install .
 sudo -H -u www ${PATH_TO_MISP}/venv/bin/pip install stix2
 ```
 
-`{% include_relative generic/INSTALL.done.md %}`
+{% comment %}
+{% include_relative generic/INSTALL.done.md %}
+{% endcomment %}
 
-`{% include_relative generic/recommended.actions.md %}`
+{% comment %}
+{% include_relative generic/recommended.actions.md %}
+{% endcomment %}
 
 ### Optional features
 -----------------

--- a/docs/archive/xINSTALL.FreeBSD.md
+++ b/docs/archive/xINSTALL.FreeBSD.md
@@ -6,7 +6,7 @@
 !!! warning
     NOT working: pydeep, lief
 
-{% include_relative ../generic/globalVariables.md %}
+`{% include_relative generic/globalVariables.md %}`
 
 ```bash
 PHP_ETC_BASE=/usr/local/etc
@@ -434,7 +434,7 @@ then
 fi
 ```
 
-{% include_relative ../generic/MISP_CAKE_init.md %}
+`{% include_relative generic/MISP_CAKE_init.md %}`
 
 ```bash
 sudo gsed -i -e '$i \sudo -u www bash /usr/local/www/MISP/app/Console/worker/start.sh > /tmp/worker_start_rc.local.log\n' /etc/rc.local
@@ -461,9 +461,9 @@ sudo -H -u www ${PATH_TO_MISP}/venv/bin/pip install .
 sudo -H -u www ${PATH_TO_MISP}/venv/bin/pip install stix2
 ```
 
-{% include_relative ../generic/INSTALL.done.md %}
+`{% include_relative generic/INSTALL.done.md %}`
 
-{% include_relative ../generic/recommended.actions.md %}
+`{% include_relative generic/recommended.actions.md %}`
 
 ### Optional features
 -----------------

--- a/docs/archive/xINSTALL.FreeBSD.md
+++ b/docs/archive/xINSTALL.FreeBSD.md
@@ -1,12 +1,12 @@
 # INSTALLATION INSTRUCTIONS
-## for FreeBSD 12.0-amd64
+## for FreeBSD 12.0-amd64!}
 
 ### 0/ WIP /!\ You are warned, this does not work yet! /!\
 
 !!! warning
     NOT working: pydeep, lief
 
-{!generic/globalVariables.md!}
+{% generic/globalVariables.md %}
 
 ```bash
 PHP_ETC_BASE=/usr/local/etc
@@ -434,7 +434,7 @@ then
 fi
 ```
 
-{!generic/MISP_CAKE_init.md!}
+{% generic/MISP_CAKE_init.md %}
 
 ```bash
 sudo gsed -i -e '$i \sudo -u www bash /usr/local/www/MISP/app/Console/worker/start.sh > /tmp/worker_start_rc.local.log\n' /etc/rc.local
@@ -461,9 +461,9 @@ sudo -H -u www ${PATH_TO_MISP}/venv/bin/pip install .
 sudo -H -u www ${PATH_TO_MISP}/venv/bin/pip install stix2
 ```
 
-{!generic/INSTALL.done.md!}
+{% generic/INSTALL.done.md %}
 
-{!generic/recommended.actions.md!}
+{% generic/recommended.actions.md %}
 
 ### Optional features
 -----------------

--- a/docs/archive/xINSTALL.debian9-postgresql.md
+++ b/docs/archive/xINSTALL.debian9-postgresql.md
@@ -101,4 +101,4 @@ pgloader --type mysql --with "reset sequences" --with "data only" --set "mainten
 systemctl stop mysql
 systemctl disable mysql
 
-{% include_relative ../generic/hardening.md %}
+`{% include_relative generic/hardening.md %}`

--- a/docs/archive/xINSTALL.debian9-postgresql.md
+++ b/docs/archive/xINSTALL.debian9-postgresql.md
@@ -101,4 +101,4 @@ pgloader --type mysql --with "reset sequences" --with "data only" --set "mainten
 systemctl stop mysql
 systemctl disable mysql
 
-{!generic/hardening.md!}
+{% generic/hardening.md %}

--- a/docs/archive/xINSTALL.debian9-postgresql.md
+++ b/docs/archive/xINSTALL.debian9-postgresql.md
@@ -101,4 +101,6 @@ pgloader --type mysql --with "reset sequences" --with "data only" --set "mainten
 systemctl stop mysql
 systemctl disable mysql
 
-`{% include_relative generic/hardening.md %}`
+{% comment %}
+{% include_relative generic/hardening.md %}
+{% endcomment %}

--- a/docs/archive/xINSTALL.debian9-postgresql.md
+++ b/docs/archive/xINSTALL.debian9-postgresql.md
@@ -101,4 +101,4 @@ pgloader --type mysql --with "reset sequences" --with "data only" --set "mainten
 systemctl stop mysql
 systemctl disable mysql
 
-{% generic/hardening.md %}
+{% include_relative generic/hardening.md %}

--- a/docs/archive/xINSTALL.debian9-postgresql.md
+++ b/docs/archive/xINSTALL.debian9-postgresql.md
@@ -101,4 +101,4 @@ pgloader --type mysql --with "reset sequences" --with "data only" --set "mainten
 systemctl stop mysql
 systemctl disable mysql
 
-{% include_relative generic/hardening.md %}
+{% include_relative ../generic/hardening.md %}

--- a/docs/archive/xINSTALL.debian9.md
+++ b/docs/archive/xINSTALL.debian9.md
@@ -23,9 +23,9 @@
 - OpenSSH server
 - This guide assumes a user name of 'misp' with sudo working
 
-{!generic/known-issues-debian.md!}
+{% generic/known-issues-debian.md %}
 
-{!generic/globalVariables.md!}
+{% generic/globalVariables.md %}
 
 ```bash
 PHP_ETC_BASE=/etc/php/7.0
@@ -35,9 +35,9 @@ sudo adduser $MISP_USER staff
 sudo adduser $MISP_USER ${WWW_USER}
 ```
 
-{!generic/sudo_etckeeper.md!}
+{% generic/sudo_etckeeper.md %}
 
-{!generic/ethX.md!}
+{% generic/ethX.md %}
 
 #### Make sure your system is up2date
 ```bash
@@ -465,7 +465,7 @@ then
     sudo chmod u+x /etc/rc.local
 fi
 ```
-{!generic/MISP_CAKE_init.md!}
+{% generic/MISP_CAKE_init.md %}
 
 ```bash
 # Add the following lines before the last line (exit 0). Make sure that you replace ${WWW_USER} with your apache user:
@@ -474,16 +474,16 @@ sudo sed -i -e '$i \echo 1024 > /proc/sys/net/core/somaxconn\n' /etc/rc.local
 sudo sed -i -e '$i \sysctl vm.overcommit_memory=1\n' /etc/rc.local
 ```
 
-{!generic/misp-modules-debian.md!}
+{% generic/misp-modules-debian.md %}
 
 ```bash
 echo "Admin (root) DB Password: $DBPASSWORD_ADMIN"
 echo "User  (misp) DB Password: $DBPASSWORD_MISP"
 ```
 
-{!generic/INSTALL.done.md!}
+{% generic/INSTALL.done.md %}
 
-{!generic/recommended.actions.md!}
+{% generic/recommended.actions.md %}
 
 ### Optional features
 -------------------
@@ -517,14 +517,14 @@ sudo phpenmod rdkafka
 sudo service apache2 restart
 ```
 
-{!generic/misp-dashboard-debian.md!}
+{% generic/misp-dashboard-debian.md %}
 
-{!generic/viper-debian.md!}
+{% generic/viper-debian.md %}
 
-{!generic/ssdeep-debian.md!}
+{% generic/ssdeep-debian.md %}
 
-{!generic/mail_to_misp-debian.md!}
+{% generic/mail_to_misp-debian.md %}
 
-{!generic/upgrading.md!}
+{% generic/upgrading.md %}
 
-{!generic/hardening.md!}
+{% generic/hardening.md %}

--- a/docs/archive/xINSTALL.debian9.md
+++ b/docs/archive/xINSTALL.debian9.md
@@ -23,9 +23,9 @@
 - OpenSSH server
 - This guide assumes a user name of 'misp' with sudo working
 
-{% include_relative ../generic/known-issues-debian.md %}
+`{% include_relative generic/known-issues-debian.md %}`
 
-{% include_relative ../generic/globalVariables.md %}
+`{% include_relative generic/globalVariables.md %}`
 
 ```bash
 PHP_ETC_BASE=/etc/php/7.0
@@ -35,9 +35,9 @@ sudo adduser $MISP_USER staff
 sudo adduser $MISP_USER ${WWW_USER}
 ```
 
-{% include_relative ../generic/sudo_etckeeper.md %}
+`{% include_relative generic/sudo_etckeeper.md %}`
 
-{% include_relative ../generic/ethX.md %}
+`{% include_relative generic/ethX.md %}`
 
 #### Make sure your system is up2date
 ```bash
@@ -465,7 +465,7 @@ then
     sudo chmod u+x /etc/rc.local
 fi
 ```
-{% include_relative ../generic/MISP_CAKE_init.md %}
+`{% include_relative generic/MISP_CAKE_init.md %}`
 
 ```bash
 # Add the following lines before the last line (exit 0). Make sure that you replace ${WWW_USER} with your apache user:
@@ -474,16 +474,16 @@ sudo sed -i -e '$i \echo 1024 > /proc/sys/net/core/somaxconn\n' /etc/rc.local
 sudo sed -i -e '$i \sysctl vm.overcommit_memory=1\n' /etc/rc.local
 ```
 
-{% include_relative ../generic/misp-modules-debian.md %}
+`{% include_relative generic/misp-modules-debian.md %}`
 
 ```bash
 echo "Admin (root) DB Password: $DBPASSWORD_ADMIN"
 echo "User  (misp) DB Password: $DBPASSWORD_MISP"
 ```
 
-{% include_relative ../generic/INSTALL.done.md %}
+`{% include_relative generic/INSTALL.done.md %}`
 
-{% include_relative ../generic/recommended.actions.md %}
+`{% include_relative generic/recommended.actions.md %}`
 
 ### Optional features
 -------------------
@@ -517,14 +517,14 @@ sudo phpenmod rdkafka
 sudo service apache2 restart
 ```
 
-{% include_relative ../generic/misp-dashboard-debian.md %}
+`{% include_relative generic/misp-dashboard-debian.md %}`
 
-{% include_relative ../generic/viper-debian.md %}
+`{% include_relative generic/viper-debian.md %}`
 
-{% include_relative ../generic/ssdeep-debian.md %}
+`{% include_relative generic/ssdeep-debian.md %}`
 
-{% include_relative ../generic/mail_to_misp-debian.md %}
+`{% include_relative generic/mail_to_misp-debian.md %}`
 
-{% include_relative ../generic/upgrading.md %}
+`{% include_relative generic/upgrading.md %}`
 
-{% include_relative ../generic/hardening.md %}
+`{% include_relative generic/hardening.md %}`

--- a/docs/archive/xINSTALL.debian9.md
+++ b/docs/archive/xINSTALL.debian9.md
@@ -23,9 +23,9 @@
 - OpenSSH server
 - This guide assumes a user name of 'misp' with sudo working
 
-{% generic/known-issues-debian.md %}
+{% include_relative generic/known-issues-debian.md %}
 
-{% generic/globalVariables.md %}
+{% include_relative generic/globalVariables.md %}
 
 ```bash
 PHP_ETC_BASE=/etc/php/7.0
@@ -35,9 +35,9 @@ sudo adduser $MISP_USER staff
 sudo adduser $MISP_USER ${WWW_USER}
 ```
 
-{% generic/sudo_etckeeper.md %}
+{% include_relative generic/sudo_etckeeper.md %}
 
-{% generic/ethX.md %}
+{% include_relative generic/ethX.md %}
 
 #### Make sure your system is up2date
 ```bash
@@ -465,7 +465,7 @@ then
     sudo chmod u+x /etc/rc.local
 fi
 ```
-{% generic/MISP_CAKE_init.md %}
+{% include_relative generic/MISP_CAKE_init.md %}
 
 ```bash
 # Add the following lines before the last line (exit 0). Make sure that you replace ${WWW_USER} with your apache user:
@@ -474,16 +474,16 @@ sudo sed -i -e '$i \echo 1024 > /proc/sys/net/core/somaxconn\n' /etc/rc.local
 sudo sed -i -e '$i \sysctl vm.overcommit_memory=1\n' /etc/rc.local
 ```
 
-{% generic/misp-modules-debian.md %}
+{% include_relative generic/misp-modules-debian.md %}
 
 ```bash
 echo "Admin (root) DB Password: $DBPASSWORD_ADMIN"
 echo "User  (misp) DB Password: $DBPASSWORD_MISP"
 ```
 
-{% generic/INSTALL.done.md %}
+{% include_relative generic/INSTALL.done.md %}
 
-{% generic/recommended.actions.md %}
+{% include_relative generic/recommended.actions.md %}
 
 ### Optional features
 -------------------
@@ -517,14 +517,14 @@ sudo phpenmod rdkafka
 sudo service apache2 restart
 ```
 
-{% generic/misp-dashboard-debian.md %}
+{% include_relative generic/misp-dashboard-debian.md %}
 
-{% generic/viper-debian.md %}
+{% include_relative generic/viper-debian.md %}
 
-{% generic/ssdeep-debian.md %}
+{% include_relative generic/ssdeep-debian.md %}
 
-{% generic/mail_to_misp-debian.md %}
+{% include_relative generic/mail_to_misp-debian.md %}
 
-{% generic/upgrading.md %}
+{% include_relative generic/upgrading.md %}
 
-{% generic/hardening.md %}
+{% include_relative generic/hardening.md %}

--- a/docs/archive/xINSTALL.debian9.md
+++ b/docs/archive/xINSTALL.debian9.md
@@ -23,9 +23,13 @@
 - OpenSSH server
 - This guide assumes a user name of 'misp' with sudo working
 
-`{% include_relative generic/known-issues-debian.md %}`
+{% comment %}
+{% include_relative generic/known-issues-debian.md %}
+{% endcomment %}
 
-`{% include_relative generic/globalVariables.md %}`
+{% comment %}
+{% include_relative generic/globalVariables.md %}
+{% endcomment %}
 
 ```bash
 PHP_ETC_BASE=/etc/php/7.0
@@ -35,9 +39,13 @@ sudo adduser $MISP_USER staff
 sudo adduser $MISP_USER ${WWW_USER}
 ```
 
-`{% include_relative generic/sudo_etckeeper.md %}`
+{% comment %}
+{% include_relative generic/sudo_etckeeper.md %}
+{% endcomment %}
 
-`{% include_relative generic/ethX.md %}`
+{% comment %}
+{% include_relative generic/ethX.md %}
+{% endcomment %}
 
 #### Make sure your system is up2date
 ```bash
@@ -465,7 +473,9 @@ then
     sudo chmod u+x /etc/rc.local
 fi
 ```
-`{% include_relative generic/MISP_CAKE_init.md %}`
+{% comment %}
+{% include_relative generic/MISP_CAKE_init.md %}
+{% endcomment %}
 
 ```bash
 # Add the following lines before the last line (exit 0). Make sure that you replace ${WWW_USER} with your apache user:
@@ -474,16 +484,22 @@ sudo sed -i -e '$i \echo 1024 > /proc/sys/net/core/somaxconn\n' /etc/rc.local
 sudo sed -i -e '$i \sysctl vm.overcommit_memory=1\n' /etc/rc.local
 ```
 
-`{% include_relative generic/misp-modules-debian.md %}`
+{% comment %}
+{% include_relative generic/misp-modules-debian.md %}
+{% endcomment %}
 
 ```bash
 echo "Admin (root) DB Password: $DBPASSWORD_ADMIN"
 echo "User  (misp) DB Password: $DBPASSWORD_MISP"
 ```
 
-`{% include_relative generic/INSTALL.done.md %}`
+{% comment %}
+{% include_relative generic/INSTALL.done.md %}
+{% endcomment %}
 
-`{% include_relative generic/recommended.actions.md %}`
+{% comment %}
+{% include_relative generic/recommended.actions.md %}
+{% endcomment %}
 
 ### Optional features
 -------------------
@@ -517,14 +533,26 @@ sudo phpenmod rdkafka
 sudo service apache2 restart
 ```
 
-`{% include_relative generic/misp-dashboard-debian.md %}`
+{% comment %}
+{% include_relative generic/misp-dashboard-debian.md %}
+{% endcomment %}
 
-`{% include_relative generic/viper-debian.md %}`
+{% comment %}
+{% include_relative generic/viper-debian.md %}
+{% endcomment %}
 
-`{% include_relative generic/ssdeep-debian.md %}`
+{% comment %}
+{% include_relative generic/ssdeep-debian.md %}
+{% endcomment %}
 
-`{% include_relative generic/mail_to_misp-debian.md %}`
+{% comment %}
+{% include_relative generic/mail_to_misp-debian.md %}
+{% endcomment %}
 
-`{% include_relative generic/upgrading.md %}`
+{% comment %}
+{% include_relative generic/upgrading.md %}
+{% endcomment %}
 
-`{% include_relative generic/hardening.md %}`
+{% comment %}
+{% include_relative generic/hardening.md %}
+{% endcomment %}

--- a/docs/archive/xINSTALL.debian9.md
+++ b/docs/archive/xINSTALL.debian9.md
@@ -23,9 +23,9 @@
 - OpenSSH server
 - This guide assumes a user name of 'misp' with sudo working
 
-{% include_relative generic/known-issues-debian.md %}
+{% include_relative ../generic/known-issues-debian.md %}
 
-{% include_relative generic/globalVariables.md %}
+{% include_relative ../generic/globalVariables.md %}
 
 ```bash
 PHP_ETC_BASE=/etc/php/7.0
@@ -35,9 +35,9 @@ sudo adduser $MISP_USER staff
 sudo adduser $MISP_USER ${WWW_USER}
 ```
 
-{% include_relative generic/sudo_etckeeper.md %}
+{% include_relative ../generic/sudo_etckeeper.md %}
 
-{% include_relative generic/ethX.md %}
+{% include_relative ../generic/ethX.md %}
 
 #### Make sure your system is up2date
 ```bash
@@ -465,7 +465,7 @@ then
     sudo chmod u+x /etc/rc.local
 fi
 ```
-{% include_relative generic/MISP_CAKE_init.md %}
+{% include_relative ../generic/MISP_CAKE_init.md %}
 
 ```bash
 # Add the following lines before the last line (exit 0). Make sure that you replace ${WWW_USER} with your apache user:
@@ -474,16 +474,16 @@ sudo sed -i -e '$i \echo 1024 > /proc/sys/net/core/somaxconn\n' /etc/rc.local
 sudo sed -i -e '$i \sysctl vm.overcommit_memory=1\n' /etc/rc.local
 ```
 
-{% include_relative generic/misp-modules-debian.md %}
+{% include_relative ../generic/misp-modules-debian.md %}
 
 ```bash
 echo "Admin (root) DB Password: $DBPASSWORD_ADMIN"
 echo "User  (misp) DB Password: $DBPASSWORD_MISP"
 ```
 
-{% include_relative generic/INSTALL.done.md %}
+{% include_relative ../generic/INSTALL.done.md %}
 
-{% include_relative generic/recommended.actions.md %}
+{% include_relative ../generic/recommended.actions.md %}
 
 ### Optional features
 -------------------
@@ -517,14 +517,14 @@ sudo phpenmod rdkafka
 sudo service apache2 restart
 ```
 
-{% include_relative generic/misp-dashboard-debian.md %}
+{% include_relative ../generic/misp-dashboard-debian.md %}
 
-{% include_relative generic/viper-debian.md %}
+{% include_relative ../generic/viper-debian.md %}
 
-{% include_relative generic/ssdeep-debian.md %}
+{% include_relative ../generic/ssdeep-debian.md %}
 
-{% include_relative generic/mail_to_misp-debian.md %}
+{% include_relative ../generic/mail_to_misp-debian.md %}
 
-{% include_relative generic/upgrading.md %}
+{% include_relative ../generic/upgrading.md %}
 
-{% include_relative generic/hardening.md %}
+{% include_relative ../generic/hardening.md %}

--- a/docs/archive/xINSTALL.ubuntu1804.with.webmin.md
+++ b/docs/archive/xINSTALL.ubuntu1804.with.webmin.md
@@ -6,9 +6,13 @@
 !!! notice
     Tested semi-working by @SteveClement on 20181120.
 
-`{% include_relative generic/community.md %}`
+{% comment %}
+{% include_relative generic/community.md %}
+{% endcomment %}
 
-`{% include_relative generic/globalVariables.md %}`
+{% comment %}
+{% include_relative generic/globalVariables.md %}
+{% endcomment %}
 
 ```bash
 PHP_ETC_BASE=/etc/php/7.2
@@ -30,9 +34,13 @@ Assuming you created the subdomanin misp.yourserver.tld to where MISP will be in
 - OpenSSH server
 - This guide assumes a user name of 'misp' with sudo working
 
-`{% include_relative generic/sudo_etckeeper.md %}`
+{% comment %}
+{% include_relative generic/sudo_etckeeper.md %}
+{% endcomment %}
 
-`{% include_relative generic/ethX.md %}`
+{% comment %}
+{% include_relative generic/ethX.md %}
+{% endcomment %}
 
 #### Make sure your system is up2date
 ```bash
@@ -431,11 +439,17 @@ sudo systemctl status rc-local.service
     # ${PATH_TO_MISP}/app/tmp/logs/resque-2015-01-01.log // where the actual date is the current date
 ```
 
-`{% include_relative generic/INSTALL.done.md %}`
+{% comment %}
+{% include_relative generic/INSTALL.done.md %}
+{% endcomment %}
 
-`{% include_relative generic/recommended.actions.md %}`
+{% comment %}
+{% include_relative generic/recommended.actions.md %}
+{% endcomment %}
 
-`{% include_relative generic/hardening.md %}`
+{% comment %}
+{% include_relative generic/hardening.md %}
+{% endcomment %}
 
 ### Optional features
 -----------------

--- a/docs/archive/xINSTALL.ubuntu1804.with.webmin.md
+++ b/docs/archive/xINSTALL.ubuntu1804.with.webmin.md
@@ -6,9 +6,9 @@
 !!! notice
     Tested semi-working by @SteveClement on 20181120.
 
-{% generic/community.md %}
+{% include_relative generic/community.md %}
 
-{% generic/globalVariables.md %}
+{% include_relative generic/globalVariables.md %}
 
 ```bash
 PHP_ETC_BASE=/etc/php/7.2
@@ -30,9 +30,9 @@ Assuming you created the subdomanin misp.yourserver.tld to where MISP will be in
 - OpenSSH server
 - This guide assumes a user name of 'misp' with sudo working
 
-{% generic/sudo_etckeeper.md %}
+{% include_relative generic/sudo_etckeeper.md %}
 
-{% generic/ethX.md %}
+{% include_relative generic/ethX.md %}
 
 #### Make sure your system is up2date
 ```bash
@@ -431,11 +431,11 @@ sudo systemctl status rc-local.service
     # ${PATH_TO_MISP}/app/tmp/logs/resque-2015-01-01.log // where the actual date is the current date
 ```
 
-{% generic/INSTALL.done.md %}
+{% include_relative generic/INSTALL.done.md %}
 
-{% generic/recommended.actions.md %}
+{% include_relative generic/recommended.actions.md %}
 
-{% generic/hardening.md %}
+{% include_relative generic/hardening.md %}
 
 ### Optional features
 -----------------

--- a/docs/archive/xINSTALL.ubuntu1804.with.webmin.md
+++ b/docs/archive/xINSTALL.ubuntu1804.with.webmin.md
@@ -6,9 +6,9 @@
 !!! notice
     Tested semi-working by @SteveClement on 20181120.
 
-{% include_relative ../generic/community.md %}
+`{% include_relative generic/community.md %}`
 
-{% include_relative ../generic/globalVariables.md %}
+`{% include_relative generic/globalVariables.md %}`
 
 ```bash
 PHP_ETC_BASE=/etc/php/7.2
@@ -30,9 +30,9 @@ Assuming you created the subdomanin misp.yourserver.tld to where MISP will be in
 - OpenSSH server
 - This guide assumes a user name of 'misp' with sudo working
 
-{% include_relative ../generic/sudo_etckeeper.md %}
+`{% include_relative generic/sudo_etckeeper.md %}`
 
-{% include_relative ../generic/ethX.md %}
+`{% include_relative generic/ethX.md %}`
 
 #### Make sure your system is up2date
 ```bash
@@ -431,11 +431,11 @@ sudo systemctl status rc-local.service
     # ${PATH_TO_MISP}/app/tmp/logs/resque-2015-01-01.log // where the actual date is the current date
 ```
 
-{% include_relative ../generic/INSTALL.done.md %}
+`{% include_relative generic/INSTALL.done.md %}`
 
-{% include_relative ../generic/recommended.actions.md %}
+`{% include_relative generic/recommended.actions.md %}`
 
-{% include_relative ../generic/hardening.md %}
+`{% include_relative generic/hardening.md %}`
 
 ### Optional features
 -----------------

--- a/docs/archive/xINSTALL.ubuntu1804.with.webmin.md
+++ b/docs/archive/xINSTALL.ubuntu1804.with.webmin.md
@@ -6,9 +6,9 @@
 !!! notice
     Tested semi-working by @SteveClement on 20181120.
 
-{% include_relative generic/community.md %}
+{% include_relative ../generic/community.md %}
 
-{% include_relative generic/globalVariables.md %}
+{% include_relative ../generic/globalVariables.md %}
 
 ```bash
 PHP_ETC_BASE=/etc/php/7.2
@@ -30,9 +30,9 @@ Assuming you created the subdomanin misp.yourserver.tld to where MISP will be in
 - OpenSSH server
 - This guide assumes a user name of 'misp' with sudo working
 
-{% include_relative generic/sudo_etckeeper.md %}
+{% include_relative ../generic/sudo_etckeeper.md %}
 
-{% include_relative generic/ethX.md %}
+{% include_relative ../generic/ethX.md %}
 
 #### Make sure your system is up2date
 ```bash
@@ -431,11 +431,11 @@ sudo systemctl status rc-local.service
     # ${PATH_TO_MISP}/app/tmp/logs/resque-2015-01-01.log // where the actual date is the current date
 ```
 
-{% include_relative generic/INSTALL.done.md %}
+{% include_relative ../generic/INSTALL.done.md %}
 
-{% include_relative generic/recommended.actions.md %}
+{% include_relative ../generic/recommended.actions.md %}
 
-{% include_relative generic/hardening.md %}
+{% include_relative ../generic/hardening.md %}
 
 ### Optional features
 -----------------

--- a/docs/archive/xINSTALL.ubuntu1804.with.webmin.md
+++ b/docs/archive/xINSTALL.ubuntu1804.with.webmin.md
@@ -6,9 +6,9 @@
 !!! notice
     Tested semi-working by @SteveClement on 20181120.
 
-{!generic/community.md!}
+{% generic/community.md %}
 
-{!generic/globalVariables.md!}
+{% generic/globalVariables.md %}
 
 ```bash
 PHP_ETC_BASE=/etc/php/7.2
@@ -30,9 +30,9 @@ Assuming you created the subdomanin misp.yourserver.tld to where MISP will be in
 - OpenSSH server
 - This guide assumes a user name of 'misp' with sudo working
 
-{!generic/sudo_etckeeper.md!}
+{% generic/sudo_etckeeper.md %}
 
-{!generic/ethX.md!}
+{% generic/ethX.md %}
 
 #### Make sure your system is up2date
 ```bash
@@ -431,11 +431,11 @@ sudo systemctl status rc-local.service
     # ${PATH_TO_MISP}/app/tmp/logs/resque-2015-01-01.log // where the actual date is the current date
 ```
 
-{!generic/INSTALL.done.md!}
+{% generic/INSTALL.done.md %}
 
-{!generic/recommended.actions.md!}
+{% generic/recommended.actions.md %}
 
-{!generic/hardening.md!}
+{% generic/hardening.md %}
 
 ### Optional features
 -----------------

--- a/docs/xINSTALL.NetBSD.md
+++ b/docs/xINSTALL.NetBSD.md
@@ -10,7 +10,7 @@
 ### 0/ WIP! You are warned, this does only partially work!
 ------------
 
-{!generic/globalVariables.md!}
+{% generic/globalVariables.md %}
 
 ```bash
 export AUTOMAKE_VERSION=1.16
@@ -456,9 +456,9 @@ sudo vi /etc/rc.local
 sudo -u www bash $PATH_TO_MISP/app/Console/worker/start.sh
 ``` 
 
-{!generic/INSTALL.done.md!}
+{% generic/INSTALL.done.md %}
 
-{!generic/recommended.actions.md!}
+{% generic/recommended.actions.md %}
 
 #### MISP Modules
 ```
@@ -771,4 +771,4 @@ sudo -u www $CAKE Admin setSetting "Plugin.ZeroMQ_tag_notifications_enable" fals
 sudo -u www $CAKE Admin setSetting "Plugin.ZeroMQ_audit_notifications_enable" false
 ```
 
-{!generic/hardening.md!}
+{% generic/hardening.md %}

--- a/docs/xINSTALL.NetBSD.md
+++ b/docs/xINSTALL.NetBSD.md
@@ -10,7 +10,7 @@
 ### 0/ WIP! You are warned, this does only partially work!
 ------------
 
-{% generic/globalVariables.md %}
+{% include_relative generic/globalVariables.md %}
 
 ```bash
 export AUTOMAKE_VERSION=1.16
@@ -456,9 +456,9 @@ sudo vi /etc/rc.local
 sudo -u www bash $PATH_TO_MISP/app/Console/worker/start.sh
 ``` 
 
-{% generic/INSTALL.done.md %}
+{% include_relative generic/INSTALL.done.md %}
 
-{% generic/recommended.actions.md %}
+{% include_relative generic/recommended.actions.md %}
 
 #### MISP Modules
 ```
@@ -771,4 +771,4 @@ sudo -u www $CAKE Admin setSetting "Plugin.ZeroMQ_tag_notifications_enable" fals
 sudo -u www $CAKE Admin setSetting "Plugin.ZeroMQ_audit_notifications_enable" false
 ```
 
-{% generic/hardening.md %}
+{% include_relative generic/hardening.md %}

--- a/docs/xINSTALL.OpenBSD.md
+++ b/docs/xINSTALL.OpenBSD.md
@@ -16,7 +16,7 @@
 !!! notice
     As of OpenBSD 6.4 the native httpd has rewrite rules and php 5.6 is gone too.
 
-{% generic/globalVariables.md %}
+{% include_relative generic/globalVariables.md %}
 
 ```bash
 export AUTOMAKE_VERSION=1.16
@@ -594,9 +594,9 @@ doas vi /etc/rc.local
 ${SUDO_WWW} bash /var/www/htdocs/MISP/app/Console/worker/start.sh
 ``` 
 
-{% generic/INSTALL.done.md %}
+{% include_relative generic/INSTALL.done.md %}
 
-{% generic/recommended.actions.md %}
+{% include_relative generic/recommended.actions.md %}
 
 #### MISP Modules
 ```
@@ -916,4 +916,4 @@ doas $CAKE Admin setSetting "Plugin.ZeroMQ_tag_notifications_enable" false
 doas $CAKE Admin setSetting "Plugin.ZeroMQ_audit_notifications_enable" false
 ```
 
-{% generic/hardening.md %}
+{% include_relative generic/hardening.md %}

--- a/docs/xINSTALL.OpenBSD.md
+++ b/docs/xINSTALL.OpenBSD.md
@@ -1,4 +1,4 @@
-# INSTALLATION INSTRUCTIONS
+# INSTALLATION INSTRUCTIONS!}
 ## for OpenBSD 7.0-amd64
 
 !!! warning
@@ -16,7 +16,7 @@
 !!! notice
     As of OpenBSD 6.4 the native httpd has rewrite rules and php 5.6 is gone too.
 
-{!generic/globalVariables.md!}
+{% generic/globalVariables.md %}
 
 ```bash
 export AUTOMAKE_VERSION=1.16
@@ -594,9 +594,9 @@ doas vi /etc/rc.local
 ${SUDO_WWW} bash /var/www/htdocs/MISP/app/Console/worker/start.sh
 ``` 
 
-{!generic/INSTALL.done.md!}
+{% generic/INSTALL.done.md %}
 
-{!generic/recommended.actions.md!}
+{% generic/recommended.actions.md %}
 
 #### MISP Modules
 ```
@@ -916,4 +916,4 @@ doas $CAKE Admin setSetting "Plugin.ZeroMQ_tag_notifications_enable" false
 doas $CAKE Admin setSetting "Plugin.ZeroMQ_audit_notifications_enable" false
 ```
 
-{!generic/hardening.md!}
+{% generic/hardening.md %}

--- a/docs/xINSTALL.centos7.md
+++ b/docs/xINSTALL.centos7.md
@@ -25,9 +25,9 @@ Make sure you are reading the parsed version of this Document. When in doubt [cl
 ### 0/ MISP CentOS 7 Minimal NetInstall - Status
 --------------------------------------------
 
-{!generic/community.md!}
+{% generic/community.md %}
 
-{!generic/rhelVScentos.md!}
+{% generic/rhelVScentos.md %}
 
 !!! notice
     Semi-maintained and tested by @SteveClement, CentOS 7.6-1804 on 20190410<br />
@@ -37,7 +37,7 @@ Make sure you are reading the parsed version of this Document. When in doubt [cl
     Maintenance for CentOS 7 will end on: June 30th, 2024 [Source[0]](https://wiki.centos.org/About/Product) [Source[1]](https://linuxlifecycle.com/)
     CentOS 7.6-1810 [NetInstallURL](http://mirror.centos.org/centos/7.6.1810/os/x86_64/)
 
-{!generic/globalVariables.md!}
+{% generic/globalVariables.md %}
 
 ```bash
 # <snippet-begin 0_RHEL_PHP_INI.sh>
@@ -597,14 +597,14 @@ ${SUDO_WWW} ${PATH_TO_MISP}/venv/bin/misp-modules -l 0.0.0.0 -s &
 sudo sed -i -e '$i \sudo -u apache ${PATH_TO_MISP}/venv/bin/misp-modules -l 127.0.0.1 -s &\n' /etc/rc.local
 ```
 
-{!generic/misp-dashboard-rhel.md!}
+{% generic/misp-dashboard-rhel.md %}
 
-{!generic/misp-dashboard-cake.md!}
+{% generic/misp-dashboard-cake.md %}
 
-{!generic/MISP_CAKE_init.md!}
+{% generic/MISP_CAKE_init.md %}
 
-{!generic/INSTALL.done.md!}
+{% generic/INSTALL.done.md %}
 
-{!generic/recommended.actions.md!}
+{% generic/recommended.actions.md %}
 
-{!generic/hardening.md!}
+{% generic/hardening.md %}

--- a/docs/xINSTALL.centos7.md
+++ b/docs/xINSTALL.centos7.md
@@ -25,9 +25,9 @@ Make sure you are reading the parsed version of this Document. When in doubt [cl
 ### 0/ MISP CentOS 7 Minimal NetInstall - Status
 --------------------------------------------
 
-{% generic/community.md %}
+{% include_relative generic/community.md %}
 
-{% generic/rhelVScentos.md %}
+{% include_relative generic/rhelVScentos.md %}
 
 !!! notice
     Semi-maintained and tested by @SteveClement, CentOS 7.6-1804 on 20190410<br />
@@ -37,7 +37,7 @@ Make sure you are reading the parsed version of this Document. When in doubt [cl
     Maintenance for CentOS 7 will end on: June 30th, 2024 [Source[0]](https://wiki.centos.org/About/Product) [Source[1]](https://linuxlifecycle.com/)
     CentOS 7.6-1810 [NetInstallURL](http://mirror.centos.org/centos/7.6.1810/os/x86_64/)
 
-{% generic/globalVariables.md %}
+{% include_relative generic/globalVariables.md %}
 
 ```bash
 # <snippet-begin 0_RHEL_PHP_INI.sh>
@@ -597,14 +597,14 @@ ${SUDO_WWW} ${PATH_TO_MISP}/venv/bin/misp-modules -l 0.0.0.0 -s &
 sudo sed -i -e '$i \sudo -u apache ${PATH_TO_MISP}/venv/bin/misp-modules -l 127.0.0.1 -s &\n' /etc/rc.local
 ```
 
-{% generic/misp-dashboard-rhel.md %}
+{% include_relative generic/misp-dashboard-rhel.md %}
 
-{% generic/misp-dashboard-cake.md %}
+{% include_relative generic/misp-dashboard-cake.md %}
 
-{% generic/MISP_CAKE_init.md %}
+{% include_relative generic/MISP_CAKE_init.md %}
 
-{% generic/INSTALL.done.md %}
+{% include_relative generic/INSTALL.done.md %}
 
-{% generic/recommended.actions.md %}
+{% include_relative generic/recommended.actions.md %}
 
-{% generic/hardening.md %}
+{% include_relative generic/hardening.md %}

--- a/docs/xINSTALL.debian10.md
+++ b/docs/xINSTALL.debian10.md
@@ -8,9 +8,9 @@
     This is mostly the install [@SteveClement](https://twitter.com/SteveClement) uses for testing, qc and random development.
     Maintained and tested by @SteveClement on 20200405
 
-{% generic/known-issues-debian.md %}
+{% include_relative generic/known-issues-debian.md %}
 
-{% generic/globalVariables.md %}
+{% include_relative generic/globalVariables.md %}
 
 ```bash
 PHP_ETC_BASE=/etc/php/7.3
@@ -24,9 +24,9 @@ PHP_INI=${PHP_ETC_BASE}/apache2/php.ini
 - OpenSSH server
 - This guide assumes a user name of 'misp' with sudo working
 
-{% generic/sudo_etckeeper.md %}
+{% include_relative generic/sudo_etckeeper.md %}
 
-{% generic/ethX.md %}
+{% include_relative generic/ethX.md %}
 
 #### Add $MISP_USER to staff and ${WWW_USER}
 
@@ -443,7 +443,7 @@ then
 fi
 ```
 
-{% generic/MISP_CAKE_init.md %}
+{% include_relative generic/MISP_CAKE_init.md %}
 
 ```bash
 # Add the following lines before the last line (exit 0). Make sure that you replace ${WWW_USER} with your apache user:
@@ -452,18 +452,18 @@ sudo sed -i -e '$i \echo 1024 > /proc/sys/net/core/somaxconn\n' /etc/rc.local
 sudo sed -i -e '$i \sysctl vm.overcommit_memory=1\n' /etc/rc.local
 ```
 
-{% generic/misp-modules-debian.md %}
+{% include_relative generic/misp-modules-debian.md %}
 
-{% generic/misp-modules-cake.md %}
+{% include_relative generic/misp-modules-cake.md %}
 
 ```bash
 echo "Admin (root) DB Password: $DBPASSWORD_ADMIN"
 echo "User  (misp) DB Password: $DBPASSWORD_MISP"
 ```
 
-{% generic/INSTALL.done.md %}
+{% include_relative generic/INSTALL.done.md %}
 
-{% generic/recommended.actions.md %}
+{% include_relative generic/recommended.actions.md %}
 
 ### Optional features
 -------------------
@@ -497,16 +497,16 @@ sudo phpenmod rdkafka
 sudo service apache2 restart
 ```
 
-{% generic/misp-dashboard-debian.md %}
+{% include_relative generic/misp-dashboard-debian.md %}
 
-{% generic/misp-dashboard-cake.md %}
+{% include_relative generic/misp-dashboard-cake.md %}
 
-{% generic/viper-debian.md %}
+{% include_relative generic/viper-debian.md %}
 
-{% generic/ssdeep-debian.md %}
+{% include_relative generic/ssdeep-debian.md %}
 
-{% generic/mail_to_misp-debian.md %}
+{% include_relative generic/mail_to_misp-debian.md %}
 
-{% generic/upgrading.md %}
+{% include_relative generic/upgrading.md %}
 
-{% generic/hardening.md %}
+{% include_relative generic/hardening.md %}

--- a/docs/xINSTALL.debian10.md
+++ b/docs/xINSTALL.debian10.md
@@ -8,9 +8,9 @@
     This is mostly the install [@SteveClement](https://twitter.com/SteveClement) uses for testing, qc and random development.
     Maintained and tested by @SteveClement on 20200405
 
-{!generic/known-issues-debian.md!}
+{% generic/known-issues-debian.md %}
 
-{!generic/globalVariables.md!}
+{% generic/globalVariables.md %}
 
 ```bash
 PHP_ETC_BASE=/etc/php/7.3
@@ -24,9 +24,9 @@ PHP_INI=${PHP_ETC_BASE}/apache2/php.ini
 - OpenSSH server
 - This guide assumes a user name of 'misp' with sudo working
 
-{!generic/sudo_etckeeper.md!}
+{% generic/sudo_etckeeper.md %}
 
-{!generic/ethX.md!}
+{% generic/ethX.md %}
 
 #### Add $MISP_USER to staff and ${WWW_USER}
 
@@ -443,7 +443,7 @@ then
 fi
 ```
 
-{!generic/MISP_CAKE_init.md!}
+{% generic/MISP_CAKE_init.md %}
 
 ```bash
 # Add the following lines before the last line (exit 0). Make sure that you replace ${WWW_USER} with your apache user:
@@ -452,18 +452,18 @@ sudo sed -i -e '$i \echo 1024 > /proc/sys/net/core/somaxconn\n' /etc/rc.local
 sudo sed -i -e '$i \sysctl vm.overcommit_memory=1\n' /etc/rc.local
 ```
 
-{!generic/misp-modules-debian.md!}
+{% generic/misp-modules-debian.md %}
 
-{!generic/misp-modules-cake.md!}
+{% generic/misp-modules-cake.md %}
 
 ```bash
 echo "Admin (root) DB Password: $DBPASSWORD_ADMIN"
 echo "User  (misp) DB Password: $DBPASSWORD_MISP"
 ```
 
-{!generic/INSTALL.done.md!}
+{% generic/INSTALL.done.md %}
 
-{!generic/recommended.actions.md!}
+{% generic/recommended.actions.md %}
 
 ### Optional features
 -------------------
@@ -497,16 +497,16 @@ sudo phpenmod rdkafka
 sudo service apache2 restart
 ```
 
-{!generic/misp-dashboard-debian.md!}
+{% generic/misp-dashboard-debian.md %}
 
-{!generic/misp-dashboard-cake.md!}
+{% generic/misp-dashboard-cake.md %}
 
-{!generic/viper-debian.md!}
+{% generic/viper-debian.md %}
 
-{!generic/ssdeep-debian.md!}
+{% generic/ssdeep-debian.md %}
 
-{!generic/mail_to_misp-debian.md!}
+{% generic/mail_to_misp-debian.md %}
 
-{!generic/upgrading.md!}
+{% generic/upgrading.md %}
 
-{!generic/hardening.md!}
+{% generic/hardening.md %}

--- a/docs/xINSTALL.ubuntu2204.md
+++ b/docs/xINSTALL.ubuntu2204.md
@@ -1,7 +1,7 @@
 # INSTALLATION INSTRUCTIONS
 ## for Ubuntu 22.04-server
 
-{!generic/manual-install-notes.md!}
+{% generic/manual-install-notes.md %}
 
 ### -1/ Installer and Manual install instructions
 
@@ -15,7 +15,7 @@ Make sure you are reading the parsed version of this Document. When in doubt [cl
 !!! notice
     If the next line is `[!generic/core.md!]()` [click here](https://misp.github.io/MISP/xINSTALL.ubuntu2204).
 
-{!generic/core.md!}
+{% generic/core.md %}
 
 ### 1/ Minimal Ubuntu install
 -------------------------
@@ -44,9 +44,9 @@ aptUpgrade () {
 # <snippet-end 0_apt-upgrade.sh>
 ```
 
-{!generic/sudo_etckeeper.md!}
+{% generic/sudo_etckeeper.md %}
 
-{!generic/ethX.md!}
+{% generic/ethX.md %}
 
 #### install postfix, there will be some questions.
 ```bash
@@ -63,7 +63,7 @@ sudo apt-get install postfix dialog -qy
     sudo postfix reload
     ```
 
-{!generic/globalVariables.md!}
+{% generic/globalVariables.md %}
 
 ### 2/ Install LAMP & dependencies
 ------------------------------
@@ -438,7 +438,7 @@ configMISP () {
 # <snippet-end 2_configMISP.sh>
 ```
 
-{!generic/gnupg.md!}
+{% generic/gnupg.md %}
 
 !!! notice
     If entropy is not high enough, you can install havegd and then start the service
@@ -492,15 +492,15 @@ echo "Admin (root) DB Password: $DBPASSWORD_ADMIN"
 echo "User  (misp) DB Password: $DBPASSWORD_MISP"
 ```
 
-{!generic/MISP_CAKE_init.md!}
+{% generic/MISP_CAKE_init.md %}
 
-{!generic/misp-modules-debian.md!}
+{% generic/misp-modules-debian.md %}
 
-{!generic/misp-modules-cake.md!}
+{% generic/misp-modules-cake.md %}
 
-{!generic/INSTALL.done.md!}
+{% generic/INSTALL.done.md %}
 
-{!generic/recommended.actions.md!}
+{% generic/recommended.actions.md %}
 
 ### Optional features
 -----------------
@@ -523,17 +523,17 @@ installKafka () {
 # <snippet-end 4_kafka.sh>
 ```
 
-{!generic/misp-dashboard-debian.md!}
+{% generic/misp-dashboard-debian.md %}
 
-{!generic/misp-dashboard-cake.md!}
+{% generic/misp-dashboard-cake.md %}
 
-{!generic/viper-debian.md!}
+{% generic/viper-debian.md %}
 
-{!generic/ssdeep-debian.md!}
+{% generic/ssdeep-debian.md %}
 
-{!generic/mail_to_misp-debian.md!}
+{% generic/mail_to_misp-debian.md %}
 
-{!generic/hardening.md!}
+{% generic/hardening.md %}
 
 # INSTALL.sh
 
@@ -541,4 +541,4 @@ installKafka () {
     The following section is an administrative section that is used by the "[INSTALL.sh](https://raw.githubusercontent.com/MISP/MISP/2.4/INSTALL/INSTALL.sh)" script.
     Please ignore.
 
-{!generic/supportFunctions.md!}
+{% generic/supportFunctions.md %}

--- a/docs/xINSTALL.ubuntu2204.md
+++ b/docs/xINSTALL.ubuntu2204.md
@@ -1,7 +1,7 @@
 # INSTALLATION INSTRUCTIONS
 ## for Ubuntu 22.04-server
 
-{% generic/manual-install-notes.md %}
+{% include_relative generic/manual-install-notes.md %}
 
 ### -1/ Installer and Manual install instructions
 
@@ -15,7 +15,7 @@ Make sure you are reading the parsed version of this Document. When in doubt [cl
 !!! notice
     If the next line is `[!generic/core.md!]()` [click here](https://misp.github.io/MISP/xINSTALL.ubuntu2204).
 
-{% generic/core.md %}
+{% include_relative generic/core.md %}
 
 ### 1/ Minimal Ubuntu install
 -------------------------
@@ -44,9 +44,9 @@ aptUpgrade () {
 # <snippet-end 0_apt-upgrade.sh>
 ```
 
-{% generic/sudo_etckeeper.md %}
+{% include_relative generic/sudo_etckeeper.md %}
 
-{% generic/ethX.md %}
+{% include_relative generic/ethX.md %}
 
 #### install postfix, there will be some questions.
 ```bash
@@ -63,7 +63,7 @@ sudo apt-get install postfix dialog -qy
     sudo postfix reload
     ```
 
-{% generic/globalVariables.md %}
+{% include_relative generic/globalVariables.md %}
 
 ### 2/ Install LAMP & dependencies
 ------------------------------
@@ -438,7 +438,7 @@ configMISP () {
 # <snippet-end 2_configMISP.sh>
 ```
 
-{% generic/gnupg.md %}
+{% include_relative generic/gnupg.md %}
 
 !!! notice
     If entropy is not high enough, you can install havegd and then start the service
@@ -492,15 +492,15 @@ echo "Admin (root) DB Password: $DBPASSWORD_ADMIN"
 echo "User  (misp) DB Password: $DBPASSWORD_MISP"
 ```
 
-{% generic/MISP_CAKE_init.md %}
+{% include_relative generic/MISP_CAKE_init.md %}
 
-{% generic/misp-modules-debian.md %}
+{% include_relative generic/misp-modules-debian.md %}
 
-{% generic/misp-modules-cake.md %}
+{% include_relative generic/misp-modules-cake.md %}
 
-{% generic/INSTALL.done.md %}
+{% include_relative generic/INSTALL.done.md %}
 
-{% generic/recommended.actions.md %}
+{% include_relative generic/recommended.actions.md %}
 
 ### Optional features
 -----------------
@@ -523,17 +523,17 @@ installKafka () {
 # <snippet-end 4_kafka.sh>
 ```
 
-{% generic/misp-dashboard-debian.md %}
+{% include_relative generic/misp-dashboard-debian.md %}
 
-{% generic/misp-dashboard-cake.md %}
+{% include_relative generic/misp-dashboard-cake.md %}
 
-{% generic/viper-debian.md %}
+{% include_relative generic/viper-debian.md %}
 
-{% generic/ssdeep-debian.md %}
+{% include_relative generic/ssdeep-debian.md %}
 
-{% generic/mail_to_misp-debian.md %}
+{% include_relative generic/mail_to_misp-debian.md %}
 
-{% generic/hardening.md %}
+{% include_relative generic/hardening.md %}
 
 # INSTALL.sh
 
@@ -541,4 +541,4 @@ installKafka () {
     The following section is an administrative section that is used by the "[INSTALL.sh](https://raw.githubusercontent.com/MISP/MISP/2.4/INSTALL/INSTALL.sh)" script.
     Please ignore.
 
-{% generic/supportFunctions.md %}
+{% include_relative generic/supportFunctions.md %}


### PR DESCRIPTION
#### What does it do?

Fixes #8954

* Replaces [jekyll include tags ](https://jekyllrb.com/docs/includes/#including-files-relative-to-another-file)`{! ... !}` with `{% include_relative ... %}`
* For docs under `docs/archive` the include blocks are commented as this feature cannot include files from parent directories [see issue](https://github.com/jekyll/jekyll/issues/1851).

The guide with these changes can be previewed here: 
* (new) https://righel.github.io/MISP/xINSTALL.ubuntu2204
* (current) https://misp.github.io/MISP/xINSTALL.ubuntu2204

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
