### PR TITLE
fix: [doc] correct filenames in rhel background worker migration guid…

### DIFF
--- a/docs/background-jobs-migration-guide.md
+++ b/docs/background-jobs-migration-guide.md
@@ -136,7 +136,7 @@ Run on your MISP instance the following commands.
     cd /tmp/misp-modules-supervisord
     ```
 3. Create file and add content to
-   `misp-modules-supervisord.te`
+   `misp-workers-httpd.te`
     ```
     policy_module(misp-workers-httpd, 1.0)
     require{
@@ -148,8 +148,8 @@ Run on your MISP instance the following commands.
     ```
 4. Make and install module
     ```
-    make -f /usr/share/selinux/devel/Makefile misp-modules-supervisord.pp
-    sudo semodule -i misp-modules-supervisord.pp
+    make -f /usr/share/selinux/devel/Makefile misp-workers-httpd.pp
+    sudo semodule -i misp-workers-httpd.pp
     ```
 
 5. Restart **Supervisord** to load the changes:


### PR DESCRIPTION
…e steps

#### What does it do?

Edit filenames so they match policy module name, otherwise running the related commands gives an error (my bad, thought to use a clearer policy name and then didn't copy everywhere).

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
