### PR TITLE
Slight improvements to user profile notification emails

### DIFF
--- a/app/Model/UserLoginProfile.php
+++ b/app/Model/UserLoginProfile.php
@@ -282,7 +282,7 @@ class UserLoginProfile extends AppModel
             $body->set('misp_org', Configure::read('MISP.org'));
             $body->set('date_time', $datetime);
             // Fetch user that contains also PGP or S/MIME keys for e-mail encryption
-            $this->User->sendEmail($user, $body, false, "[" . Configure::read('MISP.org') . " MISP] New sign in.");
+            $this->User->sendEmail($user, $body, false, "[" . Configure::read('MISP.org') . " MISP] New sign-in");
         }
     }
 
@@ -301,7 +301,7 @@ class UserLoginProfile extends AppModel
         $admins = array_keys($this->User->getSiteAdmins());
         $allAdmins = array_unique(array_merge($orgAdmins, $admins));
 
-        $subject = __("[%s MISP] Suspicious login reported.", Configure::read('MISP.org'));
+        $subject = __("[%s MISP] Suspicious login reported", Configure::read('MISP.org'));
         foreach ($allAdmins as $adminUserId) {
             $admin = $this->User->find('first', array(
                 'recursive' => -1,
@@ -324,7 +324,7 @@ class UserLoginProfile extends AppModel
             $body->set('date_time', $date_time);
             $body->set('suspiciousness_reason', $suspiciousness_reason);
             // inform the user
-            $this->User->sendEmail($user, $body, false, "[" . Configure::read('MISP.org') . " MISP] Suspicious login with your account.");
+            $this->User->sendEmail($user, $body, false, "[" . Configure::read('MISP.org') . " MISP] Suspicious login with your account");
 
             // inform the org admin
             $body = new SendEmailTemplate('userloginprofile_suspicious_orgadmin');
@@ -341,7 +341,7 @@ class UserLoginProfile extends AppModel
                     'recursive' => -1,
                     'conditions' => ['User.id' => $orgAdminID]
                 ));
-                $this->User->sendEmail($org_admin, $body, false, "[" . Configure::read('MISP.org') . " MISP] Suspicious login detected.");
+                $this->User->sendEmail($org_admin, $body, false, "[" . Configure::read('MISP.org') . " MISP] Suspicious login detected");
             }            
         }
     }

--- a/app/View/Emails/text/userloginprofile_newlogin.ctp
+++ b/app/View/Emails/text/userloginprofile_newlogin.ctp
@@ -1,6 +1,6 @@
 Hello,
 
-Your account on MISP <?= $misp_org; ?> was just signed into from a new device or location.
+Your account on <?= $misp_org; ?> MISP was just accessed from a new device or location.
 
 - When: <?= $date_time; ?>
 
@@ -13,7 +13,7 @@ Your account on MISP <?= $misp_org; ?> was just signed into from a new device or
 - IP: <?= $userLoginProfile['ip']; ?>
 
 
-Follow this link to confirm if was you: <?php echo $baseurl . '/users/view_login_history/'; ?>
+Follow this link to confirm it was you or report as malicious: <?php echo $baseurl . '/users/view_login_history/'; ?>
 
-I you don't recognize this activity, please markt the login as suspicious and IMMEDIATELY to reset your password. 
+If you don't recognize this activity, please mark the login as malicious and IMMEDIATELY reset your password. 
 


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2020-05-05: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?
Some edits to the grammar and wording used in the userloginprofile_newlogin template file. Also removed unnecessary periods from user profile email subjects.

If it fixes an existing issue, please use github syntax: `#<IssueID>`

#### Questions

- [ ] Does it require a DB change? No
- [ ] Are you using it in production? Not yet
- [ ] Does it require a change in the API (PyMISP for example)? No
