### PR TITLE
Add `startsecs=0` to worker config

### DIFF
--- a/docs/background-jobs-migration-guide.md
+++ b/docs/background-jobs-migration-guide.md
@@ -46,6 +46,7 @@ Run on your MISP instance the following commands.
     directory=/var/www/MISP
     command=/var/www/MISP/app/Console/cake start_worker default
     process_name=%(program_name)s_%(process_num)02d
+    startsecs=0
     numprocs=5
     autostart=true
     autorestart=true
@@ -59,6 +60,7 @@ Run on your MISP instance the following commands.
     directory=/var/www/MISP
     command=/var/www/MISP/app/Console/cake start_worker prio
     process_name=%(program_name)s_%(process_num)02d
+    startsecs=0
     numprocs=5
     autostart=true
     autorestart=true
@@ -72,6 +74,7 @@ Run on your MISP instance the following commands.
     directory=/var/www/MISP
     command=/var/www/MISP/app/Console/cake start_worker email
     process_name=%(program_name)s_%(process_num)02d
+    startsecs=0
     numprocs=5
     autostart=true
     autorestart=true
@@ -85,6 +88,7 @@ Run on your MISP instance the following commands.
     directory=/var/www/MISP
     command=/var/www/MISP/app/Console/cake start_worker update
     process_name=%(program_name)s_%(process_num)02d
+    startsecs=0
     numprocs=1
     autostart=true
     autorestart=true
@@ -98,6 +102,7 @@ Run on your MISP instance the following commands.
     directory=/var/www/MISP
     command=/var/www/MISP/app/Console/cake start_worker cache
     process_name=%(program_name)s_%(process_num)02d
+    startsecs=0
     numprocs=5
     autostart=true
     autorestart=true


### PR DESCRIPTION
In my case without this it was throwing an error: misp-workers:cache_00            FATAL     Exited too quickly (process log may have details)

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2020-05-05: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

If it fixes an existing issue, please use github syntax: `#<IssueID>`

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
