### PR TITLE
fix: [plugin>LdapAuth] correct ldap bind account for getUserMembershi…

### DIFF
--- a/app/Plugin/LdapAuth/Controller/Component/Auth/LdapAuthenticate.php
+++ b/app/Plugin/LdapAuth/Controller/Component/Auth/LdapAuthenticate.php
@@ -241,8 +241,13 @@ class LdapAuthenticate extends BaseAuthenticate
             $orgId = $firstOrg['Organisation']['id'];
         }
 
-        // Set role_id based on group membership or default role
+        // Set role_id based on group membership with ldapReaderUser bind or default role
         if (is_array(self::$conf['ldapDefaultRoleId'])) {
+            $ldapbind = ldap_bind($ldapconn, self::$conf['ldapReaderUser'],  self::$conf['ldapReaderPassword']);
+            if (!$ldapbind) {
+                CakeLog::error("[LdapAuth] Invalid LDAP reader user credentials: " . ldap_error($ldapconn));
+                throw new UnauthorizedException(__('User could not be authenticated by LDAP.'));
+            }
             // Get user memberships
             $groups = $this->getUserMemberships($ldapconn, $ldapUserData);
 


### PR DESCRIPTION
If we want the “getUserMemberships” function to work in all cases, we need the "ldapReaderUser" user.

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2020-05-05: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

If it fixes an existing issue, please use github syntax: `#<IssueID>`

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

ok for you @righel  ? the simple ldap user doesn't have enough rights to perform the query in getUserMemberships function otherwise
