### PR TITLE
Allow site admin to see authkey from other admins

### DIFF
--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -495,7 +495,7 @@ class UsersController extends AppController
                 unset($users[$key]['User']['totp']);
                 if (!empty(Configure::read('Security.advanced_authkeys'))) { // There is no point to show that authkey since it doesn't work when this setting is active
                     unset($users[$key]['User']['authkey']);
-                } else if ((!empty($user['Role']['perm_admin']) && $user['User']['id'] != $this->Auth->user('id'))) {
+                } else if (!$this->_isSiteAdmin() && !empty($user['Role']['perm_admin']) && $user['User']['id'] != $this->Auth->user('id')) {
                     $users[$key]['User']['authkey'] = __('Redacted');
                 }
             }


### PR DESCRIPTION
#### What does it do?

Improves the fix from 8577790e75b50d57b71a5c82d2e4611b130983f7 by explicitly checking if the current user is not a site admin before redacting the authkey.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
