### PR TITLE
[new]: add breakOnDuplicate option to attributes/add

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -2499,7 +2499,6 @@ class Attribute extends AppModel
             }
         }
         if (isset($attribute['breakOnDuplicate']) && $attribute['breakOnDuplicate'] === false) {
-            $this->data['Attribute'];
             unset($this->validate['value']['uniqueValue']);
         }
         if (!$this->save(['Attribute' => $attribute], $params)) {

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -2482,6 +2482,9 @@ class Attribute extends AppModel
         if (!isset($attribute['distribution'])) {
             $attribute['distribution'] = $this->defaultDistribution();
         }
+        if (isset($params['breakOnDuplicate'])) {
+            $this->data['Attribute']['breakOnDuplicate'] = (bool)$params['breakOnDuplicate'];
+        }
         $params = array(
             'fieldList' => self::CAPTURE_FIELDS,
         );

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -2498,7 +2498,7 @@ class Attribute extends AppModel
                 unset($attribute['sharing_group_id']);
             }
         }
-        if (isset($attribute['breakOnDuplicate']) && $attribute['breakOnDuplicate'] === false) {
+        if (isset($this->data['Attribute']['breakOnDuplicate']) && $this->data['Attribute']['breakOnDuplicate'] === false) {
             unset($this->validate['value']['uniqueValue']);
         }
         if (!$this->save(['Attribute' => $attribute], $params)) {

--- a/docs/background-jobs-migration-guide.md
+++ b/docs/background-jobs-migration-guide.md
@@ -107,6 +107,15 @@ Run on your MISP instance the following commands.
     user=www-data
     ```
 
+## MISP Config
+1. Go to your **MISP** instances `Server Settings & Maintenance` page, and then to the new [SimpleBackgroundJobs]((https://localhost/servers/serverSettings/SimpleBackgroundJobs)) tab.
+
+2. Update the `SimpleBackgroundJobs.supervisor_password` with the password you set in the _Install requirements_ section 3.
+
+3. Update the `SimpleBackgroundJobs.supervisor_user` with the supervisord username. (default: supervisor)
+
+4. Verify Redis and other settings are correct and then set `SimpleBackgroundJobs.enabled` to `true`.
+
 5. Restart **Supervisord** to load the changes:
     ```
     sudo service supervisor restart
@@ -138,21 +147,12 @@ Run on your MISP instance the following commands.
     misp-workers:update_00           RUNNING   pid 1673327, uptime 1:37:53
     ```
 
-## MISP Config
-1. Go to your **MISP** instances `Server Settings & Maintenance` page, and then to the new [SimpleBackgroundJobs]((https://localhost/servers/serverSettings/SimpleBackgroundJobs)) tab.
-
-2. Update the `SimpleBackgroundJobs.supervisor_password` with the password you set in the _Install requirements_ section 3.
-
-3. Update the `SimpleBackgroundJobs.supervisor_user` with the supervisord username. (default: supervisor)
-
-4. Verify Redis and other settings are correct and then set `SimpleBackgroundJobs.enabled` to `true`.
-
-5. Use **MISP** normally and visit [Administration -> Jobs](/jobs/index) to check Jobs are running correctly. 
+7. Use **MISP** normally and visit [Administration -> Jobs](/jobs/index) to check Jobs are running correctly. 
     If there are any issues check the logs:
     * /var/www/MISP/app/tmp/logs/misp-workers-errors.log
     * /var/www/MISP/app/tmp/logs/misp-workers.log
 
-5. Once the new workers are functioning as expected, you can remove the previous workers service:
+8. Once the new workers are functioning as expected, you can remove the previous workers service:
     ```bash
     $ sudo systemctl stop --now misp-workers
     $ sudo systemctl disable --now misp-workers


### PR DESCRIPTION
#### What does it do?
Fixes https://github.com/MISP/MISP/issues/5257

* Add support for a `breakOnDuplicate` named parameter on `/attributes/add` endpoint, default value is `true` which keeps the current behavior of throwing an error when the user tries to add duplicate attribute to an event.
When set to `false` the endpoint will work as an upsert, updating the attributes `timestamp` and any other properties provided in the payload, no error logs will be written.
* Minor fixes to objects breakOnDuplicate logic.

**Example 1:**
`/attributes/add/1/breakOnDuplicate:0`
**Body:**
```json
{
  "value": "10.0.0.11",
  "type": "ip-dst"
}
```

PyMISP related PR: https://github.com/MISP/PyMISP/pull/958

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
