### PR TITLE
fix: [Sync] Remove deleted tags when cleanup tags server setting is enabled

### DIFF
--- a/app/Model/Attribute.php
+++ b/app/Model/Attribute.php
@@ -2856,7 +2856,7 @@ class Attribute extends AppModel
         return $attribute;
     }
 
-    public function editAttributeBulk($attributes, $event, $user)
+    public function editAttributeBulk($attributes, $event, $user, $server = null)
     {
         $fieldList = self::EDITABLE_FIELDS;
         $addableFieldList = array('event_id', 'type', 'uuid', 'object_id', 'object_relation');
@@ -2887,10 +2887,10 @@ class Attribute extends AppModel
         if (!empty($attributes)) {
             $this->saveMany($attributes, $saveOptions);
         }
-        return $this->editAttributePostProcessing($attributes, $event, $user);
+        return $this->editAttributePostProcessing($attributes, $event, $user, $server);
     }
 
-    public function editAttributePostProcessing($attributes, $event, $user)
+    public function editAttributePostProcessing($attributes, $event, $user, $server)
     {
         $eventId = $event['Event']['id'];
         $tagActions = [];
@@ -2912,9 +2912,12 @@ class Attribute extends AppModel
                 if (isset($server) && isset($server['Server']['remove_missing_tags']) && $server['Server']['remove_missing_tags']) {
                     $existingTags = $this->AttributeTag->find('all', [
                         'recursive' => -1,
-                        'conditions' => ['attribute_id' => $attribute['id']]
+                        'conditions' => ['attribute_id' => $attribute['id']],
+                        'contain' => array(
+                            'Tag' => array('fields' => array('Tag.id', 'Tag.name'))
+                        )
                     ]);
-                    $this->AttributeTag->pruneOutdatedAttributeTagsFromSync(isset($attribute['Tag']) ? $attribute['Tag'] : array(), $existingTags['AttributeTag']);
+                    $this->AttributeTag->pruneOutdatedAttributeTagsFromSync(isset($attribute['Tag']) ? $attribute['Tag'] : array(), $existingTags);
                 }
                 $tag_id_store = [];
                 if (isset($attribute['Tag'])) {

--- a/app/Model/AttributeTag.php
+++ b/app/Model/AttributeTag.php
@@ -224,9 +224,9 @@ class AttributeTag extends AppModel
             $newerTagsName[] = strtolower($tag['name']);
         }
         foreach ($originalAttributeTags as $k => $attributeTag) {
-            if (!$attributeTag['local']) { //
+            if (!$attributeTag['AttributeTag']['local']) { //
                 if (!in_array(strtolower($attributeTag['Tag']['name']), $newerTagsName)) {
-                    $this->softDelete($attributeTag['id']);
+                    $this->softDelete($attributeTag['AttributeTag']['id']);
                 }
             }
         }

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -1624,7 +1624,7 @@ class Event extends AppModel
             $find_params['fields'] = array('Event.id', 'Event.attribute_count');
             $results = $this->find('list', $find_params);
         } else {
-            $find_params['fields'] = array('Event.id');   
+            $find_params['fields'] = array('Event.id');
             $results = $this->find('column', $find_params);
         }
         if (!isset($params['limit'])) {
@@ -3689,24 +3689,24 @@ class Event extends AppModel
     {
         $event = $this->updatedLockedFieldForAnalystData($event, 'Event');
         if (!empty($event['Event']['Attribute'])) {
-            for ($i=0; $i < count($event['Event']['Attribute']); $i++) { 
+            for ($i=0; $i < count($event['Event']['Attribute']); $i++) {
                 $event['Event']['Attribute'][$i] = $this->updatedLockedFieldForAnalystData($event['Event']['Attribute'][$i]);
             }
         }
         if (!empty($event['Event']['Object'])) {
-            for ($i=0; $i < count($event['Event']['Object']); $i++) { 
+            for ($i=0; $i < count($event['Event']['Object']); $i++) {
                  if (isset($event['Event']['Object'][$i])) {
                     $event['Event']['Object'][$i] = $this->updatedLockedFieldForAnalystData($event['Event']['Object'][$i]);
                 }
                 if (!empty($event['Event']['Object'][$i])) {
-                    for ($j=0; $j < count($event['Event']['Object'][$i]['Attribute']); $j++) { 
+                    for ($j=0; $j < count($event['Event']['Object'][$i]['Attribute']); $j++) {
                         $event['Event']['Object'][$i]['Attribute'][$j] = $this->updatedLockedFieldForAnalystData($event['Event']['Object'][$i]['Attribute'][$j]);
                     }
                 }
             }
         }
         if (!empty($event['Event']['EventReport'])) {
-            for ($i=0; $i < count($event['Event']['EventReport']); $i++) { 
+            for ($i=0; $i < count($event['Event']['EventReport']); $i++) {
                 $event['Event']['EventReport'][$i] = $this->updatedLockedFieldForAnalystData($event['Event']['EventReport'][$i]);
             }
         }
@@ -3721,7 +3721,7 @@ class Event extends AppModel
         }
         foreach ($this->AnalystData::ANALYST_DATA_TYPES as $type) {
             if (!empty($data[$type])) {
-                for ($i=0; $i < count($data[$type]); $i++) { 
+                for ($i=0; $i < count($data[$type]); $i++) {
                     $data[$type][$i]['locked'] = true;
                     foreach ($this->AnalystData::ANALYST_DATA_TYPES as $childType) {
                         if (!empty($data[$type][$i][$childType])) {
@@ -4216,13 +4216,13 @@ class Event extends AppModel
                         $changed = true;
                     }
                 }
-                $this->Attribute->editAttributeBulk($attributes, $saveResult, $user);
+                $this->Attribute->editAttributeBulk($attributes, $saveResult, $user, $server);
             }
             if (isset($data['Event']['Object'])) {
                 $data['Event']['Object'] = array_values($data['Event']['Object']);
                 foreach ($data['Event']['Object'] as $object) {
                     $nothingToChange = false;
-                    $result = $this->Object->editObject($object, $saveResult, $user, false, $force, $nothingToChange);
+                    $result = $this->Object->editObject($object, $saveResult, $user, false, $force, $nothingToChange, $server);
                     if ($result !== true) {
                         $validationErrors['Object'][] = $result;
                     }
@@ -4742,7 +4742,7 @@ class Event extends AppModel
             'recursive' => -1,
             'conditions' => array('Event.id' => $id)
         ));
-        
+
         if (empty($event)) {
             return false;
         }
@@ -4791,7 +4791,7 @@ class Event extends AppModel
             $success = $this->executeTrigger('event-publish', $fullEvent[0], $workflowErrors, $logging);
             if (empty($success)) {
                 $errorMessage = implode(', ', $workflowErrors);
-                
+
                 return $errorMessage;
             }
         }
@@ -7502,7 +7502,7 @@ class Event extends AppModel
         if (!empty($exportTool->additional_params)) {
             $filters = array_merge($filters, $exportTool->additional_params);
         }
-        
+
         $exportToolParams = array(
             'user' => $user,
             'params' => array(),

--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -1155,7 +1155,7 @@ class MispObject extends AppModel
         return true;
     }
 
-    public function editObject($object, array $event, $user, $log, $force = false, &$nothingToChange = false)
+    public function editObject($object, array $event, $user, $log, $force = false, &$nothingToChange = false, $server = null)
     {
         $eventId = $event['Event']['id'];
         $object['event_id'] = $eventId;
@@ -1243,8 +1243,7 @@ class MispObject extends AppModel
                     $attributes[] = $result;
                 }
             }
-            $this->Attribute->editAttributeBulk($attributes, $event, $user);
-            $this->Attribute->editAttributePostProcessing($attributes, $event, $user);
+            $this->Attribute->editAttributeBulk($attributes, $event, $user, $server);
         }
         return true;
     }


### PR DESCRIPTION
#### What does it do?

Re-enables the functionality to delete missing tags on sync, fixing issues when tags are updated on once instance, but their removal does not propagate to the receiving MISP organisation. This only runs when the `remove_missing_tags` parameter is set for a server PULL. 

Tested on both 2.4 and 2.5.

Fixes #2223 and also related to #5453, #7481, #7493 and #6846

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
