### PR TITLE
chg: [user] Update store api access time setting description

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -5615,7 +5615,7 @@ class Server extends AppModel
                 ),
                 'store_api_access_time' => array(
                     'level' => 1,
-                    'description' => __('If enabled, MISP will capture the last API access time following a successful authentication using API keys, stored against a user under the last_api_access field.'),
+                    'description' => __('If enabled, MISP will capture a users\' last API access time following every successful authentication using API keys (as opposed to once max per hour by default). Stored as last_api_access time for the user.'),
                     'value' => false,
                     'test' => 'testBool',
                     'type' => 'boolean',


### PR DESCRIPTION
Api access time is stored once per hour by default (since commit a5f5a4e113872a77d4e6c2b1a125f03ee89773c2), making the old description of this setting incorrect.


#### What does it do?

Changes the relevant setting description.

@cvandeplas , if my understanding of commit a5f5a4e113872a77d4e6c2b1a125f03ee89773c2 is correct, last_api_access is logged for users by default (once per hour max), so this description of the setting would be better in my opinion.

Unfortunately the name of the setting is now misleading, but I guess there is no way to change it without affecting people that already use it?

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
