### PR TITLE
new: [User] Add setting to limit site admin roles to instance's host …

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -6407,6 +6407,14 @@ class Server extends AppModel
                     'type' => 'boolean',
                     'null' => true
                 ),
+                'limit_site_admins_to_host_org' => array(
+                    'level' => self::SETTING_RECOMMENDED,
+                    'description' => __('If enabled, it will only be possible to assign site admin roles to users belonging to the instance\'s host org.'),
+                    'value' => false,
+                    'test' => 'testBool',
+                    'type' => 'boolean',
+                    'null' => true
+                ),
                 'disable_browser_cache' => array(
                     'level' => 0,
                     'description' => __('If enabled, HTTP headers that block browser cache will be send. Static files (like images or JavaScripts) will still be cached, but not generated pages.'),

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -262,6 +262,16 @@ class User extends AppModel
         if (empty($user['nids_sid'])) {
             $user['nids_sid'] = mt_rand(1000000, 9999999);
         }
+        if (!empty(Configure::read('Security.limit_site_admins_to_host_org'))){
+            if (!empty($user['role_id']) and !empty($user['org_id'] and $user['org_id'] != Configure::read('MISP.host_org_id'))){
+                $role = $this->Role->find('first', array(
+                    'conditions' => array('Role.id' => $user['role_id'])
+                ));
+                if (!empty($role) and $role['Role']['perm_site_admin'] === true){
+                    $this->invalidate('role_id', "Site admin roles can only be assigned to users of the host org on this instance.");
+                }
+            }
+        }
         return true;
     }
 


### PR DESCRIPTION
…org.

#### What does it do?

Adds a setting which, if set to true, will prevent assigning a site admin role to users that do not belong to the host org of the instance. This is mainly to prevent some potential oopsies.
I made it a recommended setting because my assumption is that on most instances, site admins belong to the host org.

I didn't make the role selection list conditional for the form, because:

1. I think it might be nicer that you actually get a message indicating that it's a setting on this instance that prevents you from assigning site admin role to specific user.
2. It's not something I know how to do straightaway at the moment (still getting back into php/js coding, getting more familiar with cakephp is on my todo as well)

That being said, I think it would be nice to get a warning message on the form, when about to grant site admin role to a non host org user. So I'll keep that in the back of my mind for a future improvement.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
