### PR TITLE
fix: [SharingGroupBlueprints:encode_sync_rule] remove unused code, an…

### DIFF
--- a/app/View/SharingGroupBlueprints/encode_sync_rule.ctp
+++ b/app/View/SharingGroupBlueprints/encode_sync_rule.ctp
@@ -20,13 +20,6 @@ $fields = [
         'options' => $servers
     ]
 ];
-$description = sprintf(
-    '%s<br />%s<br /><br />%s<br />%s',
-    __('Create a push or pull rule based '),
-    __('Simply create a JSON dictionary using a combination of filters and boolean operators.'),
-    '<span class="bold">Filters</span>: org_id, org_type, org_uuid, org_name, org_sector, org_nationality, sharing_group_id, , sharing_group_uuid',
-    '<span class="bold">Boolean operators</span>: OR, AND, NOT'
-);
 echo $this->element('genericElements/Form/genericForm', [
     'data' => [
         'description' => __('Create a push/pull org filter rule based on the organisations contained in a blueprint. The selected blueprint\'s rules will be transposed as either a push or a pull rule\'s OR or NOT list as per the selection.'),
@@ -34,8 +27,7 @@ echo $this->element('genericElements/Form/genericForm', [
         'title' => __('Create sync rules'),
         'fields' => $fields,
         'submit' => [
-            'action' => $this->request->params['action'],
-            'ajaxSubmit' => 'submitGenericFormInPlace();'
+            'action' => $this->request->params['action']
         ]
     ]
 ]);


### PR DESCRIPTION
…d don't try to do weird ajax redirect magic

#### What does it do?

Fixes this behavior on submitting the form:
![upload_b5b46181829729b973260f8c72a5d85d](https://github.com/user-attachments/assets/41627d6a-5d2c-4caf-85ac-680bf7d0bab6)

also removes some seemingly unused code.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
