### PR TITLE
fix: fix openioc import

### DIFF
--- a/app/Controller/Component/IOCImportComponent.php
+++ b/app/Controller/Component/IOCImportComponent.php
@@ -190,7 +190,7 @@ class IOCImportComponent extends Component
 
         $duplicateFilter = array();
         // check if we have any attributes, if yes, add their UUIDs to our list of success-array
-        if (count($event['Attribute']) > 0) {
+        if (isset($event['Attribute']) && count($event['Attribute']) > 0) {
             foreach ($event['Attribute'] as $k => $attribute) {
                 $condensed = strtolower($attribute['value']) . $attribute['category'] . $attribute['type'];
                 if (!in_array($condensed, $duplicateFilter)) {

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -2320,7 +2320,7 @@ class EventsController extends AppController
         // set the id
         $this->set('id', $id);
         // set whether it is published or not
-        $this->set('published', $this->Event->data['Event']['published']);
+        $this->set('published', $this->Event->data['Event']['published'] ?? false);
     }
 
     public function add_misp_export()
@@ -3528,6 +3528,7 @@ class EventsController extends AppController
                 'category' => 'External analysis',
                 'uuid' =>  CakeText::uuid(),
                 'type' => 'attachment',
+                'sharing_group_id' => '0',
                 'value' => $this->data['Event']['submittedioc']['name'],
                 'to_ids' => false,
                 'distribution' => $dist,
@@ -3542,7 +3543,7 @@ class EventsController extends AppController
 
             $fieldList = array(
                     'Event' => array('published', 'timestamp'),
-                    'Attribute' => array('event_id', 'category', 'type', 'value', 'value1', 'value2', 'to_ids', 'uuid', 'distribution', 'timestamp', 'comment')
+                    'Attribute' => array('event_id', 'category', 'type', 'value', 'value1', 'value2', 'to_ids', 'uuid', 'distribution', 'timestamp', 'comment', 'sharing_group_id')
             );
             // Save it all
             $saveResult = $this->Event->saveAssociated($saveEvent, array('validate' => true, 'fieldList' => $fieldList));

--- a/app/Model/Behavior/DefaultCorrelationBehavior.php
+++ b/app/Model/Behavior/DefaultCorrelationBehavior.php
@@ -95,7 +95,7 @@ class DefaultCorrelationBehavior extends ModelBehavior
             return [
                 $value,
                 (int) $a['Event']['id'],
-                (int) $a['Attribute']['object_id'],
+                (int) ($a['Attribute']['object_id'] ?? 0),
                 (int) $a['Attribute']['id'],
                 (int) $a['Event']['org_id'],
                 (int) $a['Attribute']['distribution'],
@@ -105,7 +105,7 @@ class DefaultCorrelationBehavior extends ModelBehavior
                 (int) $a['Event']['sharing_group_id'],
                 empty($a['Attribute']['object_id']) ? 0 : (int) $a['Object']['sharing_group_id'],
                 (int) $b['Event']['id'],
-                (int) $b['Attribute']['object_id'],
+                (int) ($b['Attribute']['object_id'] ?? 0),
                 (int) $b['Attribute']['id'],
                 (int) $b['Event']['org_id'],
                 (int) $b['Attribute']['distribution'],


### PR DESCRIPTION
#### What does it do?

* Fixes error when trying to import an openioc file
  ```
  Error: [PDOException] SQLSTATE[HY000]: General error: 1364 Field 'sharing_group_id' doesn't have a default value
  ```

* Fixes undefined `object_id` notice in `DefaultCorrelationBehavior.php`

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
