### PR TITLE
Fix event graph "Tag" scope

### DIFF
--- a/app/Lib/Tools/EventGraphTool.php
+++ b/app/Lib/Tools/EventGraphTool.php
@@ -372,6 +372,8 @@
                         'id' => 'tag_edge_id_' . $i,
                         'from' => $attr['id'],
                         'to' => $tag['name'],
+                        'type' => isset($tag['relationship_type']) ? $tag['relationship_type'] : '',
+                        'comment' => '',
                     );
                     $tagSet[$tag['name']] = $tag;
                     array_push($this->__json['relations'], $toPush);
@@ -410,6 +412,8 @@
                                 'id' => "tag_edge_id_" . $i,
                                 'from' => sprintf('o-%s', $obj['id']),
                                 'to' => $tag['name'],
+                                'type' => isset($tag['relationship_type']) ? $tag['relationship_type'] : '',
+                                'comment' => '',
                             );
                             $tagSet[$tag['name']] = $tag;
                             array_push($added_value, $tag['name']);

--- a/app/Lib/Tools/EventGraphTool.php
+++ b/app/Lib/Tools/EventGraphTool.php
@@ -381,6 +381,7 @@
                 }
             }
 
+            $j = 0;
             foreach ($object as $obj) {
                 $toPush = array(
                     'id' => sprintf('o-%s', $obj['id']),
@@ -395,22 +396,41 @@
                     'comment' => $obj['comment'],
                 );
                 array_push($this->__json['items'], $toPush);
-
-                // Record existing object_relation
-                foreach ($obj['Attribute'] as $attr) {
-                    $this->__json['existing_object_relation'][$attr['object_relation']] = 0; // set-alike
-                }
-
-                // get all tags in the Object's Attributes
+                
+                
+                // get all  attributes and tags in the Object's Attributes
                 $added_value = array();
                 foreach ($obj['Attribute'] as $ObjAttr) {
+                    // Record existing object_relation
+                    $this->__json['existing_object_relation'][$attr['object_relation']] = 0; // set-alike
                     $Tags = $ObjAttr['AttributeTag'];
                     foreach ($Tags as $tag) {
                         $tag = $tag['Tag'];
                         if (!in_array($tag['name'], $added_value)) {
                             $toPush = array(
-                                'id' => "tag_edge_id_" . $i,
+                                'id' => $ObjAttr['id'],
+                                'uuid' => $ObjAttr['uuid'],
+                                'type' => $ObjAttr['type'],
+                                'label' => $ObjAttr['value'],
+                                'event_id' => $ObjAttr['event_id'],
+                                'node_type' => 'attribute',
+                                'comment' => $ObjAttr['comment'],
+                            );
+                            array_push($this->__json['items'], $toPush);
+                            
+                            $toPush = array(
+                                'id' => 'obj_edge_id_' . $j,
                                 'from' => sprintf('o-%s', $obj['id']),
+                                'to' => $ObjAttr['id'],
+                                'type' => '',
+                                'comment' => '',
+                            );
+                            $j = $j + 1;
+                            array_push($this->__json['relations'], $toPush);
+
+                            $toPush = array(
+                                'id' => "tag_edge_id_" . $i,
+                                'from' => $ObjAttr['id'],
                                 'to' => $tag['name'],
                                 'type' => isset($tag['relationship_type']) ? $tag['relationship_type'] : '',
                                 'comment' => '',


### PR DESCRIPTION
#### What does it do?

This pull request fixes an issue encountered when trying to display the Event graph with "Tag" scope. Specifically, the graph is not displayed correctly and loading never completes.

![Screenshot from 2023-08-10 18-03-08](https://github.com/MISP/MISP/assets/32276363/e39afe0a-a403-4b85-bff1-0b77a3ec71b4)


The issue is caused by the lack of definition of the properties "type" and "comment" in the relationships between attributes and tags.

![immagine](https://github.com/MISP/MISP/assets/32276363/b132551b-5e58-48d1-98bd-e8bd0adcdba0)

By solving this bug, I found that when an object's attribute is tagged, the tags are attached to the object within the graph. My idea was to show only the tagged attributes along with the objects they belong to

![immagine](https://github.com/MISP/MISP/assets/32276363/5a4ae10b-903d-47c6-bae0-329b12b5cfdf)


#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
