### PR TITLE
Fix sightings rest search by org uuid

### DIFF
--- a/app/Model/Sighting.php
+++ b/app/Model/Sighting.php
@@ -1129,9 +1129,9 @@ class Sighting extends AppModel
                     }
                 }
                 if ($negation) {
-                    $conditions['Sighting.org_id'][] = $temp;
-                } else {
                     $conditions['Sighting.org_id NOT IN'][] = $temp;
+                } else {
+                    $conditions['Sighting.org_id'][] = $temp;
                 }
                 if (empty($conditions['Sighting.org_id']) && empty($conditions['Sighting.org_id NOT IN'])) {
                     $conditions['Sighting.org_id'] = -1;


### PR DESCRIPTION
The logic in `sightings/restSearch` is working backwards for org_id.

Fixes: #9880 

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
