### PR TITLE
chg: [OTP] mention authenticator app in enter OTP label

### DIFF
--- a/app/View/Users/otp.ctp
+++ b/app/View/Users/otp.ctp
@@ -7,7 +7,7 @@
 </div>
 
 <?php
-$label = __("Enter either your TOTP or paper based Single Use Token number ") . $hotp_counter;
+$label = __("Enter either your TOTP (please check your authenticator app, not e-mail) or paper based Single Use Token number ") . $hotp_counter;
 
 echo $this->element('/genericElements/Form/genericForm', array(
   "form" => $this->Form,


### PR DESCRIPTION
#### What does it do?

Clarifies the label a bit. Points out to people they will not get the OTP via e-mail, as people keep getting confused.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
