### PR TITLE
chg: [RestClient] use http_method value from template if available

### DIFF
--- a/app/webroot/js/restClient.js
+++ b/app/webroot/js/restClient.js
@@ -165,7 +165,11 @@ var debounceTimerUpdate;
             var previously_selected_template = $('#ServerUrl').data('urlWithoutParam')
             if (selected_template !== '' && allValidApis[selected_template] !== undefined) {
                 $('#template_description').show();
-                $('#ServerMethod').val('POST');
+                if(allValidApis[selected_template].http_method !== undefined){
+                    $('#ServerMethod').val(allValidApis[selected_template].http_method);
+                } else {
+                    $('#ServerMethod').val('POST');
+                }
                 var server_url_changed = $('#ServerUrl').val() != allValidApis[selected_template].url;
                 $('#ServerUrl')
                     .val(allValidApis[selected_template].url)


### PR DESCRIPTION
#### What does it do?

Some templates for the restclient have a http_method defined, but they are not set properly when using the query builder.

An example is Feed previewIndex with http_method GET.
Still keeping POST as default for the ones that don't have it specifically defined.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
