### PR TITLE
chg: [AuditLog] add SharingGroupOrg and SharingGroupBlueprint filteri…

### DIFF
--- a/app/Controller/AuditLogsController.php
+++ b/app/Controller/AuditLogsController.php
@@ -36,6 +36,8 @@ class AuditLogsController extends AppController
         'Server',
         'ShadowAttribute',
         'SharingGroup',
+        'SharingGroupBlueprint',
+        'SharingGroupOrg',
         'SystemSetting',
         'Tag',
         'TagCollection',


### PR DESCRIPTION
…ng options

#### What does it do?

Allows you to filter on these model types using the auditlog query builder.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
