### PR TITLE
new: [Users] add last password change timestamp for users

### DIFF
--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -301,6 +301,7 @@ class UsersController extends AppController
             // What fields should be saved (allowed to be saved)
             $user['User']['change_pw'] = 0;
             $user['User']['password'] = $this->request->data['User']['password'];
+            $user['User']['last_pw_change'] = time();
             if ($this->_isRest()) {
                 $user['User']['confirm_password'] = $this->request->data['User']['password'];
             } else {
@@ -475,7 +476,8 @@ class UsersController extends AppController
                     'last_api_access',
                     'force_logout',
                     'date_created',
-                    'date_modified'
+                    'date_modified',
+                    'last_pw_change'
                 ),
                 'contain' => array(
                     'Organisation' => array('id', 'name'),
@@ -687,6 +689,7 @@ class UsersController extends AppController
                 }
             }
             $this->request->data['User']['date_created'] = time();
+            $this->request->data['User']['last_pw_change'] = $this->request->data['User']['date_created'];
             if (!array_key_exists($this->request->data['User']['role_id'], $syncRoles)) {
                 $this->request->data['User']['server_id'] = 0;
             }
@@ -758,7 +761,7 @@ class UsersController extends AppController
                         $this->Flash->error(__('The user could not be saved. Invalid organisation.'));
                     }
                 } else {
-                    $fieldList = array('password', 'email', 'external_auth_required', 'external_auth_key', 'enable_password', 'confirm_password', 'org_id', 'role_id', 'authkey', 'nids_sid', 'server_id', 'gpgkey', 'certif_public', 'autoalert', 'contactalert', 'disabled', 'invited_by', 'change_pw', 'termsaccepted', 'newsread', 'date_created', 'date_modified');
+                    $fieldList = array('password', 'email', 'external_auth_required', 'external_auth_key', 'enable_password', 'confirm_password', 'org_id', 'role_id', 'authkey', 'nids_sid', 'server_id', 'gpgkey', 'certif_public', 'autoalert', 'contactalert', 'disabled', 'invited_by', 'change_pw', 'termsaccepted', 'newsread', 'date_created', 'date_modified', 'last_pw_change');
                     if ($this->User->save($this->request->data, true, $fieldList)) {
                         $notification_message = '';
                         if (!empty($this->request->data['User']['notify'])) {
@@ -953,6 +956,8 @@ class UsersController extends AppController
                     $this->__canChangePassword()
                 ) {
                     $fields[] = 'password';
+                    $fields[] = 'last_pw_change';
+                    $this->request->data['User']['last_pw_change'] = time();
                     if ($this->_isRest() && !isset($this->request->data['User']['confirm_password'])) {
                         $this->request->data['User']['confirm_password'] = $this->request->data['User']['password'];
                         $fields[] = 'confirm_password';

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -85,7 +85,7 @@ class AppModel extends Model
         93 => false, 94 => false, 95 => true, 96 => false, 97 => true, 98 => false,
         99 => false, 100 => false, 101 => false, 102 => false, 103 => false, 104 => false,
         105 => false, 106 => false, 107 => false, 108 => false, 109 => false, 110 => false,
-        111 => false, 112 => false, 113 => true, 114 => false
+        111 => false, 112 => false, 113 => true, 114 => false, 115 => false
     );
 
     const ADVANCED_UPDATES_DESCRIPTION = array(
@@ -1972,6 +1972,10 @@ class AppModel extends Model
                 break;
             case 114:
                 $indexArray[] = ['object_references', 'uuid'];
+                break;
+            case 115:
+                $sqlArray[] = "ALTER TABLE `users` ADD COLUMN `last_pw_change` BIGINT(20) NULL DEFAULT NULL;";
+                $sqlArray[] = "UPDATE `users` SET last_pw_change=date_modified WHERE last_pw_change IS NULL";
                 break;
             case 'fixNonEmptySharingGroupID':
                 $sqlArray[] = 'UPDATE `events` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -984,6 +984,7 @@ class User extends AppModel
         if ($result) {
             $this->id = $user['User']['id'];
             $this->saveField('password', $password);
+            $this->saveField('last_pw_change', time());
             $this->updateField($user['User'], 'change_pw', 1);
             if ($simpleReturn) {
                 return true;

--- a/app/View/Users/view.ctp
+++ b/app/View/Users/view.ctp
@@ -157,6 +157,10 @@ if ($admin_view && $isSiteAdmin && $isTotp) {
         'key' => __('Created'),
         'html' => $user['User']['date_created'] ? $this->Time->time($user['User']['date_created']) : __('N/A')
     );
+    $table_data[] = array(
+        'key' => __('Last password change'),
+        'html' => $user['User']['last_pw_change'] ? $this->Time->time($user['User']['last_pw_change']) : __('N/A')
+    );
     if ($admin_view) {
         $table_data[] = array(
             'key' => __('News read at'),

--- a/db_schema.json
+++ b/db_schema.json
@@ -8612,6 +8612,17 @@
                 "column_type": "int(11)",
                 "column_default": "NULL",
                 "extra": ""
+            },
+            {
+                "column_name": "last_pw_change",
+                "is_nullable": "YES",
+                "data_type": "bigint",
+                "character_maximum_length": null,
+                "numeric_precision": "19",
+                "collation_name": null,
+                "column_type": "bigint(20)",
+                "column_default": "NULL",
+                "extra": ""
             }
         ],
         "user_settings": [
@@ -9549,5 +9560,5 @@
             "uuid": false
         }
     },
-    "db_version": "114"
+    "db_version": "115"
 }

--- a/tests/testlive_comprehensive_local.py
+++ b/tests/testlive_comprehensive_local.py
@@ -10,6 +10,7 @@ import time
 from xml.etree import ElementTree as ET
 from io import BytesIO
 import urllib3  # type: ignore
+from datetime import datetime, timedelta
 
 import logging
 logging.disable(logging.CRITICAL)
@@ -972,6 +973,114 @@ class TestComprehensive(unittest.TestCase):
         response = self.admin_misp_connector._check_response(response)
         check_response(response)
         return response
+
+
+class TestLastPwChange(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.admin_misp_connector = PyMISP(url, key)
+
+        organisation = MISPOrganisation()
+        organisation.name = 'Test org for last pw change tests'
+        cls.test_org = cls.admin_misp_connector.add_organisation(organisation, pythonify=True)
+        check_response(cls.test_org)
+        cls.test_org_id = cls.test_org.id
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.admin_misp_connector.delete_organisation(cls.test_org)
+
+    def setUp(self) -> None:
+        self.admin_misp_connector = type(self).admin_misp_connector
+
+        # Create a user
+        user = MISPUser()
+        user.email = 'testusr_last_pw_change@user' + gen_random_id() + '.local'  # make name always unique
+        user.org_id = type(self).test_org_id
+        user.role_id = 3  # User role
+        user.password = str(uuid.uuid4())
+        self.test_usr = self.admin_misp_connector.add_user(user, pythonify=True)
+        check_response(self.test_usr)
+        self.test_usr_misp_connector = PyMISP(url, self.test_usr.authkey)
+
+    def tearDown(self) -> None:
+        # Delete Authkey and user
+        body = {
+            "authkey_start": self.test_usr.authkey[0:4],
+            "authkey_end": self.test_usr.authkey[-4:],
+            "User.id": self.test_usr.id
+        }
+        auth_key = type(self).admin_misp_connector.direct_call('auth_keys', body)
+        check_response(auth_key)
+        if len(auth_key) == 1 and "AuthKey" in auth_key[0]:
+            type(self).admin_misp_connector.direct_call(f'auth_keys/delete/{auth_key[0]["AuthKey"]["id"]}', {})
+
+        type(self).admin_misp_connector.delete_user(self.test_usr)
+
+    def test_new_user_last_pw_change_is_date_created(self):
+        self.assertEqual(self.test_usr.last_pw_change, self.test_usr.date_created)
+
+    def test_admin_edit_password_updates_last_pw_change(self):
+        old_last_pw_change = self.test_usr.last_pw_change
+
+        # edit user password
+        self.test_usr.password = uuid.uuid4()
+        time_just_before_update = datetime.now()
+        self.updated_test_usr = self.admin_misp_connector.update_user(self.test_usr, pythonify=True)
+        time_just_after_update = datetime.now()
+        check_response(self.updated_test_usr)
+
+        self.check_last_pw_change_timestamp(old_last_pw_change, time_just_before_update, time_just_after_update)
+
+    def test_user_change_password_updates_last_pw_change(self):
+        old_last_pw_change = self.test_usr.last_pw_change
+
+        # edit user password
+        time_just_before_update = datetime.now()
+        change_password_result = self.test_usr_misp_connector.change_user_password(uuid.uuid4())
+        time_just_after_update = datetime.now()
+        check_response(change_password_result)
+        self.updated_test_usr = self.test_usr_misp_connector.get_user(pythonify=True)
+        check_response(self.updated_test_usr)
+
+        self.check_last_pw_change_timestamp(old_last_pw_change, time_just_before_update, time_just_after_update)
+
+    def test_reset_user_password_updates_last_pw_change(self):
+        old_last_pw_change = self.test_usr.last_pw_change
+
+        # reset user password
+        time_just_before_update = datetime.now()
+        self.admin_misp_connector.direct_call(f'users/initiatePasswordReset/{self.test_usr.id}', {})
+        time.sleep(1)
+        time_just_after_update = datetime.now()
+        self.updated_test_usr = self.test_usr_misp_connector.get_user(pythonify=True)
+        check_response(self.updated_test_usr)
+
+        self.check_last_pw_change_timestamp(old_last_pw_change, time_just_before_update, time_just_after_update)
+
+    def last_pw_change_almost_equal_to_date_modified(self):
+        date_modified = datetime.fromtimestamp(int(self.updated_test_usr.date_modified))
+        last_pw_change = datetime.fromtimestamp(int(self.updated_test_usr.last_pw_change))
+        return date_modified - last_pw_change < timedelta(milliseconds=5)
+
+    def last_pw_change_time_is_in_expected_range(self, time_just_before_update, time_just_after_update):
+        timediff_last_pw_change_now = datetime.fromtimestamp(int(self.updated_test_usr.last_pw_change)) - time_just_before_update
+        max_accepted_timediff = time_just_after_update - time_just_before_update
+        return timediff_last_pw_change_now <= max_accepted_timediff
+
+    def check_last_pw_change_timestamp(self, old_last_pw_change, time_just_before_update, time_just_after_update):
+        # check if new last_pw_change timestamp looks okay, starting with fact that it should be newer than previous one
+        self.assertGreater(self.updated_test_usr.last_pw_change, old_last_pw_change)
+
+        # last pw change should be set to timestamp sometime between time_just_before_update and time_just_after_update
+        self.assertTrue(self.last_pw_change_time_is_in_expected_range(time_just_before_update, time_just_after_update))
+
+        # last_pw_change should be relatively close to date_modified
+        self.assertTrue(self.last_pw_change_almost_equal_to_date_modified())
+
+
+def gen_random_id() -> str:
+    return str(uuid.uuid4()).split("-")[0]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Creating PR for an initial review / input if possible. Don't think it's ready as-is.
Still testing myself, note that I didn't test the db update part with MISP update procedure yet.

If you see an opportunity to finish / fix this from your end please feel free.

#### What does it do?

Adds a last_pw_change timestamp for users.
Idea is to use it to trigger a password change on next login after a specific time (will create a cli command and/or pymisp script for this).

For existing users, the last_pw_change timestamp would initially be set to date_modified. This feels like the best option at the moment.

#### Questions

- [x] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
