### PR TITLE
chg: [totp] add clarifications to totp setup view

### DIFF
--- a/app/View/Users/totp_new.ctp
+++ b/app/View/Users/totp_new.ctp
@@ -1,7 +1,7 @@
 <?php echo $this->Flash->render(); ?>
 <?php
-$detailsHtml = __("To enable TOTP for your account, scan the following QR code with your TOTP application and validate the token.");;
-$secretHtml = __("Alternatively you can enter the following secret in your TOTP application: ") . "<pre>" . $secret . "</pre>";
+$detailsHtml = __("To enable TOTP for your account, scan the following QR code with your TOTP application (for example Google authenticator or KeepassXC) and validate the token.");;
+$secretHtml = __("Alternatively you can enter the following secret in your TOTP application. This can be particularly handy in case you don't have a supported application in your working environment. Once the verification is done you'll also get 50 \"paper-based\" login tokens so you don't have to use a TOTP application each time: ") . "<pre>" . $secret . "</pre>";
 
 echo $this->element('/genericElements/Form/genericForm', array(
   "form" => $this->Form,


### PR DESCRIPTION
#### What does it do?

Adds some clarifications to the totp setup page. We've noticed some people get confused when they see this page (especially if totp was mandated on the instance).

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
