### PR TITLE
Fix bug: New users cannot use the platform when AAD is enabled

### DIFF
--- a/app/Controller/Component/ACLComponent.php
+++ b/app/Controller/Component/ACLComponent.php
@@ -977,6 +977,22 @@ class ACLComponent extends Component
             }
             return true;
         };
+        // Ensure new users with AAD enabled are not required to set a new password
+        $this->dynamicChecks['aad_password_change_disabled'] = function ($user) {
+            if (Configure::read('AadAuth.enabled') && $user['change_pw'] == 1) {
+                $user['change_pw'] = 0;
+                $this->User->save($user);
+            }
+            return true;
+        };
+        // Ensure new users with AAD enabled are not required to edit their profile
+        $this->dynamicChecks['aad_profile_edit_disabled'] = function ($user) {
+            if (Configure::read('AadAuth.enabled') && $user['Role']['perm_self_management']) {
+                $user['Role']['perm_self_management'] = 0;
+                $this->User->save($user);
+            }
+            return true;
+        };
     }
 
     /**

--- a/app/Plugin/AadAuth/Controller/Component/Auth/AadAuthenticateAuthenticate.php
+++ b/app/Plugin/AadAuth/Controller/Component/Auth/AadAuthenticateAuthenticate.php
@@ -277,6 +277,11 @@ class AadAuthenticateAuthenticate extends BaseAuthenticate
 						$user = $this->_findUser($mispUsername);
 						if ($user) {
 							$this->_log("info", "AAD authentication successful for ${mispUsername}");
+							// Ensure new users can operate without setting a new password
+							if ($user['User']['change_pw'] == 1) {
+								$user['User']['change_pw'] = 0;
+								$this->User->save($user);
+							}
 						}
 						return $user;
 					}

--- a/app/View/Users/admin_add.ctp
+++ b/app/View/Users/admin_add.ctp
@@ -30,7 +30,12 @@
     <div class="clear"></div>
     <div id="passwordDivDiv" style="<?= (!empty(Configure::read('Plugin.CustomAuth_required')) && !empty(Configure::read('Plugin.CustomAuth_enable'))) ? 'display:none;' : ''?>">
         <?php
-            echo $this->Form->input('enable_password', array('type' => 'checkbox', 'label' => __('Set password')));
+            echo $this->Form->input('enable_password', array(
+                'type' => 'checkbox',
+                'label' => __('Set password'),
+                'disabled' => Configure::read('MISP.disable_user_password_change'),
+                'checked' => !Configure::read('MISP.disable_user_password_change')
+            ));
         ?>
         <div id="PasswordDiv">
             <div class="clear"></div>


### PR DESCRIPTION
Fixes #9915

Even when passwords are disabled, new users were forced to change their password when logging in through Azure Active Directory/ EntraID.

