### PR TITLE
Fix event hyperlink in discussion view page

### DIFF
--- a/app/View/Threads/view.ctp
+++ b/app/View/Threads/view.ctp
@@ -1,7 +1,7 @@
 <div class="threads view">
     <h3><?php
-        if (isset($event_id)) {
-            echo '<a href="' . $baseurl . '/events/view/' . $event_id . '">' . h($thread['Thread']['title']) . '</a>';
+        if (isset($thread['Thread']['event_id']) && $thread['Thread']['event_id']) {
+            echo '<a href="' . $baseurl . '/events/view/' . $thread['Thread']['event_id'] . '">' . h($thread['Thread']['title']) . '</a>';
         } else {
             echo h($thread['Thread']['title']);
         }


### PR DESCRIPTION
#### What does it do?

This pull request fixes the missing hyperlink to the corresponding event in the discussion thread view page 

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
