### PR TITLE
Attribute tag removal: fix timestamp touch

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -2809,7 +2809,7 @@ class AttributesController extends AppController
             $attribute = $this->MispAttribute->find('first', [
                 'recursive' => -1,
                 'conditions' => ['Attribute.id' => $id],
-                'fields' => ['Attribute.deleted', 'Attribute.event_id', 'Attribute.id', 'Attribute.object_id', 'Event.orgc_id', 'Event.user_id'],
+                'fields' => ['Attribute.deleted', 'Attribute.event_id', 'Attribute.id', 'Attribute.object_id', 'Attribute.type', 'Event.orgc_id', 'Event.user_id'],
                 'contain' => ['Event'],
             ]);
             if (empty($attribute) || $attribute['Attribute']['deleted']) {


### PR DESCRIPTION
#### What does it do?

Adds missing field (i.e. Attribute.type) when fetching an attribute to make timestamp of an attribute updated after global tag removal.

#### Questions

- [N] Does it require a DB change?
- [Y] Are you using it in production?
- [N] Does it require a change in the API (PyMISP for example)?
