### PR TITLE
fix: [AuthKeys] Allow users to edit own authkeys, fix #9292

### DIFF
--- a/app/Controller/AuthKeysController.php
+++ b/app/Controller/AuthKeysController.php
@@ -279,6 +279,7 @@ class AuthKeysController extends AppController
             'conditions' => [
                 'AuthKey.id' => $key_id
             ]]);
+        if(!empty($user_id)) $user_id = $user_id[0];
         return $this->__canCreateAuthKeyForUser($user_id);
     }
 }


### PR DESCRIPTION
#### What does it do?

fix #9292

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
