### PR TITLE
fix: [Sightingdb:org_picker] show all local orgs as possible options …

### DIFF
--- a/app/View/Elements/genericElements/org_picker.ctp
+++ b/app/View/Elements/genericElements/org_picker.ctp
@@ -11,10 +11,10 @@
         );
     }
     $select = sprintf(
-        '<select id="OrgPickerEntry" style="margin-bottom:0px;>%s</select>',
+        '<select id="OrgPickerEntry" style="margin-bottom:0px;">%s</select>',
         $options
     );
-    $addOrgButton = '<span class="OrgPickerEntrySubmit btn btn-inverse"">' . __('Add') . '</span>';
+    $addOrgButton = '<span class="OrgPickerEntrySubmit btn btn-inverse">' . __('Add') . '</span>';
     echo sprintf(
         '<div id="OrgPickerEntryList" class="tag-list-container" style="margin-bottom:10px;"></div>'
     );


### PR DESCRIPTION
…for org restrictions

#### What does it do?

Adds a missing double quote, and removes a duplicate one. The missing one led to one of the orgs not being shown properly in the selection list. Easiest to test / check is with the Sightingdb create / edit view. If you had 6 local orgs, you could only see 5. Inspect element to see the funky html. I think this generic element is only used there atm.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
