### PR TITLE
fix: bug that prevents galaxy clusters to be added to a galaxy by uuid

### DIFF
--- a/app/Controller/GalaxyClustersController.php
+++ b/app/Controller/GalaxyClustersController.php
@@ -234,6 +234,7 @@ class GalaxyClustersController extends AppController
         if (empty($galaxy)) {
             throw new NotFoundException(__('Invalid galaxy'));
         }
+        $galaxyId = $galaxy['Galaxy']['id'];
         $this->loadModel('MispAttribute');
         $distributionLevels = $this->MispAttribute->distributionLevels;
         unset($distributionLevels[5]);


### PR DESCRIPTION
#### What does it do?

This pull request addresses an issue where the GalaxyClustersController::add() action required the galaxy ID to be extracted after fetching the galaxy as the fetch method can return a UUID.

1274b17a07572000616ac365ed1101b07daf4b90 introduced changes that affected handling the galaxyId. This resulted in an attempt to insert a UUID into the galaxy_id column of the galaxy_clusters table, which is an integer field, causing the "Invalid integer value" error.

This pull request restores the correct functionality by ensuring that the Galaxy ID is used when creating a new GalaxyCluster by assigning the returned galaxy id after the fetchGalaxyById call.

#### Issue description
After updating my MISP instance from v2.4.197 to v2.4.204 my API scripts that add galaxy clusters started receiving errors.
I have tracked the issue down to the code changes made in https://github.com/MISP/MISP/commit/1274b17a07572000616ac365ed1101b07daf4b90#diff-3b9b96b0d100ec364567474a49e1d35b33dcd5fb3aa5b81ef4634f647e977322L227-L237

```
2025-02-04 11:31:06 Error: [PDOException] SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect integer value: 'facb609b-887d-4b47-a04a-9c0b578e78ea' for column `misp`.`galaxy_clusters`.`galaxy_id` at row 1
Request URL: /galaxy_clusters/add/facb609b-887d-4b47-a04a-9c0b578e78ea
Stack Trace:
#0 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Datasource/DboSource.php(502): PDOStatement->execute()
#1 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Datasource/DboSource.php(468): DboSource->_execute()
#2 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Datasource/DboSource.php(1132): DboSource->execute()
#3 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Model.php(1942): DboSource->create()
#4 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Model.php(1760): Model->_doSave()
#5 /var/www/MISP/app/Model/GalaxyCluster.php(342): Model->save()
#6 /var/www/MISP/app/Controller/GalaxyClustersController.php(327): GalaxyCluster->saveCluster()
#7 [internal function]: GalaxyClustersController->add()
#8 /var/www/MISP/app/Lib/cakephp/lib/Cake/Controller/Controller.php(499): ReflectionMethod->invokeArgs()
#9 /var/www/MISP/app/Lib/cakephp/lib/Cake/Routing/Dispatcher.php(193): Controller->invokeAction()
#10 /var/www/MISP/app/Lib/cakephp/lib/Cake/Routing/Dispatcher.php(167): Dispatcher->_invoke()
#11 /var/www/MISP/app/webroot/index.php(105): Dispatcher->dispatch()
#12 {main}
```

```
Unknown error: the response is not in JSON.
Something is broken server-side, please send us everything that follows (careful with the auth key):
Request headers:
{'User-Agent': 'PyMISP 2.5.4 - Python 3.13', 'Accept-Encoding': 'gzip, deflate', 'Accept': 'application/json', 'Connection': 'keep-alive', 'Cookie': '', 'Content-Length': '116', 'content-type': 'application/json'}
Request body:
{"meta": {}, "default": false, "value": "Test", "uuid": "feb40524-63b9-4276-9b92-91d61df3b100", "distribution": "0"}
Response (if any):
{"name":"An Internal Error Has Occurred.","message":"An Internal Error Has Occurred.","url":"\/galaxy_clusters\/add\/facb609b-887d-4b47-a04a-9c0b578e78ea"}... (enable debug mode for more details)
```

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
