### PR TITLE
fix: [internal] Fix email refang regex

### DIFF
--- a/app/Lib/Tools/ComplexTypeTool.php
+++ b/app/Lib/Tools/ComplexTypeTool.php
@@ -12,7 +12,7 @@ class ComplexTypeTool
         array(
             'from' => '/(\[\.\]|\[dot\]|\(dot\))/',
             'to' => '.',
-            'types' => array('link', 'url', 'ip-dst', 'ip-src', 'domain|ip', 'domain', 'hostname')
+            'types' => array('link', 'url', 'ip-dst', 'ip-src', 'domain|ip', 'domain', 'hostname', 'email', 'email-src', 'email-dst')
         ),
         array(
             'from' => '/\[hxxp:\/\/\]/',
@@ -20,7 +20,7 @@ class ComplexTypeTool
             'types' => array('link', 'url')
         ),
         array(
-            'from' => '/[\@]|\[at\]/',
+            'from' => '/\[\@\]|\[at\]/',
             'to' => '@',
             'types' => array('email', 'email-src', 'email-dst')
         ),


### PR DESCRIPTION
#### What does it do?

If it fixes an issue when adding defanged email attributes (email, email-src, email-dst) to events. 

#### Questions

- [x] Are you using it in production?


#### Freetext Import 
![Freetext Import Tool](https://github.com/user-attachments/assets/c7db08f9-2aff-44da-b8cf-24f68784b457)

![Freetext Import Results](https://github.com/user-attachments/assets/2f3d0c25-4854-4368-8976-19b057159506)


The refanging works as expected when using freetext import, however adding defanged email attributes either through the UI or over the API does not get refanged when adding to the event.


#### Add Attribute (current)
![Add Attribute](https://github.com/user-attachments/assets/4b468465-e0f2-4651-a213-b0efe390622c)

![Category](https://github.com/user-attachments/assets/d4cede8f-9a46-460d-b1ba-4772bf6f7c63)


Currently, we see neither the `@` or `.` characters get refanged, and the admin3 email does not get added due to an error: `Email address has an invalid format. Please double check the value or select type "other".`


#### Add Attribute (with proposed changes)
![Category](https://github.com/user-attachments/assets/ab672360-eecb-4f82-ba4c-a2836637dbde)

These proposed changes to `REFANG_REGEX_TABLE` will fix the issue with `@` characters not being refanged, and adds emails (email, email-src, email-dot) to the types for `.` character refanging. 
