### PR TITLE
fix: [GalaxyClusters] fix tag_name restsearch filter

### DIFF
--- a/app/Controller/Component/RestSearchComponent.php
+++ b/app/Controller/Component/RestSearchComponent.php
@@ -204,7 +204,7 @@ class RestSearchComponent extends Component
             'distribution',
             'org',
             'orgc',
-            'tag',
+            'tag_name',
             'custom',
             'sgReferenceOnly',
             'minimal',


### PR DESCRIPTION
#### What does it do?

fixes #9511

It was probably just a typo as there is a 'tag_name' in GalaxyCluster buildFilterConditions .
https://github.com/MISP/MISP/blob/c5737d6f676454db6f65ec1618b619a36c23c5e8/app/Model/GalaxyCluster.php#L1338

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
