### PR TITLE
chg: [internal] Log content type when JSON could not be parsed

### DIFF
--- a/app/Lib/Tools/HttpSocketExtended.php
+++ b/app/Lib/Tools/HttpSocketExtended.php
@@ -121,7 +121,8 @@ class HttpSocketResponseExtended extends HttpSocketResponse
         try {
             return JsonTool::decode($this->body);
         } catch (Exception $e) {
-            throw new HttpSocketJsonException('Could not parse response as JSON.', $this, $e);
+            $contentType = $this->getHeader('content-type');
+            throw new HttpSocketJsonException("Could not parse HTTP response as JSON. Received Content-Type $contentType.", $this, $e);
         }
     }
 }


### PR DESCRIPTION
#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
