### PR TITLE
fix: [Taxonomies] fix enabling of individual taxonomy tags for tags w…

### DIFF
--- a/app/Model/Taxonomy.php
+++ b/app/Model/Taxonomy.php
@@ -445,11 +445,11 @@ class Taxonomy extends AppModel
             }
             if ($tagList) {
                 foreach ($tagList as $tagName) {
-                    if ($tagName === $entry['tag']) {
+                    if ($tagName === $entry['tag'] || $tagName === h($entry['tag'])) {
                         if (isset($tags[strtoupper($entry['tag'])])) {
-                            $this->Tag->quickEdit($tags[strtoupper($entry['tag'])], $tagName, $colour, 0, $numerical_value);
+                            $this->Tag->quickEdit($tags[strtoupper($entry['tag'])], $entry['tag'], $colour, 0, $numerical_value);
                         } else {
-                            $this->Tag->quickAdd($tagName, $colour, $numerical_value);
+                            $this->Tag->quickAdd($entry['tag'], $colour, $numerical_value);
                         }
                     }
                 }


### PR DESCRIPTION
…ith special chars. fixes #9300

#### What does it do?

proposal to fix #9300 , or at least the part about enabling individual taxonomy tags.

IndexTable actions view (actions.ctp) has this line for onclick params:
$temp[] = h($k) . ':' . urlencode(h($extracted_value[0]));


resulting in urls like these for the onclick action in case of tags with double quotes " (note the \&quot; for quotes): /taxonomies/addTag/taxonomy_id:166/name:workflow%3Astate%3D%26quot%3Bcomplete%26quot%3B

Basically MISP is/was comparing a html encoded version with the non encoded one stored in db, which results in no match.
Added a second check so these values are accepted by taxonomy addTags as well. Modified 2 other lines so that when there is resulting match, it uses the _taxonomy_ version of the tag name (those end up in $entry['tag'].

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
