### PR TITLE
fix: No events returned when one of many orgs in filter does not exist

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -427,6 +427,7 @@ class EventsController extends AppController
                     // if the first character is '!', search for NOT LIKE the rest of the string (excluding the '!' itself of course)
                     $pieces = is_array($v) ? $v : explode('|', $v);
                     $test = array();
+                    $foundOrg = false;
                     foreach ($pieces as $piece) {
                         if ($piece[0] === '!') {
                             $piece = substr($piece, 1); // remove `!` char
@@ -440,6 +441,7 @@ class EventsController extends AppController
                             }
                             if ($orgId) {
                                 $this->paginate['conditions']['AND'][] = array('Event.orgc_id !=' => $orgId);
+                                $foundOrg = true;
                             }
                         } else {
                             if (is_numeric($piece)) {
@@ -453,13 +455,17 @@ class EventsController extends AppController
                                 }
                                 if ($orgId) {
                                     $test['OR'][] = array('Event.orgc_id' => $orgId);
-                                } else {
-                                    $nothing = true;
+                                    $foundOrg = true;
                                 }
                             }
                         }
                     }
-                    $this->paginate['conditions']['AND'][] = $test;
+                    if (!$foundOrg) {
+                        $nothing = true;
+                    }
+                    if (!empty($test)) {
+                        $this->paginate['conditions']['AND'][] = $test;
+                    }
                     break;
                 case 'sharinggroup':
                     $pieces = explode('|', $v);


### PR DESCRIPTION
#### What does it do?
Discovered that when using the search_index endpoint (or filtering through UI), if you pass a list of organisations in the `org` parameter, and at least **one** of the orgs does not exist (either by ID, UUID or Name), then no results are returned. It did not matter if other orgs provided in the parameter exist.

To replicate:
The following search returns a result:
```
pm.search_index(org=["CIRCL"], limit=1)
```

The following does not:
```
pm.search_index(org=["CIRCL", "CIRCL_____MISSING"], limit=1)
```

Fixed by handling where at least one org was found, and also skipping including an empty `$test` in the conditions (for code cleanup) 

#### Questions
- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
