### PR TITLE
fix: localisation typo in diagnostic page

### DIFF
--- a/app/View/Elements/healthElements/diagnostics.ctp
+++ b/app/View/Elements/healthElements/diagnostics.ctp
@@ -239,7 +239,7 @@ $humanReadableFilesize = function ($bytes, $dec = 2) {
     </table>
 
     <h4><?= __('PHP Dependencies') ?></h4>
-    <p><?= _("Dependencies located in the Vendor folder. You can use composer to install them: 'php composer.phar help' ") ?></p>
+    <p><?= __("Dependencies located in the Vendor folder. You can use composer to install them: 'php composer.phar help' ") ?></p>
     <table class="table table-condensed table-bordered" style="width: 40vw">
         <thead>
             <tr>


### PR DESCRIPTION
#### What does it do?

Fixes a typo in diagnostics.ctp that breaks the complete loading of MISP diagnostic page from v2.4.169. 

Closes #9088

#### Questions

- [N] Does it require a DB change?
- [N] Are you using it in production?
- [N] Does it require a change in the API (PyMISP for example)?
