### PR TITLE
fix: [RestSearch] allow filtering on eventinfo for events and attributes again

### DIFF
--- a/app/Controller/Component/RestSearchComponent.php
+++ b/app/Controller/Component/RestSearchComponent.php
@@ -13,13 +13,13 @@ class RestSearchComponent extends Component
             'includeProposals', 'returnFormat', 'limit', 'page', 'requested_attributes', 'includeContext', 'headerless',
             'includeWarninglistHits', 'attackGalaxy', 'object_relation', 'includeSightings', 'includeCorrelations', 'includeDecayScore',
             'decayingModel', 'excludeDecayed', 'modelOverrides', 'includeFullModel', 'score', 'attribute_timestamp', 'first_seen', 'last_seen',
-            'threat_level_id'
+            'threat_level_id', 'eventinfo'
         ),
         'Event' => array(
             'returnFormat', 'value', 'type', 'category', 'org', 'tags', 'searchall', 'from', 'to', 'last', 'eventid', 'withAttachments',
             'metadata', 'uuid', 'publish_timestamp', 'timestamp', 'published', 'enforceWarninglist', 'sgReferenceOnly',
             'limit', 'page', 'requested_attributes', 'includeContext', 'headerless', 'includeWarninglistHits', 'attackGalaxy', 'to_ids', 'deleted',
-            'excludeLocalTags', 'date', 'includeSightingdb', 'tag', 'object_relation', 'threat_level_id'
+            'excludeLocalTags', 'date', 'includeSightingdb', 'tag', 'object_relation', 'threat_level_id', 'eventinfo'
         ),
         'Object' => array(
             'returnFormat', 'value' , 'type', 'category', 'org', 'tags', 'from', 'to', 'last', 'eventid', 'withAttachments', 'uuid', 'publish_timestamp',


### PR DESCRIPTION
#### What does it do?

You might want to include this in 2.4 directly.
It used to be possible to filter on eventinfo when using /events/restsearch and /attributes/restsearch. Now the filter is simply ignored (which can lead to some bad stuff, if the results are used for other operations).
I'm guessing 37ecf81b84a01baa4d4b1fade4de94a9018c32ed broke it. Not (yet) sure if some other filters are affected as well, would be nice if someone can double check and fix those if necessary.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
