### PR TITLE
OIDC: customize usernameProperty, add default role, use default_org, 

### DIFF
--- a/app/Plugin/OidcAuth/Lib/Oidc.php
+++ b/app/Plugin/OidcAuth/Lib/Oidc.php
@@ -50,7 +50,7 @@ class Oidc
         }
 
         $organisationProperty = $this->getConfig('organisation_property', 'organization');
-        $organisationName = $claims->{$organisationProperty} ?? null;
+        $organisationName = $claims->{$organisationProperty} ?? $this->getConfig('default_org');
 
         $organisationUuidProperty = $this->getConfig('organisation_uuid_property', 'organization_uuid');
         $organisationUuid = $claims->{$organisationUuidProperty} ?? null;

--- a/app/Plugin/OidcAuth/Lib/Oidc.php
+++ b/app/Plugin/OidcAuth/Lib/Oidc.php
@@ -27,7 +27,8 @@ class Oidc
 
         $claims = $oidc->getVerifiedClaims();
 
-        $mispUsername = $claims->email ?? $oidc->requestUserInfo('email');
+        $usernameProperty = $this->getConfig('username_property', 'email');
+        $mispUsername = $claims->$usernameProperty ?? $oidc->requestUserInfo($usernameProperty);
         if (empty($mispUsername)) {
             $sub = $claims->sub ?? 'UNKNOWN';
             throw new Exception("OIDC user $sub doesn't have email address, that is required by MISP.");

--- a/app/Plugin/OidcAuth/Lib/Oidc.php
+++ b/app/Plugin/OidcAuth/Lib/Oidc.php
@@ -69,7 +69,12 @@ class Oidc
         }
 
         $roleProperty = $this->getConfig('roles_property', 'roles');
-        $roles = $claims->{$roleProperty} ?? $oidc->requestUserInfo($roleProperty);
+        try {
+            $roles = $claims->{$roleProperty} ?? $oidc->requestUserInfo($roleProperty);
+        } catch (JakubOnderka\OpenIDConnectClientException $e) {
+            $this->log(null, "Could not get roles from $$roleProperty , using default");
+            $roles = array($this->getConfig('default_role'));
+        }
         if ($roles === null) {
             $this->log($mispUsername, "Role property `$roleProperty` is missing in claims, access prohibited.", LOG_WARNING);
             return false;


### PR DESCRIPTION
#### What does it do?

Add OIDC config setting `username_property` to define which claim to use. Defaults to `email` to keep the same behavior.
Add OIDC config setting `default_role` in case IdP does not send the claim `roles_property` AND IdP userInfo cannot be queried. Defaults to `null` to keep the same behavior.
Use OIDC config setting `default_org` in case IdP does not send the claim `organization_property`.
Does not fail if IdP userInfo cannot be queried.

#### Questions

- [ ] Does it require a DB change? NO.
- [ ] Are you using it in production? YES.
- [ ] Does it require a change in the API (PyMISP for example)? NO.
