### PR TITLE
fix: [workflows:editor] Prepend baseurl to url

### DIFF
--- a/app/webroot/js/workflows-editor/workflows-editor.js
+++ b/app/webroot/js/workflows-editor/workflows-editor.js
@@ -1132,7 +1132,7 @@ function mergeNodeAndModuleFilters(node, moduleFilters) {
 
 /* API */
 function fetchWorkflow(id, callback) {
-    var url = '/workflows/view/' + id + '.json'
+    var url = baseurl + '/workflows/view/' + id + '.json'
     $.ajax({
         beforeSend: function () {
             toggleEditorLoading(true, 'Loading workflow')


### PR DESCRIPTION
#### What does it do?

fixes #9435

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

##### Description

Prepends `baseurl` to url path.
This fixes what looks like an accidentally omitted `baseurl`.
In all the other places in `workflows-editor.js` file where url is created, `baseurl` is already prepended.