### PR TITLE
Added new setting to block event publication if the user is the creator

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -3210,7 +3210,7 @@ class EventsController extends AppController
             Configure::read('MISP.block_publishing_for_same_creator', false) &&
             $this->Auth->user()['id'] == $event['Event']['user_id']
         ) {
-            $message = __('Could not publish event, the user cannot be the same as the event creator');
+            $message = __('Could not publish the event, the publishing user cannot be the same as the event creator as per this instance\'s configuration.');
             if (!$this->_isRest()) {
                 $this->Flash->error($message);
             }

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -3764,7 +3764,7 @@ class Event extends AppModel
         }
         unset($data['Event']['id']);
         if (
-            Configure::read('MISP.block_publishing_for_same_creator', false) ||
+            (Configure::read('MISP.block_publishing_for_same_creator', false) && !$user['Role']['perm_sync']) ||
             (isset($data['Event']['published']) && $data['Event']['published'] && $user['Role']['perm_publish'] == 0)
         ) {
             $data['Event']['published'] = 0;
@@ -3913,9 +3913,7 @@ class Event extends AppModel
                 if (('true' != Configure::read('MISP.disablerestalert')) && (empty($server) || empty($server['Server']['publish_without_email']))) {
                     $this->sendAlertEmailRouter($this->id, $user);
                 }
-                if (!Configure::read('MISP.block_publishing_for_same_creator', false)) {
-                    $this->publish($this->id, $passAlong);
-                }
+                $this->publish($this->id, $passAlong);
             }
             if (empty($data['Event']['locked']) && !empty(Configure::read('MISP.default_event_tag_collection'))) {
                 $this->TagCollection = ClassRegistry::init('TagCollection');
@@ -4086,7 +4084,7 @@ class Event extends AppModel
         }
         if (
             (!empty($data['Event']['published']) && !$user['Role']['perm_publish']) ||
-            (Configure::read('MISP.block_publishing_for_same_creator', false) && $user['id'] == $existingEvent['Event']['user_id'])
+            (Configure::read('MISP.block_publishing_for_same_creator', false) && $user['id'] == $existingEvent['Event']['user_id'] && !$user['Role']['perm_sync'])
         ) {
             $data['Event']['published'] = 0;
         }
@@ -6019,7 +6017,7 @@ class Event extends AppModel
                     $this->add_original_file($tempFile, $original_file, $created_id, $stix_version);
                 }
                 if ($publish && $user['Role']['perm_publish']) {
-                    if (!Configure::read('MISP.block_publishing_for_same_creator', false)) {
+                    if (!Configure::read('MISP.block_publishing_for_same_creator', false) || $user['Role']['perm_sync']) {
                         $this->publish($created_id);
                     }
                 }

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -4083,8 +4083,8 @@ class Event extends AppModel
             return array('error' => 'Event could not be saved: Could not find the local event.');
         }
         if (
-            (!empty($data['Event']['published']) && !$user['Role']['perm_publish']) ||
-            (Configure::read('MISP.block_publishing_for_same_creator', false) && $user['id'] == $existingEvent['Event']['user_id'] && !$user['Role']['perm_sync'])
+            (Configure::read('MISP.block_publishing_for_same_creator', false) && !$user['Role']['perm_sync'] && $user['id'] == $existingEvent['Event']['user_id']) ||
+            (!empty($data['Event']['published']) && !$user['Role']['perm_publish'])
         ) {
             $data['Event']['published'] = 0;
         }

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -6135,6 +6135,14 @@ class Server extends AppModel
                     'type' => 'boolean',
                     'null' => true,
                 ],
+                'block_publishing_for_same_creator' => [
+                    'level' => self::SETTING_OPTIONAL,
+                    'description' => __('Enable this setting will make MISP blocks publishing if the publisher is the same as the event creator'),
+                    'value' => false,
+                    'test' => 'testBool',
+                    'type' => 'boolean',
+                    'null' => true,
+                ],
                 'self_update' => [
                     'level' => self::SETTING_CRITICAL,
                     'description' => __('Enable the GUI button for MISP self-update on the Diagnostics page.'),

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -6137,7 +6137,7 @@ class Server extends AppModel
                 ],
                 'block_publishing_for_same_creator' => [
                     'level' => self::SETTING_OPTIONAL,
-                    'description' => __('Enable this setting will make MISP blocks publishing if the publisher is the same as the event creator'),
+                    'description' => __('Enabling this setting will make MISP block event publishing in the case of the publisher being the same user as the event creator.'),
                     'value' => false,
                     'test' => 'testBool',
                     'type' => 'boolean',


### PR DESCRIPTION
Enabling this setting will change the behavior of MISP so that it will block the publication of an Event if the publisher is the same as the event creator.