### PR TITLE
fix:  loginAction illegal offeset

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -1182,9 +1182,7 @@ class AppController extends Controller
 
     private function _redirectToLogin()
     {
-        $targetRoute = $this->Auth->loginAction;
-        $targetRoute['admin'] = false;
-        $this->redirect($targetRoute);
+        $this->redirect($this->Auth->loginAction);
     }
 
     /**

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -111,7 +111,7 @@ class AppController extends Controller
 
         $this->_setupBaseurl();
         $this->Auth->loginRedirect = $this->baseurl . '/users/routeafterlogin';
-        $this->Auth->loginAction = $this->baseurl . '/users/login';
+        $this->Session->write('Auth.redirect', $this->baseurl . '/users/login');
 
         $customLogout = Configure::read('Plugin.CustomAuth_custom_logout');
         $this->Auth->logoutRedirect = $customLogout ?: ($this->baseurl . '/users/login');
@@ -1182,7 +1182,9 @@ class AppController extends Controller
 
     private function _redirectToLogin()
     {
-        $this->redirect($this->Auth->loginAction);
+        $targetRoute = $this->Auth->loginAction;
+        $targetRoute['admin'] = false;
+        $this->redirect($targetRoute);
     }
 
     /**


### PR DESCRIPTION
#### What does it do?

fixes CI, bug introduced by 015c5a4b9488bd115b57fef5649f9a60939f7d35
```
[Warning (2)](javascript:void(0);): Illegal string offset 'admin' [APP/Controller/AppController.php, line 1186]
[Warning (2)](javascript:void(0);): Cannot assign an empty string to a string offset [APP/Controller/AppController.php, line 1186]
```

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
