### PR TITLE
fix: [feed] Feed pull, check events against rules only when rules are specified

### DIFF
--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -217,9 +217,11 @@ class Feed extends AppModel
         $manifest = $this->isFeedLocal($feed) ? $this->downloadManifest($feed) : $this->getRemoteManifest($feed, $HttpSocket);
         $this->Event = ClassRegistry::init('Event');
         $rules = json_decode($feed['Feed']['rules'], true);
-        foreach ($manifest as $k => $event) {
-            if (!$this->checkEventAgainstRules($event, $rules)) {
-                unset($manifest[$k]);
+        if ($rules != NULL) {
+            foreach ($manifest as $k => $event) {
+                if (!$this->checkEventAgainstRules($event, $rules)) {
+                    unset($manifest[$k]);
+                }
             }
         }
         $events = $this->Event->find('all', array(


### PR DESCRIPTION
#### What does it do?
During feed pull, all events are checked against sync rules. If no rules specified, the pull fails with exception because `$rules` is null. With this change, the check is only executed when rules are specified.
This should fix Issue #9887

https://github.com/MISP/MISP/commit/d0c9f467ecbffb97b5e40c4626cec4c315f6a8a2#r144827758

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
