### PR TITLE
chg: [diagnostics] add Database/MysqlObserverExtended to valid data s…

### DIFF
--- a/app/View/Elements/healthElements/db_schema_diagnostic.ctp
+++ b/app/View/Elements/healthElements/db_schema_diagnostic.ctp
@@ -168,7 +168,7 @@ function highlightAndSanitize($dirty, $toHighlight, $colorType = 'success')
             : __('Updates are not locked'),
         $updateLocked ? 'times' : 'check'
     );
-    $validDataSource = in_array($dataSource, ['Database/Mysql', 'Database/MysqlExtended'], true);
+    $validDataSource = in_array($dataSource, ['Database/Mysql', 'Database/MysqlExtended', 'Database/MysqlObserverExtended'], true);
     echo sprintf('<span class="label label-%s" title="%s" style="margin-left: 5px;">%s <i class="fas fa-%s"></i></span>',
         $validDataSource ? 'success' : 'important',
         __('DataSource: ') . h($dataSource),


### PR DESCRIPTION
…ources list

#### What does it do?
Makes sure the datasource shows as okay on diagnostics page when using Database/MysqlObserverExtended

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
