### PR TITLE
chg: [config] Set Oidc issuer

### DIFF
--- a/app/Plugin/OidcAuth/Lib/Oidc.php
+++ b/app/Plugin/OidcAuth/Lib/Oidc.php
@@ -302,9 +302,10 @@ class Oidc
         $providerUrl = $this->getConfig('provider_url');
         $clientId = $this->getConfig('client_id');
         $clientSecret = $this->getConfig('client_secret');
+        $issuer = $this->getConfig('issuer', $providerUrl);
 
         if (class_exists("\JakubOnderka\OpenIDConnectClient")) {
-            $oidc = new \JakubOnderka\OpenIDConnectClient($providerUrl, $clientId, $clientSecret);
+            $oidc = new \JakubOnderka\OpenIDConnectClient($providerUrl, $clientId, $clientSecret, $issuer);
         } else if (class_exists("\Jumbojett\OpenIDConnectClient")) {
             throw new Exception("Jumbojett OIDC implementation is not supported anymore, please use JakubOnderka's client");
         } else {

--- a/app/Plugin/OidcAuth/README.md
+++ b/app/Plugin/OidcAuth/README.md
@@ -32,6 +32,7 @@ $config = array(
     ...
     'OidcAuth' = [
         'provider_url' => '{{ OIDC_PROVIDER }}',
+        'issuer' => '{{ OIDC_ISSUER }}', // If omitted, it defaults to provider_url
         'client_id' => '{{ OIDC_CLIENT_ID }}',
         'client_secret' => '{{ OIDC_CLIENT_SECRET }}',
         'role_mapper' => [ // if user has multiple roles, first role that match will be assigned to user


### PR DESCRIPTION
#### What does it do?

It allows to specify an OIDC issuer other than the `provider_url`, it still defaults to `provider_url` if issuer is not specified, making the update transparent for current deployments.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
