### PR TITLE
Update UPGRADE.ubuntu2404.sh

### DIFF
--- a/INSTALL/UPGRADE.ubuntu2404.sh
+++ b/INSTALL/UPGRADE.ubuntu2404.sh
@@ -188,7 +188,7 @@ error_check "PECL simdjson extension installation"
 sudo pecl install zstd &>> $logfile
 error_check "PECL zstd extension installation"
 
-if [ $INSTALL_SSDEEP ]; then
+if $INSTALL_SSDEEP; then
     sudo apt install make -y &>> $logfile
     error_check "The installation of make"
     git clone --recursive --depth=1 https://github.com/JakubOnderka/pecl-text-ssdeep.git /tmp/pecl-text-ssdeep


### PR DESCRIPTION
With  `if [ $INSTALL_SSDEEP ]; then` the condition will always be True ('check for a non-empty string'); needs to be `if $INSTALL_SSDEEP; then` (check for the result of the 'command' INSTALL_SSDEEP)

#### Questions

- [ ] Does it require a DB change? No  
- [ ] Are you using it in production? Almost
- [ ] Does it require a change in the API (PyMISP for example)? No
