### PR TITLE
fix: fix objects restsearch first_seen filter

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -2428,7 +2428,7 @@ class Attribute extends AppModel
             $conditions['AND'][] = array($scope . ' <=' => $timestamp[1]);
         } else {
             $timestamp = intval($this->resolveTimeDelta($timestamp)) * 1000000; // seen in stored in micro-seconds in the DB
-            if ($scope == 'Attribute.first_seen') {
+            if ($scope == 'Attribute.first_seen' || $scope == 'Object.first_seen') {
                 $conditions['AND'][] = array($scope . ' >=' => $timestamp);
             } else {
                 $conditions['AND'][] = array($scope . ' <=' => $timestamp);


### PR DESCRIPTION
#### What does it do?

Makes objects restsearch's first_seen filter work the same way as attribute first_seen (meaning if you use "2d" it should return those with a first_seen timestamp >= current time - 2d

Looks like a small oversight in commit 713a9f4 , which should do some of the lifting for #9503 I believe?

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
