### PR TITLE
Update DecayingModelController.php

### DIFF
--- a/app/Controller/DecayingModelController.php
+++ b/app/Controller/DecayingModelController.php
@@ -55,9 +55,9 @@ class DecayingModelController extends AppController
             $json['org_id'] = $this->Auth->user()['org_id'];
 
             $attribute_types = array();
-            if (!empty($json['attribute_types'])) {
-                $attribute_types = $json['attribute_types'];
-                unset($json['attribute_types']);
+            if (!empty($json['DecayingModel']['attribute_types'])) {
+                $attribute_types = $json['DecayingModel']['attribute_types'];
+                unset($json['DecayingModel']['attribute_types']);
             }
 
             if ($this->DecayingModel->save($json)) {


### PR DESCRIPTION
Found a bug importing DecayingModels to a new instance that hinders the Decaying Model Mapping with attribute types

#### What does it do?

If it fixes an existing issue, please use github syntax: #8972 

#### Questions

- [ ] Does it require a DB change? NO
- [ ] Are you using it in production? Yes
- [ ] Does it require a change in the API (PyMISP for example)? NO
