### PR TITLE
fix: [Templates] make element attribute and element file validation c…

### DIFF
--- a/app/Model/TemplateElementAttribute.php
+++ b/app/Model/TemplateElementAttribute.php
@@ -20,16 +20,38 @@ class TemplateElementAttribute extends AppModel
                 ),
             ),
             'category' => array(
-                'rule'    => array('comparison', '!=', 'Select Category'),
-                'message' => 'Please choose a category.'
+                'notDefault' => array(
+                    'rule'    => array('notDefaultCategory'),
+                    'message' => 'Please choose a category, do not leave it on Select Category.'
+                ),
+                'valueNotEmpty' => array(
+                    'rule' => array('valueNotEmpty'),
+                    'message' => 'Please choose a type.'
+                )
             ),
             'type' => array(
-                'rule'    => array('comparison', '!=', 'Select Type'),
-                'message' => 'Please choose a type.'
+                'notDefault' => array(
+                    'rule'    => array('notDefaultType'),
+                    'message' => 'Please choose a type, do not leave it on Select Type.'
+                 ),
+                'valueNotEmpty' => array(
+                    'rule' => array('valueNotEmpty'),
+                    'message' => 'Please choose a type.'
+                )
             ),
     );
     public function beforeValidate($options = array())
     {
         parent::beforeValidate();
+    }
+
+    public function notDefaultCategory($check)
+    {
+        return $check['category'] != 'Select Category';
+    }
+
+    public function notDefaultType($check)
+    {
+        return $check['type'] != 'Select Type';
     }
 }

--- a/app/Model/TemplateElementFile.php
+++ b/app/Model/TemplateElementFile.php
@@ -18,11 +18,11 @@ class TemplateElementFile extends AppModel
             ),
             'category' => array(
                 'notDefault' => array(
-                    'rule'    => array('comparison', '!=', 'Select Category'),
-                    'message' => 'Please choose a category.'
+                    'rule'    => array('notDefaultCategory'),
+                    'message' => 'Please choose a category, do not leave it on Select Category.'
                 ),
                 'valueNotEmpty' => array(
-                    'rule' => array('valueNotEmpty'),
+                    'rule' => 'array(valueNotEmpty'),
                     'message' => 'Please choose a category.'
                 )
             ),
@@ -30,5 +30,10 @@ class TemplateElementFile extends AppModel
     public function beforeValidate($options = array())
     {
         parent::beforeValidate();
+    }
+
+    public function notDefaultCategory($check)
+    {
+        return $check['category'] != 'Select Category';
     }
 }


### PR DESCRIPTION
…hecks work with php8

#### What does it do?

The cakephp comparison validation rule is supposed to be for numeric values.
It uses something like below to check the first value is a number, which now breaks the usage these model classes had of it (attempting to compare strings):
```
// PHP 7
$data = (float)"da da" != "da da";
var\_dump($data); // bool(false)

// PHP 8
$data = (float)"da da" != "da da";
var\_dump($data); // bool(true)
```
"This difference is due to PHP 8's improved type comparison system that makes fewer implicit type conversions compared to PHP 7, especially when comparing different data types. This change was made to make PHP's type system more consistent and predictable."

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
