### PR TITLE
fix: [misp-zmq] Include ZMQ support for connecting to Redis over TLS

### DIFF
--- a/app/files/scripts/mispzmq/mispzmq.py
+++ b/app/files/scripts/mispzmq/mispzmq.py
@@ -80,9 +80,14 @@ class MispZmq:
         with open((self.tmp_location / "mispzmq_settings.json").as_posix()) as settings_file:
             self.settings = json.load(settings_file)
         self.namespace = self.settings["redis_namespace"]
-        self.r = redis.StrictRedis(host=self.settings["redis_host"], db=self.settings["redis_database"],
+        # Check if TLS is being used with Redis host
+        redis_host = self.settings["redis_host"]
+        redis_ssl = redis_host.startswith("tls://")
+        if redis_host.startswith("tls://"):
+            redis_host = redis_host[6:]
+        self.r = redis.StrictRedis(host=redis_host, db=self.settings["redis_database"],
                                    password=self.settings["redis_password"], port=self.settings["redis_port"],
-                                   decode_responses=True)
+                                   decode_responses=True, ssl=redis_ssl)
         self.timestamp_settings = time.time()
         self._logger.debug("Connected to Redis {}:{}/{}".format(self.settings["redis_host"], self.settings["redis_port"],
                                                            self.settings["redis_database"]))


### PR DESCRIPTION
#### What does it do?

Adds support for ZeroMQ to connect to Redis backend via TLS. This is implemented by checking the start of the `redis_host` setting for `tls://`. We check for this because if you want to connect to redis over TLS in CakePHP (i.e. for any other setting in MISP using redis) you prepend the redis hostname with `tls://`.

If it does begin with `tls://` then we remove the scheme, otherwise it throws an error as below:

```
redis.exceptions.ConnectionError: Error -2 connecting to tls://redis_host:6379. Name or service not known.
```

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
