### PR TITLE
Add cli cmd to trigger pw change for old pws

### DIFF
--- a/app/Console/Command/UserShell.php
+++ b/app/Console/Command/UserShell.php
@@ -104,6 +104,14 @@ class UserShell extends AppShell
                 ],
             ],
         ]);
+        $parser->addSubcommand('require_password_change_for_old_passwords', [
+            'help' => __('Trigger forced password change on next login for users with an old (older than x days) password.'),
+            'parser' => [
+                'arguments' => [
+                    'days' => ['help' => __('Amount of days after which a password is considered "old" and needs to be changed.'), 'required' => true]
+                ],
+            ]
+        ]);
         return $parser;
     }
 
@@ -428,6 +436,35 @@ class UserShell extends AppShell
                 '%s==============================%sIP: %s%s==============================%sUser #%s: %s%s==============================%s',
                 PHP_EOL, PHP_EOL, $ip, PHP_EOL, PHP_EOL, $user['User']['id'], $user['User']['email'], PHP_EOL, PHP_EOL
             ));
+        }
+    }
+
+    public function require_password_change_for_old_passwords(){
+        list($days) = $this->args;
+        if(!is_numeric($days)){
+            $this->error("The amount of days after which a password change is required (the argument) should be numeric.");
+        }
+        $interval  = 'P' . $days . 'D';
+
+        $current_time = new DateTime();
+        $time_before_change_required = $current_time->sub(new DateInterval($interval))->getTimestamp();
+        $users = $this->User->find('all', [
+            'conditions' => [
+                'OR' => [
+                    'last_pw_change <' => $time_before_change_required
+                ]
+            ],
+            'fields' => ['id'],
+            'recursive' => 0
+        ]);
+        foreach ($users as $user) {
+            $user['User']['change_pw'] = true;
+            $userId = $user['User']['id'];
+            if (!$this->User->save($user['User'], true, ["change_pw"])) {
+                $this->out("Could not update user $userId.");
+                $this->out($this->json($this->User->validationErrors));
+                $this->_stop(self::CODE_ERROR);
+            }
         }
     }
 

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -301,6 +301,7 @@ class UsersController extends AppController
             // What fields should be saved (allowed to be saved)
             $user['User']['change_pw'] = 0;
             $user['User']['password'] = $this->request->data['User']['password'];
+            $user['User']['last_pw_change'] = time();
             if ($this->_isRest()) {
                 $user['User']['confirm_password'] = $this->request->data['User']['password'];
             } else {
@@ -475,7 +476,8 @@ class UsersController extends AppController
                     'last_api_access',
                     'force_logout',
                     'date_created',
-                    'date_modified'
+                    'date_modified',
+                    'last_pw_change'
                 ),
                 'contain' => array(
                     'Organisation' => array('id', 'name'),
@@ -687,6 +689,7 @@ class UsersController extends AppController
                 }
             }
             $this->request->data['User']['date_created'] = time();
+            $this->request->data['User']['last_pw_change'] = $this->request->data['User']['date_created'];
             if (!array_key_exists($this->request->data['User']['role_id'], $syncRoles)) {
                 $this->request->data['User']['server_id'] = 0;
             }
@@ -758,7 +761,7 @@ class UsersController extends AppController
                         $this->Flash->error(__('The user could not be saved. Invalid organisation.'));
                     }
                 } else {
-                    $fieldList = array('password', 'email', 'external_auth_required', 'external_auth_key', 'enable_password', 'confirm_password', 'org_id', 'role_id', 'authkey', 'nids_sid', 'server_id', 'gpgkey', 'certif_public', 'autoalert', 'contactalert', 'disabled', 'invited_by', 'change_pw', 'termsaccepted', 'newsread', 'date_created', 'date_modified');
+                    $fieldList = array('password', 'email', 'external_auth_required', 'external_auth_key', 'enable_password', 'confirm_password', 'org_id', 'role_id', 'authkey', 'nids_sid', 'server_id', 'gpgkey', 'certif_public', 'autoalert', 'contactalert', 'disabled', 'invited_by', 'change_pw', 'termsaccepted', 'newsread', 'date_created', 'date_modified', 'last_pw_change');
                     if ($this->User->save($this->request->data, true, $fieldList)) {
                         $notification_message = '';
                         if (!empty($this->request->data['User']['notify'])) {
@@ -953,6 +956,8 @@ class UsersController extends AppController
                     $this->__canChangePassword()
                 ) {
                     $fields[] = 'password';
+                    $fields[] = 'last_pw_change';
+                    $this->request->data['User']['last_pw_change'] = time();
                     if ($this->_isRest() && !isset($this->request->data['User']['confirm_password'])) {
                         $this->request->data['User']['confirm_password'] = $this->request->data['User']['password'];
                         $fields[] = 'confirm_password';

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -85,7 +85,7 @@ class AppModel extends Model
         93 => false, 94 => false, 95 => true, 96 => false, 97 => true, 98 => false,
         99 => false, 100 => false, 101 => false, 102 => false, 103 => false, 104 => false,
         105 => false, 106 => false, 107 => false, 108 => false, 109 => false, 110 => false,
-        111 => false, 112 => false, 113 => true, 114 => false
+        111 => false, 112 => false, 113 => true, 114 => false, 115 => false
     );
 
     const ADVANCED_UPDATES_DESCRIPTION = array(
@@ -1972,6 +1972,10 @@ class AppModel extends Model
                 break;
             case 114:
                 $indexArray[] = ['object_references', 'uuid'];
+                break;
+            case 115:
+                $sqlArray[] = "ALTER TABLE `users` ADD COLUMN `last_pw_change` BIGINT(20) NULL DEFAULT NULL;";
+                $sqlArray[] = "UPDATE `users` SET last_pw_change=date_modified WHERE last_pw_change IS NULL";
                 break;
             case 'fixNonEmptySharingGroupID':
                 $sqlArray[] = 'UPDATE `events` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';

--- a/app/View/Users/view.ctp
+++ b/app/View/Users/view.ctp
@@ -157,6 +157,10 @@ if ($admin_view && $isSiteAdmin && $isTotp) {
         'key' => __('Created'),
         'html' => $user['User']['date_created'] ? $this->Time->time($user['User']['date_created']) : __('N/A')
     );
+    $table_data[] = array(
+        'key' => __('Last password change'),
+        'html' => $user['User']['last_pw_change'] ? $this->Time->time($user['User']['last_pw_change']) : __('N/A')
+    );
     if ($admin_view) {
         $table_data[] = array(
             'key' => __('News read at'),

--- a/db_schema.json
+++ b/db_schema.json
@@ -8612,6 +8612,17 @@
                 "column_type": "int(11)",
                 "column_default": "NULL",
                 "extra": ""
+            },
+            {
+                "column_name": "last_pw_change",
+                "is_nullable": "YES",
+                "data_type": "bigint",
+                "character_maximum_length": null,
+                "numeric_precision": "19",
+                "collation_name": null,
+                "column_type": "bigint(20)",
+                "column_default": "NULL",
+                "extra": ""
             }
         ],
         "user_settings": [
@@ -9549,5 +9560,5 @@
             "uuid": false
         }
     },
-    "db_version": "114"
+    "db_version": "115"
 }


### PR DESCRIPTION
#### What does it do?

This is a companion to #9254
Idea is to trigger a password change on next login after a specific time.
This is a proposal for related cli command.

I'm including the commit from the other PR here to make it easier to test / verify.

example SQL query to set time stamp for testing (I used 30 days for test):
UPDATE users SET last_pw_change=UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL 29 day)) WHERE email='last_pw_change_29_days_ago@test.test';
UPDATE users SET last_pw_change=UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL 31 day)) WHERE email='last_pw_change_31_days_ago@test.test';

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
