### PR TITLE
fix: [collections] internal server error thrown on view if not site a…

### DIFF
--- a/app/Model/Collection.php
+++ b/app/Model/Collection.php
@@ -115,7 +115,7 @@ class Collection extends AppModel
         if ($user['Role']['perm_site_admin']) {
             return true;
         }
-        if ($collection['Collection']['org_id'] == $user('org_id')) {
+        if ($collection['Collection']['org_id'] == $user['org_id']) {
             return true;
         }
         if (in_array($collection['Collection']['distribution'], [1,2,3])) {


### PR DESCRIPTION
…dmin

#### What does it do?

Fixes typo, which results in internal server error being thrown on viewing a collection if the user is not a site admin.

Please note this PR is on develop! I'm sorry I don't have 2.4 dev instance atm.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
