### PR TITLE
Fix proposal version check mismatch after 2.5 update

### DIFF
--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -1785,7 +1785,7 @@ class ServersController extends AppController
                         }
                     }
                 }
-                if (!$mismatch && $version[2] < 111) {
+                if (!$mismatch && $version[1] < 5 && $version[2] < 111) {
                     $mismatch = 'proposal';
                 }
                 if (!$perm_sync && !$perm_sighting) {


### PR DESCRIPTION
#### What does it do?

After upgrade to MISP version 2.5.0, the server compatibility check fails due to the check only looking at the patch version being >111. 

This fix adds a check that the minor version is less than 5.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
