### PR TITLE
Fixes the response on three rest API requests: GalaxyClusterRelation (Add/Edit) and  SightingsDB (Add)

### DIFF
--- a/app/Controller/GalaxyClusterRelationsController.php
+++ b/app/Controller/GalaxyClusterRelationsController.php
@@ -131,7 +131,7 @@ class GalaxyClusterRelationsController extends AppController
             if (isset($clusterSource['authorized']) && !$clusterSource['authorized']) {
                 $errors = array($clusterSource['error']);
             }
-            
+
             if (!empty($relation['GalaxyClusterRelation']['tags'])) {
                 $tags = explode(',', $relation['GalaxyClusterRelation']['tags']);
                 $tags = array_map('trim', $tags);
@@ -139,11 +139,11 @@ class GalaxyClusterRelationsController extends AppController
             } else {
                 $relation['GalaxyClusterRelation' ]['tags'] = array();
             }
-            
+
             if (empty($errors)) {
                 $errors = $this->GalaxyClusterRelation->saveRelation($this->Auth->user(), $clusterSource['SourceCluster'], $relation);
             }
-            
+
             if (empty($errors)) {
                 $message = __('Relationship added.');
                 $this->GalaxyClusterRelation->SourceCluster->touchTimestamp($clusterSource['SourceCluster']['id']);
@@ -153,7 +153,7 @@ class GalaxyClusterRelationsController extends AppController
             }
             if ($this->_isRest()) {
                 if (empty($errors)) {
-                    return $this->RestResponse->saveSuccessResponse('GalaxyClusterRelation', 'add', $this->response->type(), $message);
+                    return $this->RestResponse->saveSuccessResponse('GalaxyClusterRelation', 'add', $this->GalaxyClusterRelation->id, $this->response->type(), $message);
                 } else {
                     $message .= sprintf('Reasons: %s', json_encode(array_merge($errors, $this->GalaxyClusterRelation->validationErrors)));
                     return $this->RestResponse->saveFailResponse('GalaxyClusterRelation', 'add', $message, $this->response->type());
@@ -248,7 +248,7 @@ class GalaxyClusterRelationsController extends AppController
             }
             if ($this->_isRest()) {
                 if (empty($errors)) {
-                    return $this->RestResponse->saveSuccessResponse('GalaxyClusterRelation', 'edit', $this->response->type(), $message);
+                    return $this->RestResponse->saveSuccessResponse('GalaxyClusterRelation', 'edit', $id, $this->response->type(), $message);
                 } else {
                     return $this->RestResponse->saveFailResponse('GalaxyClusterRelation', 'edit', false, $message, $this->response->type());
                 }

--- a/app/Controller/SightingdbController.php
+++ b/app/Controller/SightingdbController.php
@@ -37,7 +37,7 @@ class SightingdbController extends AppController
             }
             if ($this->_isRest()) {
                 if ($result) {
-                    return $this->RestResponse->saveSuccessResponse('Sightingdb', 'add', $this->response->type(), $message);
+                    return $this->RestResponse->saveSuccessResponse('Sightingdb', 'add', $this->Sightingdb->id, $this->response->type(), $message);
                 } else {
                     return $this->RestResponse->saveFailResponse('Sightingdb', 'add', $message, $this->response->type());
                 }


### PR DESCRIPTION
#### What does it do?

I noticed that three requests using the $this->RestReponse->saveSuccessResponse were incorrectly skipping the $id parameter of the function. This meant that the `format` (e.g. "application/json") was being provided as an ID, not the output format.

This was working OK until mid this year, but as a byproduct of this commit https://github.com/MISP/MISP/commit/f08a2eaec25f0212c22b225c0b654bd60d089ef9#diff-de60e7431e287347ac0b63a74341482e0fe06916b7e891391e56c11d8a7e54ae any invalid formats resulted the response being encoded with HTML entities. This spits out bad JSON and broke PyMISP parsing of the JSON output as result.

This pull request does two things:
1. Places the $format in the correct positional parameter for the `saveSuccessResponse`
2. Passes the ID in the omitted `$id` parameter, 'cause we have an ID available for all 3 replacements so why not.

Before fix:
```
'{&quot;saved&quot;:true,&quot;success&quot;:true,&quot;name&quot;:&quot;GalaxyClusterRelation added&quot;,&quot;message&quot;:&quot;GalaxyClusterRelation added&quot;,&quot;url&quot;:&quot;/galaxy_cluster_relations/add/application/json&quot;,&quot;id&quot;:&quot;application/json&quot;}'
```

After fix:
```json
{"saved":true,"success":true,"name":"Relationship added.","message":"Relationship added.","url":"/galaxy_cluster_relations/add/72493","id":"72493"}
```

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
