### PR TITLE
Fix import of TmpFileTool in RestResponseComponent

### DIFF
--- a/app/Controller/Component/RestResponseComponent.php
+++ b/app/Controller/Component/RestResponseComponent.php
@@ -631,6 +631,7 @@ class RestResponseComponent extends Component
                     }
                 }
 
+                App::uses('TmpFileTool', 'Tools');
                 // If response is big array, encode items separately to save memory
                 if (is_array($response) && count($response) > 10000) {
                     $output = new TmpFileTool();
@@ -661,7 +662,6 @@ class RestResponseComponent extends Component
             }
         }
 
-        App::uses('TmpFileTool', 'Tools');
         if ($response instanceof Generator) {
             $tmpFile = new TmpFileTool();
             $tmpFile->writeWithSeparator($response, null);

--- a/app/Controller/Component/RestResponseComponent.php
+++ b/app/Controller/Component/RestResponseComponent.php
@@ -589,6 +589,7 @@ class RestResponseComponent extends Component
      */
     private function __sendResponse($response, $code, $format = false, $raw = false, $download = false, $headers = array())
     {
+        App::uses('TmpFileTool', 'Tools');
         $format = !empty($format) ? strtolower($format) : 'json';
         if ($format === 'application/xml' || $format === 'xml') {
             if (!$raw) {
@@ -630,8 +631,7 @@ class RestResponseComponent extends Component
                         $response['sql_dump'] = $this->getSqlLog();
                     }
                 }
-
-                App::uses('TmpFileTool', 'Tools');
+                
                 // If response is big array, encode items separately to save memory
                 if (is_array($response) && count($response) > 10000) {
                     $output = new TmpFileTool();


### PR DESCRIPTION
#### What does it do?

Line 636 produces error: 
```
2023-11-21 09:37:11 Error: [Error] Class 'TmpFileTool' not found
Request URL: /eventBlocklists/index
Stack Trace:
#0 /var/www/MISP/app/Controller/Component/RestResponseComponent.php(773): RestResponseComponent->__sendResponse()
#1 /var/www/MISP/app/Controller/Component/BlockListComponent.php(28): RestResponseComponent->viewData()
#2 /var/www/MISP/app/Controller/EventBlocklistsController.php(46): BlocklistComponent->index()
#3 [internal function]: EventBlocklistsController->index()
#4 /var/www/MISP/app/Vendor/cakephp/cakephp/lib/Cake/Controller/Controller.php(499): ReflectionMethod->invokeArgs()
#5 /var/www/MISP/app/Vendor/cakephp/cakephp/lib/Cake/Routing/Dispatcher.php(193): Controller->invokeAction()
#6 /var/www/MISP/app/Vendor/cakephp/cakephp/lib/Cake/Routing/Dispatcher.php(167): Dispatcher->_invoke()
#7 /var/www/MISP/app/webroot/index.php(99): Dispatcher->dispatch()
#8 {main}
```
You can trigger this error by this PyMISP call `MISP.event_blocklists()`, where `MISP` is a `PyMISP` instance.

The fix is just to import `TmpFileTool` earlier in the code.

#### Questions

- [ ] Does it require a DB change? NO
- [ ] Are you using it in production? NO
- [ ] Does it require a change in the API (PyMISP for example)? NO
