### PR TITLE
chg: [attributes:addTag] allow combinations of tag collection tags, a…

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -2623,7 +2623,7 @@ class AttributesController extends AppController
                                 if (empty($tagCollection)) {
                                     return new CakeResponse(array('body'=> json_encode(array('saved' => false, 'errors' => 'Invalid Tag Collection.')), 'status'=>200, 'type' => 'json'));
                                 }
-                                $tag_id_list = array_column($tagCollection[0]['TagCollectionTag'], 'tag_id');
+                                $tag_id_list = array_merge($tag_id_list, array_column($tagCollection[0]['TagCollectionTag'], 'tag_id'));
                             } else if(is_numeric($tag_id)){
                                 $tag_id_list[] = $tag_id;
                             } else {


### PR DESCRIPTION
…nd other tags, to be added at the same time

#### What does it do?

Allows payload like below: add tags from collection_1, tag with id 7, tag bla, at the same time.
{
    "attribute_ids": "[\"1\",\"2\"]",
    "tag": "[\"bla\",\"7\",\"collection_1\"]"
}

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
