### PR TITLE
Fixes performance of sightings restSearch when performing MISP sync

### DIFF
--- a/app/Model/Sighting.php
+++ b/app/Model/Sighting.php
@@ -1199,7 +1199,7 @@ class Sighting extends AppModel
         $tmpfile = new TmpFileTool();
         $tmpfile->write($exportTool->header($exportToolParams));
         $separator = $exportTool->separator($exportToolParams);
-        
+
 
         if (empty(Configure::read('MISP.disable_sighting_loading'))) {
             // fetch sightings matching the query without ACL checks
@@ -1209,7 +1209,7 @@ class Sighting extends AppModel
                 foreach ($conditions['Sighting.event_id'] as $e_id) {
                     $conditions_copy['Sighting.event_id'] = $e_id;
                     $tempIds = $this->find('column', [
-                        'conditions' => $conditions,
+                        'conditions' => $conditions_copy,
                         'fields' => ['Sighting.id'],
                         'contain' => $contain
                     ]);
@@ -1224,7 +1224,7 @@ class Sighting extends AppModel
                     'contain' => $contain
                 ]);
             }
-            
+
             foreach (array_chunk($sightingIds, 10000) as $chunk) {
                 // fetch sightings with ACL checks and sighting policies
                 $sightings = $this->getSightings($user, $chunk, $includeEvent, $includeAttribute, $includeUuid);


### PR DESCRIPTION
#### What does it do?

There is a bug in the current sightings `restSearch` function when pulling sightings on a per-event basis. 

Instead of pulling sightings just for each event sequentially in a loop, sightings for all events are pulled repeatedly, based on the number of events requested. This has a significant knock-on effect, as the amount of data to process was multiplying based on the number of events. Significant impact on both memory consumption and processing time. As simple as a variable change to change the code to its intended function.

For example when I request 20 events - lets say there are 1000 sightings in total - 20000 sightings are returned. When de-duplicated on the client side this drops down to the 1000 as intended.

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
