### PR TITLE
chg: [logging] Add user id to sys logged actions

### DIFF
--- a/app/Model/AuditLog.php
+++ b/app/Model/AuditLog.php
@@ -275,7 +275,7 @@ class AuditLog extends AppModel
             }
         }
         if ($this->syslog) {
-            $entry = $data['AuditLog']['action'];
+            $entry = "User (" . $data['AuditLog']['user_id'] . ") -- " . $data['AuditLog']['action'];
             $title = $this->generateUserFriendlyTitle($data['AuditLog']);
             if ($title) {
                 $entry .= " -- $title";


### PR DESCRIPTION
When a user performs an action, the user id is not logged with it. As a result, when multiple users are doing changes in MIPS it is hard to track which user did what.

This change will prepend the user id to sys logged actions.


#### What does it do?

If it fixes an existing issue, please use github syntax: #8974

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
