### PR TITLE
add direct LDAP auth

### DIFF
--- a/app/Config/bootstrap.default.php
+++ b/app/Config/bootstrap.default.php
@@ -140,6 +140,7 @@ CakePlugin::load('SysLogLogable');
 // CakePlugin::load('CertAuth');
 // CakePlugin::load('ShibbAuth');
 // CakePlugin::load('LinOTPAuth');
+// CakePlugin::load('LdapAuth');
 /**
  * You can attach event listeners to the request lifecyle as Dispatcher Filter . By Default CakePHP bundles two filters:
  *

--- a/app/Config/config.default.php
+++ b/app/Config/config.default.php
@@ -22,6 +22,7 @@ $config = array(
         //'auth'                            => array('ShibbAuth.ApacheShibb'),
         //'auth'                            => array('AadAuth.AadAuthenticate'),
         //'auth'                            => array('LinOTPAuth.LinOTP'),
+        //'auth'                            => array('LdapAuth.Ldap'),
     ),
     'MISP' => array(
         'baseurl'                        => '',

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -2581,7 +2581,7 @@ class Server extends AppModel
             'debug', 'MISP', 'GnuPG', 'SMIME', 'Proxy', 'SecureAuth',
             'Security', 'Session', 'site_admin_debug', 'Plugin', 'CertAuth',
             'ApacheShibbAuth', 'ApacheSecureAuth', 'OidcAuth', 'AadAuth',
-            'SimpleBackgroundJobs', 'LinOTPAuth'
+            'SimpleBackgroundJobs', 'LinOTPAuth', 'LdapAuth'
         );
         $settingsArray = array();
         foreach ($settingsToSave as $setting) {

--- a/app/Plugin/LdapAuth/Controller/Component/Auth/LdapAuthenticate.php
+++ b/app/Plugin/LdapAuth/Controller/Component/Auth/LdapAuthenticate.php
@@ -1,0 +1,255 @@
+<?php
+
+App::uses('BaseAuthenticate', 'Controller/Component/Auth');
+
+class LdapAuthenticate extends BaseAuthenticate
+{
+
+    /**
+     * Holds the user information
+     *
+     * @var array
+     */
+    protected static $user = false;
+
+    protected static $conf;
+
+    /* 
+    'LdapAuth' => [
+        'ldapHost' => 'ldap://openldap:389',
+        'ldapDn' => 'dc=example,dc=com',
+        'ldapReaderUser' => 'cn=reader,dc=example,dc=com',
+        'ldapReaderPassword' => 'readerpassword',
+        'ldapSearchFilter' => ''
+    ]
+    */
+
+    public function __construct()
+    {
+        self::$conf = [
+            'ldapServer' => Configure::read('LdapAuth.ldapServer'),
+            'ldapDn' => Configure::read('LdapAuth.ldapDn'),
+            'ldapReaderUser' => Configure::read('LdapAuth.ldapReaderUser'),
+            'ldapReaderPassword' => Configure::read('LdapAuth.ldapReaderPassword'),
+            'ldapSearchFilter' => Configure::read('LdapAuth.ldapSearchFilter'),
+            'ldapSearchAttribute' => Configure::read('LdapAuth.ldapSearchAttribute') ?? 'mail',
+            'ldapEmailField' => Configure::read('LdapAuth.ldapEmailField') ?? ['mail'],
+            'ldapNetworkTimeout' => Configure::read('LdapAuth.ldapNetworkTimeout') ?? -1,
+            'ldapProtocol' => Configure::read('LdapAuth.ldapProtocol') ?? 3,
+            'ldapAllowReferrals' => Configure::read('LdapAuth.ldapAllowReferrals') ?? false,
+            'starttls' => Configure::read('LdapAuth.starttls') ?? false,
+            'mixedAuth' => Configure::read('LdapAuth.starttls') ?? false,
+            'ldapDefaultOrg' => Configure::read('LdapAuth.ldapDefaultOrg'),
+            'ldapDefaultRoleId' => Configure::read('LdapAuth.ldapDefaultRoleId') ?? 3,
+            'updateUser' => Configure::read('LdapAuth.updateUser') ?? false,
+        ];
+    }
+
+    public function authenticate(CakeRequest $request, CakeResponse $response)
+    {
+        $user = $this->getUser($request);
+
+        $userFields = $request->data['User'];
+        $email = $userFields['email'];
+        $password = $userFields['password'];
+
+        $ldapconn = $this->ldapConnect();
+
+        if ($ldapconn) {
+            // LDAP bind
+            $ldapbind = ldap_bind($ldapconn, self::$conf['ldapReaderUser'],  self::$conf['ldapReaderPassword']);
+            // authentication verification
+            if (!$ldapbind) {
+                CakeLog::error("[LdapAuth] LDAP bind failed: " . ldap_error($ldapconn));
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function ldapConnect()
+    {
+        // LDAP connection
+        ldap_set_option(NULL, LDAP_OPT_NETWORK_TIMEOUT, self::$conf['ldapNetworkTimeout']);
+        $ldapconn = ldap_connect(self::$conf['ldapServer']);
+
+        if (!$ldapconn) {
+            CakeLog::error("[LdapAuth] LDAP server connection failed.");
+            return false;
+        }
+
+        // LDAP protocol configuration
+        ldap_set_option($ldapconn, LDAP_OPT_PROTOCOL_VERSION, self::$conf['ldapProtocol']);
+        ldap_set_option($ldapconn, LDAP_OPT_REFERRALS, self::$conf['ldapAllowReferrals']);
+
+        if (self::$conf['starttls'] == true) {
+            # Default is false, sine STARTTLS support is a new feature
+            # Ignored on ldaps://, but can trigger problems for orgs
+            # using unencrypted LDAP. Loose comparison allows users to
+            # use # true / 1 / etc.
+            ldap_start_tls($ldapconn);
+        }
+
+        return $ldapconn;
+    }
+
+    private function getEmailAddress($ldapEmailField, $ldapUserData)
+    {
+        // return the email address of an LDAP user if one of the fields in $ldapEmaiLField exists
+        foreach ($ldapEmailField as $field) {
+            if (isset($ldapUserData[0][$field][0])) {
+                return $ldapUserData[0][$field][0];
+            }
+        }
+        return null;
+    }
+
+    private function isUserMemberOf($group, $ldapUserData)
+    {
+        // return true of false depeding on if user is a member of group.
+        $returnCode = false;
+        unset($ldapUserData[0]['memberof']["count"]);
+        foreach ($ldapUserData[0]['memberof'] as $result) {
+            $r = explode(",", $result, 2);
+            $ldapgroup = explode("=", $r[0]);
+            if ($ldapgroup[1] == $group) {
+                $returnCode = true;
+            }
+        }
+        return $returnCode;
+    }
+
+    /*
+     * Retrieve a user by validating the request data
+     */
+    public function getUser(CakeRequest $request)
+    {
+        if (!array_key_exists("User", $request->data)) {
+            return false;
+        }
+
+        $userFields = $request->data['User'];
+        $email = $userFields['email'];
+        $password = $userFields['password'];
+
+        CakeLog::debug("[LdapAuth] Login attempt with email: $email");
+        $this->settings['fields'] = array('username' => "email");
+
+
+        $filter = '(' . self::$conf['ldapSearchAttribute'] . '=' . $email . ')';
+        if (!empty(self::$conf['ldapSearchFilter'])) {
+            $filter =  '(&' . self::$conf['ldapSearchFilter'] . ')' . $filter;
+        }
+
+        $ldapconn = $this->ldapConnect();
+
+        $ldapUser = ldap_search($ldapconn, self::$conf['ldapDn'], $filter, ['uid', 'mail']);
+
+        if (!$ldapUser) {
+            CakeLog::error("[LdapAuth] LDAP user search failed: " . ldap_error($ldapconn));
+            return false;
+        }
+
+        $ldapUserData = ldap_get_entries($ldapconn, $ldapUser);
+
+        if (!$ldapUserData) {
+            CakeLog::error("[LdapAuth] LDAP get user entries failed: " . ldap_error($ldapconn));
+            return false;
+        }
+
+        // Check user LDAP password
+        $ldapbind = ldap_bind($ldapconn, $ldapUserData[0]['dn'], $password);
+        if (!$ldapbind) {
+            CakeLog::error("[LdapAuth] LDAP user authentication failed: " . ldap_error($ldapconn));
+            return false;
+        }
+
+        if (!isset(self::$conf['ldapEmailField']) && isset($ldapUserData[0]['mail'][0])) {
+            // Assign the real user for MISP
+            $mispUsername = $ldapUserData[0]['mail'][0];
+        } else if (isset(self::$conf['ldapEmailField'])) {
+            $mispUsername = $this->getEmailAddress(self::$conf['ldapEmailField'], $ldapUserData);
+        } else {
+            CakeLog::error("[LdapAuth] User not found in LDAP.");
+            return false;
+        }
+
+        // Find user with real username (mail)
+        $user = $this->_findUser($mispUsername);
+
+        if ($user && !self::$conf['updateUser']) {
+            return $user;
+        }
+
+        // Insert user in database if not existent
+        $userModel = ClassRegistry::init($this->settings['userModel']);
+        $org_id = self::$conf['ldapDefaultOrg'];
+
+        // If not in config, take first local org
+        if (!isset($org_id)) {
+            $firstOrg = $userModel->Organisation->find(
+                'first',
+                array(
+                    'conditions' => array(
+                        'Organisation.local' => true
+                    ),
+                    'order' => 'Organisation.id ASC'
+                )
+            );
+            $org_id = $firstOrg['Organisation']['id'];
+        }
+
+        // Set role_id depending on group membership
+        $roleIds = self::$conf['ldapDefaultRoleId'];
+        if (is_array($roleIds)) {
+            foreach ($roleIds as $key => $id) {
+                if ($this->isUserMemberOf($key, $ldapUserData)) {
+                    $roleId = $roleIds[$key];
+                }
+            }
+        } else {
+            $roleId = $roleIds;
+        }
+
+        if (!$user) {
+            // create user
+            $userData = array('User' => array(
+                'email' => $mispUsername,
+                'org_id' => $org_id,
+                'password' => '',
+                'confirm_password' => '',
+                'authkey' => $userModel->generateAuthKey(),
+                'nids_sid' => 4000000,
+                'newsread' => 0,
+                'role_id' => $roleId,
+                'change_pw' => 0
+            ));
+            // save user
+            $userModel->save($userData, false);
+        } else {
+            if (!isset($roleId)) {
+                // User has no role anymore, disable user
+                $user['disabled'] = 1;
+                return false;
+            } else {
+                // Update existing user
+                $user['email'] = $mispUsername;
+                $user['org_id'] = $org_id;
+                $user['role_id'] = $roleId;
+                # Reenable user in case it has been disabled
+                $user['disabled'] = 0;
+            }
+
+            $userModel->save($user, false);
+        }
+
+        return $this->_findUser(
+            $mispUsername
+        );
+
+        # TODO: mixedAuth, check LinOTPAuthenticate
+
+        return $ldapUserData;
+    }
+}

--- a/app/Plugin/LdapAuth/README.md
+++ b/app/Plugin/LdapAuth/README.md
@@ -1,0 +1,144 @@
+# LdapAuth 
+This plugin allows MISP to authenticate against an LDAP server.
+
+## How to
+1. For enabling this plugin, uncomment the line `CakePlugin::load('LdapAuth');` in the `app/Config/bootstrap.php` configuration file.
+2. Add your LDAP server configuration to  `app/Config/config.php` configuration file:
+    ```
+    'LdapAuth' => [
+        'ldapServer' => 'ldap://openldap:1389',
+        'ldapDn' => 'dc=example,dc=com',
+        'ldapReaderUser' => 'cn=reader,dc=example,dc=com',
+        'ldapReaderPassword' => 'password'
+    ],
+    ```
+    > **NOTE:** This plugin requires a reader user to query the LDAP server.
+3. Log in with your LDAP credentials using the MISP Login form, if the user doesn't exist on MISP it will be created on the first log in.
+
+## Settings
+Each setting is stored in the `LdapAuth` configuration array and can be customized as per your LDAP server and application requirements.
+
+### `ldapServer`
+- **Description**: The LDAP server's hostname or IP address.
+- **Type**: `string`
+- **Example**: `'ldap://ldap.example.com'` or `'ldap://ldap.example.com:3389'` for using a custom port.
+
+### `ldapDn`
+- **Description**: The distinguished name (DN) for the LDAP search base.
+- **Type**: `string`
+- **Example**: `'dc=example,dc=com'`
+
+### `ldapReaderUser`
+- **Description**: The username for the LDAP reader account, used to authenticate search requests.
+- **Type**: `string`
+- **Example**: `'cn=reader,dc=example,dc=com'`
+
+### `ldapReaderPassword`
+- **Description**: The password for the LDAP reader account.
+- **Type**: `string`
+- **Example**: `'password'`
+
+### `ldapSearchFilter`
+- **Description**: The LDAP search filter used to locate the user entry.
+- **Type**: `string`
+- **Example**: `'(objectclass=inetOrgPerson)(!(nsaccountlock=True))(memberOf=cn=misp,cn=groups,cn=accounts,dc=example,dc=com)'`
+
+### `ldapSearchAttribute`
+- **Description**: The LDAP attribute used to match the user's identifier, typically their email or username.
+- **Type**: `string`
+- **Default**: `'mail'`
+- **Example**: `'uid'`
+
+### `ldapEmailField`
+- **Description**: Specifies which LDAP attribute(s) to use for retrieving the user's email address.
+- **Type**: `array`
+- **Default**: `['mail']`
+- **Example**: `['mail', 'userPrincipalName']`
+
+### `ldapNetworkTimeout`
+- **Description**: Sets the timeout for the network connection to the LDAP server, in seconds.
+- **Type**: `integer`
+- **Default**: `-1` (no timeout)
+- **Example**: `10`
+
+### `ldapProtocol`
+- **Description**: Specifies the LDAP protocol version.
+- **Type**: `integer`
+- **Default**: `3`
+- **Example**: `3`
+
+### `ldapAllowReferrals`
+- **Description**: Determines whether LDAP referrals are allowed.
+- **Type**: `boolean`
+- **Default**: `true`
+- **Example**: `true`
+
+### `starttls`
+- **Description**: Enables or disables StartTLS for LDAP, which provides a secure connection.
+- **Type**: `boolean`
+- **Default**: `false`
+- **Example**: `true`
+
+### `mixedAuth`
+- **Description**: Allows mixed authentication modes (e.g., both LDAP and local database authentication).
+- **Type**: `boolean`
+- **Default**: `true`
+- **Example**: `true`
+
+### `ldapDefaultOrgId`
+- **Description**: Specifies the default organisation ID when creating LDAP users on MISP.
+- **Type**: `string`
+- **Example**: `1`
+
+### `ldapDefaultRoleId`
+- **Description**: The default role ID assigned to users authenticated through LDAP. Can also be an array representing the mapping of group memberships of the LDAP user with the corresponding MISP `role_id`.
+- **Type**: `integer` | `array`
+- **Default**: `3`
+- **Example**: `3`
+- **Example of _LDAP group -> role_id_ mapping**: 
+    ```
+    [
+        'misp_admin'        => 1,
+        'misp_orgadmin'     => 2,
+        'misp_user'         => 3,
+        'misp_publisher'    => 4,
+        'misp_syncuser'     => 5,
+        'misp_readonly'     => 6,
+    ]
+    ```
+
+### `updateUser`
+- **Description**: Indicates whether user information in the local application database should be updated with LDAP data on each login. If the user exists on MISP but the LDAP role doesn't, the user is disabled and not allowed to log in.
+- **Type**: `boolean`
+- **Default**: `true`
+- **Example**: `true`
+
+## Example Usage
+
+To configure these settings in your application, ensure each setting is defined in your configuration file as follows:
+
+```php
+'LdapAuth', [
+    'ldapServer' => 'ldap://ldap.example.com',
+    'ldapDn' => 'dc=example,dc=com',
+    'ldapReaderUser' => 'cn=reader,dc=example,dc=com',
+    'ldapReaderPassword' => 'password',
+    'ldapSearchFilter' => '(objectClass=inetOrgPerson)',
+    'ldapSearchAttribute' => 'mail',
+    'ldapEmailField' => ['mail', 'uid'],
+    'ldapNetworkTimeout' => -1,
+    'ldapProtocol' => 3,
+    'ldapAllowReferrals' => false,
+    'starttls' => true,
+    'mixedAuth' => true,
+    'ldapDefaultOrg' => 1,
+    'ldapDefaultRoleId' => 3,
+    'updateUser' => true
+];
+```
+
+Adjust the values as needed based on your LDAP server setup.
+
+## Troubleshooting
+* Start your tests with `starttls` set to `false`.
+* Check `app/tmp/logs/error.log`, you can see the error responses from the LDAP server.


### PR DESCRIPTION
#### What does it do?

Add LDAP authentication as a plugin with a direct connection to an LDAP server (no Apache Basic Auth required).

closes https://github.com/MISP/MISP/issues/5742

based on the `ApacheAuthenticate` component by @truckydev

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
