### PR TITLE
Explicitly add dependency to 'php-http/message-factory'

### DIFF
--- a/docs/background-jobs-migration-guide.md
+++ b/docs/background-jobs-migration-guide.md
@@ -21,7 +21,8 @@ Run on your MISP instance the following commands.
     cd /var/www/MISP/app
     sudo -u www-data php composer.phar require --with-all-dependencies supervisorphp/supervisor:^4.0 \
         guzzlehttp/guzzle \
-        php-http/message  \
+        php-http/message \
+        php-http/message-factory \
         lstrojny/fxmlrpc
     ```
 


### PR DESCRIPTION
This is needed because `php-http/message-factory` is not an explicit dependency of `php-http/message` since https://github.com/php-http/message/releases/tag/1.16.0

CC @garanews @iglocska 

