### PR TITLE
Fix pagination issue

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -1773,7 +1773,8 @@ class Attribute extends AppModel
             if (($params['limit'] != 0) && ($options['enforceWarninglist'] || $proposals_block_attributes || $options['excludeDecayed'])) {
                 $loopLimit = $params['limit']; // optimistic approach
                 $loop = true;
-                $preventUnfinishedPages = True;                
+                $preventUnfinishedPages = True;
+                $params['page'] = 1;
             } else {
                 $loop = false;
             }         


### PR DESCRIPTION
#### What does it do?

Fixes Issue: #9175
Bug: When attributes are fetched using pagination pages can be empty or not full when items are skipped

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Note
This fix should be considered as an example because of the fact that this implementation has an impact on performance. The main impact is, that all previous pages must be fetched in any case, otherwise the exact beginning of a page could not be determined.

A better solution would be, to do the filtering on SQL-level but this wouldn't be a quick fix.

Maybe we should also consider to avoid the n+1 select (indirect recursive call) when decay-score is included:
1. [attachScoresToAttribute](https://github.com/MISP/MISP/blob/648c1c9ea21b85e2d360033a65882fe33c8b9bbe/app/Model/Attribute.php#L1846C48-L1846C96)
2. [getScore](https://github.com/MISP/MISP/blob/648c1c9ea21b85e2d360033a65882fe33c8b9bbe/app/Model/DecayingModel.php#L625C33-L625C33)
3. [fetchAttributes](https://github.com/MISP/MISP/blob/648c1c9ea21b85e2d360033a65882fe33c8b9bbe/app/Model/DecayingModel.php#L691)

To avoid this it could be possible to add the most recent sighting date to the attribute like the last seen date.