### PR TITLE
new: [ Workflows ] Add shadow attribute before save trigger for Workflows

### DIFF
--- a/app/Model/ShadowAttribute.php
+++ b/app/Model/ShadowAttribute.php
@@ -196,6 +196,23 @@ class ShadowAttribute extends AppModel
 
         // convert into utc and micro sec
         $this->data = $this->Attribute->ISODatetimeToUTC($this->data, $this->alias);
+
+        $trigger_id = 'shadow-attribute-before-save';
+        $isTriggerCallable = $this->isTriggerCallable($trigger_id);
+        if ($isTriggerCallable) {
+            $triggerData = $this->data;
+            $workflowErrors = [];
+            $logging = [
+                'model' => 'ShadowAttribute',
+                'action' => 'add',
+                'id' => $this->data['ShadowAttribute']['id'],
+                'message' => __('The workflow `%s` prevented the saving of this proposal.', $trigger_id)
+            ];
+            $workflowSuccess = $this->executeTrigger($trigger_id, $triggerData, $workflowErrors, $logging);
+            if (!$workflowSuccess) {
+                return false;
+            }
+        }
         return true;
     }
 

--- a/app/Model/ShadowAttribute.php
+++ b/app/Model/ShadowAttribute.php
@@ -201,11 +201,12 @@ class ShadowAttribute extends AppModel
         $isTriggerCallable = $this->isTriggerCallable($trigger_id);
         if ($isTriggerCallable) {
             $triggerData = $this->data;
+            $shadowAttribute_id = $triggerData['ShadowAttribute']['id'] ?? 0;
             $workflowErrors = [];
             $logging = [
                 'model' => 'ShadowAttribute',
                 'action' => 'add',
-                'id' => $this->data['ShadowAttribute']['id'],
+                'id' => $shadowAttribute_id,
                 'message' => __('The workflow `%s` prevented the saving of this proposal.', $trigger_id)
             ];
             $workflowSuccess = $this->executeTrigger($trigger_id, $triggerData, $workflowErrors, $logging);

--- a/app/Model/WorkflowModules/trigger/Module_shadow_attribute_before_save.php
+++ b/app/Model/WorkflowModules/trigger/Module_shadow_attribute_before_save.php
@@ -7,7 +7,7 @@ class Module_shadow_attribute_before_save extends WorkflowBaseTriggerModule
     public $scope = 'shadow-attribute';
     public $name = 'Shadow Attribute Before Save';
     public $description = 'This trigger is called just before a Shadow Attribute is saved in the database';
-    public $icon = 'cube';
+    public $icon = 'comment';
     public $inputs = 0;
     public $outputs = 1;
     public $blocking = true;

--- a/app/Model/WorkflowModules/trigger/Module_shadow_attribute_before_save.php
+++ b/app/Model/WorkflowModules/trigger/Module_shadow_attribute_before_save.php
@@ -1,0 +1,44 @@
+<?php
+include_once APP . 'Model/WorkflowModules/WorkflowBaseModule.php';
+
+class Module_shadow_attribute_before_save extends WorkflowBaseTriggerModule
+{
+    public $id = 'shadow-attribute-before-save';
+    public $scope = 'attribute';
+    public $name = 'Shadow Attribute Before Save';
+    public $description = 'This trigger is called just before a Shadow Attribute is saved in the database';
+    public $icon = 'cube';
+    public $inputs = 0;
+    public $outputs = 1;
+    public $blocking = true;
+    public $misp_core_format = true;
+    public $trigger_overhead = self::OVERHEAD_MEDIUM;
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function normalizeData(array $data)
+    {
+        $this->Event = ClassRegistry::init('Event');
+        $this->Attribute = ClassRegistry::init('Attribute');
+
+        if (empty($data['ShadowAttribute'])) {
+            return false;
+        }
+        
+        // If we're dealing with a proposed edit, we retrieve the data about the attribute 
+        if ($data['ShadowAttribute']['old_id']) {
+            $event = $this->Attribute->fetchAttribute($data['ShadowAttribute']['old_id']);
+            $event['Attribute']['ShadowAttribute'] = array($data['ShadowAttribute']);
+        } else {
+            // If it is a proposal to add a new attribute, we retrieve only the data about the event
+            $event = $this->Event->quickFetchEvent($data['ShadowAttribute']['event_id']);
+            $event['Event']['ShadowAttribute'] = [$data['ShadowAttribute']];
+        }
+
+        $event = parent::normalizeData($event);
+        return $event;
+    }
+}

--- a/app/Model/WorkflowModules/trigger/Module_shadow_attribute_before_save.php
+++ b/app/Model/WorkflowModules/trigger/Module_shadow_attribute_before_save.php
@@ -17,8 +17,7 @@ class Module_shadow_attribute_before_save extends WorkflowBaseTriggerModule
     public function __construct()
     {
         parent::__construct();
-        $this->trigger_overhead_message = __('This trigger is called each time a Shadow Attribute is about to be saved. This means that when a large quantity of Shadow Attributes are being saved (e.g. Feed pulling or synchronisatio
-    n), the workflow will be run for as many time as there are Shadow Attributes.');  
+        $this->trigger_overhead_message = __('This trigger is called each time a Shadow Attribute is about to be saved. This means that when a large quantity of Shadow Attributes are being saved (e.g. Feed pulling or synchronisation), the workflow will be run for as many time as there are Shadow Attributes.');  
     }
 
     public function normalizeData(array $data)

--- a/app/Model/WorkflowModules/trigger/Module_shadow_attribute_before_save.php
+++ b/app/Model/WorkflowModules/trigger/Module_shadow_attribute_before_save.php
@@ -4,7 +4,7 @@ include_once APP . 'Model/WorkflowModules/WorkflowBaseModule.php';
 class Module_shadow_attribute_before_save extends WorkflowBaseTriggerModule
 {
     public $id = 'shadow-attribute-before-save';
-    public $scope = 'attribute';
+    public $scope = 'shadow-attribute';
     public $name = 'Shadow Attribute Before Save';
     public $description = 'This trigger is called just before a Shadow Attribute is saved in the database';
     public $icon = 'cube';

--- a/app/Model/WorkflowModules/trigger/Module_shadow_attribute_before_save.php
+++ b/app/Model/WorkflowModules/trigger/Module_shadow_attribute_before_save.php
@@ -17,6 +17,8 @@ class Module_shadow_attribute_before_save extends WorkflowBaseTriggerModule
     public function __construct()
     {
         parent::__construct();
+        $this->trigger_overhead_message = __('This trigger is called each time a Shadow Attribute is about to be saved. This means that when a large quantity of Shadow Attributes are being saved (e.g. Feed pulling or synchronisatio
+    n), the workflow will be run for as many time as there are Shadow Attributes.');  
     }
 
     public function normalizeData(array $data)


### PR DESCRIPTION
#### What does it do?

This pull request adds a new workflow trigger that is called just before a Shadow Attribute is saved. I think this can be useful to design workflows to prevent the creation of proposal under certain conditions.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
