### PR TITLE
chg:[attributes:restSearch] Allow publish_timstamp as order key and a…

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -3185,7 +3185,7 @@ class Attribute extends AppModel
         $conditions = $this->buildFilterConditions($user, $filters, true);
         $params = array(
             'conditions' => $conditions,
-            'fields' => array('Attribute.*', 'Event.org_id', 'Event.distribution'),
+            'fields' => array('Attribute.*', 'Event.org_id', 'Event.distribution', 'Event.publish_timestamp'),
             'withAttachments' => !empty($filters['withAttachments']) ? $filters['withAttachments'] : 0,
             'enforceWarninglist' => !empty($filters['enforceWarninglist']) ? $filters['enforceWarninglist'] : 0,
             'includeAllTags' => !empty($filters['includeAllTags']) ? $filters['includeAllTags'] : 0,
@@ -3238,7 +3238,7 @@ class Attribute extends AppModel
             $params['order'] = $this->findOrder(
                 $filters['order'],
                 'Attribute',
-                ['id', 'event_id', 'object_id', 'type', 'category', 'value', 'distribution', 'timestamp', 'object_relation']
+                ['id', 'event_id', 'object_id', 'type', 'category', 'value', 'distribution', 'timestamp', 'object_relation', 'publish_timestamp']
             );
         }
         if ($paramsOnly) {


### PR DESCRIPTION
Querying attributes in a polling manner without loosing Attributes is difficult using the current API for the following reasons:
- Attribute timestamp cannot be used as restart filter, as sync mechanisms can import attributes with older timestamps
- Attribute id cannot be used, as this would loose all attribute updates.
- Event publish_timestamp could be a possible restart point, but it is currently not possible to sort after publish_timestamp.

#### What does it do?

This change adds the ability to sort queried attributes regarding the publish_timestamp field and adds the Event.publish_timestamp field automatically to each attribute.
Due to this change it would be possible to query attributes since a specific publish_timestamp and sorted after this field in a paged manner. On the next interval, the polling can be restarted by the latest publish timestamp without loosing any attributes.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [x] Does it require a change in the API (PyMISP for example)?

It adds the Event.publish_timestamp to each Attribute
