### PR TITLE
fix: [UI] wrong closing html tag on hard/soft delete form for a button

### DIFF
--- a/app/View/Elements/genericElements/Form/hardSoftDeleteForm.ctp
+++ b/app/View/Elements/genericElements/Form/hardSoftDeleteForm.ctp
@@ -47,7 +47,7 @@
                 array('class' => 'btn btn-danger')
             );
         ?>
-        <button type="button" tabindex="0" aria-label="<?php echo __('Cancel');?>" class="btn btn-inverse" style="margin-left: auto; height: fit-content;" id="PromptNoButton" onClick="cancelPrompt();"><?php echo __('No');?></span>
+        <button type="button" tabindex="0" aria-label="<?php echo __('Cancel');?>" class="btn btn-inverse" style="margin-left: auto; height: fit-content;" id="PromptNoButton" onClick="cancelPrompt();"><?php echo __('No');?></button>
     </div>
 </div>
 <?php


### PR DESCRIPTION
#### What does it do?

Fixes wrong html closing tag (no impact on users, as it looks like browsers autocorrect this kind of thing).

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
