### PR TITLE
Add config option to select the property to use for Azure AD authentication

### DIFF
--- a/app/Plugin/AadAuth/Controller/Component/Auth/AadAuthenticateAuthenticate.php
+++ b/app/Plugin/AadAuth/Controller/Component/Auth/AadAuthenticateAuthenticate.php
@@ -56,6 +56,14 @@ class AadAuthenticateAuthenticate extends BaseAuthenticate
 	 */
 	protected static $auth_provider_user;
 
+        /**
+         * Name of the property to use for authentication.
+         * The value must be either 'mail' or 'userPrincipalName'
+         *
+         * @var string
+         */
+        protected static $auth_property_name;
+
 	/**
 	 * Flag that indicates if we need to check for AD groups for defining MISP access
 	 *
@@ -96,6 +104,7 @@ class AadAuthenticateAuthenticate extends BaseAuthenticate
 		self::$misp_orgadmin =  Configure::read('AadAuth.misp_orgadmin');
 		self::$misp_siteadmin =  Configure::read('AadAuth.misp_siteadmin');
 		self::$check_ad_groups =  Configure::read('AadAuth.check_ad_groups');
+                self::$auth_property_name =  Configure::read('AadAuth.auth_property_name');
 
 		$this->Log = ClassRegistry::init('Log');
 		$this->Log->create();
@@ -255,8 +264,8 @@ class AadAuthenticateAuthenticate extends BaseAuthenticate
 				}
 
 				$mispUsername = false;
-				if (isset($userdata["userPrincipalName"])) {
-					$userPrincipalName = $userdata["userPrincipalName"];
+                                if ((self::$auth_property_name == "mail" || self::$auth_property_name == "userPrincipalName") && isset($userdata[self::$auth_property_name])) {
+                                        $authProperty = $userdata[self::$auth_property_name];
 
 					/*
 					 * TODO: add code to create users that exist in AAD but not in MISP
@@ -265,11 +274,11 @@ class AadAuthenticateAuthenticate extends BaseAuthenticate
 
 					if (self::$check_ad_groups) {
 						if ($this->_checkAdGroup($authdata)) {
-							$mispUsername = $userPrincipalName;
+							$mispUsername = $authProperty;
 							$this->_log("info", "Successful AAD group check for for ${mispUsername}");
 						}
 					} else {
-						$mispUsername = $userPrincipalName;
+						$mispUsername = $authProperty;
 					}
 
 					if ($mispUsername) {

--- a/app/Plugin/AadAuth/README.md
+++ b/app/Plugin/AadAuth/README.md
@@ -119,6 +119,7 @@ Scroll down to near the bottom of the page and add in the following configuratio
     'misp_orgadmin' => 'Misp Org Admins', // The AD group for MISP administrators
     'misp_siteadmin' => 'Misp Site Admins', // The AD group for MISP site administrators
     'check_ad_groups' => true, // Should we check if the user belongs to one of the above AD groups?
+    'auth_property_name' => 'userPrincipalName' // The name of the property to use for authentication. The value must be either 'mail' or 'userPrincipalName'
   ),
 ```
 

--- a/app/View/GalaxyClusters/cluster_export_misp_galaxy.ctp
+++ b/app/View/GalaxyClusters/cluster_export_misp_galaxy.ctp
@@ -5,7 +5,7 @@
         <p>This JSON can be added added to the <code class="quickSelect">misp-galaxy/clusters/<?= h($cluster['GalaxyCluster']['type']) ?>.json</code>.</p>
         <p>Don't forget to bump the <code>version</code> specified at the end of the <code><?= h($cluster['GalaxyCluster']['type']) ?>.json</code> file.</p>
 
-        <pre class="quickSelect"><?= JsonTool::encode($convertedCluster, true) ?></pre>
+        <pre class="quickSelect"><?= JsonTool::encode(h($convertedCluster), true) ?></pre>
     </div>
 </div>
 <?= $this->element('/genericElements/SideMenu/side_menu', ['menuList' => 'galaxies', 'menuItem' => 'view_cluster']);

--- a/app/webroot/js/workflows-editor/workflows-editor.js
+++ b/app/webroot/js/workflows-editor/workflows-editor.js
@@ -1,15 +1,15 @@
 var dotBlock_default = doT.template(' \
-<div class="canvas-workflow-block {{? it.module_data.is_misp_module }} is-misp-module {{?}}" data-nodeuid="{{=it.node_uid}}"> \
+<div class="canvas-workflow-block {{? it.module_data.is_misp_module }} is-misp-module {{?}}" data-nodeuid="{{!it.node_uid}}"> \
     <div style="width: 100%;"> \
         <div class="default-main-container"> \
             {{? it.module_data.icon }} \
-                <i class="fa-fw fa-{{=it.module_data.icon}} {{=it.module_data.icon_class}}"></i> \
+                <i class="fa-fw fa-{{!it.module_data.icon}} {{!it.module_data.icon_class}}"></i> \
             {{?}} \
             {{? it.module_data.icon_path }} \
-                <span style="display: flex; height: 1em;"><img src="/img/{{=it.module_data.icon_path}}" alt="Icon of {{=it.module_data.name}}" width="18" height="18" style="margin: auto 0; filter: grayscale(1);"></span> \
+                <span style="display: flex; height: 1em;"><img src="/img/{{!it.module_data.icon_path}}" alt="Icon of {{!it.module_data.name}}" width="18" height="18" style="margin: auto 0; filter: grayscale(1);"></span> \
             {{?}} \
             <strong style="margin-left: 0.25em;"> \
-                {{=it.module_data.name}} \
+                {{!it.module_data.name}} \
             </strong> \
             {{? it.module_data.is_misp_module }} \
                 <sup class="is-misp-module"></sup> \
@@ -29,23 +29,23 @@ var dotBlock_default = doT.template(' \
                 </span> \
             </span> \
         </div> \
-        <div class="muted" class="description" style="margin-bottom: 0.5em;">{{=it.module_data.description}}</div> \
+        <div class="muted" class="description" style="margin-bottom: 0.5em;">{{!it.module_data.description}}</div> \
         {{=it._node_param_html}} \
     </div> \
 </div>')
 
 var dotBlock_trigger = doT.template(' \
-<div class="canvas-workflow-block" data-nodeuid="{{=it.node_uid}}"> \
+<div class="canvas-workflow-block" data-nodeuid="{{!it.node_uid}}"> \
     <div style="width: 100%;"> \
         <div class="default-main-container" style="border:none;"> \
             {{? it.module_data.icon }} \
-                <i class="fa-fw fa-{{=it.module_data.icon}} {{=it.module_data.icon_class}}"></i> \
+                <i class="fa-fw fa-{{!it.module_data.icon}} {{!it.module_data.icon_class}}"></i> \
             {{?}} \
             {{? it.module_data.icon_path }} \
-                <span style="display: flex; height: 1em;"><img src="/img/{{=it.module_data.icon_path}}" alt="Icon of {{=it.module_data.name}}" width="18" height="18" style="margin: auto 0;"></span> \
+                <span style="display: flex; height: 1em;"><img src="/img/{{!it.module_data.icon_path}}" alt="Icon of {{!it.module_data.name}}" width="18" height="18" style="margin: auto 0;"></span> \
             {{?}} \
             <strong style="margin-left: 0.25em;"> \
-                {{=it.module_data.name}} \
+                {{!it.module_data.name}} \
             </strong> \
             <span style="margin-left: auto; display: flex; align-items: center; gap: 3px;"> \
                 {{? it.module_data.blocking }} \
@@ -69,23 +69,23 @@ var dotBlock_trigger = doT.template(' \
                 {{?}} \
             </span> \
         </div> \
-        <div class="muted" class="description" style="margin-bottom: 0.5em;">{{=it.module_data.description}}</div> \
+        <div class="muted" class="description" style="margin-bottom: 0.5em;">{{!it.module_data.description}}</div> \
         {{=it._node_param_html}} \
     </div> \
 </div>')
 
 var dotBlock_if = doT.template(' \
-<div class="canvas-workflow-block" data-nodeuid="{{=it.node_uid}}"> \
+<div class="canvas-workflow-block" data-nodeuid="{{!it.node_uid}}"> \
     <div style="width: 100%;"> \
         <div class="default-main-container"> \
             {{? it.module_data.icon }} \
-                <i class="fa-fw fa-{{=it.module_data.icon}} {{=it.module_data.icon_class}}"></i> \
+                <i class="fa-fw fa-{{!it.module_data.icon}} {{!it.module_data.icon_class}}"></i> \
             {{?}} \
             {{? it.module_data.icon_path }} \
-                <span style="display: flex; height: 1em;"><img src="/img/{{=it.module_data.icon_path}}" alt="Icon of {{=it.module_data.name}}" width="18" height="18" style="margin: auto 0;"></span> \
+                <span style="display: flex; height: 1em;"><img src="/img/{{!it.module_data.icon_path}}" alt="Icon of {{!it.module_data.name}}" width="18" height="18" style="margin: auto 0;"></span> \
             {{?}} \
             <strong style="margin-left: 0.25em;"> \
-                {{=it.module_data.name}} \
+                {{!it.module_data.name}} \
             </strong> \
             <span style="margin-left: auto;"> \
                 <span class="block-notification-container"> \
@@ -101,17 +101,17 @@ var dotBlock_if = doT.template(' \
 </div>')
 
 var dotBlock_concurrent = doT.template(' \
-<div class="canvas-workflow-block" data-nodeuid="{{=it.node_uid}}"> \
+<div class="canvas-workflow-block" data-nodeuid="{{!it.node_uid}}"> \
     <div style="width: 100%;"> \
         <div class="default-main-container"> \
             {{? it.module_data.icon }} \
-                <i class="fa-fw fa-{{=it.module_data.icon}} {{=it.module_data.icon_class}}"></i> \
+                <i class="fa-fw fa-{{!it.module_data.icon}} {{!it.module_data.icon_class}}"></i> \
             {{?}} \
             {{? it.module_data.icon_path }} \
-                <span style="display: flex; height: 1em;"><img src="/img/{{=it.module_data.icon_path}}" alt="Icon of {{=it.module_data.name}}" width="18" height="18" style="margin: auto 0;"></span> \
+                <span style="display: flex; height: 1em;"><img src="/img/{{!it.module_data.icon_path}}" alt="Icon of {{!it.module_data.name}}" width="18" height="18" style="margin: auto 0;"></span> \
             {{?}} \
             <strong style="margin-left: 0.25em;"> \
-                {{=it.module_data.name}} \
+                {{!it.module_data.name}} \
             </strong> \
             <span style="margin-left: auto;"> \
                 <span class="block-notification-container"> \
@@ -123,21 +123,21 @@ var dotBlock_concurrent = doT.template(' \
             </span> \
         </div> \
         {{=it._node_param_html}} \
-        <div class="muted" class="description" style="margin-bottom: 0.5em;">{{=it.module_data.description}}</div> \
+        <div class="muted" class="description" style="margin-bottom: 0.5em;">{{!it.module_data.description}}</div> \
     </div> \
 </div>')
 
 var dotBlock_error = doT.template(' \
-<div class="canvas-workflow-block" data-nodeuid="{{=it.node_uid}}"> \
+<div class="canvas-workflow-block" data-nodeuid="{{!it.node_uid}}"> \
     <div style="width: 100%;"> \
-        <div class="alert alert-danger">{{=it.error}}</div> \
+        <div class="alert alert-danger">{{!it.error}}</div> \
         <div>Data:</div> \
-        <textarea rows=6 style="width: 95%;">{{=it.data}}</textarea> \
+        <textarea rows=6 style="width: 95%;">{{!it.data}}</textarea> \
     </div> \
 </div>')
 
 var dotBlock_connectionLabel = doT.template(' \
-<span class="label label-{{=it.variant}}" id="{{=it.id}}">{{=it.name}}</span>')
+<span class="label label-{{!it.variant}}" id="{{!it.id}}">{{!it.name}}</span>')
 
 var classBySeverity = {
     'info': 'info',


### PR DESCRIPTION
#### What does it do?

This pull request adds a configuration option to the AadAuth plugin, allowing users to select the property used to check for the existence of a user in MISP during the authentication process.

Before this modification, the plugin would default to checking the UPN (User Principal Name). With this pull request, the property "mail" can be used instead of "userPrincipalName". The selection is controlled via the `auth_property_name` option.

I have tested it only on version 2.4, but I believe it should also work on version 2.5.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?