### PR TITLE
fix: [Templates] use correct encoding in upload_file view element

### DIFF
--- a/app/View/Templates/upload_file.ctp
+++ b/app/View/Templates/upload_file.ctp
@@ -18,7 +18,7 @@ if ($batch == 'yes') {
         echo $this->Form->end();
     ?>
 </div>
-<span id="fileUploadButton_<?php echo h($element_id); ?>"  role="button" tabindex="0" aria-label="<?php echo $buttonText; ?>" title="<?php echo $buttonText; ?>" class="btn btn-primary" onClick="templateFileUploadTriggerBrowse(<?php echo json_encode($element_id); ?>);"><?php echo $buttonText; ?></span>
+<span id="fileUploadButton_<?php echo h($element_id); ?>"  role="button" tabindex="0" aria-label="<?php echo $buttonText; ?>" title="<?php echo $buttonText; ?>" class="btn btn-primary" onClick="templateFileUploadTriggerBrowse(<?php echo h($element_id); ?>);"><?php echo $buttonText; ?></span>
 <script type="text/javascript">
 $(document).ready(function() {
     <?php if (isset($filenames)): ?>


### PR DESCRIPTION
#### What does it do?

using json_encode here breaks the functionality. Change to use h() instead.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
