### PR TITLE
fix: broken recorrelation on 2.5 branch

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -5,7 +5,7 @@ App::uses('File', 'Utility');
 App::uses('AttachmentTool', 'Tools');
 
 /**
- * @property MispAttribute $MispAttribute
+ * @property MispAttribute $Attribute
  */
 class AttributesController extends AppController
 {

--- a/app/View/Attributes/ajax/recorrelationConfirmation.ctp
+++ b/app/View/Attributes/ajax/recorrelationConfirmation.ctp
@@ -1,6 +1,6 @@
 <div class="confirmation">
     <?php
-    echo $this->Form->create('Attribute', ['style' => 'margin:0px;', 'id' => 'PromptForm', 'url' => $baseurl . '/attributes/generateCorrelation']);
+    echo $this->Form->create('MISPAttribute', ['style' => 'margin:0px;', 'id' => 'PromptForm', 'url' => $baseurl . '/attributes/generateCorrelation']);
     $message = __('Recorrelate instance');
     $buttonTitle = __('Recorrelate');
     ?>


### PR DESCRIPTION
#### What does it do?

Fixes failing Recorrelate button on /servers/serverSettings/correlations on `2.5` branch

```
2025-02-18 13:24:30 Error: [TypeError] Attribute::__construct(): Argument #1 ($flags) must be of type int, array given
Request URL: /attributes/generateCorrelation?_=1739885068534
Stack Trace:
#0 [internal function]: Attribute->__construct()
#1 /var/www/MISP/app/Lib/cakephp/lib/Cake/Utility/ClassRegistry.php(169): ReflectionClass->newInstance()
#2 /var/www/MISP/app/Lib/cakephp/lib/Cake/View/Helper/FormHelper.php(171): ClassRegistry::init()
#3 /var/www/MISP/app/Lib/cakephp/lib/Cake/View/Helper/FormHelper.php(204): FormHelper->_getModel()
#4 /var/www/MISP/app/Lib/cakephp/lib/Cake/View/Helper/FormHelper.php(354): FormHelper->_introspectModel()
#5 /var/www/MISP/app/View/Attributes/ajax/recorrelationConfirmation.ctp(3): FormHelper->create()
#6 /var/www/MISP/app/Lib/cakephp/lib/Cake/View/View.php(971): include('...')
#7 /var/www/MISP/app/Lib/cakephp/lib/Cake/View/View.php(933): View->_evaluate()
#8 /var/www/MISP/app/Lib/cakephp/lib/Cake/View/View.php(473): View->_render()
#9 /var/www/MISP/app/Lib/cakephp/lib/Cake/Controller/Controller.php(973): View->render()
#10 /var/www/MISP/app/Controller/AttributesController.php(1947): Controller->render()
#11 [internal function]: AttributesController->generateCorrelation()
#12 /var/www/MISP/app/Lib/cakephp/lib/Cake/Controller/Controller.php(500): ReflectionMethod->invokeArgs()
#13 /var/www/MISP/app/Lib/cakephp/lib/Cake/Routing/Dispatcher.php(193): Controller->invokeAction()
#14 /var/www/MISP/app/Lib/cakephp/lib/Cake/Routing/Dispatcher.php(167): Dispatcher->_invoke()
#15 /var/www/MISP/app/webroot/index.php(107): Dispatcher->dispatch()
```


#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
