### PR TITLE
Regression - Rest search with 'attributes' controller no longer filters by sharing group ID

### DIFF
--- a/app/Controller/Component/RestSearchComponent.php
+++ b/app/Controller/Component/RestSearchComponent.php
@@ -52,6 +52,7 @@ class RestSearchComponent extends Component
             'first_seen',
             'last_seen',
             'eventinfo',
+            'sharinggroup',
             'allow_proposal_blocking',
             'flatten',
             'list',


### PR DESCRIPTION
#### What does it do?
Fixes a regression that occurred during REST API improvements that stopped the 'attributes' filtering by Sharing Group (using the `sharinggroup` parameter)

Appears to be as simple as exposing `sharinggroup` as an allowed parameter for an Attribute REST.

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
