### PR TITLE
fix: Add missing requestMethod in Module_splunk_hec_export

### DIFF
--- a/app/Model/WorkflowModules/action/Module_splunk_hec_export.php
+++ b/app/Model/WorkflowModules/action/Module_splunk_hec_export.php
@@ -144,6 +144,7 @@ class Module_splunk_hec_export extends Module_webhook
                     'json',
                     $hec_event,
                     $headers,
+                    'post',
                     $serverConfig
                 );
                 if (!$response->isOk()) {


### PR DESCRIPTION
Fixes: #9680

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
