### PR TITLE
fix: [galaxy_clusters] Add orgc filter option for index, set it as de…

### DIFF
--- a/app/Controller/GalaxyClustersController.php
+++ b/app/Controller/GalaxyClustersController.php
@@ -59,6 +59,8 @@ class GalaxyClustersController extends AppController
             $contextConditions['GalaxyCluster.default'] = true;
         } elseif ($filters['context'] == 'custom') {
             $contextConditions['GalaxyCluster.default'] = false;
+        } elseif ($filters['context'] == 'orgc') {
+            $contextConditions['GalaxyCluster.orgc_id'] = $this->Auth->user('org_id');
         } elseif ($filters['context'] == 'org') {
             $contextConditions['GalaxyCluster.org_id'] = $this->Auth->user('org_id');
         } elseif ($filters['context'] == 'deleted') {

--- a/app/View/GalaxyClusters/ajax/index.ctp
+++ b/app/View/GalaxyClusters/ajax/index.ctp
@@ -34,7 +34,7 @@
                             ),
                             array(
                                 'active' => $context === 'org',
-                                'url' => sprintf('%s/galaxies/view/%s/context:org', $baseurl, $galaxy_id),
+                                'url' => sprintf('%s/galaxies/view/%s/context:orgc', $baseurl, $galaxy_id),
                                 'text' => __('My Clusters'),
                             ),
                             array(


### PR DESCRIPTION
…fault for galaxy view 'My Clusters'

#### What does it do?

As per discussion on gitter.
Note that I also updated the "My Clusters" button which is on the galaxy view page for example. This is also more aligned with events index (org events there means only events created by your org, not owned by).

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
