### PR TITLE
fix: [EventReport:markdownEditor] fix typos in messages and code

### DIFF
--- a/app/View/Elements/markdownEditor/markdownEditor.ctp
+++ b/app/View/Elements/markdownEditor/markdownEditor.ctp
@@ -22,7 +22,7 @@
     }
 ?>
 
-<div id="mardown-viewer-toolbar" class="btn-toolbar">
+<div id="markdown-viewer-toolbar" class="btn-toolbar">
     <div class="btn-group">
         <?php if ($canEdit && !$insideModal): ?>
             <button type="button" class="btn" data-togglemode="editor" onclick="setMode('editor')">
@@ -190,7 +190,7 @@
     var saveSuccessMessage = '<?= 'Markdown saved' ?>'
     var saveFailedMessage = '<?= 'Could not save markdown. Reason' ?>'
     var imgPictureFailedMessage = '<?= 'Could not upload picture. Reason' ?>'
-    var savePDFConfirmMessage = '<?= __('In order to save the PDF, you have to set the print destination to `Save as PDF`. Warning: The prefered way to download as PDF is to use the misp-module download.') ?>'
+    var savePDFConfirmMessage = '<?= __('In order to save the PDF, you have to set the print destination to `Save as PDF`. Warning: The preferred way to download as PDF is to use the misp-module download.') ?>'
     var confirmationMessageUnsavedChanges = '<?= __('You are about to leave the page with unsaved changes. Do you want to proceed?') ?>'
     var changeDetectedMessage = '<?= __('Unsaved changes') ?>'
     var canEdit = <?= $canEdit ? 'true' : 'false' ?>;

--- a/app/webroot/js/markdownEditor/event-report.js
+++ b/app/webroot/js/markdownEditor/event-report.js
@@ -1353,7 +1353,7 @@ function toggleSuggestionInterface(enabled) {
         setEditorData(originalRaw)
         $('#editor-subcontainer').show()
         $suggestionContainer.hide()
-        $mardownViewerToolbar.find('.btn-group:first button').css('visibility', 'visible')
+        $markdownViewerToolbar.find('.btn-group:first button').css('visibility', 'visible')
         $('#suggestionCloseButton').remove()
         cm.refresh()
     }
@@ -2271,7 +2271,7 @@ function constructContextReplacementTable(unreferencedContext) {
 }
 
 function addCloseSuggestionButtonToToolbar() {
-    var $toolbarMode = $mardownViewerToolbar.find('.btn-group:first')
+    var $toolbarMode = $markdownViewerToolbar.find('.btn-group:first')
     if ($toolbarMode.find('#suggestionCloseButton').length == 0) {
         $toolbarMode.find('button').css('visibility', 'hidden')
         var $closeButton = $('<button id="suggestionCloseButton" type="button"/>').addClass('btn btn-danger').css({

--- a/app/webroot/js/markdownEditor/markdownEditor.js
+++ b/app/webroot/js/markdownEditor/markdownEditor.js
@@ -5,7 +5,7 @@ var renderTimer, scrollTimer, attackMatrixTimer, eventgraphTimer;
 var scrollMap;
 var $splitContainer, $editorContainer, $rawContainer, $viewerContainer, $fullContainer, $resizableHandle, $autocompletionCB, $syncScrollCB, $autoRenderMarkdownCB, $topBar, $lastModifiedField, $markdownDropdownRulesMenu, $markdownDropdownGeneralMenu, $toggleFullScreenMode, $loadingBackdrop
 var $editor, $viewer, $raw
-var $saveMarkdownButton, $mardownViewerToolbar
+var $saveMarkdownButton, $markdownViewerToolbar
 var loadingSpanAnimation = '<span id="loadingSpan" class="fa fa-spin fa-spinner" style="margin-left: 5px;"></span>';
 
 var contentChanged = false
@@ -37,7 +37,7 @@ $(document).ready(function() {
     $editor = $('#editor')
     $viewer = $('#viewer')
     $raw = $('#raw')
-    $mardownViewerToolbar = $('#mardown-viewer-toolbar')
+    $markdownViewerToolbar = $('#markdown-viewer-toolbar')
     $loadingBackdrop = $('#loadingBackdrop')
     $saveMarkdownButton = $('#saveMarkdownButton')
     $autocompletionCB = $('#autocompletionCB')
@@ -391,8 +391,8 @@ function hideAll() {
 
 function setMode(mode) {
     currentMode = mode
-    $mardownViewerToolbar.find('button').removeClass('btn-inverse')
-    $mardownViewerToolbar.find('button[data-togglemode="' + mode + '"]').addClass('btn-inverse')
+    $markdownViewerToolbar.find('button').removeClass('btn-inverse')
+    $markdownViewerToolbar.find('button[data-togglemode="' + mode + '"]').addClass('btn-inverse')
     hideAll()
     $editorContainer.css('width', '');
     if (mode === 'raw') {


### PR DESCRIPTION
**Might be worth waiting for Sami to confirm this didn't break the javascript**


#### What does it do?

Fixes a typo in one of the messages, plus 1 in the code.

I did a quick check that the toolbar still works after, but perhaps it's better to have Sami double check as well if you want to merge this.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
