### PR TITLE
fix: [UI] Fix MISP logo display on object templates index

### DIFF
--- a/app/View/ObjectTemplates/index.ctp
+++ b/app/View/ObjectTemplates/index.ctp
@@ -83,7 +83,7 @@ foreach ($list as $template):
             <?php
                 if ($template['ObjectTemplate']['fixed']):
             ?>
-                <img src="<?php echo $baseurl;?>/img/orgs/MISP.png" width="24" height="24" style="padding-bottom:3px;" />
+                    <?php echo '<img src="' . $this->Image->base64(APP . 'files/img/orgs/MISP.png') . '" alt="' . __('MISP logo') . '" width="24" height="24" style="padding-bottom:3px" onerror="this.style.display=\'none\';">';?>
             <?php
                 endif;
             ?>


### PR DESCRIPTION
#### What does it do?

Makes these display properly again:

![image](https://github.com/MISP/MISP/assets/9868873/430bf7b0-1525-46b0-98ff-be5eb18b171d)


#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
