### PR TITLE
Fix /taxonomies/view string filter

### DIFF
--- a/app/Controller/TaxonomiesController.php
+++ b/app/Controller/TaxonomiesController.php
@@ -77,9 +77,6 @@ class TaxonomiesController extends AppController
         $urlparams = '';
         App::uses('CustomPaginationTool', 'Tools');
         $filter = isset($this->passedArgs['filter']) ? $this->passedArgs['filter'] : false;
-        if (isset($this->passedArgs['enabled'])) {
-            $options['enabled'] = $this->passedArgs['enabled'];
-        }
         $taxonomy = $this->Taxonomy->getTaxonomy($id, true, $filter);
         if (empty($taxonomy)) {
             throw new NotFoundException(__('Taxonomy not found.'));

--- a/app/Controller/TaxonomiesController.php
+++ b/app/Controller/TaxonomiesController.php
@@ -77,11 +77,10 @@ class TaxonomiesController extends AppController
         $urlparams = '';
         App::uses('CustomPaginationTool', 'Tools');
         $filter = isset($this->passedArgs['filter']) ? $this->passedArgs['filter'] : false;
-        $options = ['full' => true, 'filter' => $filter];
         if (isset($this->passedArgs['enabled'])) {
             $options['enabled'] = $this->passedArgs['enabled'];
         }
-        $taxonomy = $this->Taxonomy->getTaxonomy($id, $options);
+        $taxonomy = $this->Taxonomy->getTaxonomy($id, true, $filter);
         if (empty($taxonomy)) {
             throw new NotFoundException(__('Taxonomy not found.'));
         }

--- a/app/Model/Taxonomy.php
+++ b/app/Model/Taxonomy.php
@@ -179,9 +179,10 @@ class Taxonomy extends AppModel
 
     /**
      * @param int|string $id Taxonomy ID or namespace
+     * @param string|boolean $filter String to filter to apply to the tags
      * @return array|false
      */
-    private function __getTaxonomy($id)
+    private function __getTaxonomy($id, $filter = false)
     {
         if (!is_numeric($id)) {
             $conditions = ['Taxonomy.namespace' => trim(mb_strtolower($id))];
@@ -215,7 +216,9 @@ class Taxonomy extends AppModel
                     if (isset($entry['numerical_value'])) {
                         $temp['numerical_value'] = $entry['numerical_value'];
                     }
-                    $entries[] = $temp;
+                    if (empty($filter) || mb_strpos(mb_strtolower($temp['tag']), mb_strtolower($filter)) !== false) {
+                        $entries[] = $temp;
+                    }
                 }
             } else {
                 $temp = [
@@ -231,7 +234,9 @@ class Taxonomy extends AppModel
                 if (isset($predicate['numerical_value'])) {
                     $temp['numerical_value'] = $predicate['numerical_value'];
                 }
-                $entries[] = $temp;
+                if (empty($filter) || mb_strpos(mb_strtolower($temp['tag']), mb_strtolower($filter)) !== false) {
+                    $entries[] = $temp;
+                }
             }
         }
         $taxonomy = [
@@ -349,11 +354,12 @@ class Taxonomy extends AppModel
     /**
      * @param int|string $id Taxonomy ID or namespace
      * @param bool $full Add tag information to entries
+     * @param string|boolean $filter String filter to apply to the tag names
      * @return array|false
      */
-    public function getTaxonomy($id, $full = true)
+    public function getTaxonomy($id, $full = true, $filter = false)
     {
-        $taxonomy = $this->__getTaxonomy($id);
+        $taxonomy = $this->__getTaxonomy($id, $filter);
         if (empty($taxonomy)) {
             return false;
         }


### PR DESCRIPTION
#### What does it do?
re-implements `/taxonomies/view` string filter removed by 5da9497efdb5bde654811641523c23fce752f5b5
fixes #8875

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
