### PR TITLE
explicitly set loginAction with baseurl

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -111,6 +111,7 @@ class AppController extends Controller
 
         $this->_setupBaseurl();
         $this->Auth->loginRedirect = $this->baseurl . '/users/routeafterlogin';
+        $this->Auth->loginAction = $this->baseurl . '/users/login';
 
         $customLogout = Configure::read('Plugin.CustomAuth_custom_logout');
         $this->Auth->logoutRedirect = $customLogout ?: ($this->baseurl . '/users/login');


### PR DESCRIPTION
Fix https://github.com/MISP/MISP/issues/2876

Got issues with *http* instead of *https* 302 redirects to http://example.com/users/login when accessing https://example.com, while the baseurl starts with *https*.

Here, the redirect uses the default `loginAction` :
https://github.com/MISP/MISP/blob/2.4/app/Controller/AppController.php#L1184

Explicitly defining `loginAction` with the baseurl fixes the issue and I get correct *https* 302 redirects to https://example.com/users/login.