### PR TITLE
chg: Disable X-XSS-Protection explicitly according to OWASP recommendation

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -157,7 +157,7 @@ class AppController extends Controller
         }
         if (!$this->_isRest()) {
             $this->__contentSecurityPolicy();
-            $this->response->header('X-XSS-Protection', '1; mode=block');
+            $this->response->header('X-XSS-Protection', '0');
         }
 
         $this->_setupDatabaseConnection();


### PR DESCRIPTION
#### What does it do?
[OWASP](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_1) recommends:
> Do not set this header or explicitly turn it off. `X-XSS-Protection: 0` 

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
