### PR TITLE
fix: [internal] Fix "Integrity constraint violation: 1052 Column 'id' in where clause is ambiguous" when fetching galaxy matrix

### DIFF
--- a/app/Controller/GalaxyClustersController.php
+++ b/app/Controller/GalaxyClustersController.php
@@ -723,7 +723,7 @@ class GalaxyClustersController extends AppController
             'conditions' => array('GalaxyCluster.id' => $id)
         ), $full=false);
         if (empty($cluster)) {
-            throw new MethodNotAllowedException("Invalid Galaxy Cluster.");
+            throw new NotFoundException("Invalid Galaxy Cluster.");
         }
         $cluster = $cluster[0];
         $this->loadModel('Event');
@@ -731,7 +731,7 @@ class GalaxyClustersController extends AppController
         if ($mitreAttackGalaxyId == 0) { // Mitre Att&ck galaxy not found
             return new CakeResponse(array('body' => '', 'status' => 200, 'type' => 'text'));
         }
-        $attackPatternTagNames = $this->GalaxyCluster->find('list', array(
+        $attackPatternTagNames = $this->GalaxyCluster->find('column', array(
             'conditions' => array('galaxy_id' => $mitreAttackGalaxyId),
             'fields' => array('tag_name')
         ));
@@ -740,7 +740,7 @@ class GalaxyClustersController extends AppController
         $tag_name = $cluster['tag_name'];
 
         // fetch all event ids having the requested cluster
-        $eventIds = $this->Event->EventTag->find('list', array(
+        $eventIds = $this->Event->EventTag->find('column', array(
             'contain' => array('Tag'),
             'conditions' => array(
                 'Tag.name' => $tag_name


### PR DESCRIPTION
#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
