### PR TITLE
Accessibility: Improved tag reporting in Event view

### DIFF
--- a/app/View/Elements/rich_tag.ctp
+++ b/app/View/Elements/rich_tag.ctp
@@ -35,7 +35,7 @@ if (isset($tag_display_style)) {
 }
 $aText = h($aText);
 $span_scope = !empty($hide_global_scope) ? '' : sprintf(
-    '<span class="%s" title="%s" aria-label="%s"><i class="fas fa-%s"></i></span>',
+    '<span class="%s" title="%s" role="img" aria-label="%s"><i class="fas fa-%s"></i></span>',
     'black-white tag',
     !empty($tag['local']) ? __('Local tag') : __('Global tag'),
     !empty($tag['local']) ? __('Local tag') : __('Global tag'),


### PR DESCRIPTION
Added a "role" attribute so the global/local nature of tags are read correctly by all screen readers.

Without "role" attributes, JAWS ignore the whole "<span><i> ... </i></span>", even if aria-label is specified. 