### PR TITLE
fix: [misp-core] MySQL HA DB Schema Fix for bruteforces table

### DIFF
--- a/INSTALL/MYSQL.sql
+++ b/INSTALL/MYSQL.sql
@@ -121,9 +121,11 @@ CREATE TABLE IF NOT EXISTS `auth_keys` (
 --
 
 CREATE TABLE IF NOT EXISTS `bruteforces` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `ip` varchar(255) COLLATE utf8_bin NOT NULL,
   `username` varchar(255) COLLATE utf8_bin NOT NULL,
-  `expire` datetime NOT NULL
+  `expire` datetime NOT NULL,
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
 -- --------------------------------------------------------

--- a/INSTALL/POSTGRESQL-data-initial.sql
+++ b/INSTALL/POSTGRESQL-data-initial.sql
@@ -44,7 +44,7 @@ COPY public.attributes (id, event_id, object_id, object_relation, category, type
 -- Data for Name: bruteforces; Type: TABLE DATA; Schema: public; Owner: -
 --
 
-COPY public.bruteforces (ip, username, expire) FROM stdin;
+COPY public.bruteforces (id, ip, username, expire) FROM stdin;
 \.
 
 

--- a/INSTALL/POSTGRESQL-structure.sql
+++ b/INSTALL/POSTGRESQL-structure.sql
@@ -128,6 +128,7 @@ ALTER SEQUENCE public.attributes_id_seq OWNED BY public.attributes.id;
 --
 
 CREATE TABLE public.bruteforces (
+    id serial PRIMARY KEY,
     ip character varying(255) NOT NULL,
     username character varying(255) NOT NULL,
     expire timestamp with time zone NOT NULL

--- a/db_schema.json
+++ b/db_schema.json
@@ -865,6 +865,17 @@
         ],
         "bruteforces": [
             {
+                "column_name": "id",
+                "is_nullable": "NO",
+                "data_type": "int",
+                "character_maximum_length": null,
+                "numeric_precision": "10",
+                "collation_name": null,
+                "column_type": "int(10) unsigned",
+                "column_default": null,
+                "extra": "auto_increment"
+            },
+            {
                 "column_name": "ip",
                 "is_nullable": "NO",
                 "data_type": "varchar",


### PR DESCRIPTION
### What does it do?

If it fixes an existing issue -  fixes #7522 

A Stack trace occurs when logging into a MISP instance that utilises a MySQL Cluster HA setup. In order to be compliant with group replication [Group Replication Requirements](https://dev.mysql.com/doc/refman/5.7/en/group-replication-requirements.html) the bruteforces table must have a primary key. It is the only table in the schema that does not conform to this requirement.

Can be checked in the current 2.4 branch in the database with the following query - 

```SQL
SELECT tables.table_schema , tables.table_name , tables.engine
FROM information_schema.tables
LEFT JOIN (
   SELECT table_schema , table_name
   FROM information_schema.statistics
   GROUP BY table_schema, table_name, index_name HAVING
     SUM( case when non_unique = 0 and nullable != 'YES' then 1 else 0 end ) = count(*) ) puks
 ON tables.table_schema = puks.table_schema and tables.table_name = puks.table_name
 WHERE puks.table_name is null
   AND tables.table_type = 'BASE TABLE' AND Engine="InnoDB";
```

Results in
```
+--------------+-------------+--------+
| TABLE_SCHEMA | TABLE_NAME  | ENGINE |
+--------------+-------------+--------+
| misp         | bruteforces | InnoDB |
+--------------+-------------+--------+
```

In addition, due to the changes in db_schema.json. I also updated the relevant table structure in Postgresql related files.



#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
