### PR TITLE
Add scopes to OIDC client

### DIFF
--- a/app/Plugin/OidcAuth/Controller/Component/Auth/OidcAuthenticate.php
+++ b/app/Plugin/OidcAuth/Controller/Component/Auth/OidcAuthenticate.php
@@ -18,6 +18,7 @@ App::uses('Oidc', 'OidcAuth.Lib');
  *  - OidcAuth.offline_access (boolean, default: false)
  *  - OidcAuth.check_user_validity (integer, default `0`)
  *  - OidcAuth.update_user_role (boolean, default: true) - if disabled, manually modified role in MISP admin interface will be not changed from OIDC
+ *  - OidcAuth.scopes (array, ex. 'scopes' => array ('profile', 'email'))
  */
 class OidcAuthenticate extends BaseAuthenticate
 {

--- a/app/Plugin/OidcAuth/Lib/Oidc.php
+++ b/app/Plugin/OidcAuth/Lib/Oidc.php
@@ -19,6 +19,13 @@ class Oidc
     {
         $oidc = $this->prepareClient();
 
+        $scopes = $this->getConfig('scopes');
+        if (is_array($scopes)) {
+            foreach ($scopes as $scope) {
+                $oidc->addScope($scope);
+            }
+        }
+
         $this->log(null, 'Authenticate');
 
         if (!$oidc->authenticate()) {

--- a/app/Plugin/OidcAuth/README.md
+++ b/app/Plugin/OidcAuth/README.md
@@ -40,6 +40,7 @@ $config = array(
             'misp-admin' => 1, // Admin
         ],
         'default_org' => '{{ MISP_ORG }}',
+        'scopes' => array ('profile', 'email'),
     ],
     ...
 ```


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2020-05-05: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

This PR addresses an issue with OIDC functionality.  Currently, the OIDC client only checks for claims in the default scope of the authentication.  However, depending on the IdP, necessary attributes like email and roles are not included in this scope.

This change allows the user to configure in the `config.php` file which scopes they want to include, and adds each of them to the OIDC client object.

This partially addresses the issue in https://github.com/MISP/MISP/issues/8598.

#### Questions

- [ ] Does it require a DB change?  No
- [ ] Are you using it in production?  Yes
- [ ] Does it require a change in the API (PyMISP for example)?  No
