### PR TITLE
chg: use default settings for backgroundjobs

### DIFF
--- a/app/Lib/Tools/BackgroundJobsTool.php
+++ b/app/Lib/Tools/BackgroundJobsTool.php
@@ -122,6 +122,25 @@ class BackgroundJobsTool
     {
         $this->settings = $settings;
 
+        if (!isset($this->settings['redis_host'])) {
+            $this->settings['redis_host'] = 'localhost';
+        }
+        if (!isset($this->settings['redis_port'])) {
+            $this->settings['redis_port'] = 6379;
+        }
+        if (!isset($this->settings['redis_database'])) {
+            $this->settings['redis_database'] = 1;
+        }
+        if (!isset($this->settings['redis_namespace'])) {
+            $this->settings['redis_namespace'] = 'background_jobs';
+        }
+        if (!isset($this->settings['max_job_history_ttl'])) {
+            $this->settings['max_job_history_ttl'] = 86400;
+        }
+        if (!isset($this->settings['supervisor_port'])) {
+            $this->settings['supervisor_port'] = 9001;
+        }
+        
         if ($this->settings['enabled'] === true) {
             $this->RedisConnection = $this->createRedisConnection();
         }


### PR DESCRIPTION
#### What does it do?

avoid having SimpleBackgroundJobs enabled but without basic settings set 

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
