### PR TITLE
fix: fix workflow attribute edition actions

### DIFF
--- a/app/Model/WorkflowModules/action/Module_attribute_edition_operation.php
+++ b/app/Model/WorkflowModules/action/Module_attribute_edition_operation.php
@@ -39,7 +39,6 @@ class Module_attribute_edition_operation extends WorkflowBaseActionModule
     protected function __saveAttributes(array $attributes, array $rData, array $params, array $user): array
     {
         $success = false;
-        $attributes = [];
         $newAttributes = [];
         foreach ($attributes as $k => $attribute) {
             $newAttribute = $this->_editAttribute($attribute, $rData, $params);


### PR DESCRIPTION
#### What does it do?

I noticed attribute ids flag operation action module was not working properly (it didn't remove ids flag as I expected).
Found a related issue by cudeso:

Likely fixes #9547.

I don't really understand what the deleted line was supposed to be for, maybe just copy pasta?
FYI: https://github.com/MISP/MISP/blob/b2cb4faedcde13492f5d7526af7b8934e010a33a/app/Model/WorkflowModules/action/Module_attribute_edition_operation.php#L46C12-L46C46

is also strange? $newAttributes is not used later on. Would be nice to have a review of this function.
Impact for people using ids flag unset module can be pretty large.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
