### PR TITLE
new: Add config option user_org_uuid_in_response_header, allowing to …

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -292,6 +292,12 @@ class AppController extends Controller
                 $this->RestResponse->setHeader('X-Username', $headerValue);
             }
 
+            if (Configure::read('Security.user_org_uuid_in_response_header')) {
+                $userOrgHeaderValue = $user['Organisation']['uuid'];
+                $this->response->header('X-UserOrgUUID', $userOrgHeaderValue);
+                $this->RestResponse->setHeader('X-UserOrgUUID', $userOrgHeaderValue);
+            }
+
             if (!$this->__verifyUser($user))  {
                 $this->_stop(); // just for sure
             }

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -6870,6 +6870,14 @@ class Server extends AppModel
                     'type' => 'boolean',
                     'null' => true
                 ],
+                'user_org_uuid_in_response_header' => [
+                    'level' => self::SETTING_OPTIONAL,
+                    'description' => __('When enabled, logged in user\'s organisation uuid will be included in X-UserOrgUUID HTTP response header.'),
+                    'value' => false,
+                    'test' => 'testBool',
+                    'type' => 'boolean',
+                    'null' => true
+                ],
                 'encryption_key' => [
                     'level' => self::SETTING_OPTIONAL,
                     'description' => __('Encryption key used to store sensitive data (like authkeys) in database encrypted. If empty, data are stored unencrypted. Requires PHP 7.1 or newer.'),


### PR DESCRIPTION
…include a response header with the requesting user's org UUID

#### What does it do?

If enabled, MISP will return a header with the requesting user's org uuid.
This would allow to do some packet inspection / validation, checking sharing group membership of the requesting user on proxy, by only looking at the json response (if/when it includes sharing group definition).

I'm not sure whether a lot of other people would use it, but thought I'd propose a PR anyway.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
