### PR TITLE
fix: [Templates:index] correctly display template names

### DIFF
--- a/app/View/Templates/index.ctp
+++ b/app/View/Templates/index.ctp
@@ -26,7 +26,7 @@ echo $this->element('genericElements/IndexTable/scaffold', [
                     'class' => 'short'
                 ],
                 [
-                    'name' => 'Share',
+                    'name' => 'Shared',
                     'sort' => 'Template.share',
                     'data_path' => 'Template.share',
                     'element' => 'boolean',
@@ -34,8 +34,8 @@ echo $this->element('genericElements/IndexTable/scaffold', [
                 ],
                 [
                     'name' => 'Name',
-                    'sort' => 'Template.org',
-                    'data_path' => 'Template.org',
+                    'sort' => 'Template.name',
+                    'data_path' => 'Template.name',
                     'class' => 'short'
                 ],
                 [


### PR DESCRIPTION
#### What does it do?

Fixes issue with template index view. Org names were shown in the 'name' columns instead of the template names.

Also modified column name Share to Shared.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
