### PR TITLE
fix: taxii server upload action tooltip typo

### DIFF
--- a/app/View/TaxiiServers/index.ctp
+++ b/app/View/TaxiiServers/index.ctp
@@ -89,7 +89,7 @@
                             $baseurl
                         ),
                         'onclick_params_data_path' => 'TaxiiServer.id',
-                        'title' => __('Pull all filtered data to TAXII server'),
+                        'title' => __('Push all filtered data to TAXII server'),
                         'icon' => 'upload'
                     ],
                     [


### PR DESCRIPTION
The tooltip for the action to "push" to a taxii server says "pull". This patch corrects the typo.

#### What does it do?
Fixes #10187

#### Questions
- Does it require a DB change? **no**
- Are you using it in production? **yes**
- Does it require a change in the API (PyMISP for example)? **no**
