### PR TITLE
new: [events:view] New UI feature allowing to collapse Attributes con…

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -5930,6 +5930,14 @@ class Server extends AppModel
                     'type' => 'boolean',
                     'null' => true
                 ),
+                'collapse_attribute_in_object' => array(
+                    'level' => 1,
+                    'description' => __('When enabled, all Attributes contained inside an object will be automatically collapsed when viewing an Event.'),
+                    'value' => false,
+                    'test' => 'testBool',
+                    'type' => 'boolean',
+                    'null' => true
+                ),
                 'disableUserSelfManagement' => array(
                     'level' => 1,
                     'description' => __('When enabled only Org and Site admins can edit a user\'s profile.'),

--- a/app/View/Elements/Events/View/row_attribute.ctp
+++ b/app/View/Elements/Events/View/row_attribute.ctp
@@ -1,5 +1,5 @@
 <?php
-  $tr_class = '';
+  $tr_class = empty($trClass) ? '' : ($trClass . ' ') ;
   if (empty($context)) {
       $context = 'event';
   }

--- a/app/View/Elements/Events/View/row_object.ctp
+++ b/app/View/Elements/Events/View/row_object.ctp
@@ -86,8 +86,11 @@ $objectId = intval($object['id']);
   <td colspan="<?= $includeRelatedTags ? 6 : 5 ?>">
     <div style="display: flex">
       <div style="width: 25%;">
-        <span class="bold"><?php echo __('Object name: ');?></span><?php echo h($object['name']);?>
-        <span class="fa fa-expand useCursorPointer" title="<?php echo __('Expand or Collapse');?>" role="button" tabindex="0" aria-label="<?php echo __('Expand or Collapse');?>" data-toggle="collapse" data-target="#Object_<?php echo $objectId ?>_collapsible"></span>
+        <span class="bold"><?php echo __('Object name: ');?></span>
+        <span style="white-space: nowrap;">
+          <?php echo h($object['name']);?>
+          <span class="fa fa-expand useCursorPointer" title="<?php echo __('Expand or Collapse');?>" role="button" tabindex="0" aria-label="<?php echo __('Expand or Collapse');?>" data-toggle="collapse" data-target="#Object_<?php echo $objectId ?>_collapsible"></span>
+        </span>
         <br>
         <div id="Object_<?= $objectId ?>_collapsible" class="collapse">
             <span class="bold"><?php echo __('UUID');?>: </span><?php echo h($object['uuid']);?><br />
@@ -111,7 +114,9 @@ $objectId = intval($object['id']);
       </div>
       <div style="margin-left: 2em; flex-grow: 1;">
           <?php if (!empty($object['Attribute'])): ?>
-            <?php $firstAttr = $object['Attribute'][0]; ?>
+            <?php
+              $firstAttr = $object['Attribute'][0]; // Attributes are already ordered based on their UI priority
+            ?>
             <strong><?= h($firstAttr['object_relation']) ?></strong> :: <span><?= h($firstAttr['type']) ?></span>
             <span><pre style="margin-bottom: 0; padding: 0.25em 0.5em;"><?= h($firstAttr['value']) ?></pre></span>
             <div style="margin-top: 0.25em;">

--- a/app/View/Elements/Events/View/row_object.ctp
+++ b/app/View/Elements/Events/View/row_object.ctp
@@ -117,8 +117,10 @@ $objectId = intval($object['id']);
             <?php
               $firstAttr = $object['Attribute'][0]; // Attributes are already ordered based on their UI priority
             ?>
-            <strong><?= h($firstAttr['object_relation']) ?></strong> :: <span><?= h($firstAttr['type']) ?></span>
-            <span><pre style="margin-bottom: 0; padding: 0.25em 0.5em;"><?= h($firstAttr['value']) ?></pre></span>
+            <span style="border: 1px solid #2f5a93; background-color: #5184c8; border-radius: 5px 5px 0 0; padding: 2px 4px; margin-left: -1px;">
+              <strong><?= h($firstAttr['object_relation']) ?></strong> :: <span><?= h($firstAttr['type']) ?></span>
+            </span>
+            <span><pre style="margin-bottom: 0; padding: 0.25em 0.5em; border-radius: 0 5px 5px 5px;"><?= h($firstAttr['value']) ?></pre></span>
             <div style="margin-top: 0.25em;">
               <button class="btn btn-mini btn-primary <?= $attributeInObjectCollapsed ? 'content-hidden' : '' ?>" title="<?php echo __('Toggle Attributes visibility');?>" role="button" tabindex="0" aria-label="<?php echo __('Toggle Attributes visibility');?>" data-toggle="quickcollapse" data-target=".Object_<?php echo $objectId ?>_collapsible_attr">
                 <span class="fa fa-angle-double-<?= $attributeInObjectCollapsed ? 'down' : 'up' ?>" data-text-show="fa-angle-double-down" data-class-hide="fa-angle-double-up"></span>

--- a/app/View/Elements/eventattribute.ctp
+++ b/app/View/Elements/eventattribute.ctp
@@ -234,7 +234,7 @@ attributes or the appropriate distribution level. If you think there is a mistak
         var $targetElement = $(targetClass)
         var $textElement = $button.find('.text')
         var $iconElement = $button.find('.fa')
-        var shouldShow = show !== undefined ? show : $targetElement[0].style.display === 'none'
+        var shouldShow = show !== undefined ? show : ($targetElement[0].style.display !== 'table-row')
         if (shouldShow) {
             $targetElement.show()
             $textElement.text($textElement.data('text-hide'))

--- a/app/View/Elements/eventattribute.ctp
+++ b/app/View/Elements/eventattribute.ctp
@@ -222,7 +222,41 @@ attributes or the appropriate distribution level. If you think there is a mistak
             });
             
         });
+
+        $('[data-toggle="quickcollapse"').click(function() {
+            var $clicked = $(this)
+            toggleVisibilityForAttributes($clicked)
+        })
     });
+
+    function toggleVisibilityForAttributes($button, show) {
+        var targetClass = $button.data('target')
+        var $targetElement = $(targetClass)
+        var $textElement = $button.find('.text')
+        var $iconElement = $button.find('.fa')
+        var shouldShow = show !== undefined ? show : $targetElement[0].style.display === 'none'
+        if (shouldShow) {
+            $targetElement.show()
+            $textElement.text($textElement.data('text-hide'))
+            $iconElement.addClass($iconElement.data('class-hide')).removeClass($iconElement.data('class-show'))
+        } else {
+            $targetElement.hide()
+            $textElement.text($textElement.data('text-show'))
+            $iconElement.addClass($iconElement.data('class-show')).removeClass($iconElement.data('class-hide'))
+        }
+    }
+
+    function showAllAttributeInObjects() {
+        $('[data-toggle="quickcollapse"').each(function() {
+            toggleVisibilityForAttributes($(this), true)
+        })
+    }
+    function hideAllAttributeInObjects() {
+        $('[data-toggle="quickcollapse"').each(function() {
+            toggleVisibilityForAttributes($(this), false)
+        })
+    }
+
     $(function() {
         <?php
             if (isset($focus)):

--- a/app/View/Elements/eventattributetoolbar.ctp
+++ b/app/View/Elements/eventattributetoolbar.ctp
@@ -259,6 +259,26 @@
                     )
                 )
             ),
+            [
+                'children' => [
+                    [
+                        'id' => 'expand-all-objects',
+                        'text' => _('Expand all Objects'),
+                        'title' => __('Show all Attribute contained in Objects'),
+                        'fa-icon' => 'angle-double-down',
+                        'onClick' => 'showAllAttributeInObjects',
+                        'onClickParams' => [],
+                    ],
+                    [
+                        'id' => 'collapse-all-objects',
+                        'text' => _('Collapse all Attributes'),
+                        'title' => __('Hide all Attribute contained in Objects'),
+                        'fa-icon' => 'angle-double-up',
+                        'onClick' => 'hideAllAttributeInObjects',
+                        'onClickParams' => [],
+                    ],
+                ],
+            ],
             array(
                 'type' => 'search',
                 'fa-icon' => 'search',

--- a/app/webroot/css/main.css
+++ b/app/webroot/css/main.css
@@ -85,6 +85,10 @@ pre {
     font-size: 12px;
 }
 
+.d-none {
+    display: none;
+}
+
 .ellipsis-overflow {
     white-space: nowrap;
     text-overflow: ellipsis;


### PR DESCRIPTION
It comes with a MISP setting (`MISP.collapse_attribute_in_object`) to toggle a different behavior for the instance.
By default, Objects are not collapsed.
The Attribute included in the Object's row will always be the one having the highest `ui-priority` defined in its template. If there is none or if multiple Attributes have the same value, the display might be random.

**Collapsed view**
![Screenshot from 2024-05-22 15-37-05](https://github.com/MISP/MISP/assets/6977223/807d3d4b-e926-4a8e-8541-8762db8a96fa)

**Expanded view** (normal view)
![Screenshot from 2024-05-22 15-37-27](https://github.com/MISP/MISP/assets/6977223/30534258-1cb3-465c-925d-38ea45dd61f0)

