### PR TITLE
fix: [Upgrade] Fix conditionals in 2.5 upgrade script

### DIFF
--- a/INSTALL/UPGRADE.ubuntu2404.sh
+++ b/INSTALL/UPGRADE.ubuntu2404.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # MISP 2.5 upgrade for MISP 2.4 installations on Ubuntu 24.04 LTS
 
-# For other Ubuntu versions, make sure that you first dist-upgrade to 24.04. 
+# For other Ubuntu versions, make sure that you first dist-upgrade to 24.04.
 
 # This guide liberally borrows from three sources:
 # - The previous iterations of the official MISP installation guide, which can be found at: https://misp.github.io/MISP
@@ -188,7 +188,7 @@ error_check "PECL simdjson extension installation"
 sudo pecl install zstd &>> $logfile
 error_check "PECL zstd extension installation"
 
-if [ $INSTALL_SSDEEP ]; then
+if [ "$INSTALL_SSDEEP" = "true" ]; then
     sudo apt install make -y &>> $logfile
     error_check "The installation of make"
     git clone --recursive --depth=1 https://github.com/JakubOnderka/pecl-text-ssdeep.git /tmp/pecl-text-ssdeep
@@ -245,7 +245,7 @@ print_status "Setting up background workers"
 
 SUPERVISOR_ALREADY_ENABLED=$(${MISP_PATH}/app/Console/cake Admin getSetting SimpleBackgroundJobs.enabled | jq -r '.value')
 
-if [ $SWITCH_TO_SUPERVISOR ] && [ $SUPERVISOR_ALREADY_ENABLED != true ]; then
+if [ "$SWITCH_TO_SUPERVISOR" = "true" ] && [ "$SUPERVISOR_ALREADY_ENABLED" != "true" ]; then
 
 sudo echo "
 [inet_http_server]


### PR DESCRIPTION
#### What does it do?

I'm pretty sure two of the conditional statements in the upgrade script are slightly wrong, as they currently always resolve to 'true' as it's a string evaluation. This is the SSDEEP and supervisor checks.

This should correctly evaluate if the string is `true` or not.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
