### PR TITLE
[users:totp] set correct rest response action for totp_delete

### DIFF
--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -1931,7 +1931,7 @@ class UsersController extends AppController
                 $fieldsDescrStr = 'User (' . $id . '): ' . $user['User']['email'] . ' TOTP deleted';
                 $this->User->extralog($this->Auth->user(), "update", $fieldsDescrStr, '');
                 if ($this->_isRest()) {
-                    return $this->RestResponse->saveSuccessResponse('User', 'admin_totp_delete', $id, $this->response->type(), 'User TOTP deleted.');
+                    return $this->RestResponse->saveSuccessResponse('User', 'totp_delete', $id, $this->response->type(), 'User TOTP deleted.');
                 } else {
                     $this->Flash->success(__('User TOTP deleted'));
                     $this->redirect('/admin/users/index');


### PR DESCRIPTION
#### What does it do?

Fixes likely typo in the rest response action for totp_delete. As far as I can see the action is totp_delete and not admin_totp_delete.

perhaps @cvandeplas can review this / confirm.

Doesn't really cause issues though it just changes the resulting message:
![image](https://github.com/MISP/MISP/assets/9868873/9560c675-08eb-4f0f-bfb8-3df751d05cfd)

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
