### PR TITLE
Pin python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,19 @@
-pyzmq
-coveralls
-codecov
-stix
-pymisp
-requests-mock
-pip
-nose
+cybox>=2.1.0.21
 jsonschema
-plyara >= 2.0.2
+lief>=0.13.1
+maec>=4.1.0.17
+misp-lib-stix2>=3.0.0
+mixbox>=1.0.5
+plyara>=2.0.2
+pydeep2>=0.5.1
+pymisp==2.4.175
+python-magic
+pyzmq
+redis
+stix>=1.2.0.11
+# test dependencies
+codecov
+coveralls
+nose
+pip
+requests-mock


### PR DESCRIPTION
Pin python dependencies (minimum versions as per diagnostic page and/or urgent fixes)

Open questions:
- Should I remove pip from list of dependencies used (theoretically) by tests?
- Should I change the doc and edit the install script?
- Should I split requirements.txt into two files (so the two sets of dependencies are separate)?





