### PR TITLE
Add TLS support for LdapAuth

### DIFF
--- a/app/Plugin/LdapAuth/README.md
+++ b/app/Plugin/LdapAuth/README.md
@@ -123,6 +123,42 @@ Each setting is stored in the `LdapAuth` configuration array and can be customiz
 - **Default**: `true`
 - **Example**: `true`
 
+
+### `debug`
+- **Description**: Increments the default debug level of the PHP LDAP library.
+- **Type**: `boolean`
+- **Default**: `false`
+- **Example**: `true`
+
+### `ldapTlsRequireCert`
+- **Description**: Sets the value for `LDAP_OPT_X_TLS_REQUIRE_CERT` setting.
+- **Type**: `int`
+- **Default**: `LDAP_OPT_X_TLS_DEMAND`
+- **Options**: `LDAP_OPT_X_TLS_NEVER` | `LDAP_OPT_X_TLS_HARD` | `LDAP_OPT_X_TLS_DEMAND` | `LDAP_OPT_X_TLS_ALLOW` | `LDAP_OPT_X_TLS_TRY`
+- **Example**: `LDAP_OPT_X_TLS_NEVER`
+
+### `ldapTlsCustomCaCert`
+- **Description**: Sets the value for `LDAP_OPT_X_TLS_CACERTDIR` and `LDAP_OPT_X_TLS_CACERTFILE`.
+- **Type**: `boolean|string`
+- **Default**: `false`
+- **Example**: `/var/wwww/MISP/app/files/certs/ldap.crt`
+
+### `ldapTlsCrlCheck`
+- **Description**: Sets the value for `LDAP_OPT_X_TLS_CRLCHECK`.
+- **Type**: `int`
+- **Options**: `LDAP_OPT_X_TLS_CRL_NONE`|`LDAP_OPT_X_TLS_CRL_PEER`|`LDAP_OPT_X_TLS_CRL_ALL`.
+- **Default**: `LDAP_OPT_X_TLS_CRL_PEER`
+- **Example**: `LDAP_OPT_X_TLS_CRL_NONE`
+
+### `ldapTlsProtocolMin`
+- **Description**: Sets the value for `LDAP_OPT_X_TLS_PROTOCOL_MIN`.
+- **Type**: `int`
+- **Options**: `LDAP_OPT_X_TLS_PROTOCOL_SSL2`|`LDAP_OPT_X_TLS_PROTOCOL_SSL3`|`LDAP_OPT_X_TLS_PROTOCOL_TLS1_0`|`LDAP_OPT_X_TLS_PROTOCOL_TLS1_1`|`LDAP_OPT_X_TLS_PROTOCOL_TLS1_2`
+- **Default**: `LDAP_OPT_X_TLS_PROTOCOL_TLS1_2`
+- **Example**: `LDAP_OPT_X_TLS_PROTOCOL_SSL3`
+
+See also: https://www.php.net/manual/en/ldap.constants.php
+
 ## Example Usage
 
 To configure these settings in your application, ensure each setting is defined in your configuration file as follows:
@@ -150,5 +186,54 @@ To configure these settings in your application, ensure each setting is defined 
 Adjust the values as needed based on your LDAP server setup.
 
 ## Troubleshooting
+* Start your tests with `debug` set to `true`.
 * Start your tests with `starttls` set to `false`.
 * Check `app/tmp/logs/error.log`, you can see the error responses from the LDAP server.
+
+### TLS
+If experiencing issues when configuring MISP to use LDAPS, try:
+1. Set `ldapTlsRequireCert` to `LDAP_OPT_X_TLS_NEVER`.
+2. Set `ldapTlsCrlCheck` to `LDAP_OPT_X_TLS_CRL_NONE`
+3. Set `ldapTlsProtocolMin` to `LDAP_OPT_X_TLS_PROTOCOL_SSL3`.
+4. Then set the this setting to the correct (safe) value one at a time.
+
+
+* Ensure the user www-data has sufficient permissions to read the custom CA certificate. 
+
+* If you are using a self-signed certificate, ensure the CN matches the host name of the LDAP server, otherwise the TLS session will fail.
+
+
+#### Debugging
+Additionally, you can install `ldap-utils` and use the `ldapsearch` tool to verify the connection.
+In this scenairo you may have to edit the `/etc/ldap/ldap.conf` to match the LDAP settings used by MISP
+
+Example `/etc/ldap/ldap.conf` configuration using a custom CA, equivalent to setting `LdapAuthldapTlsCustomCaCert`:
+```
+#
+# LDAP Defaults
+#
+
+# See ldap.conf(5) for details
+# This file should be world readable but not world writable.
+
+#BASE   dc=example,dc=com
+#URI    ldap://ldap.example.com ldap://ldap-provider.example.com:666
+
+#SIZELIMIT      12
+#TIMELIMIT      15
+#DEREF          never
+
+# TLS certificates (needed for GnuTLS)
+
+#TLS_CACERT     /etc/ssl/certs/ca-certificates.crt
+#TLS_REQCERT    never
+
+TLS_CACERTDIR   /var/www/MISP/app/files/certs
+TLS_CACERT      /var/www/MISP/app/files/certs/ldap.crt
+```
+
+Example test (failed) search:
+```
+# ldapsearch -H ldaps://localhost:1636 -x -b "dc=example,dc=com" -D "cn=reader,dc=example,dc=com" -w password -d 1
+TLS: hostname (localhost) does not match common name in certificate (ldap.example.com).
+TLS: can't connect: (unknown error code).


### PR DESCRIPTION
#### What does it do?
* Add support for LDAPS for LdapAuth.
* Supports self-signed certificates and custom CAs.
* Implements https://github.com/MISP/MISP/pull/10038#issuecomment-2489439284

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
