### PR TITLE
chg: [Attributes restSearch] added sort support for publish_timestamp

### DIFF
--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -4186,20 +4186,46 @@ class AppModel extends Model
 
     public function findOrder($order, $orderModel, $validOrderFields)
     {
-        if (!is_array($order)) {
-            $orderRules = explode(' ', strtolower($order));
-            $orderField = explode('.', $orderRules[0]);
-            $orderField = end($orderField);
-            if (in_array($orderField, $validOrderFields, true)) {
-                $direction = 'asc';
-                if (!empty($orderRules[1]) && trim($orderRules[1]) === 'desc') {
-                    $direction = 'desc';
+        if (is_string($order)) {
+            $orderRules = explode(',', $order);
+        } elseif (is_array($order)) {
+            $orderRules = $order; // to support multiple column order
+        }
+
+        $order = array();
+        foreach ($orderRules as $rule) {
+            if (!is_string($rule)) {
+                return null;
+            }
+            $ruleItems = explode(' ', trim($rule));
+            $direction = 'asc';
+            if (count($ruleItems) === 2) {
+                if (strtolower(end($ruleItems)) === 'asc' || strtolower(end($ruleItems)) === 'desc') {
+                    $direction = end($ruleItems);
                 }
+            }
+            $orderPath = explode('.', $ruleItems[0]);
+            if (count($orderPath) === 1) {
+                $model = $orderModel;
+                $field = strtolower($orderPath[0]);
+            } elseif (count($orderPath) === 2) {
+                $model = $orderPath[0];
+                $field = strtolower($orderPath[1]);
             } else {
                 return null;
             }
-            return $orderModel . '.' . $orderField . ' ' . $direction;
+            if (
+                    (in_array($field, $validOrderFields) && $model === $orderModel) ||
+                    (array_key_exists($model, $validOrderFields) && in_array($field, $validOrderFields[$model]))
+            ) {
+                $order[] = $model . '.' . $field . ' ' . $direction;
+            } else {
+                return null;
+            }
         }
+        if (count($order) > 0) {
+           return $order;
+        } 
         return null;
     }
 

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -1868,15 +1868,11 @@ class Attribute extends AppModel
             $params['order'] = $this->findOrder(
                 $options['order'],
                 'Attribute',
-                ['id', 'event_id', 'object_id', 'type', 'category', 'value', 'distribution', 'timestamp', 'object_relation']
+                array(
+                    'Attribute' => array('id', 'event_id', 'object_id', 'type', 'category', 'value', 'distribution', 'timestamp', 'object_relation'),
+                    'Event' => array('publish_timestamp'),
+                )
             );
-            if (is_null($params['order'])) {
-                $params['order'] = $this->findOrder(
-                    $options['order'],
-                    'Event',
-                    ['publish_timestamp']
-                );
-            }
         }
         if (!isset($options['withAttachments'])) {
             $options['withAttachments'] = false;
@@ -3245,15 +3241,11 @@ class Attribute extends AppModel
             $params['order'] = $this->findOrder(
                 $filters['order'],
                 'Attribute',
-                ['id', 'event_id', 'object_id', 'type', 'category', 'value', 'distribution', 'timestamp', 'object_relation']
+                array(
+                    'Attribute' => array('id', 'event_id', 'object_id', 'type', 'category', 'value', 'distribution', 'timestamp', 'object_relation'),
+                    'Event' => array('publish_timestamp'),
+                )
             );
-            if (is_null($params['order'])) {
-                $params['order'] = $this->findOrder(
-                    $filters['order'],
-                    'Event',
-                    ['publish_timestamp']
-                );
-            }
         }
         if ($paramsOnly) {
             return $params;

--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -1870,6 +1870,13 @@ class Attribute extends AppModel
                 'Attribute',
                 ['id', 'event_id', 'object_id', 'type', 'category', 'value', 'distribution', 'timestamp', 'object_relation']
             );
+            if (is_null($params['order'])) {
+                $params['order'] = $this->findOrder(
+                    $options['order'],
+                    'Event',
+                    ['publish_timestamp']
+                );
+            }
         }
         if (!isset($options['withAttachments'])) {
             $options['withAttachments'] = false;
@@ -3185,7 +3192,7 @@ class Attribute extends AppModel
         $conditions = $this->buildFilterConditions($user, $filters, true);
         $params = array(
             'conditions' => $conditions,
-            'fields' => array('Attribute.*', 'Event.org_id', 'Event.distribution'),
+            'fields' => array('Attribute.*', 'Event.org_id', 'Event.distribution', 'Event.publish_timestamp'),
             'withAttachments' => !empty($filters['withAttachments']) ? $filters['withAttachments'] : 0,
             'enforceWarninglist' => !empty($filters['enforceWarninglist']) ? $filters['enforceWarninglist'] : 0,
             'includeAllTags' => !empty($filters['includeAllTags']) ? $filters['includeAllTags'] : 0,
@@ -3240,6 +3247,13 @@ class Attribute extends AppModel
                 'Attribute',
                 ['id', 'event_id', 'object_id', 'type', 'category', 'value', 'distribution', 'timestamp', 'object_relation']
             );
+            if (is_null($params['order'])) {
+                $params['order'] = $this->findOrder(
+                    $filters['order'],
+                    'Event',
+                    ['publish_timestamp']
+                );
+            }
         }
         if ($paramsOnly) {
             return $params;


### PR DESCRIPTION
#### What does it do?

Querying attributes in a polling manner without loosing Attributes is difficult using the current API for the following reasons:
- Attribute timestamp cannot be used as restart filter, as sync mechanisms can import attributes with older timestamps
- Attribute id cannot be used, as this would loose all attribute updates.
- Event publish_timestamp could be a possible restart point, but it is currently not possible to sort after publish_timestamp.

This change adds the ability to sort queried attributes regarding the Event.publish_timestamp field and adds the Event.publish_timestamp field automatically to each attribute.
Due to this change it would be possible to query attributes since a specific publish_timestamp and sorted after this field in a paged manner. On the next interval, the polling can be restarted by the latest publish timestamp without loosing any attributes.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [x] Does it require a change in the API (PyMISP for example)?

It adds the Event.publish_timestamp to each Attribute

#### Note:
I tried to avoid to modify the  `AppModel:findOrder` function first, but it would make sense to modify this function to make it more generic.