### PR TITLE
fix: [doc:rhel-installer] Correct conditional addition of httpd Liste…

### DIFF
--- a/docs/INSTALL.rhel7.md
+++ b/docs/INSTALL.rhel7.md
@@ -411,7 +411,9 @@ apacheConfig_RHEL7 () {
   #sudo sed -i "s/SetHandler/\#SetHandler/g" /etc/httpd/conf.d/misp.ssl.conf
   sudo rm /etc/httpd/conf.d/ssl.conf
   sudo chmod 644 /etc/httpd/conf.d/misp.ssl.conf
-  sudo sed -i '/Listen 443/!s/Listen 80/a Listen 443/' /etc/httpd/conf/httpd.conf
+  if ! grep -x "Listen 443" /etc/httpd/conf/httpd.conf; then
+  sudo sed -i '/Listen 80/a Listen 443' /etc/httpd/conf/httpd.conf
+  fi
 
   # If a valid SSL certificate is not already created for the server, create a self-signed certificate:
   echo "The Common Name used below will be: ${OPENSSL_CN}"

--- a/docs/INSTALL.rhel8.md
+++ b/docs/INSTALL.rhel8.md
@@ -452,7 +452,9 @@ apacheConfig_RHEL8 () {
   #sudo sed -i "s/SetHandler/\#SetHandler/g" /etc/httpd/conf.d/misp.ssl.conf
   sudo rm /etc/httpd/conf.d/ssl.conf
   sudo chmod 644 /etc/httpd/conf.d/misp.ssl.conf
-  sudo sed -i '/Listen 443/!s/Listen 80/a Listen 443/' /etc/httpd/conf/httpd.conf
+  if ! grep -x "Listen 443" /etc/httpd/conf/httpd.conf; then
+  sudo sed -i '/Listen 80/a Listen 443' /etc/httpd/conf/httpd.conf
+  fi
 
   # If a valid SSL certificate is not already created for the server, create a self-signed certificate:
   echo "The Common Name used below will be: ${OPENSSL_CN}"


### PR DESCRIPTION
…n 443 line

#### What does it do?

Hope these are the correct files to edit to be included in the installer.
Fixes an issue with rhel installer which has been there for a while. Installation added a line 'a Listen 443', so the httpd service didn't start properly, giving an error.

This should still keep the addition conditional. 

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
