### PR TITLE
fix: [serverSettings] mismatch in description of MISP.disablerestalert

### DIFF
--- a/app/Locale/ara/LC_MESSAGES/default.po
+++ b/app/Locale/ara/LC_MESSAGES/default.po
@@ -6854,7 +6854,7 @@ msgid "Turn Weakness type attributes into links linking to the provided CWE look
 msgstr ""
 
 #: Model/Server.php:5067
-msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to disable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
+msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to enable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
 msgstr ""
 
 #: Model/Server.php:5074

--- a/app/Locale/cze/LC_MESSAGES/default.po
+++ b/app/Locale/cze/LC_MESSAGES/default.po
@@ -6840,7 +6840,7 @@ msgid "Turn Weakness type attributes into links linking to the provided CWE look
 msgstr ""
 
 #: Model/Server.php:5067
-msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to disable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
+msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to enable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
 msgstr ""
 
 #: Model/Server.php:5074

--- a/app/Locale/dan/LC_MESSAGES/default.po
+++ b/app/Locale/dan/LC_MESSAGES/default.po
@@ -6825,7 +6825,7 @@ msgid "Turn Weakness type attributes into links linking to the provided CWE look
 msgstr ""
 
 #: Model/Server.php:5067
-msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to disable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
+msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to enable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
 msgstr "Denne indstilling styrer, om der sendes en e-mail notofikation, når en event bliver oprettet via REST interfacet. Det kan være en god ide at deaktivere denne indstilling, når der første gang oprettes et link til en anden instans, for at undgå at spamme din brugere mens du alver det første pull. Hurtigt Resumé: sand = E-mails sendes ikke, falsk = E-mails sendes på events publiceret via sync / REST."
 
 #: Model/Server.php:5074

--- a/app/Locale/default.pot
+++ b/app/Locale/default.pot
@@ -7792,7 +7792,7 @@ msgid "Turn Weakness type attributes into links linking to the provided CWE look
 msgstr ""
 
 #: Model/Server.php:5079
-msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to disable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
+msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to enable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
 msgstr ""
 
 #: Model/Server.php:5086

--- a/app/Locale/deu/LC_MESSAGES/default.po
+++ b/app/Locale/deu/LC_MESSAGES/default.po
@@ -6825,7 +6825,7 @@ msgid "Turn Weakness type attributes into links linking to the provided CWE look
 msgstr ""
 
 #: Model/Server.php:5067
-msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to disable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
+msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to enable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
 msgstr "Diese Einstellung kontrolliert ob Benachrichtigungs E-Mails versendet werden wenn Events über das REST Interface erstellt werden. Es ist gut diese Einstellung beim ersten Verbinden zu einer anderen Instanz zu deaktivieren um zu verhindern, dass die Nutzer während dem initialen Pull überschwemmt werden. In Kürze: True = E-Mails werden NICHT gesendet, False = E-Mails werden gesendet beim publizieren von Events über Sync und REST."
 
 #: Model/Server.php:5074

--- a/app/Locale/fra/LC_MESSAGES/default.po
+++ b/app/Locale/fra/LC_MESSAGES/default.po
@@ -6828,8 +6828,8 @@ msgid "Turn Weakness type attributes into links linking to the provided CWE look
 msgstr ""
 
 #: Model/Server.php:5067
-msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to disable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
-msgstr "Ce paramètre contrôle si les mails de notification vont être envoyés ou non lorsqu'un événement est créé par l'interface REST. Cela peut être une bonne idée de désactivé ce paramètre lors du premier paramétrage d'un lien à une autre instance pour éviter le spam des utilisateurs durant la première récupération. Récapitulatif rapide: True = Les mails ne sont pas envoyés, False, les mail sont envoyé pour les événements publiés par synchronisation/REST API."
+msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to enable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
+msgstr "Ce paramètre contrôle si les mails de notification vont être envoyés ou non lorsqu'un événement est créé par l'interface REST. Cela peut être une bonne idée de activé ce paramètre lors du premier paramétrage d'un lien à une autre instance pour éviter le spam des utilisateurs durant la première récupération. Récapitulatif rapide: True = Les mails ne sont pas envoyés, False, les mail sont envoyé pour les événements publiés par synchronisation/REST API."
 
 #: Model/Server.php:5074
 msgid "Enabling this flag will allow the event description to be transmitted in the alert e-mail's subject. Be aware that this is not encrypted by GnuPG, so only enable it if you accept that part of the event description will be sent out in clear-text."

--- a/app/Locale/hun/LC_MESSAGES/default.po
+++ b/app/Locale/hun/LC_MESSAGES/default.po
@@ -6825,7 +6825,7 @@ msgid "Turn Weakness type attributes into links linking to the provided CWE look
 msgstr ""
 
 #: Model/Server.php:5067
-msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to disable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
+msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to enable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
 msgstr ""
 
 #: Model/Server.php:5074

--- a/app/Locale/ita/LC_MESSAGES/default.po
+++ b/app/Locale/ita/LC_MESSAGES/default.po
@@ -6826,7 +6826,7 @@ msgid "Turn Weakness type attributes into links linking to the provided CWE look
 msgstr ""
 
 #: Model/Server.php:5067
-msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to disable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
+msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to enable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
 msgstr "Questa impostazione controlla se le notifiche email verranno inviate quando un evento è creato dall'interfaccia REST. Potrebbe essere una buova idea disabilitare l'impostazione quando si configura per la prima volta un collegamento ad un'altra istanza, per evitare spam agli utenti durante il primo pull di dati. Breve riepilogo: 'True' = le email non sono inviata, 'False' = le email saranno inviate per gli eventi pubblicati via sincronizzazione / REST."
 
 #: Model/Server.php:5074

--- a/app/Locale/jpn/LC_MESSAGES/default.po
+++ b/app/Locale/jpn/LC_MESSAGES/default.po
@@ -6818,7 +6818,7 @@ msgid "Turn Weakness type attributes into links linking to the provided CWE look
 msgstr ""
 
 #: Model/Server.php:5067
-msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to disable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
+msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to enable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
 msgstr "この設定は、イベントが REST インターフェイス経由で作成されたときに通知Eメールを送信するかどうかを制御します。 別のインスタンスとのリンクを最初に設定する際、最初のプルでユーザーにスパムをしないために、この設定を無効化することをお勧めします。クイックリキャップ: True = Eメールは送信されません。False = Eメールは、sync / REST を経由して公開されたイベントで送信されます。"
 
 #: Model/Server.php:5074

--- a/app/Locale/kor/LC_MESSAGES/default.po
+++ b/app/Locale/kor/LC_MESSAGES/default.po
@@ -6819,7 +6819,7 @@ msgid "Turn Weakness type attributes into links linking to the provided CWE look
 msgstr ""
 
 #: Model/Server.php:5067
-msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to disable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
+msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to enable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
 msgstr ""
 
 #: Model/Server.php:5074

--- a/app/Locale/no/LC_MESSAGES/default.po
+++ b/app/Locale/no/LC_MESSAGES/default.po
@@ -6825,7 +6825,7 @@ msgid "Turn Weakness type attributes into links linking to the provided CWE look
 msgstr ""
 
 #: Model/Server.php:5067
-msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to disable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
+msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to enable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
 msgstr "Denne innstillingen styrer om e-post med e-post vil bli sendt når en hendelse er opprettet via REST-grensesnittet. Det kan være lurt å deaktivere denne innstillingen når du først oppretter en kobling til en annen forekomst for å unngå å spammere brukerne dine under den første trekkingen. Rask oppsummering: True = E-postmeldinger er IKKE sendt, False = E-postmeldinger sendes på hendelser publisert via synkronisering / REST."
 
 #: Model/Server.php:5074

--- a/app/Locale/pol/LC_MESSAGES/default.po
+++ b/app/Locale/pol/LC_MESSAGES/default.po
@@ -6840,7 +6840,7 @@ msgid "Turn Weakness type attributes into links linking to the provided CWE look
 msgstr ""
 
 #: Model/Server.php:5067
-msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to disable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
+msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to enable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
 msgstr ""
 
 #: Model/Server.php:5074

--- a/app/Locale/pt/LC_MESSAGES/default.po
+++ b/app/Locale/pt/LC_MESSAGES/default.po
@@ -3001,7 +3001,7 @@ msgid "Turn Vulnerability type attributes into links linking to the provided CVE
 msgstr ""
 
 #: Model/Server.php:519
-msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to disable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
+msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to enable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
 msgstr ""
 
 #: Model/Server.php:527

--- a/app/Locale/pt_BR/LC_MESSAGES/default.po
+++ b/app/Locale/pt_BR/LC_MESSAGES/default.po
@@ -6826,7 +6826,7 @@ msgid "Turn Weakness type attributes into links linking to the provided CWE look
 msgstr ""
 
 #: Model/Server.php:5067
-msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to disable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
+msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to enable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
 msgstr ""
 
 #: Model/Server.php:5074

--- a/app/Locale/ro/LC_MESSAGES/default.po
+++ b/app/Locale/ro/LC_MESSAGES/default.po
@@ -6832,7 +6832,7 @@ msgid "Turn Weakness type attributes into links linking to the provided CWE look
 msgstr ""
 
 #: Model/Server.php:5067
-msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to disable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
+msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to enable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
 msgstr ""
 
 #: Model/Server.php:5074

--- a/app/Locale/rus/LC_MESSAGES/default.po
+++ b/app/Locale/rus/LC_MESSAGES/default.po
@@ -6839,7 +6839,7 @@ msgid "Turn Weakness type attributes into links linking to the provided CWE look
 msgstr ""
 
 #: Model/Server.php:5067
-msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to disable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
+msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to enable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
 msgstr "Отправка электронной почты (уведомлений) при создании событий по REST интерфейсу. При настройке связи с сторонним инстансом хорошая идея - отключать посылку уведомлений. Если параметр равен true, то электронные письма не посылаются."
 
 #: Model/Server.php:5074

--- a/app/Locale/spa/LC_MESSAGES/default.po
+++ b/app/Locale/spa/LC_MESSAGES/default.po
@@ -6827,7 +6827,7 @@ msgid "Turn Weakness type attributes into links linking to the provided CWE look
 msgstr ""
 
 #: Model/Server.php:5067
-msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to disable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
+msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to enable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
 msgstr ""
 
 #: Model/Server.php:5074

--- a/app/Locale/swe/LC_MESSAGES/default.po
+++ b/app/Locale/swe/LC_MESSAGES/default.po
@@ -4424,7 +4424,7 @@ msgid "Turn Weakness type attributes into links linking to the provided CWE look
 msgstr ""
 
 #: Model/Server.php:595
-msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to disable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
+msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to enable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
 msgstr ""
 
 #: Model/Server.php:603

--- a/app/Locale/th_TH/LC_MESSAGES/default.po
+++ b/app/Locale/th_TH/LC_MESSAGES/default.po
@@ -6822,7 +6822,7 @@ msgid "Turn Weakness type attributes into links linking to the provided CWE look
 msgstr "เปลี่ยนแอตทริบิวต์ประเภทจุดอ่อนเป็นลิงก์ที่เชื่อมโยงไปยังการค้นหา CWE ที่ให้มา"
 
 #: Model/Server.php:5067
-msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to disable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
+msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to enable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
 msgstr "การตั้งค่านี้ควบคุมว่าจะส่งอีเมลแจ้งเตือนเมื่อมีการสร้างเหตุการณ์ผ่านอินเทอร์เฟซ REST หรือไม่ อาจเป็นความคิดที่ดีที่จะปิดใช้งานการตั้งค่านี้เมื่อตั้งค่าลิงก์ไปยังอินสแตนซ์อื่นในครั้งแรก เพื่อหลีกเลี่ยงสแปมผู้ใช้ของคุณในระหว่างการดึงครั้งแรก สรุป: True = ไม่ได้ส่งอีเมล, False = อีเมลถูกส่งในเหตุการณ์ที่เผยแพร่ผ่านการซิงค์ / REST"
 
 #: Model/Server.php:5074

--- a/app/Locale/ukr/LC_MESSAGES/default.po
+++ b/app/Locale/ukr/LC_MESSAGES/default.po
@@ -1354,7 +1354,7 @@ msgid "Turn Vulnerability type attributes into links linking to the provided CVE
 msgstr ""
 
 #: Model/Server.php:473
-msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to disable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
+msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to enable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
 msgstr ""
 
 #: Model/Server.php:481

--- a/app/Locale/zh-s/LC_MESSAGES/default.po
+++ b/app/Locale/zh-s/LC_MESSAGES/default.po
@@ -6819,7 +6819,7 @@ msgid "Turn Weakness type attributes into links linking to the provided CWE look
 msgstr "将弱点类型属性转化为所提供的CWE查询的链接"
 
 #: Model/Server.php:5067
-msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to disable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
+msgid "This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to enable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST."
 msgstr "这个设置控制了通过REST接口创建事件时是否会发送通知邮件, 在首次设置链接到另一个实例时, 最好禁用此设置, 以避免在初始拉动期间向用户发送垃圾邮件. 快速回顾一下, True = 不发送电子邮件, False = 通过同步/REST发布的事件会发送电子邮件."
 
 #: Model/Server.php:5074

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -5579,7 +5579,7 @@ class Server extends AppModel
                 ),
                 'disablerestalert' => array(
                     'level' => 1,
-                    'description' => __('This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to disable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST.'),
+                    'description' => __('This setting controls whether notification e-mails will be sent when an event is created via the REST interface. It might be a good idea to enable this setting when first setting up a link to another instance to avoid spamming your users during the initial pull. Quick recap: True = Emails are NOT sent, False = Emails are sent on events published via sync / REST.'),
                     'value' => true,
                     'test' => 'testBool',
                     'type' => 'boolean',


### PR DESCRIPTION
#### What does it do?

Fixes an inconsistency in the description of MISP.disablerestalert. Please note I only changed the English and French text. I don't know if there's any way to ask people to submit updated translations.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
