### PR TITLE
Add Infoblox feed to defaults.json

### DIFF
--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -1819,5 +1819,25 @@
       "exportable": true,
       "hide_tag": false
     }
+  },
+  {
+    "Feed": {
+      "name": "Infoblox-Threat-Intelligence",
+      "provider": "infoblox.com",
+      "url": "https:\/\/github.com\/infobloxopen\/threat-intelligence\/tree\/main\/indicators\/misp",
+      "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]}}",
+      "enabled": true,
+      "distribution": "0",
+      "default": false,
+      "source_format": "misp",
+      "fixed_event": false,
+      "delta_merge": false,
+      "publish": false,
+      "override_ids": false,
+      "settings": "{\"csv\":{\"value\":\"\",\"delimiter\":\"\"},\"common\":{\"excluderegex\":\"\"}}",
+      "input_source": "network",
+      "delete_local_file": false,
+      "lookup_visible": false
+    }
   }
 ]


### PR DESCRIPTION
Request for addition of the Infoblox MISP feed to the defaults.json