### PR TITLE
Default to env dependencies, and fallback to submodules'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,7 +148,8 @@ jobs:
           app/Console/cake Admin setSetting "MISP.python_bin" "$GITHUB_WORKSPACE/venv/bin/python"
           . ./venv/bin/activate
           export PYTHONPATH=$PYTHONPATH:./app/files/scripts
-          pip install ./PyMISP[fileobjects,email] ./app/files/scripts/python-stix ./app/files/scripts/cti-python-stix2 pyzmq redis plyara pytest
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
           deactivate
 
       - name: DB Update

--- a/app/files/scripts/misp2stix.py
+++ b/app/files/scripts/misp2stix.py
@@ -23,12 +23,23 @@ import sys
 import traceback
 from pathlib import Path
 
-_current_path = Path(__file__).resolve().parent
-sys.path.insert(0, str(_current_path / 'cti-python-stix2'))
-sys.path.insert(1, str(_current_path / 'python-stix'))
-sys.path.insert(2, str(_current_path / 'python-cybox'))
-sys.path.insert(3, str(_current_path / 'mixbox'))
-sys.path.insert(4, str(_current_path / 'misp-stix'))
+import importlib
+MODULE_TO_DIRECTORY = {
+    "stix2": "cti-python-stix2",
+    "stix": "python-stix",
+    "cybox": "python-cybox",
+    "mixbox": "mixbox",
+    "misp_stix_converter": "misp-stix",
+    "maec": "python-maec",
+}
+_CURRENT_PATH = Path(__file__).resolve().parent
+_CURRENT_PATH_IDX = 0
+for module_name, dir_path in MODULE_TO_DIRECTORY.items():
+    try:
+        importlib.import_module(module_name)
+    except ImportError:
+        sys.path.insert(_CURRENT_PATH_IDX, str(_CURRENT_PATH / dir_path))
+        _CURRENT_PATH_IDX += 1
 from cybox.core.observable import Observables
 from stix.core import Campaigns, CoursesOfAction, ExploitTargets, Indicators, ThreatActors
 from stix.core.ttps import TTPs

--- a/app/files/scripts/misp_framing.py
+++ b/app/files/scripts/misp_framing.py
@@ -5,12 +5,23 @@ import json
 import sys
 from pathlib import Path
 
-_current_path = Path(__file__).resolve().parent
-sys.path.insert(0, str(_current_path / 'cti-python-stix2'))
-sys.path.insert(1, str(_current_path / 'python-stix'))
-sys.path.insert(2, str(_current_path / 'python-cybox'))
-sys.path.insert(3, str(_current_path / 'mixbox'))
-sys.path.insert(4, str(_current_path / 'misp-stix'))
+import importlib
+MODULE_TO_DIRECTORY = {
+    "stix2": "cti-python-stix2",
+    "stix": "python-stix",
+    "cybox": "python-cybox",
+    "mixbox": "mixbox",
+    "misp_stix_converter": "misp-stix",
+    "maec": "python-maec",
+}
+_CURRENT_PATH = Path(__file__).resolve().parent
+_CURRENT_PATH_IDX = 0
+for module_name, dir_path in MODULE_TO_DIRECTORY.items():
+    try:
+        importlib.import_module(module_name)
+    except ImportError:
+        sys.path.insert(_CURRENT_PATH_IDX, str(_CURRENT_PATH / dir_path))
+        _CURRENT_PATH_IDX += 1
 from misp_stix_converter import stix1_attributes_framing, stix1_framing, stix20_framing, stix21_framing
 
 

--- a/app/files/scripts/stix2/misp2stix2.py
+++ b/app/files/scripts/stix2/misp2stix2.py
@@ -24,12 +24,23 @@ import traceback
 from pathlib import Path
 from typing import Union
 
-_scripts_path = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(_scripts_path / 'cti-python-stix2'))
-sys.path.insert(1, str(_scripts_path / 'python-stix'))
-sys.path.insert(2, str(_scripts_path / 'python-cybox'))
-sys.path.insert(3, str(_scripts_path / 'mixbox'))
-sys.path.insert(4, str(_scripts_path / 'misp-stix'))
+import importlib
+MODULE_TO_DIRECTORY = {
+    "stix2": "cti-python-stix2",
+    "stix": "python-stix",
+    "cybox": "python-cybox",
+    "mixbox": "mixbox",
+    "misp_stix_converter": "misp-stix",
+    "maec": "python-maec",
+}
+_CURRENT_PATH = Path(__file__).resolve().parent
+_CURRENT_PATH_IDX = 0
+for module_name, dir_path in MODULE_TO_DIRECTORY.items():
+    try:
+        importlib.import_module(module_name)
+    except ImportError:
+        sys.path.insert(_CURRENT_PATH_IDX, str(_CURRENT_PATH / dir_path))
+        _CURRENT_PATH_IDX += 1
 from stix2.base import STIXJSONEncoder
 from misp_stix_converter import MISPtoSTIX20Parser, MISPtoSTIX21Parser
 

--- a/app/files/scripts/stix2/stix2misp.py
+++ b/app/files/scripts/stix2/stix2misp.py
@@ -22,12 +22,23 @@ import sys
 import traceback
 from pathlib import Path
 
-_scripts_path = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(_scripts_path / 'cti-python-stix2'))
-sys.path.insert(1, str(_scripts_path / 'python-stix'))
-sys.path.insert(2, str(_scripts_path / 'python-cybox'))
-sys.path.insert(3, str(_scripts_path / 'mixbox'))
-sys.path.insert(4, str(_scripts_path / 'misp-stix'))
+import importlib
+MODULE_TO_DIRECTORY = {
+    "stix2": "cti-python-stix2",
+    "stix": "python-stix",
+    "cybox": "python-cybox",
+    "mixbox": "mixbox",
+    "misp_stix_converter": "misp-stix",
+    "maec": "python-maec",
+}
+_CURRENT_PATH = Path(__file__).resolve().parent
+_CURRENT_PATH_IDX = 0
+for module_name, dir_path in MODULE_TO_DIRECTORY.items():
+    try:
+        importlib.import_module(module_name)
+    except ImportError:
+        sys.path.insert(_CURRENT_PATH_IDX, str(_CURRENT_PATH / dir_path))
+        _CURRENT_PATH_IDX += 1
 from misp_stix_converter import (
     ExternalSTIX2toMISPParser, InternalSTIX2toMISPParser,
     MISP_org_uuid, _from_misp)

--- a/app/files/scripts/stix2misp.py
+++ b/app/files/scripts/stix2misp.py
@@ -28,11 +28,23 @@ from operator import attrgetter
 from collections import defaultdict
 from pathlib import Path
 
-_current_path = Path(__file__).resolve().parent
-sys.path.insert(0, str(_current_path / 'python-stix'))
-sys.path.insert(1, str(_current_path / 'python-cybox'))
-sys.path.insert(2, str(_current_path / 'mixbox'))
-sys.path.insert(3, str(_current_path / 'python-maec'))
+import importlib
+MODULE_TO_DIRECTORY = {
+    "stix2": "cti-python-stix2",
+    "stix": "python-stix",
+    "cybox": "python-cybox",
+    "mixbox": "mixbox",
+    "misp_stix_converter": "misp-stix",
+    "maec": "python-maec",
+}
+_CURRENT_PATH = Path(__file__).resolve().parent
+_CURRENT_PATH_IDX = 0
+for module_name, dir_path in MODULE_TO_DIRECTORY.items():
+    try:
+        importlib.import_module(module_name)
+    except ImportError:
+        sys.path.insert(_CURRENT_PATH_IDX, str(_CURRENT_PATH / dir_path))
+        _CURRENT_PATH_IDX += 1
 import stix.extensions.marking.ais
 from mixbox.namespaces import NamespaceNotFoundError
 from stix.core import STIXPackage

--- a/app/files/scripts/stixtest.py
+++ b/app/files/scripts/stixtest.py
@@ -3,13 +3,23 @@ import sys
 import json
 from pathlib import Path
 
-_current_path = Path(__file__).resolve().parent
-sys.path.insert(0, str(_current_path / 'cti-python-stix2'))
-sys.path.insert(1, str(_current_path / 'python-stix'))
-sys.path.insert(2, str(_current_path / 'python-cybox'))
-sys.path.insert(3, str(_current_path / 'mixbox'))
-sys.path.insert(4, str(_current_path / 'python-maec'))
-sys.path.insert(5, str(_current_path / 'misp-stix'))
+import importlib
+MODULE_TO_DIRECTORY = {
+    "stix2": "cti-python-stix2",
+    "stix": "python-stix",
+    "cybox": "python-cybox",
+    "mixbox": "mixbox",
+    "misp_stix_converter": "misp-stix",
+    "maec": "python-maec",
+}
+_CURRENT_PATH = Path(__file__).resolve().parent
+_CURRENT_PATH_IDX = 0
+for module_name, dir_path in MODULE_TO_DIRECTORY.items():
+    try:
+        importlib.import_module(module_name)
+    except ImportError:
+        sys.path.insert(_CURRENT_PATH_IDX, str(_CURRENT_PATH / dir_path))
+        _CURRENT_PATH_IDX += 1
 
 results = {
     'success': 1,

--- a/app/files/scripts/stixtest/stix2_check.py
+++ b/app/files/scripts/stixtest/stix2_check.py
@@ -8,8 +8,23 @@ from compare_events import Comparer
 from query_rest_client import query_misp
 from stix2validator import validate_file, print_results
 
-_scripts_path = '/'.join(os.path.realpath(__file__).split('/')[:-2])
-sys.path.insert(0, f'{_scripts_path}/stix2')
+import importlib
+MODULE_TO_DIRECTORY = {
+    "stix2": "cti-python-stix2",
+    "stix": "python-stix",
+    "cybox": "python-cybox",
+    "mixbox": "mixbox",
+    "misp_stix_converter": "misp-stix",
+    "maec": "python-maec",
+}
+_CURRENT_PATH = Path(__file__).resolve().parent
+_CURRENT_PATH_IDX = 0
+for module_name, dir_path in MODULE_TO_DIRECTORY.items():
+    try:
+        importlib.import_module(module_name)
+    except ImportError:
+        sys.path.insert(_CURRENT_PATH_IDX, str(_CURRENT_PATH / dir_path))
+        _CURRENT_PATH_IDX += 1
 from stix2misp import ExternalStixParser, StixFromMISPParser
 
 

--- a/app/files/scripts/taxii/taxii_push.py
+++ b/app/files/scripts/taxii/taxii_push.py
@@ -12,8 +12,23 @@ from base64 import b64decode
 from pathlib import Path
 from requests.auth import HTTPBasicAuth
 
-_script_path = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(_script_path / 'misp-stix'))
+import importlib
+MODULE_TO_DIRECTORY = {
+    "stix2": "cti-python-stix2",
+    "stix": "python-stix",
+    "cybox": "python-cybox",
+    "mixbox": "mixbox",
+    "misp_stix_converter": "misp-stix",
+    "maec": "python-maec",
+}
+_CURRENT_PATH = Path(__file__).resolve().parent
+_CURRENT_PATH_IDX = 0
+for module_name, dir_path in MODULE_TO_DIRECTORY.items():
+    try:
+        importlib.import_module(module_name)
+    except ImportError:
+        sys.path.insert(_CURRENT_PATH_IDX, str(_CURRENT_PATH / dir_path))
+        _CURRENT_PATH_IDX += 1
 import misp_stix_converter
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ codecov
 coveralls
 nose
 requests-mock
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ jsonschema>=4.19.1
 lief>=0.13.1
 maec>=4.1.0.17
 misp-lib-stix2>=3.0.1.1
+misp-stix>=2.4.194
 mixbox>=1.0.5
 plyara>=2.1.1
 pydeep2>=0.5.1


### PR DESCRIPTION
#### What does it do?

* Fix requirements.txt and requirements-dev.txt 
* Make all scripts default to env python dependencies but fallback to submodules' in case they are not installed
