### PR TITLE
FIX:  change flag 'local' and 'active' sharing group via api

### DIFF
--- a/app/Model/SharingGroup.php
+++ b/app/Model/SharingGroup.php
@@ -662,7 +662,7 @@ class SharingGroup extends AppModel
             $isSGOwner = !$user['Role']['perm_sync'] && $existingSG['org_id'] == $user['org_id'];
             if ($isUpdatableBySync || $isSGOwner || $user['Role']['perm_site_admin']) {
                 $editedSG = $existingSG['SharingGroup'];
-                $attributes = ['name', 'releasability', 'description', 'created', 'modified', 'roaming'];
+                $attributes = ['name', 'releasability', 'description', 'created', 'modified', 'roaming', 'active', 'local'];
                 foreach ($attributes as $a) {
                     if (isset($sg[$a])) {
                         $editedSG[$a] = $sg[$a];


### PR DESCRIPTION
## "active" / "local" flag - Sharing Group API

#### Pull Request per:
https://github.com/MISP/MISP/blob/1399a8d2f00c3f2ec628716b8836566d41888735/app/Model/SharingGroup.php#L665C1-L666C1


#### What does it do?

allow update a sharing groups "active" / "local" flag via API
Issue: #9958

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [x] Does it require a change in the API (PyMISP for example)?
