### PR TITLE
chg: [SharingGroup] Enable editing 'active' flag from API

### DIFF
--- a/app/Model/SharingGroup.php
+++ b/app/Model/SharingGroup.php
@@ -658,7 +658,7 @@ class SharingGroup extends AppModel
             $isSGOwner = !$user['Role']['perm_sync'] && $existingSG['org_id'] == $user['org_id'];
             if ($isUpdatableBySync || $isSGOwner || $user['Role']['perm_site_admin']) {
                 $editedSG = $existingSG['SharingGroup'];
-                $attributes = ['name', 'releasability', 'description', 'created', 'modified', 'roaming'];
+                $attributes = ['name', 'releasability', 'description', 'created', 'modified', 'active', 'roaming'];
                 foreach ($attributes as $a) {
                     if (isset($sg[$a])) {
                         $editedSG[$a] = $sg[$a];


### PR DESCRIPTION
#### What does it do?

Resolves request #9942 by enabling users to update the `active` flag of a sharing group via the API

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
