### PR TITLE
fix: Attachments deletion when accepting a delegation request

### DIFF
--- a/app/Model/EventDelegation.php
+++ b/app/Model/EventDelegation.php
@@ -31,7 +31,10 @@ class EventDelegation extends AppModel
 
     public function transferEvent($delegation, $user)
     {
-        $event = $this->Event->fetchEvent($user, array('eventid' => $delegation['EventDelegation']['event_id']));
+        $event = $this->Event->fetchEvent($user, array(
+            'eventid' => $delegation['EventDelegation']['event_id'],
+            'includeAttachments' => 1
+        ));
         if (empty($event)) {
             throw new NotFoundException('Invalid event.');
         }


### PR DESCRIPTION
#### What does it do?

This pull request fixes an issue that causes the deletion of attachments when accepting an Event delegation request.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
