### PR TITLE
3.x: github actions cache docker build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,17 +32,17 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Build test containers
-        run: docker-compose -f docker-compose.yml -f docker-compose.dev.yml --env-file="./docker/.env.test" build
+      # - name: Build test containers
+      #   run: docker-compose -f docker-compose.yml -f docker-compose.dev.yml --env-file="./docker/.env.test" build
 
-      - name: Docker save cache
-        run: |
-          mkdir -p ${{ env.IMAGE_CACHE_DIR }}
-          docker save -o ${{ env.IMAGE_CACHE_DIR }}/misp3-image.tar misp3/php:8.2-fpm
-
-      # - name: Docker load
+      # - name: Docker save cache
       #   run: |
-      #     docker load --input ${{ env.IMAGE_CACHE_DIR }}/misp3-image.tar
+      #     mkdir -p ${{ env.IMAGE_CACHE_DIR }}
+      #     docker save -o ${{ env.IMAGE_CACHE_DIR }}/misp3-image.tar misp3/php:8.2-fpm
+
+      - name: Docker load
+        run: |
+          docker load --input ${{ env.IMAGE_CACHE_DIR }}/misp3-image.tar
 
       - name: Run tests
         run: docker-compose -f docker-compose.yml -f docker-compose.dev.yml --env-file="./docker/.env.test" run misp

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Docker save cache
         run: |
+          mkdir -p ${{ env.IMAGE_CACHE_DIR }}
           docker save -o ${{ env.IMAGE_CACHE_DIR }}/misp3-image.tar misp3/php:8.2-fpm
 
       # - name: Docker load

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,16 +4,29 @@ on:
   push:
     branches:
       - 3.x
+      - gh-actions-cache-docker-build
   pull_request:
     branches:
       - 3.x
 
+env:
+  IMAGE_CACHE_DIR: /tmp/cache/docker-image
+  IMAGE_CACHE_KEY: cache-image
+
 jobs:
   test:
-    timeout-minutes: 10
+    timeout-minutes: 20
     runs-on: ubuntu-latest
 
     steps:
+      - name: Declare Cache Registry
+        id: cache-docker-images
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.IMAGE_CACHE_DIR }}
+          key: ${{ runner.os }}-docker-images-test
+          # key: ${{ runner.os }}-docker-images-${{ needs.image-build-and-cache.outputs.sha }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -21,6 +34,14 @@ jobs:
 
       - name: Build test containers
         run: docker-compose -f docker-compose.yml -f docker-compose.dev.yml --env-file="./docker/.env.test" build
+
+      - name: Docker save cache
+        run: |
+          docker save -o ${{ env.IMAGE_CACHE_DIR }}/misp3-image.tar misp3/php:8.2-fpm
+
+      # - name: Docker load
+      #   run: |
+      #     docker load --input ${{ env.IMAGE_CACHE_DIR }}/misp3-image.tar
 
       - name: Run tests
         run: docker-compose -f docker-compose.yml -f docker-compose.dev.yml --env-file="./docker/.env.test" run misp

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,30 +19,34 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Declare Cache Registry
-        id: cache-docker-images
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.IMAGE_CACHE_DIR }}
-          key: ${{ runner.os }}-docker-images-test
-          # key: ${{ runner.os }}-docker-images-${{ needs.image-build-and-cache.outputs.sha }}
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      # - name: Build test containers
-      #   run: docker-compose -f docker-compose.yml -f docker-compose.dev.yml --env-file="./docker/.env.test" build
+      - name: Get last docker dir commit
+        id: docker-dir-commit
+        run: |
+          echo "::set-output name=sha::$(git log -n 1 --pretty=format:%h docker)"
 
-      # - name: Docker save cache
-      #   run: |
-      #     mkdir -p ${{ env.IMAGE_CACHE_DIR }}
-      #     docker save -o ${{ env.IMAGE_CACHE_DIR }}/misp3-image.tar misp3/php:8.2-fpm
+      - name: Cache docker images
+        id: cache-docker-images
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.IMAGE_CACHE_DIR }}
+          key: docker-images-test-${{ GITHUB_REF_NAME }}-${{ steps.docker-dir-commit.outputs.sha }}
 
-      # - name: Docker load
-      #   run: |
-      #     docker load --input ${{ env.IMAGE_CACHE_DIR }}/misp3-image.tar
+      - if: ${{ steps.cache-docker-images.outputs.cache-hit != 'true' }}
+        name: Build test containers and save cache
+        run: |
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml --env-file="./docker/.env.test" build
+          mkdir -p ${{ env.IMAGE_CACHE_DIR }}
+          docker save -o ${{ env.IMAGE_CACHE_DIR }}/misp3-image.tar misp3/php:8.2-fpm
+
+      - if: ${{ steps.cache-docker-images.outputs.cache-hit == 'true' }}
+        name: Docker load
+        run: |
+          docker load --input ${{ env.IMAGE_CACHE_DIR }}/misp3-image.tar
 
       - name: Run tests
         run: docker-compose -f docker-compose.yml -f docker-compose.dev.yml --env-file="./docker/.env.test" run misp

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,17 +24,17 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Get last docker dir commit
-        id: docker-dir-commit
+      - name: Get docker dir checksum
+        id: docker-dir-checksum
         run: |
-          echo "::set-output name=sha::$(git log -n 1 --pretty=format:%h docker)"
+          echo "{sha}={$(find ./docker -type f -print0 | LC_ALL=C sort -z | xargs -0 shasum | shasum | head -c 40)}" >> $GITHUB_OUTPUT
 
       - name: Cache docker images
         id: cache-docker-images
         uses: actions/cache@v3
         with:
           path: ${{ env.IMAGE_CACHE_DIR }}
-          key: docker-images-test-${{ github.ref_name }}-${{ steps.docker-dir-commit.outputs.sha }}
+          key: docker-images-test-${{ github.ref_name }}-${{ steps.docker-dir-checksum.outputs.sha }}
 
       - if: ${{ steps.cache-docker-images.outputs.cache-hit != 'true' }}
         name: Build test containers and save cache
@@ -44,7 +44,7 @@ jobs:
           docker save -o ${{ env.IMAGE_CACHE_DIR }}/misp3-image.tar misp3/php:8.2-fpm
 
       - if: ${{ steps.cache-docker-images.outputs.cache-hit == 'true' }}
-        name: Docker load
+        name: Docker load cached image
         run: |
           docker load --input ${{ env.IMAGE_CACHE_DIR }}/misp3-image.tar
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   test:
-    timeout-minutes: 20
+    timeout-minutes: 10
     runs-on: ubuntu-latest
 
     steps:
@@ -34,7 +34,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.IMAGE_CACHE_DIR }}
-          key: docker-images-test-${{ github.ref_name }}-${{ steps.docker-dir-checksum.outputs.SHA }}
+          key: 3.x-docker-images-test-${{ steps.docker-dir-checksum.outputs.SHA }}
 
       - if: ${{ steps.cache-docker-images.outputs.cache-hit != 'true' }}
         name: Build test containers and save cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.IMAGE_CACHE_DIR }}
-          key: docker-images-test-${{ GITHUB_REF_NAME }}-${{ steps.docker-dir-commit.outputs.sha }}
+          key: docker-images-test-${{ github.ref_name }}-${{ steps.docker-dir-commit.outputs.sha }}
 
       - if: ${{ steps.cache-docker-images.outputs.cache-hit != 'true' }}
         name: Build test containers and save cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 3.x
-      - gh-actions-cache-docker-build
   pull_request:
     branches:
       - 3.x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,9 +40,9 @@ jobs:
       #     mkdir -p ${{ env.IMAGE_CACHE_DIR }}
       #     docker save -o ${{ env.IMAGE_CACHE_DIR }}/misp3-image.tar misp3/php:8.2-fpm
 
-      - name: Docker load
-        run: |
-          docker load --input ${{ env.IMAGE_CACHE_DIR }}/misp3-image.tar
+      # - name: Docker load
+      #   run: |
+      #     docker load --input ${{ env.IMAGE_CACHE_DIR }}/misp3-image.tar
 
       - name: Run tests
         run: docker-compose -f docker-compose.yml -f docker-compose.dev.yml --env-file="./docker/.env.test" run misp

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,14 +27,14 @@ jobs:
       - name: Get docker dir checksum
         id: docker-dir-checksum
         run: |
-          echo "{sha}={$(find ./docker -type f -print0 | LC_ALL=C sort -z | xargs -0 shasum | shasum | head -c 40)}" >> $GITHUB_OUTPUT
+          echo "SHA=$(find ./docker -type f -print0 | LC_ALL=C sort -z | xargs -0 shasum | shasum | head -c 40)" >> $GITHUB_OUTPUT
 
       - name: Cache docker images
         id: cache-docker-images
         uses: actions/cache@v3
         with:
           path: ${{ env.IMAGE_CACHE_DIR }}
-          key: docker-images-test-${{ github.ref_name }}-${{ steps.docker-dir-checksum.outputs.sha }}
+          key: docker-images-test-${{ github.ref_name }}-${{ steps.docker-dir-checksum.outputs.SHA }}
 
       - if: ${{ steps.cache-docker-images.outputs.cache-hit != 'true' }}
         name: Build test containers and save cache

--- a/docker/misp/Dockerfile
+++ b/docker/misp/Dockerfile
@@ -14,7 +14,7 @@ COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 # Install additional PHP extensions and system packages
 RUN apt-get -y update \
-    && apt-get install -y libicu-dev libpq-dev zip libzip-dev default-mysql-client gnupg supervisor \
+    && apt-get install -y libicu-dev libpq-dev zip libzip-dev default-mysql-client gnupg supervisor git sendmail sudo \
     && docker-php-ext-configure intl \
     && docker-php-ext-install intl pdo pdo_mysql mysqli zip \
     && apt-get remove -y --purge libicu-dev libzip-dev \
@@ -77,11 +77,11 @@ RUN pecl install -f xdebug pcov \
     && docker-php-ext-enable xdebug pcov
 
 # Install additional packages
-RUN apt-get update \
-    && apt-get install -y \
-    git sendmail sudo \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+# RUN apt-get update \
+#     && apt-get install -y \
+#     && <package> \
+#     && apt-get clean \
+#     && rm -rf /var/lib/apt/lists/*
 
 # Write Xdebug configuration
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \

--- a/tests/TestCase/Api/Users/ViewUserApiTest.php
+++ b/tests/TestCase/Api/Users/ViewUserApiTest.php
@@ -23,6 +23,7 @@ class ViewUserApiTest extends TestCase
 
     public function testViewMyUser(): void
     {
+        ;
         $this->setAuthToken(AuthKeysFixture::ADMIN_API_KEY);
         $this->get(self::ENDPOINT);
 

--- a/tests/TestCase/Api/Users/ViewUserApiTest.php
+++ b/tests/TestCase/Api/Users/ViewUserApiTest.php
@@ -23,7 +23,6 @@ class ViewUserApiTest extends TestCase
 
     public function testViewMyUser(): void
     {
-        ;
         $this->setAuthToken(AuthKeysFixture::ADMIN_API_KEY);
         $this->get(self::ENDPOINT);
 


### PR DESCRIPTION
#### What does it do?
Cache `misp` container image so it's not re-built unless there are changes in the `/docker` directory.
Makes test action run ~350% faster.

some limitations on scopes: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
