### PR TITLE
Catch errors during opening of GeoIP database

### DIFF
--- a/app/Model/UserLoginProfile.php
+++ b/app/Model/UserLoginProfile.php
@@ -89,8 +89,8 @@ class UserLoginProfile extends AppModel
     public function countryByIp($ip)
     {
         if (class_exists('GeoIp2\Database\Reader')) {
-            $geoDbReader = new GeoIp2\Database\Reader(UserLoginProfile::GEOIP_DB_FILE);
             try {
+                $geoDbReader = new GeoIp2\Database\Reader(UserLoginProfile::GEOIP_DB_FILE);
                 $record = $geoDbReader->country($ip);
                 return $record->country->isoCode;
             } catch (InvalidArgumentException $e) {


### PR DESCRIPTION
#### What does it do?

When the GeoIp2 database cannot be opened, e.g. due to a filesystem error, an InvalidArgumentException may be thrown during creation of the Reader object. Since this is not caught, users cannot be authenticated when this issue appears, throwing a HTTP 500 error in the process.

Simply adding the creation of the Reader to the already existing try/catch-block fixes it.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
