### PR TITLE
new: [RestClient] Add user totp_delete to query builder

### DIFF
--- a/app/Controller/Component/RestResponseComponent.php
+++ b/app/Controller/Component/RestResponseComponent.php
@@ -323,6 +323,11 @@ class RestResponseComponent extends Component
                 'description' => 'Simply GET the url endpoint to view the API output of the statistics API. Additional statistics are available via the following tab-options similar to the UI: data, orgs, users, tags, attributehistogram, sightings, attackMatrix',
                 'params' => array('tab'),
                 'http_method' => 'GET'
+            ),
+            'totp_delete' => array(
+                'description' => 'Simply do a DELETE or POST request to the url',
+                'params' => array('user_id'),
+                'http_method' => 'DELETE'
             )
         ),
         'UserSetting' => array(


### PR DESCRIPTION
#### What does it do?

Adds user totp delete to restclient query builder

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
