### PR TITLE
fix: CurlClient doesn't use correct Proxy settings

### DIFF
--- a/app/Lib/Tools/CurlClient.php
+++ b/app/Lib/Tools/CurlClient.php
@@ -30,9 +30,6 @@ class CurlClient extends HttpSocketExtended
     /** @var array */
     private $proxy = [];
 
-    /** @var array */
-    private $defaultOptions;
-
     /**
      * @param array $params
      * @noinspection PhpMissingParentConstructorInspection
@@ -60,7 +57,6 @@ class CurlClient extends HttpSocketExtended
         if (isset($params['ssl_verify_peer'])) {
             $this->verifyPeer = $params['ssl_verify_peer'];
         }
-        $this->defaultOptions = $this->generateDefaultOptions();
     }
 
     /**
@@ -198,7 +194,7 @@ class CurlClient extends HttpSocketExtended
             $url .= '?' . http_build_query($query, '', '&', PHP_QUERY_RFC3986);
         }
 
-        $options = $this->defaultOptions;
+        $options = $this->generateOptions();
         $options[CURLOPT_URL] = $url;
         $options[CURLOPT_CUSTOMREQUEST] = $method;
 
@@ -312,7 +308,7 @@ class CurlClient extends HttpSocketExtended
     /**
      * @return array
      */
-    private function generateDefaultOptions()
+    private function generateOptions()
     {
         $options = [
             CURLOPT_FOLLOWLOCATION => true, // Allows to follow redirect


### PR DESCRIPTION
#### What does it do?

The change fixed #9550 
Changes the configuration behavior of `CurlClient`, currently the `defaultOptions` field is only initialized once, during object construction. As the proxy is usually defined after object construction, using the `configProxy` method, the proxy config is not evaluated correctly.
This change removes the `defaultOptions` field and changes the `internalRequest` function to call the `generateOptions` method (former `generateDefaultOptions`) each time.

An alternative working implementation would be that the `configProxy` method changes the proxy in `defaultOptions` directly, but I think the implementation in this change is much more error resistant and as there are no real things loaded during `generateOptions`, only values from other fields are assigned, there is no performance benefit from generating the options only once.  

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
