### PR TITLE
[users] fix user view totp delete checks

### DIFF
--- a/app/View/Users/view.ctp
+++ b/app/View/Users/view.ctp
@@ -27,12 +27,12 @@ $totpHtml = $boolean;
 $totpHtml .= (!$isTotp && !$admin_view ? $this->Html->link(__('Generate'), array('action' => 'totp_new')) : '');
 $totpHtml .= ($isTotp && !$admin_view ? $this->Html->link(__('View paper tokens'), array('action' => 'hotp', $user['User']['id'])): '');
 
-if ($admin_view && $isSiteAdmin && $isTotp) {
+if ($isAdmin && $isTotp) {
     $totpHtml .= sprintf(
         '<a href="#" onClick="openGenericModal(\'%s/users/totp_delete/%s\')">%s</a>',
         h($baseurl),
         h($user['User']['id']),
-        __('Delete')
+        __($isTotp && !$admin_view ? ' Delete' : 'Delete')
     );
 }
     $table_data = [


### PR DESCRIPTION
#### What does it do?

fixes:

- Org admins can delete totp for users, but the link doesn't show up in the view.
screenshot after the change:
![2023-09-27 14_59_41-misp-dev - VMware Workstation](https://github.com/MISP/MISP/assets/9868873/2985367d-bd99-442c-be3e-09f8a0623ddb)

- The delete link doesn't show up on your own profile view when you are site admin or org admin

Granted, the my profile page doesn't look very nice this way when you have totp (two links next to each other). If you have an easy fix to make it look better... would be welcome:
![2023-09-27 14_35_18-misp-dev - VMware Workstation](https://github.com/MISP/MISP/assets/9868873/1de1e6c3-90fe-4bc2-adb0-035a0a069d55)


#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
