### PR TITLE
fix: [UI] use acl to determine whether to show "audit logs" and "sear…

### DIFF
--- a/app/View/Elements/global_menu.ctp
+++ b/app/View/Elements/global_menu.ctp
@@ -465,7 +465,7 @@
                     array(
                         'text' => __('Audit Logs'),
                         'url' => $baseurl . '/admin/audit_logs/index',
-                        'requirement' => Configure::read('MISP.log_new_audit') && $isAdmin,
+                        'requirement' => Configure::read('MISP.log_new_audit') && $this->Acl->canAccess('auditLogs', 'admin_index'),
                     ),
                     array(
                         'text' => __('Access Logs'),
@@ -475,7 +475,7 @@
                     array(
                         'text' => __('Search Logs'),
                         'url' => $baseurl . '/admin/logs/search',
-                        'requirement' => $isAdmin
+                        'requirement' => $this->Acl->canAccess('logs', 'admin_search')
                     )
                 )
             ),


### PR DESCRIPTION
…ch logs" buttons

#### What does it do?

fix #8949

Please note that this doesn't change anything for access logs, because it doesn't look like perm_audit grants access to that one.

It's somewhat odd that these pages under /admin are accessible by a normal user with audit permissions, but on the other hand it makes sense (since audit permission is there to check the audit logs...). I don't know what the intended design is here in the end, but this commit should at least align the UI with the allowed access.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
