### PR TITLE
fix: [oidc] Use the same handling of org also for Oidc::isUserValid

### DIFF
--- a/app/Plugin/OidcAuth/Controller/Component/Auth/OidcAuthenticate.php
+++ b/app/Plugin/OidcAuth/Controller/Component/Auth/OidcAuthenticate.php
@@ -13,7 +13,7 @@ App::uses('Oidc', 'OidcAuth.Lib');
  *  - OidcAuth.organisation_property (default: `organization`)
  *  - OidcAuth.organisation_uuid_property (default: `organization_uuid`)
  *  - OidcAuth.roles_property (default: `roles`)
- *  - OidcAuth.default_org - organisation ID, UUID or name if organsation is not provided by OIDC
+ *  - OidcAuth.default_org - organisation ID, UUID or name if organisation is not provided by OIDC
  *  - OidcAuth.unblock (boolean, default: false)
  *  - OidcAuth.offline_access (boolean, default: false)
  *  - OidcAuth.check_user_validity (integer, default `0`)


### PR DESCRIPTION
#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
