### PR TITLE
fix: [Export] Allow proposal blocking in Bro/Zeek exports

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -3467,6 +3467,7 @@ class Attribute extends AppModel
                 'fields' => array('Attribute.id', 'Attribute.event_id', 'Attribute.type', 'Attribute.category', 'Attribute.comment', 'Attribute.to_ids', 'Attribute.value', 'Attribute.value' . $valueField),
                 'contain' => array('Event' => array('fields' => array('Event.id', 'Event.threat_level_id', 'Event.orgc_id', 'Event.uuid'))),
                 'enforceWarninglist' => $enforceWarninglist,
+                'allow_proposal_blocking' => true,
                 'flatten' => 1
             )
         );


### PR DESCRIPTION
#### What does it do?

It allows proposal blocking for Zeek exports. Without this one line fix the proposals to remove the IDS flag or delete attributes do not have any effect for the export to Zeek.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
