### PR TITLE
chg: Set BrowscapPHP logging from default DEBUG to INFO

### DIFF
--- a/app/Model/UserLoginProfile.php
+++ b/app/Model/UserLoginProfile.php
@@ -46,6 +46,8 @@ class UserLoginProfile extends AppModel
     private function browscapGetBrowser()
     {
         $logger = new \Monolog\Logger('name');
+        $streamHandler = new \Monolog\Handler\StreamHandler('php://stderr', \Monolog\Logger::INFO);
+        $logger->pushHandler($streamHandler);
 
         if (function_exists('apcu_fetch')) {
             App::uses('ApcuCacheTool', 'Tools');


### PR DESCRIPTION
In the `browscapGetBrowser()` function of `class UserLoginProfile`, Mongolog is used for logging of BrowscapPHP.

It seems that Mongolog will default to DEBUG if a log level is not set.  This results in a huge number of entries in the Apache error log, and since we are not debugging BrowscapPHP in production, these entries are unwanted.

Example log entry:
> [2024-02-09 04:49:46] name.DEBUG: cache key "browscap.patterns.df" was empty [] []

#### What does it do?
Code change adds a Mongolog StreamHandler set to INFO.
This significantly reduces the log output from BrowscapPHP.

If anyone has a better way of resolving this issue, I'd be happy to see it.

#### Questions
- [ ] Does it require a DB change? No
- [ ] Are you using it in production? Yes
- [ ] Does it require a change in the API (PyMISP for example)? No
