### PR TITLE
new: Comment field for Bookmarks

### DIFF
--- a/app/View/Bookmarks/add.ctp
+++ b/app/View/Bookmarks/add.ctp
@@ -12,6 +12,11 @@ $fields = [
         'class' => 'input span6',
     ],
     [
+        'field' => 'Comment',
+        'type' => 'textarea',
+        'class' => 'input span6',
+    ],
+    [
         'field' => 'exposed_to_org',
         'type' => 'checkbox',
         'label' => __('Should this bookmark be exposed to all users from the organisation'),

--- a/app/View/Bookmarks/index.ctp
+++ b/app/View/Bookmarks/index.ctp
@@ -27,6 +27,11 @@
             'data_path' => 'Bookmark.url',
         ],
         [
+            'name' => __('Comment'),
+            'sort' => 'Bookmark.comment',
+            'data_path' => 'Bookmark.comment',
+        ],
+        [
             'name' => __('Exposed to Organsation'),
             'title' => __('Is this bookmark exposed to all users belonging to the bookmark\'s organisation'),
             'sort' => 'Bookmark.exposed_to_org',

--- a/app/View/Bookmarks/view.ctp
+++ b/app/View/Bookmarks/view.ctp
@@ -20,7 +20,7 @@ echo $this->element(
             [
                 'key' => __('Comment'),
                 'path' => 'Bookmark.comment',
-            ]
+            ],
             [
                 'key' => __('Exposed to Organsation'),
                 'path' => 'Bookmark.exposed_to_org',

--- a/app/View/Bookmarks/view.ctp
+++ b/app/View/Bookmarks/view.ctp
@@ -18,6 +18,10 @@ echo $this->element(
                 'path' => 'Bookmark.url',
             ],
             [
+                'key' => __('Comment'),
+                'path' => 'Bookmark.comment',
+            ]
+            [
                 'key' => __('Exposed to Organsation'),
                 'path' => 'Bookmark.exposed_to_org',
                 'type' => 'boolean'


### PR DESCRIPTION
This is my very first commit. I tried my best and hope it works.

#### What does it do?

I tried to add a comment field to the new Bookmark feature. Analysts could use this feature to add additional context on why they saved and shared a bookmark with their org. For example internal ticket ID, actions that have to be taken on the event, etc. 

#### Questions

- [ ] Does it require a DB change?
   Maybe, since I added a new field for additional information.
- [ ] Are you using it in production?
   No.
- [ ] Does it require a change in the API (PyMISP for example)?
   No, as far as I know is the bookmark feature not yet part of pyMISP. If so then yes.