### PR TITLE
new: add param to get exact matches on attribute values

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -73,6 +73,9 @@ class AttributesController extends AppController
     {
         $user = $this->Auth->user();
         $this->paginate['conditions']['AND'][] = $this->Attribute->buildConditions($user);
+
+        $this->__setIndexFilterConditions();
+
         $attributes = $this->paginate();
 
         if ($this->_isRest()) {
@@ -3016,5 +3019,16 @@ class AttributesController extends AppController
     {
         $sg = $this->Attribute->Event->SharingGroup->fetchAllAuthorised($this->Auth->user(), 'name', true, $sharingGroupId);
         return !empty($sg);
+    }
+
+    private function __setIndexFilterConditions() {
+        // search by attribute value
+        if ($this->params['named']['searchvalue']) {
+            $v = $this->params['named']['searchvalue'];
+            $this->paginate['conditions']['AND']['OR'] = [
+                ['Attribute.value1' => $v],
+                ['Attribute.value2' => $v],
+            ];
+        }
     }
 }

--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -3021,13 +3021,16 @@ class AttributesController extends AppController
         return !empty($sg);
     }
 
-    private function __setIndexFilterConditions() {
+    private function __setIndexFilterConditions()
+    {
         // search by attribute value
         if ($this->params['named']['searchvalue']) {
             $v = $this->params['named']['searchvalue'];
-            $this->paginate['conditions']['AND']['OR'] = [
-                ['Attribute.value1' => $v],
-                ['Attribute.value2' => $v],
+            $this->paginate['conditions']['AND'][] = [
+                'OR' => [
+                    ['Attribute.value1' => $v],
+                    ['Attribute.value2' => $v],
+                ]
             ];
         }
     }

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -670,6 +670,25 @@ class EventsController extends AppController
                         ]
                     ];
                     break;
+                case 'value':
+                    if ($v == "") {
+                        continue 2;
+                    }
+                    $conditions['OR'] = [
+                        ['Attribute.value1' => $v],
+                        ['Attribute.value2' => $v],
+                    ];
+
+                    $eventIds = $this->Event->Attribute->fetchAttributes($this->Auth->user(), array(
+                        'conditions' => $conditions,
+                        'flatten' => true,
+                        'event_ids' => true,
+                        'list' => true,
+                    ));
+
+                    $this->paginate['conditions']['AND'][] = array('Event.id' => $eventIds);
+
+                    break;
                 default:
                     continue 2;
             }
@@ -682,7 +701,7 @@ class EventsController extends AppController
     {
         // list the events
         $urlparams = "";
-        $overrideAbleParams = array('all', 'attribute', 'published', 'eventid', 'datefrom', 'dateuntil', 'org', 'eventinfo', 'tag', 'tags', 'distribution', 'sharinggroup', 'analysis', 'threatlevel', 'email', 'hasproposal', 'timestamp', 'publishtimestamp', 'publish_timestamp', 'minimal');
+        $overrideAbleParams = array('all', 'attribute', 'published', 'eventid', 'datefrom', 'dateuntil', 'org', 'eventinfo', 'tag', 'tags', 'distribution', 'sharinggroup', 'analysis', 'threatlevel', 'email', 'hasproposal', 'timestamp', 'publishtimestamp', 'publish_timestamp', 'minimal', 'value');
         $paginationParams = array('limit', 'page', 'sort', 'direction', 'order');
         $passedArgs = $this->passedArgs;
         if (!empty($this->request->data)) {

--- a/app/View/Events/automation.ctp
+++ b/app/View/Events/automation.ctp
@@ -372,6 +372,7 @@
     <b>searchdistribution</b>: <?php echo __('Filters on the distribution level [0,1,2,3] - negatable');?><br />
     <b>searchanalysis</b>: <?php echo __('Filters on the given analysis phase of the event [0,1,2] - negatable');?><br />
     <b>searchattribute</b>: <?php echo __('Filters on a contained attribute value - negatable');?><br />
+    <b>searchvalue</b>: <?php echo __('Filter exact matches on the attribute value');?><br />
     <b>searchorg</b>: <?php echo __('Filters on the creator organisation - negatable');?><br />
     <b>searchemail</b>: <?php echo __('Filters on the creator user\'s email address (admin only) - negatable');?><br />
     <b>searchDatefrom</b>: <?php echo __('Filters on the date, anything newer than the given date in YYYY-MM-DD format is taken - non-negatable');?><br />


### PR DESCRIPTION
#### What does it do?

Implements #9036
Adds `searchvalue` param on `events/index` and `attributes/index` to perform a exact match `value1` and `value2`.

Usage:
* `https://MISP_URL/attributes/index/searchvalue:2.2.2.2`
* `https://MISP_URL/events/index/searchvalue:2.2.2.2`

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
