### PR TITLE
Add attributes to warninglist workflow module

### DIFF
--- a/app/Model/WorkflowModules/action/Module_add_to_warninglist.php
+++ b/app/Model/WorkflowModules/action/Module_add_to_warninglist.php
@@ -1,0 +1,85 @@
+<?php
+include_once APP . 'Model/WorkflowModules/action/Module_attribute_edition_operation.php';
+
+class Module_add_to_warninglist extends WorkflowBaseActionModule 
+{
+    public $version = '0.1';
+    public $blocking = false;
+    public $id = 'add_to_warninglist';
+    public $name = 'Add to warninglist';
+    public $description = 'Add attributes to a custom warninglist';
+    public $icon = 'exclamation-triangle';
+    public $inputs = 1;
+    public $outputs = 1;
+    public $support_filters = true;
+    public $expect_misp_core_format = true;
+    public $params = [];
+
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->Log = ClassRegistry::init('Log');
+        $this->Warninglist = ClassRegistry::init('Warninglist');
+        $warninglists = $this->Warninglist->find('all', [
+            'fields' => ['id', 'name', 'enabled', 'version', 'description', 'type'],
+            'recursive' => -1,
+            'conditions' => ['default' => 0, 'enabled' => 1],
+        ]);
+        $this->warninglists = $warninglists;
+
+        $moduleOptions = array();
+        foreach ($warninglists as $item) {
+            $moduleOptions[$item['Warninglist']['id']] = $item['Warninglist']['name'];
+        }
+        $this->params = [
+            [
+                'id' => 'warninglists',
+                'label' => __('Warninglists'),
+                'type' => 'select',
+                'options' => $moduleOptions
+            ],
+        ];
+    }
+
+    public function exec(array $node, WorkflowRoamingData $roamingData, array &$errors = []): bool
+    {
+        parent::exec($node, $roamingData, $errors);
+
+        $params = $this->getParamsWithValues($node);
+        $rData = $roamingData->getData();
+
+        $matchingItems = $this->getMatchingItemsForAttributes($node, $rData);
+        if ($matchingItems === false) {
+            return true;
+        }
+        
+        $selectedWarninglist = $params['warninglists']['value'];
+        
+        $warninglist = array_values(array_filter($this->warninglists, function($wl) use ($selectedWarninglist) {
+            return $wl['Warninglist']['id'] == $selectedWarninglist;
+        }))[0]['Warninglist'];
+        
+        $this->WarninglistEntry = ClassRegistry::init('WarninglistEntry');
+        $entries = $this->WarninglistEntry->find('column', array(
+            'conditions' => array('warninglist_id' => $warninglist['id']),
+            'fields' => array('WarninglistEntry.value')
+        ));
+       
+        foreach($rData['Event']['Attribute'] as $attribute) {
+            if(!in_array($attribute['value'], $entries)) {
+                array_push($entries, $attribute['value']);
+            }
+
+        }
+        $warninglist += array('list' => $entries);
+        $id = $this->Warninglist->import($warninglist);
+        
+        if($id && $id>0) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+}

--- a/app/Model/WorkflowModules/action/Module_add_to_warninglist.php
+++ b/app/Model/WorkflowModules/action/Module_add_to_warninglist.php
@@ -1,5 +1,5 @@
 <?php
-include_once APP . 'Model/WorkflowModules/action/Module_attribute_edition_operation.php';
+include_once APP . 'Model/WorkflowModules/action/WorkflowBaseActionModule.php';
 
 class Module_add_to_warninglist extends WorkflowBaseActionModule 
 {


### PR DESCRIPTION
#### What does it do?

This pull request adds a new workflow module for adding attributes to a custom (non-default) warninglist.

Possible use cases:

- Add an attribute to a warninglist when soft-deleted
![immagine](https://github.com/MISP/MISP/assets/32276363/3a980e0e-fe33-45d2-80c3-af4417084efb)

- Add an attribute to a warninglist when tagged with a specific tag

- Add attributes with false-positive sightings when an event is published/saved
![immagine](https://github.com/MISP/MISP/assets/32276363/c814209b-0af4-4e2e-9d58-db21ce651f47)

During tests I noticed that if appropriate logic checks are not added to the workflow, attributes not matching the warninglist type (e.g.: string in cidr warninglist) will be added without errors. At the moment, it is up to the user to properly add logic modules and filters to the workflow to avoid this. 

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
