### PR TITLE
NATO MISP only for cyber defense

### DIFF
--- a/app/files/community-metadata/defaults.json
+++ b/app/files/community-metadata/defaults.json
@@ -168,7 +168,7 @@
     "uuid": "53a830e6-8d07-4dd8-98d5-18cc4e66fc8c",
     "org_uuid": "",
     "org_name": "",
-    "description": "The ultimate goal of the project is to develop a NATO capability, available to all NATO nations, through which nations commit to sharing their information. This community is only open for official government entities, sponsored by their nation representative in the NATO Multinational MISP Steering Board.",
+    "description": "The ultimate goal of the project is to develop a NATO capability, available to all NATO nations, through which nations commit to sharing their information. This community is only open for official government cyber defense related entities, sponsored by their nation representative in the NATO Multinational MISP Steering Board.",
     "url": "https://misp.ncirc.nato.int",
     "sector": "Governmental",
     "nationality": "International",


### PR DESCRIPTION
According to NATO MISP terms of use, NATO MISP is open only for cyber defense related governmental entities, not to all governmental entities.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
