### PR TITLE
chg: [doc/openapi] clarify 'deleted' restsearch filter

### DIFF
--- a/app/Controller/Component/RestResponseComponent.php
+++ b/app/Controller/Component/RestResponseComponent.php
@@ -1052,7 +1052,7 @@ class RestResponseComponent extends Component
                 'input' => 'radio',
                 'type' => 'integer',
                 'values' => array(1 => 'True', 0 => 'False' ),
-                'help' => __('Include deleted elements')
+                'help' => __('Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned')
             ),
             'delta_merge' => array(
                 'input' => 'radio',

--- a/app/Locale/ara/LC_MESSAGES/default.po
+++ b/app/Locale/ara/LC_MESSAGES/default.po
@@ -14679,7 +14679,7 @@ msgstr ""
 
 #: View/Events/automation.ctp:67
 #: View/Events/legacy_automation.ctp:315
-msgid "If this parameter is set to 1, it will return soft-deleted attributes along with active ones. By using \"only\" as a parameter it will limit the returned data set to soft-deleted data only."
+msgid "Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned."
 msgstr ""
 
 #: View/Events/automation.ctp:68

--- a/app/Locale/cze/LC_MESSAGES/default.po
+++ b/app/Locale/cze/LC_MESSAGES/default.po
@@ -14651,7 +14651,7 @@ msgstr ""
 
 #: View/Events/automation.ctp:67
 #: View/Events/legacy_automation.ctp:315
-msgid "If this parameter is set to 1, it will return soft-deleted attributes along with active ones. By using \"only\" as a parameter it will limit the returned data set to soft-deleted data only."
+msgid "Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned."
 msgstr ""
 
 #: View/Events/automation.ctp:68

--- a/app/Locale/dan/LC_MESSAGES/default.po
+++ b/app/Locale/dan/LC_MESSAGES/default.po
@@ -14624,7 +14624,7 @@ msgstr ""
 
 #: View/Events/automation.ctp:67
 #: View/Events/legacy_automation.ctp:315
-msgid "If this parameter is set to 1, it will return soft-deleted attributes along with active ones. By using \"only\" as a parameter it will limit the returned data set to soft-deleted data only."
+msgid "Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned."
 msgstr ""
 
 #: View/Events/automation.ctp:68

--- a/app/Locale/default.pot
+++ b/app/Locale/default.pot
@@ -15934,7 +15934,7 @@ msgstr ""
 
 #: View/Events/automation.ctp:67
 #: View/Events/legacy_automation.ctp:315
-msgid "If this parameter is set to 1, it will return soft-deleted attributes along with active ones. By using \"only\" as a parameter it will limit the returned data set to soft-deleted data only."
+msgid "Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned."
 msgstr ""
 
 #: View/Events/automation.ctp:68

--- a/app/Locale/deu/LC_MESSAGES/default.po
+++ b/app/Locale/deu/LC_MESSAGES/default.po
@@ -14622,7 +14622,7 @@ msgstr ""
 
 #: View/Events/automation.ctp:67
 #: View/Events/legacy_automation.ctp:315
-msgid "If this parameter is set to 1, it will return soft-deleted attributes along with active ones. By using \"only\" as a parameter it will limit the returned data set to soft-deleted data only."
+msgid "Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned."
 msgstr ""
 
 #: View/Events/automation.ctp:68

--- a/app/Locale/fra/LC_MESSAGES/default.po
+++ b/app/Locale/fra/LC_MESSAGES/default.po
@@ -14626,7 +14626,7 @@ msgstr "Par défaut (0), tout les attributs qui correspondent aux autres paramè
 
 #: View/Events/automation.ctp:67
 #: View/Events/legacy_automation.ctp:315
-msgid "If this parameter is set to 1, it will return soft-deleted attributes along with active ones. By using \"only\" as a parameter it will limit the returned data set to soft-deleted data only."
+msgid "Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned."
 msgstr "Si le paramètre est défini à 1, cela va retourner les attributs mis à la corbeille ainsi que les attributs actifs. En utilisant \"only\" en tant que paramètre, cela va seulement retourner les données mises à la corbeille."
 
 #: View/Events/automation.ctp:68

--- a/app/Locale/hun/LC_MESSAGES/default.po
+++ b/app/Locale/hun/LC_MESSAGES/default.po
@@ -14622,7 +14622,7 @@ msgstr ""
 
 #: View/Events/automation.ctp:67
 #: View/Events/legacy_automation.ctp:315
-msgid "If this parameter is set to 1, it will return soft-deleted attributes along with active ones. By using \"only\" as a parameter it will limit the returned data set to soft-deleted data only."
+msgid "Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned."
 msgstr ""
 
 #: View/Events/automation.ctp:68

--- a/app/Locale/ita/LC_MESSAGES/default.po
+++ b/app/Locale/ita/LC_MESSAGES/default.po
@@ -14625,7 +14625,7 @@ msgstr "Per impostazione predefinita (0) tutti gli attributi restituiti rispondo
 
 #: View/Events/automation.ctp:67
 #: View/Events/legacy_automation.ctp:315
-msgid "If this parameter is set to 1, it will return soft-deleted attributes along with active ones. By using \"only\" as a parameter it will limit the returned data set to soft-deleted data only."
+msgid "Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned."
 msgstr "Se questo parametro è impostato a 1, verranno restituiti attributi \"soft-deleted\" insieme a quelli attivi. Utilizzando \"only\" come parametro verranno restituiti solo gli attributi \"soft-deleted\"."
 
 #: View/Events/automation.ctp:68

--- a/app/Locale/jpn/LC_MESSAGES/default.po
+++ b/app/Locale/jpn/LC_MESSAGES/default.po
@@ -14608,7 +14608,7 @@ msgstr "デフォルトの (0) では、to_ids の設定に関係なく、他の
 
 #: View/Events/automation.ctp:67
 #: View/Events/legacy_automation.ctp:315
-msgid "If this parameter is set to 1, it will return soft-deleted attributes along with active ones. By using \"only\" as a parameter it will limit the returned data set to soft-deleted data only."
+msgid "Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned."
 msgstr "このパラメーターを 1 に設定すると、ソフト削除されたアトリビュートがアクティなアトリビュートと共に返されます。\"only\"をパラメーターとして使用すると、返されるデータはソフト削除されたデータのみに制限されます。"
 
 #: View/Events/automation.ctp:68

--- a/app/Locale/kor/LC_MESSAGES/default.po
+++ b/app/Locale/kor/LC_MESSAGES/default.po
@@ -14609,7 +14609,7 @@ msgstr ""
 
 #: View/Events/automation.ctp:67
 #: View/Events/legacy_automation.ctp:315
-msgid "If this parameter is set to 1, it will return soft-deleted attributes along with active ones. By using \"only\" as a parameter it will limit the returned data set to soft-deleted data only."
+msgid "Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned."
 msgstr ""
 
 #: View/Events/automation.ctp:68

--- a/app/Locale/no/LC_MESSAGES/default.po
+++ b/app/Locale/no/LC_MESSAGES/default.po
@@ -14625,7 +14625,7 @@ msgstr "Som standard (0) returneres alle attributter som samsvarer med de andre 
 
 #: View/Events/automation.ctp:67
 #: View/Events/legacy_automation.ctp:315
-msgid "If this parameter is set to 1, it will return soft-deleted attributes along with active ones. By using \"only\" as a parameter it will limit the returned data set to soft-deleted data only."
+msgid "Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned."
 msgstr "Hvis denne parameteren er satt til 1, vil den returnere myke slettede attributter sammen med aktive. Ved å bruke \"only\" som en parameter, vil det begrense det returnerte datasettet til bare slettede data."
 
 #: View/Events/automation.ctp:68

--- a/app/Locale/pol/LC_MESSAGES/default.po
+++ b/app/Locale/pol/LC_MESSAGES/default.po
@@ -14651,7 +14651,7 @@ msgstr ""
 
 #: View/Events/automation.ctp:67
 #: View/Events/legacy_automation.ctp:315
-msgid "If this parameter is set to 1, it will return soft-deleted attributes along with active ones. By using \"only\" as a parameter it will limit the returned data set to soft-deleted data only."
+msgid "Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned."
 msgstr ""
 
 #: View/Events/automation.ctp:68

--- a/app/Locale/pt/LC_MESSAGES/default.po
+++ b/app/Locale/pt/LC_MESSAGES/default.po
@@ -7964,7 +7964,7 @@ msgstr ""
 
 #: View/Events/automation.ctp:42
 #: View/Events/legacy_automation.ctp:315
-msgid "If this parameter is set to 1, it will return soft-deleted attributes along with active ones. By using \"only\" as a parameter it will limit the returned data set to soft-deleted data only."
+msgid "Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned."
 msgstr ""
 
 #: View/Events/automation.ctp:43

--- a/app/Locale/pt_BR/LC_MESSAGES/default.po
+++ b/app/Locale/pt_BR/LC_MESSAGES/default.po
@@ -14623,7 +14623,7 @@ msgstr ""
 
 #: View/Events/automation.ctp:67
 #: View/Events/legacy_automation.ctp:315
-msgid "If this parameter is set to 1, it will return soft-deleted attributes along with active ones. By using \"only\" as a parameter it will limit the returned data set to soft-deleted data only."
+msgid "Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned."
 msgstr ""
 
 #: View/Events/automation.ctp:68

--- a/app/Locale/ro/LC_MESSAGES/default.po
+++ b/app/Locale/ro/LC_MESSAGES/default.po
@@ -14636,7 +14636,7 @@ msgstr ""
 
 #: View/Events/automation.ctp:67
 #: View/Events/legacy_automation.ctp:315
-msgid "If this parameter is set to 1, it will return soft-deleted attributes along with active ones. By using \"only\" as a parameter it will limit the returned data set to soft-deleted data only."
+msgid "Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned."
 msgstr ""
 
 #: View/Events/automation.ctp:68

--- a/app/Locale/rus/LC_MESSAGES/default.po
+++ b/app/Locale/rus/LC_MESSAGES/default.po
@@ -14650,7 +14650,7 @@ msgstr "По-умолчанию (а также при значении 0) в п�
 
 #: View/Events/automation.ctp:67
 #: View/Events/legacy_automation.ctp:315
-msgid "If this parameter is set to 1, it will return soft-deleted attributes along with active ones. By using \"only\" as a parameter it will limit the returned data set to soft-deleted data only."
+msgid "Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned."
 msgstr "По-умолчанию (а также при значении 0) в поиск попадают только активные атрибуты. Если параметр равен 1, то в поиск попадут дополнительно удаленные атрибуты. Если используется ключевое слово \"only\", то в результаты поиска попадут только удаленные атрибуты. "
 
 #: View/Events/automation.ctp:68

--- a/app/Locale/si-LK/LC_MESSAGES/default.po
+++ b/app/Locale/si-LK/LC_MESSAGES/default.po
@@ -14638,7 +14638,7 @@ msgstr "පෙරනිමියෙන් (0) to_ids සිටුවම් න�
 
 #: View/Events/automation.ctp:67
 #: View/Events/legacy_automation.ctp:315
-msgid "If this parameter is set to 1, it will return soft-deleted attributes along with active ones. By using \"only\" as a parameter it will limit the returned data set to soft-deleted data only."
+msgid "Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned."
 msgstr "මෙම පරාමිතිය 1 ලෙස සකසා ඇත්නම්, එය සක්‍රිය ඒවා සමඟ මෘදු-මකා දැමූ ගුණාංග ලබා දෙනු ඇත. පරාමිතියක් ලෙස \"පමණක්\" භාවිතා කිරීමෙන් එය ආපසු ලබා දෙන දත්ත කට්ටලය මෘදු-මකා දැමූ දත්ත වලට පමණක් සීමා කරයි."
 
 #: View/Events/automation.ctp:68

--- a/app/Locale/spa/LC_MESSAGES/default.po
+++ b/app/Locale/spa/LC_MESSAGES/default.po
@@ -14624,7 +14624,7 @@ msgstr ""
 
 #: View/Events/automation.ctp:67
 #: View/Events/legacy_automation.ctp:315
-msgid "If this parameter is set to 1, it will return soft-deleted attributes along with active ones. By using \"only\" as a parameter it will limit the returned data set to soft-deleted data only."
+msgid "Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned."
 msgstr ""
 
 #: View/Events/automation.ctp:68

--- a/app/Locale/swe/LC_MESSAGES/default.po
+++ b/app/Locale/swe/LC_MESSAGES/default.po
@@ -10898,7 +10898,7 @@ msgstr ""
 
 #: View/Events/automation.ctp:52
 #: View/Events/legacy_automation.ctp:315
-msgid "If this parameter is set to 1, it will return soft-deleted attributes along with active ones. By using \"only\" as a parameter it will limit the returned data set to soft-deleted data only."
+msgid "Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned."
 msgstr ""
 
 #: View/Events/automation.ctp:53

--- a/app/Locale/th_TH/LC_MESSAGES/default.po
+++ b/app/Locale/th_TH/LC_MESSAGES/default.po
@@ -14620,7 +14620,7 @@ msgstr ""
 
 #: View/Events/automation.ctp:67
 #: View/Events/legacy_automation.ctp:315
-msgid "If this parameter is set to 1, it will return soft-deleted attributes along with active ones. By using \"only\" as a parameter it will limit the returned data set to soft-deleted data only."
+msgid "Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned."
 msgstr ""
 
 #: View/Events/automation.ctp:68

--- a/app/Locale/ukr/LC_MESSAGES/default.po
+++ b/app/Locale/ukr/LC_MESSAGES/default.po
@@ -6030,7 +6030,7 @@ msgid "By default (0) all attributes are returned that match the other filter pa
 msgstr ""
 
 #: View/Events/automation.ctp:315
-msgid "If this parameter is set to 1, it will return soft-deleted attributes along with active ones. By using \"only\" as a parameter it will limit the returned data set to soft-deleted data only."
+msgid "Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned."
 msgstr ""
 
 #: View/Events/automation.ctp:316

--- a/app/Locale/zh-s/LC_MESSAGES/default.po
+++ b/app/Locale/zh-s/LC_MESSAGES/default.po
@@ -14619,7 +14619,7 @@ msgstr "默认情况下(0), 返回所有与其他过滤器参数匹配的属性,
 
 #: View/Events/automation.ctp:67
 #: View/Events/legacy_automation.ctp:315
-msgid "If this parameter is set to 1, it will return soft-deleted attributes along with active ones. By using \"only\" as a parameter it will limit the returned data set to soft-deleted data only."
+msgid "Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned."
 msgstr "如果这个参数被设置为1, 它将返回软删除的属性和活动属性. 如果使用\"only\"作为参数, 则返回的数据集将只限于软删除的数据."
 
 #: View/Events/automation.ctp:68

--- a/app/View/Events/automation.ctp
+++ b/app/View/Events/automation.ctp
@@ -64,7 +64,7 @@
                 "published" => __('Set whether published or unpublished events should be returned. Do not set the parameter if you want both.'),
                 "enforceWarninglist" => __('Remove any attributes from the result that would cause a hit on a warninglist entry.'),
                 "to_ids" => __('By default (0) all attributes are returned that match the other filter parameters, regardless of their to_ids setting. To restrict the returned data set to to_ids only attributes set this parameter to 1. You can only use the special "exclude" setting to only return attributes that have the to_ids flag disabled.'),
-                "deleted" => __('If this parameter is set to 1, it will return soft-deleted attributes along with active ones. By using "only" as a parameter it will limit the returned data set to soft-deleted data only.'),
+                "deleted" => __('Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned.'),
                 "includeEventUuid" => __('Instead of just including the event ID, also include the event UUID in each of the attributes.'),
                 "event_timestamp" => __('Only return attributes from events that have received a modification after the given timestamp. The input can be a timestamp or a short-hand time description (7d or 24h for example). You can also pass a list with two values to set a time range (for example ["14d", "7d"]).'),
                 "sgReferenceOnly" => __('If this flag is set, sharing group objects will not be included, instead only the sharing group ID is set.'),

--- a/app/View/Events/legacy_automation.ctp
+++ b/app/View/Events/legacy_automation.ctp
@@ -312,7 +312,7 @@
     <b>timestamp</b>: <?php echo __('Restrict the results by the timestamp (of the attribute). Any attributes with a timestamp newer than the given timestamp will be returned.');?><br />
     <b>enforceWarninglist</b>: <?php echo __('Remove any attributes from the result that would cause a hit on a warninglist entry.');?><br />
     <b>to_ids</b>: <?php echo __('By default (0) all attributes are returned that match the other filter parameters, irregardless of their to_ids setting. To restrict the returned data set to to_ids only attributes set this parameter to 1. You can only use the special "exclude" setting to only return attributes that have the to_ids flag disabled.'); ?> <br />
-    <b>deleted</b>: <?php echo __('If this parameter is set to 1, it will return soft-deleted attributes along with active ones. By using "only" as a parameter it will limit the returned data set to soft-deleted data only.'); ?> <br />
+    <b>deleted</b>: <?php echo __('Default value 0. If set to 1, only soft-deleted attributes will be returned. If set to [0,1] , both deleted and non-deleted attributes wil be returned.'); ?> <br />
     <b>includeEventUuid</b>: <?php echo __('Instead of just including the event ID, also include the event UUID in each of the attributes.'); ?> <br />
     <b>event_timestamp</b>: <?php echo __('Only return attributes from events that have received a modification after the given timestamp.'); ?> <br /><br />
     <p>For example, to get all attributes of events modified after a given timestamp, simply POST to:</p>

--- a/app/webroot/doc/openapi.yaml
+++ b/app/webroot/doc/openapi.yaml
@@ -2908,7 +2908,7 @@ components:
         to_ids:
           $ref: "#/components/schemas/ToIDSRestSearchFlag"
         deleted:
-          $ref: "#/components/schemas/SoftDeletedFlag"
+          $ref: "#/components/schemas/SoftDeletedFlagValuesToInclude"
         event_timestamp:
           $ref: "#/components/schemas/Timestamp"
         threat_level_id:
@@ -5433,6 +5433,11 @@ components:
       type: boolean
       default: false
 
+    SoftDeletedFlagValuesToInclude:
+      description: 'Whether to include soft-deleted attributes. Default value 0. If set to 1, only deleted attributes will be returned. If set to [0,1], both deleted and non-deleted attributes wil be returned.'
+      type: boolean
+      default: false
+
     PublishedFlag:
       type: boolean
       default: false
@@ -6469,7 +6474,7 @@ components:
               to_ids:
                 $ref: "#/components/schemas/ToIDS"
               deleted:
-                $ref: "#/components/schemas/SoftDeletedFlag"
+                $ref: "#/components/schemas/SoftDeletedFlagValuesToInclude"
               excludeLocalTags:
                 $ref: "#/components/schemas/ExcludeLocalTagsRestSearchFilter"
               date:


### PR DESCRIPTION
#### What does it do?

Fix documentation for /events/restSearch and /attributes/restSearch 'deleted' filter.

fix #9437

I am not sure whether these app/Locale files should be updated as well, but included them in the PR just in case.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
