### PR TITLE
taxii query proxying and proxy skipping

### DIFF
--- a/INSTALL/MYSQL.sql
+++ b/INSTALL/MYSQL.sql
@@ -1479,6 +1479,7 @@ CREATE TABLE `taxii_servers` (
   `filters` text DEFAULT NULL,
   `api_key` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL,
   `collection` varchar(40) CHARACTER SET ascii COLLATE ascii_general_ci DEFAULT NULL,
+  `skip_proxy` tinyint(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   KEY `uuid` (`uuid`),
   KEY `name` (`name`),

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -92,7 +92,8 @@ class AppModel extends Model
         111 => false, 112 => false, 113 => true, 114 => false, 115 => false, 116 => false,
         117 => false, 118 => false, 119 => false, 120 => false, 121 => false, 122 => false,
         123 => false, 124 => false, 125 => false, 126 => false, 127 => false, 128 => false,
-        129 => false, 130 => false, 131 => false, 132 => false, 133 => false, 134 => true
+        129 => false, 130 => false, 131 => false, 132 => false, 133 => false, 134 => true,
+        135 => true
     );
 
     const ADVANCED_UPDATES_DESCRIPTION = array(
@@ -2275,6 +2276,9 @@ class AppModel extends Model
             case 134:
                 $sqlArray[] = "ALTER TABLE `roles` ADD `perm_server_sign` tinyint(1) NOT NULL DEFAULT 0;";
                 $sqlArray[] = "UPDATE `roles` SET `perm_server_sign`=1 WHERE `perm_site_admin` = 1;";
+                break;
+            case 135:
+                $sqlArray[] = "ALTER TABLE `taxii_servers` ADD `skip_proxy` tinyint(1) NOT NULL DEFAULT 0;";
                 break;
             case 'fixNonEmptySharingGroupID':
                 $sqlArray[] = 'UPDATE `events` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';

--- a/app/Model/TaxiiServer.php
+++ b/app/Model/TaxiiServer.php
@@ -29,6 +29,15 @@ class TaxiiServer extends AppModel
         if (empty($this->id) && empty($this->data['TaxiiServer']['uuid'])) {
             $this->data['TaxiiServer']['uuid'] = CakeText::uuid();
         }
+        // Set skip_proxy to false if not provided
+        if (!isset($this->data['TaxiiServer']['skip_proxy'])) {
+            $this->data['TaxiiServer']['skip_proxy'] = false;
+        }
+
+        // Validate skip_proxy as a boolean
+        if (isset($this->data['TaxiiServer']['skip_proxy']) && !is_bool($this->data['TaxiiServer']['skip_proxy'])) {
+            $this->invalidate('skip_proxy', 'Invalid value for skip_proxy. Must be a boolean.');
+        }
         return true;
     }
 
@@ -157,6 +166,12 @@ class TaxiiServer extends AppModel
         $url = $options['TaxiiServer']['baseurl'] . $options['TaxiiServer']['uri'];
         App::uses('HttpSocket', 'Network/Http');
         $HttpSocket = new HttpSocket();
+        if (!$options['TaxiiServer']['skip_proxy']) {
+            $proxy = Configure::read('Proxy');
+            if (isset($proxy['host']) && !empty($proxy['host'])) {
+                $HttpSocket->configProxy($proxy['host'], $proxy['port'], $proxy['method'], $proxy['user'], $proxy['password']);
+            }
+        }
         $request = [
             'header' => [
                 'Accept' => 'application/taxii+json;version=2.1',

--- a/app/View/TaxiiServers/add.ctp
+++ b/app/View/TaxiiServers/add.ctp
@@ -14,6 +14,12 @@ $fields = [
         'class' => 'span6'
     ],
     [
+        'field' => 'skip_proxy',
+        'label' => 'Skip Proxy (if applicable)',
+        'type' => 'checkbox',
+        'default' => false
+    ],
+    [
         'field' => 'api_key',
         'label' => 'API Key',
         'type' => 'text',

--- a/app/View/TaxiiServers/index.ctp
+++ b/app/View/TaxiiServers/index.ctp
@@ -49,6 +49,12 @@
                         'data_path' => 'TaxiiServer.baseurl'
                     ],
                     [
+                        'name' => __('Skip Proxy'),
+                        'sort' => 'TaxiiServer.skip_proxy',
+                        'data_path' => 'TaxiiServer.skip_proxy',
+                        'element' => 'boolean'
+                    ],
+                    [
                         'name' => __('API root'),
                         'sort' => 'TaxiiServer.api_root',
                         'data_path' => 'TaxiiServer.api_root'

--- a/app/View/TaxiiServers/view.ctp
+++ b/app/View/TaxiiServers/view.ctp
@@ -22,6 +22,11 @@ echo $this->element(
                 'path' => 'TaxiiServer.baseurl'
             ],
             [
+                'key' => __('Skip Proxy'),
+                'path' => 'TaxiiServer.skip_proxy',
+                'type' => 'json'
+            ],
+            [
                 'key' => __('API Root'),
                 'path' => 'TaxiiServer.api_root'
             ],

--- a/db_schema.json
+++ b/db_schema.json
@@ -8654,6 +8654,17 @@
                 "column_type": "varchar(40)",
                 "column_default": "NULL",
                 "extra": ""
+            },
+            {
+                "column_name": "skip_proxy",
+                "is_nullable": "NO",
+                "data_type": "tinyint",
+                "character_maximum_length": null,
+                "numeric_precision": "3",
+                "collation_name": null,
+                "column_type": "tinyint(1)",
+                "column_default": "0",
+                "extra": ""
             }
         ],
         "taxonomies": [
@@ -10984,5 +10995,5 @@
             "uuid": false
         }
     },
-    "db_version": "134"
+    "db_version": "135"
 }


### PR DESCRIPTION
Adds:
- consideration for proxy settings to the TAXII queries made by the TaxiiServer Model
- a new `skip_proxy` (false by default) setting to taxii server view, model and database table (3 corresponding commits)

This PR arguably includes two features (fixes proxy usage by TaxiiServer Model, and adds the ability to skip_proxy), happy to separate into two PRs if preferred.

#### What does it do?

Fixes issue #10209 where Taxii queries don't use MISPs proxy settings 
Adds option to skip_proxy

#### Questions

- [x] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)? 
