### PR TITLE
fix: Localisation workflow typo

### DIFF
--- a/app/View/Workflows/editor.ctp
+++ b/app/View/Workflows/editor.ctp
@@ -184,7 +184,7 @@ $debugEnabled = !empty($selectedWorkflow['Workflow']['debug_enabled']);
                             <a href="#"><i class="fa-fw <?= $this->FontAwesome->getClass('file-import') ?>"></i> <?= __('Import blueprint') ?></a>
                             <ul class="dropdown-menu pull-right">
                                 <?php if (empty($workflowBlueprints)) : ?>
-                                    <li><a href="#"><?= _('No workflow blueprints saved') ?></a></li>
+                                    <li><a href="#"><?= __('No workflow blueprints saved') ?></a></li>
                                 <?php endif; ?>
                                 <?php foreach ($workflowBlueprints as $workflowBlueprint) : ?>
                                     <li>
@@ -202,7 +202,7 @@ $debugEnabled = !empty($selectedWorkflow['Workflow']['debug_enabled']);
                             <a href="#"><i class="fa-fw <?= $this->FontAwesome->getClass('edit') ?>"></i> <?= __('Edit existing blueprint') ?></a>
                             <ul class="dropdown-menu pull-right disabled">
                                 <?php if (empty($workflowBlueprints)) : ?>
-                                    <li><a href="#"><?= _('No workflow blueprints saved') ?></a></li>
+                                    <li><a href="#"><?= __('No workflow blueprints saved') ?></a></li>
                                 <?php endif; ?>
                                 <?php foreach ($workflowBlueprints as $workflowBlueprint) : ?>
                                     <li class="control-edit-bp-blocks">


### PR DESCRIPTION
#### What does it do?

Fixes a typo in `editor.ctp` that breaks the loading of the workflow page.

#### Questions

- [ ] Does it require a DB change?
- [x]  Are you using it in production?
- [ ]  Does it require a change in the API (PyMISP for example)?
