### PR TITLE
Update INSTALL.sh

### DIFF
--- a/INSTALL/INSTALL.sh
+++ b/INSTALL/INSTALL.sh
@@ -2543,7 +2543,7 @@ apacheConfig_RHEL7 () {
   #sudo sed -i "s/SetHandler/\#SetHandler/g" /etc/httpd/conf.d/misp.ssl.conf
   sudo rm /etc/httpd/conf.d/ssl.conf
   sudo chmod 644 /etc/httpd/conf.d/misp.ssl.conf
-  sudo sed -i '/Listen 80/a Listen 443' /etc/httpd/conf/httpd.conf
+  sudo sed -i '/Listen 443/!s/Listen 80/a Listen 443/' /etc/httpd/conf/httpd.conf
 
   # If a valid SSL certificate is not already created for the server, create a self-signed certificate:
   echo "The Common Name used below will be: ${OPENSSL_CN}"
@@ -2591,7 +2591,7 @@ apacheConfig_RHEL8 () {
   #sudo sed -i "s/SetHandler/\#SetHandler/g" /etc/httpd/conf.d/misp.ssl.conf
   sudo rm /etc/httpd/conf.d/ssl.conf
   sudo chmod 644 /etc/httpd/conf.d/misp.ssl.conf
-  sudo sed -i '/Listen 80/a Listen 443' /etc/httpd/conf/httpd.conf
+  sudo sed -i '/Listen 443/!s/Listen 80/a Listen 443/' /etc/httpd/conf/httpd.conf
 
   # If a valid SSL certificate is not already created for the server, create a self-signed certificate:
   echo "The Common Name used below will be: ${OPENSSL_CN}"


### PR DESCRIPTION
#### What does it do?

The current command in the RHEL install adds the line "Listen 443" after the line containing "Listen 80" even if "Listen 443" already exists.

In my update, the "Listen 443" line will only be added if it doesn't already exist in the file.

#### Questions

- [NO] Does it require a DB change?
- [YES] Are you using it in production?
- [NO] Does it require a change in the API (PyMISP for example)?
