### PR TITLE
fix: [bookmarks] delete bookmark buttons on index page not working

### DIFF
--- a/app/View/Bookmarks/index.ctp
+++ b/app/View/Bookmarks/index.ctp
@@ -97,7 +97,7 @@
                     ],
                     [
                         'class' => 'modal-open',
-                        'url' => $baseurl . '/bookmarks/delete/',
+                        'url' => $baseurl . '/bookmarks/delete',
                         'url_params_data_paths' => 'Bookmark.id',
                         'icon' => 'trash',
                         'title' => __('Delete'),


### PR DESCRIPTION
#### What does it do?

Delete buttons point to wrong url, leading to them not working properly.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
