### PR TITLE
Setting to disable IP retention in DB on Authkey use

### DIFF
--- a/app/Locale/ara/LC_MESSAGES/default.po
+++ b/app/Locale/ara/LC_MESSAGES/default.po
@@ -6997,6 +6997,10 @@ msgstr ""
 msgid "Log user IP and key usage on each API request. All logs for given keys are deleted after one year when this key is not used."
 msgstr ""
 
+#: Model/Server.php:5706
+msgid "Store IP addresses used to make API calls with an AuthKey against this AuthKey in the database."
+msgstr ""
+
 #: Model/Server.php:5330
 msgid "Enable new audit log system."
 msgstr ""

--- a/app/Locale/cze/LC_MESSAGES/default.po
+++ b/app/Locale/cze/LC_MESSAGES/default.po
@@ -6983,6 +6983,10 @@ msgstr ""
 msgid "Log user IP and key usage on each API request. All logs for given keys are deleted after one year when this key is not used."
 msgstr ""
 
+#: Model/Server.php:5706
+msgid "Store IP addresses used to make API calls with an AuthKey against this AuthKey in the database."
+msgstr ""
+
 #: Model/Server.php:5330
 msgid "Enable new audit log system."
 msgstr ""

--- a/app/Locale/dan/LC_MESSAGES/default.po
+++ b/app/Locale/dan/LC_MESSAGES/default.po
@@ -6968,6 +6968,10 @@ msgstr ""
 msgid "Log user IP and key usage on each API request. All logs for given keys are deleted after one year when this key is not used."
 msgstr ""
 
+#: Model/Server.php:5706
+msgid "Store IP addresses used to make API calls with an AuthKey against this AuthKey in the database."
+msgstr ""
+
 #: Model/Server.php:5330
 msgid "Enable new audit log system."
 msgstr ""

--- a/app/Locale/default.pot
+++ b/app/Locale/default.pot
@@ -7939,6 +7939,10 @@ msgstr ""
 msgid "Log user IP and key usage on each API request. All logs for given keys are deleted after one year when this key is not used."
 msgstr ""
 
+#: Model/Server.php:5706
+msgid "Store IP addresses used to make API calls with an AuthKey against this AuthKey in the database."
+msgstr ""
+
 #: Model/Server.php:5355
 msgid "Enable new audit log system."
 msgstr ""

--- a/app/Locale/deu/LC_MESSAGES/default.po
+++ b/app/Locale/deu/LC_MESSAGES/default.po
@@ -6968,6 +6968,10 @@ msgstr ""
 msgid "Log user IP and key usage on each API request. All logs for given keys are deleted after one year when this key is not used."
 msgstr ""
 
+#: Model/Server.php:5706
+msgid "Store IP addresses used to make API calls with an AuthKey against this AuthKey in the database."
+msgstr ""
+
 #: Model/Server.php:5330
 msgid "Enable new audit log system."
 msgstr ""

--- a/app/Locale/fra/LC_MESSAGES/default.po
+++ b/app/Locale/fra/LC_MESSAGES/default.po
@@ -6971,6 +6971,10 @@ msgstr ""
 msgid "Log user IP and key usage on each API request. All logs for given keys are deleted after one year when this key is not used."
 msgstr ""
 
+#: Model/Server.php:5706
+msgid "Store IP addresses used to make API calls with an AuthKey against this AuthKey in the database."
+msgstr ""
+
 #: Model/Server.php:5330
 msgid "Enable new audit log system."
 msgstr ""

--- a/app/Locale/hun/LC_MESSAGES/default.po
+++ b/app/Locale/hun/LC_MESSAGES/default.po
@@ -6968,6 +6968,10 @@ msgstr ""
 msgid "Log user IP and key usage on each API request. All logs for given keys are deleted after one year when this key is not used."
 msgstr ""
 
+#: Model/Server.php:5706
+msgid "Store IP addresses used to make API calls with an AuthKey against this AuthKey in the database."
+msgstr ""
+
 #: Model/Server.php:5330
 msgid "Enable new audit log system."
 msgstr ""

--- a/app/Locale/ita/LC_MESSAGES/default.po
+++ b/app/Locale/ita/LC_MESSAGES/default.po
@@ -6969,6 +6969,10 @@ msgstr ""
 msgid "Log user IP and key usage on each API request. All logs for given keys are deleted after one year when this key is not used."
 msgstr ""
 
+#: Model/Server.php:5706
+msgid "Store IP addresses used to make API calls with an AuthKey against this AuthKey in the database."
+msgstr ""
+
 #: Model/Server.php:5330
 msgid "Enable new audit log system."
 msgstr ""

--- a/app/Locale/jpn/LC_MESSAGES/default.po
+++ b/app/Locale/jpn/LC_MESSAGES/default.po
@@ -6961,6 +6961,10 @@ msgstr ""
 msgid "Log user IP and key usage on each API request. All logs for given keys are deleted after one year when this key is not used."
 msgstr ""
 
+#: Model/Server.php:5706
+msgid "Store IP addresses used to make API calls with an AuthKey against this AuthKey in the database."
+msgstr ""
+
 #: Model/Server.php:5330
 msgid "Enable new audit log system."
 msgstr ""

--- a/app/Locale/kor/LC_MESSAGES/default.po
+++ b/app/Locale/kor/LC_MESSAGES/default.po
@@ -6962,6 +6962,10 @@ msgstr ""
 msgid "Log user IP and key usage on each API request. All logs for given keys are deleted after one year when this key is not used."
 msgstr ""
 
+#: Model/Server.php:5706
+msgid "Store IP addresses used to make API calls with an AuthKey against this AuthKey in the database."
+msgstr ""
+
 #: Model/Server.php:5330
 msgid "Enable new audit log system."
 msgstr ""

--- a/app/Locale/no/LC_MESSAGES/default.po
+++ b/app/Locale/no/LC_MESSAGES/default.po
@@ -6968,6 +6968,10 @@ msgstr ""
 msgid "Log user IP and key usage on each API request. All logs for given keys are deleted after one year when this key is not used."
 msgstr ""
 
+#: Model/Server.php:5706
+msgid "Store IP addresses used to make API calls with an AuthKey against this AuthKey in the database."
+msgstr ""
+
 #: Model/Server.php:5330
 msgid "Enable new audit log system."
 msgstr ""

--- a/app/Locale/pol/LC_MESSAGES/default.po
+++ b/app/Locale/pol/LC_MESSAGES/default.po
@@ -6983,6 +6983,10 @@ msgstr ""
 msgid "Log user IP and key usage on each API request. All logs for given keys are deleted after one year when this key is not used."
 msgstr ""
 
+#: Model/Server.php:5706
+msgid "Store IP addresses used to make API calls with an AuthKey against this AuthKey in the database."
+msgstr ""
+
 #: Model/Server.php:5330
 msgid "Enable new audit log system."
 msgstr ""

--- a/app/Locale/pt_BR/LC_MESSAGES/default.po
+++ b/app/Locale/pt_BR/LC_MESSAGES/default.po
@@ -6969,6 +6969,10 @@ msgstr ""
 msgid "Log user IP and key usage on each API request. All logs for given keys are deleted after one year when this key is not used."
 msgstr ""
 
+#: Model/Server.php:5706
+msgid "Store IP addresses used to make API calls with an AuthKey against this AuthKey in the database."
+msgstr ""
+
 #: Model/Server.php:5330
 msgid "Enable new audit log system."
 msgstr ""

--- a/app/Locale/ro/LC_MESSAGES/default.po
+++ b/app/Locale/ro/LC_MESSAGES/default.po
@@ -6975,6 +6975,10 @@ msgstr ""
 msgid "Log user IP and key usage on each API request. All logs for given keys are deleted after one year when this key is not used."
 msgstr ""
 
+#: Model/Server.php:5706
+msgid "Store IP addresses used to make API calls with an AuthKey against this AuthKey in the database."
+msgstr ""
+
 #: Model/Server.php:5330
 msgid "Enable new audit log system."
 msgstr ""

--- a/app/Locale/rus/LC_MESSAGES/default.po
+++ b/app/Locale/rus/LC_MESSAGES/default.po
@@ -6982,6 +6982,10 @@ msgstr ""
 msgid "Log user IP and key usage on each API request. All logs for given keys are deleted after one year when this key is not used."
 msgstr ""
 
+#: Model/Server.php:5706
+msgid "Store IP addresses used to make API calls with an AuthKey against this AuthKey in the database."
+msgstr ""
+
 #: Model/Server.php:5330
 msgid "Enable new audit log system."
 msgstr ""

--- a/app/Locale/si-LK/LC_MESSAGES/default.po
+++ b/app/Locale/si-LK/LC_MESSAGES/default.po
@@ -6972,6 +6972,10 @@ msgstr "එක් එක් ඉල්ලීම මත පරිශීලක IPs 
 msgid "Log user IP and key usage on each API request. All logs for given keys are deleted after one year when this key is not used."
 msgstr "එක් එක් API ඉල්ලීම මත පරිශීලක IP සහ යතුරු භාවිතය ලොග් කරන්න. මෙම යතුර භාවිතා නොකරන විට ලබා දී ඇති යතුරු සඳහා සියලුම ලොග් වසරකට පසුව මකා දමනු ලැබේ."
 
+#: Model/Server.php:5706
+msgid "Store IP addresses used to make API calls with an AuthKey against this AuthKey in the database."
+msgstr ""
+
 #: Model/Server.php:5330
 msgid "Enable new audit log system."
 msgstr "නව විගණන ලොග් පද්ධතිය සබල කරන්න."

--- a/app/Locale/spa/LC_MESSAGES/default.po
+++ b/app/Locale/spa/LC_MESSAGES/default.po
@@ -6970,6 +6970,10 @@ msgstr ""
 msgid "Log user IP and key usage on each API request. All logs for given keys are deleted after one year when this key is not used."
 msgstr ""
 
+#: Model/Server.php:5706
+msgid "Store IP addresses used to make API calls with an AuthKey against this AuthKey in the database."
+msgstr ""
+
 #: Model/Server.php:5330
 msgid "Enable new audit log system."
 msgstr ""

--- a/app/Locale/th_TH/LC_MESSAGES/default.po
+++ b/app/Locale/th_TH/LC_MESSAGES/default.po
@@ -6965,6 +6965,10 @@ msgstr "บันทึก IP ของผู้ใช้ในแต่ละ�
 msgid "Log user IP and key usage on each API request. All logs for given keys are deleted after one year when this key is not used."
 msgstr "บันทึก IP ของผู้ใช้และการใช้คีย์ในคำขอ API แต่ละรายการ บันทึกทั้งหมดสำหรับคีย์ที่ระบุจะถูกลบหลังจากหนึ่งปีเมื่อไม่ได้ใช้คีย์นี้"
 
+#: Model/Server.php:5706
+msgid "Store IP addresses used to make API calls with an AuthKey against this AuthKey in the database."
+msgstr ""
+
 #: Model/Server.php:5330
 msgid "Enable new audit log system."
 msgstr "เปิดใช้งานระบบบันทึกการตรวจสอบใหม่"

--- a/app/Locale/zh-s/LC_MESSAGES/default.po
+++ b/app/Locale/zh-s/LC_MESSAGES/default.po
@@ -6962,6 +6962,10 @@ msgstr "在每次请求中记录用户的IP. 30天的保留期, 通过IP查询, 
 msgid "Log user IP and key usage on each API request. All logs for given keys are deleted after one year when this key is not used."
 msgstr ""
 
+#: Model/Server.php:5706
+msgid "Store IP addresses used to make API calls with an AuthKey against this AuthKey in the database."
+msgstr ""
+
 #: Model/Server.php:5330
 msgid "Enable new audit log system."
 msgstr ""

--- a/app/Model/AuthKey.php
+++ b/app/Model/AuthKey.php
@@ -189,18 +189,20 @@ class AuthKey extends AppModel
         foreach ($possibleAuthkeys as $possibleAuthkey) {
             if ($passwordHasher->check($authkey, $possibleAuthkey['AuthKey']['authkey'])) {  // valid authkey
                 // store IP in db if not there yet
-                $remote_ip = $this->_remoteIp();
-                $update_db_ip = true;
-                if (in_array($remote_ip, $possibleAuthkey['AuthKey']['unique_ips'])) {
-                    $update_db_ip = false;  // IP already seen, skip saving in DB
-                } else {   // first time this IP is seen for this API key
-                    $possibleAuthkey['AuthKey']['unique_ips'][] = $remote_ip;
-                }
-                if ($update_db_ip) {
-                    // prevent double entries due to race condition
-                    $possibleAuthkey['AuthKey']['unique_ips'] = array_unique($possibleAuthkey['AuthKey']['unique_ips']);
-                    // save in db
-                    $this->save($possibleAuthkey, ['fieldList' => ['unique_ips']]);
+                if(Configure::read("MISP.remember_seen_ips_authkeys")) {
+                    $remote_ip = $this->_remoteIp();
+                    $update_db_ip = true;
+                    if (in_array($remote_ip, $possibleAuthkey['AuthKey']['unique_ips'])) {
+                        $update_db_ip = false;  // IP already seen, skip saving in DB
+                    } else {   // first time this IP is seen for this API key
+                        $possibleAuthkey['AuthKey']['unique_ips'][] = $remote_ip;
+                    }
+                    if ($update_db_ip) {
+                        // prevent double entries due to race condition
+                        $possibleAuthkey['AuthKey']['unique_ips'] = array_unique($possibleAuthkey['AuthKey']['unique_ips']);
+                        // save in db
+                        $this->save($possibleAuthkey, ['fieldList' => ['unique_ips']]);
+                    }
                 }
                 // fetch user
                 $user = $this->User->getAuthUser($possibleAuthkey['AuthKey']['user_id']);

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -5701,6 +5701,14 @@ class Server extends AppModel
                     'type' => 'boolean',
                     'null' => true
                 ],
+                'remember_seen_ips_authkeys' => [
+                    'level' => self::SETTING_RECOMMENDED,
+                    'description' => __('Store IP addresses used to make API calls with an AuthKey against this AuthKey in the database.'),
+                    'value' => false,
+                    'test' => 'testBool',
+                    'type' => 'boolean',
+                    'null' => true
+                ],
                 'log_new_audit' => [
                     'level' => self::SETTING_RECOMMENDED,
                     'description' => __('Enable new audit log system.'),

--- a/app/View/AuthKeys/index.ctp
+++ b/app/View/AuthKeys/index.ctp
@@ -3,6 +3,13 @@
     if (!$advancedEnabled) {
         echo '<div class="alert">' . __('Advanced auth keys are not enabled.') . '</div>';
     }
+    $seenIPsField = Configure::read("MISP.remember_seen_ips_authkeys") ? [
+        [
+            'name' => __('Seen IPs'),
+            'data_path' => 'AuthKey.unique_ips',
+            'element' => 'authkey_pin',
+        ]
+    ] : [];
     echo $this->element('genericElements/IndexTable/index_table', [
         'data' => [
             'data' => $data,
@@ -73,11 +80,7 @@
                     'name' => __('Allowed IPs'),
                     'data_path' => 'AuthKey.allowed_ips',
                 ],
-                [
-                    'name' => __('Seen IPs'),
-                    'data_path' => 'AuthKey.unique_ips',
-                    'element' => 'authkey_pin',
-                ]
+                ...$seenIPsField
             ],
             'title' => empty($ajax) ? __('Authentication key Index') : false,
             'description' => empty($ajax) ? __('A list of API keys bound to a user.') : false,

--- a/app/View/AuthKeys/index.ctp
+++ b/app/View/AuthKeys/index.ctp
@@ -3,13 +3,57 @@
     if (!$advancedEnabled) {
         echo '<div class="alert">' . __('Advanced auth keys are not enabled.') . '</div>';
     }
-    $seenIPsField = Configure::read("MISP.remember_seen_ips_authkeys") ? [
+    $fields = [
         [
-            'name' => __('Seen IPs'),
-            'data_path' => 'AuthKey.unique_ips',
-            'element' => 'authkey_pin',
-        ]
-    ] : [];
+            'name' => '#',
+            'sort' => 'AuthKey.id',
+            'data_path' => 'AuthKey.id',
+        ],
+        [
+            'name' => __('User'),
+            'sort' => 'User.email',
+            'data_path' => 'User.email',
+            'element' => empty($user_id) ? 'links' : 'generic_field',
+            'url' => $baseurl . '/users/view',
+            'url_params_data_paths' => ['User.id'],
+            'requirement' => $me['Role']['perm_admin'] || $me['Role']['perm_site_admin'],
+        ],
+        [
+            'name' => __('Auth Key'),
+            'sort' => 'AuthKey.authkey_start',
+            'element' => 'authkey',
+            'data_path' => 'AuthKey',
+        ],
+        [
+            'name' => __('Expiration'),
+            'sort' => 'AuthKey.expiration',
+            'data_path' => 'AuthKey.expiration',
+            'element' => 'expiration'
+        ],
+        [
+            'name' => ('Last used'),
+            'data_path' => 'AuthKey.last_used',
+            'element' => 'datetime',
+            'requirements' => $keyUsageEnabled,
+            'empty' => __('Never'),
+        ],
+        [
+            'name' => __('Comment'),
+            'sort' => 'AuthKey.comment',
+            'data_path' => 'AuthKey.comment',
+        ],
+        [
+            'name' => __('Allowed IPs'),
+            'data_path' => 'AuthKey.allowed_ips',
+        ],
+    ];
+    if(Configure::read("MISP.remember_seen_ips_authkeys")){
+            $fields[] =[
+                'name' => __('Seen IPs'),
+                'data_path' => 'AuthKey.unique_ips',
+                'element' => 'authkey_pin',
+            ];
+    }
     echo $this->element('genericElements/IndexTable/index_table', [
         'data' => [
             'data' => $data,
@@ -37,51 +81,7 @@
                     ]
                 ]
             ],
-            'fields' => [
-                [
-                    'name' => '#',
-                    'sort' => 'AuthKey.id',
-                    'data_path' => 'AuthKey.id',
-                ],
-                [
-                    'name' => __('User'),
-                    'sort' => 'User.email',
-                    'data_path' => 'User.email',
-                    'element' => empty($user_id) ? 'links' : 'generic_field',
-                    'url' => $baseurl . '/users/view',
-                    'url_params_data_paths' => ['User.id'],
-                    'requirement' => $me['Role']['perm_admin'] || $me['Role']['perm_site_admin'],
-                ],
-                [
-                    'name' => __('Auth Key'),
-                    'sort' => 'AuthKey.authkey_start',
-                    'element' => 'authkey',
-                    'data_path' => 'AuthKey',
-                ],
-                [
-                    'name' => __('Expiration'),
-                    'sort' => 'AuthKey.expiration',
-                    'data_path' => 'AuthKey.expiration',
-                    'element' => 'expiration'
-                ],
-                [
-                    'name' => ('Last used'),
-                    'data_path' => 'AuthKey.last_used',
-                    'element' => 'datetime',
-                    'requirements' => $keyUsageEnabled,
-                    'empty' => __('Never'),
-                ],
-                [
-                    'name' => __('Comment'),
-                    'sort' => 'AuthKey.comment',
-                    'data_path' => 'AuthKey.comment',
-                ],
-                [
-                    'name' => __('Allowed IPs'),
-                    'data_path' => 'AuthKey.allowed_ips',
-                ],
-                ...$seenIPsField
-            ],
+            'fields' => $fields,
             'title' => empty($ajax) ? __('Authentication key Index') : false,
             'description' => empty($ajax) ? __('A list of API keys bound to a user.') : false,
             'pull' => 'right',

--- a/app/View/AuthKeys/view.ctp
+++ b/app/View/AuthKeys/view.ctp
@@ -15,80 +15,80 @@ if (isset($keyUsage)) {
     $uniqueIps = null;
 }
 
-$seenIPsField = Configure::read("MISP.remember_seen_ips_authkeys") ? [
+$fields = [
     [
+        'key' => __('ID'),
+        'path' => 'AuthKey.id'
+    ],
+    [
+        'key' => __('UUID'),
+        'path' => 'AuthKey.uuid',
+    ],
+    [
+        'key' => __('Auth Key'),
+        'path' => 'AuthKey',
+        'type' => 'authkey'
+    ],
+    [
+        'key' => __('User'),
+        'path' => 'User.id',
+        'pathName' => 'User.email',
+        'model' => 'users',
+        'type' => 'model'
+    ],
+    [
+        'key' => __('Comment'),
+        'path' => 'AuthKey.comment'
+    ],
+    [
+        'key' => __('Allowed IPs'),
+        'type' => 'custom',
+        'function' => function (array $data) {
+            if (is_array($data['AuthKey']['allowed_ips'])) {
+                return implode("<br />", array_map('h', $data['AuthKey']['allowed_ips']));
+            }
+            return __('All');
+        }
+    ],
+    [
+        'key' => __('Created'),
+        'path' => 'AuthKey.created',
+        'type' => 'datetime'
+    ],
+    [
+        'key' => __('Expiration'),
+        'path' => 'AuthKey.expiration',
+        'type' => 'expiration'
+    ],
+    [
+        'key' => __('Read only'),
+        'path' => 'AuthKey.read_only',
+        'type' => 'boolean'
+    ],
+    [
+        'key' => __('Key usage'),
+        'type' => 'sparkline',
+        'path' => 'AuthKey.id',
+        'csv' => [
+            'data' => $keyUsageCsv,
+        ],
+        'requirement' => isset($keyUsage),
+    ],
+    [
+        'key' => __('Last used'),
+        'raw' => $lastUsed ? $this->Time->time($lastUsed) : __('Not used yet'),
+        'requirement' => isset($keyUsage),
+    ],
+];
+if (Configure::read("MISP.remember_seen_ips_authkeys")) {
+    $fields[] =[
         'key' => __('Seen IPs'),
         'path' => 'AuthKey.unique_ips',
         'type' => 'authkey_pin'
-    ]
-] : [];
+    ];
+}
 echo $this->element('genericElements/SingleViews/single_view', [
     'title' => 'Auth key view',
     'data' => $data,
-    'fields' => [
-        [
-            'key' => __('ID'),
-            'path' => 'AuthKey.id'
-        ],
-        [
-            'key' => __('UUID'),
-            'path' => 'AuthKey.uuid',
-        ],
-        [
-            'key' => __('Auth Key'),
-            'path' => 'AuthKey',
-            'type' => 'authkey'
-        ],
-        [
-            'key' => __('User'),
-            'path' => 'User.id',
-            'pathName' => 'User.email',
-            'model' => 'users',
-            'type' => 'model'
-        ],
-        [
-            'key' => __('Comment'),
-            'path' => 'AuthKey.comment'
-        ],
-        [
-            'key' => __('Allowed IPs'),
-            'type' => 'custom',
-            'function' => function (array $data) {
-                if (is_array($data['AuthKey']['allowed_ips'])) {
-                    return implode("<br />", array_map('h', $data['AuthKey']['allowed_ips']));
-                }
-                return __('All');
-            }
-        ],
-        [
-            'key' => __('Created'),
-            'path' => 'AuthKey.created',
-            'type' => 'datetime'
-        ],
-        [
-            'key' => __('Expiration'),
-            'path' => 'AuthKey.expiration',
-            'type' => 'expiration'
-        ],
-        [
-            'key' => __('Read only'),
-            'path' => 'AuthKey.read_only',
-            'type' => 'boolean'
-        ],
-        [
-            'key' => __('Key usage'),
-            'type' => 'sparkline',
-            'path' => 'AuthKey.id',
-            'csv' => [
-                'data' => $keyUsageCsv,
-            ],
-            'requirement' => isset($keyUsage),
-        ],
-        [
-            'key' => __('Last used'),
-            'raw' => $lastUsed ? $this->Time->time($lastUsed) : __('Not used yet'),
-            'requirement' => isset($keyUsage),
-        ],
-        ...$seenIPsField
-    ],
+    'fields' => $fields,
 ]);

--- a/app/View/AuthKeys/view.ctp
+++ b/app/View/AuthKeys/view.ctp
@@ -15,6 +15,13 @@ if (isset($keyUsage)) {
     $uniqueIps = null;
 }
 
+$seenIPsField = Configure::read("MISP.remember_seen_ips_authkeys") ? [
+    [
+        'key' => __('Seen IPs'),
+        'path' => 'AuthKey.unique_ips',
+        'type' => 'authkey_pin'
+    ]
+] : [];
 echo $this->element('genericElements/SingleViews/single_view', [
     'title' => 'Auth key view',
     'data' => $data,
@@ -82,10 +89,6 @@ echo $this->element('genericElements/SingleViews/single_view', [
             'raw' => $lastUsed ? $this->Time->time($lastUsed) : __('Not used yet'),
             'requirement' => isset($keyUsage),
         ],
-        [
-            'key' => __('Seen IPs'),
-            'path' => 'AuthKey.unique_ips',
-            'type' => 'authkey_pin'
-        ]
+        ...$seenIPsField
     ],
 ]);


### PR DESCRIPTION
#### What does it do?

Adds a new setting - `MISP.remember_seen_ips_authkeys` - to control whether IP addresses used to access the API with an Authkey are retained in the `unique_ips` field of the `auth_keys` table.  Since TEXT columns in MySQL are at most 64KB long, this field can overflow if the same authkey accesses the API from a sufficient number of remote endpoint addresses.  Upon such overflow, API calls fail with 5xx errors.

If this setting is set to false, the "Seen IPs" column in the "Authentication Key Index" UI will be hidden, as it will likely not contain complete, meaningful data.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
