### PR TITLE
fix: [authkeys] add accepts the user_id via URL params and posted JSO…

### DIFF
--- a/app/Controller/AuthKeysController.php
+++ b/app/Controller/AuthKeysController.php
@@ -114,7 +114,7 @@ class AuthKeysController extends AppController
     public function add($user_id = false)
     {
         $options = $this->IndexFilter->harvestParameters(['user_id']);
-        if (!empty($params['user_id'])) {
+        if (!empty($options['user_id'])) {
             $user_id = $options['user_id'];
         }
         $params = [


### PR DESCRIPTION
…N body

#### What does it do?

Fixes likely copy pasta error, sets correct variable name to accept the user_id via URL params and posted JSON body.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
