### PR TITLE
fix: [Validation] Add validation for S3 bucket prefix when deleting e…

### DIFF
--- a/app/Lib/Tools/AttachmentTool.php
+++ b/app/Lib/Tools/AttachmentTool.php
@@ -278,8 +278,25 @@ class AttachmentTool
     public function deleteAll($eventId)
     {
         if ($this->attachmentDirIsS3()) {
+            // AWS S3 SDK validates that the Directory (Prefix) to delete is a string.
+            // So we need to validate that it can be casted to string
+            if (is_object($eventId) && !method_exists($eventId, '__toString')) {
+                throw new \InvalidArgumentException("Object of class " . get_class($eventId) . " cannot be cast to string.");
+            }
+            // Also validate that we're not trying to cast arrays, resources or closures
+            if (is_array($eventId) || is_resource($eventId) || $eventId instanceof \Closure) {
+                throw new \InvalidArgumentException("Value of type " . get_debug_type($eventId) . " cannot be cast to string.");
+            }
+            $prefix = (string) $eventId;
+            // Check if casting resulted in an empty string when it shouldn't have. Also check the edge case when $eventId is bool(true)
+            if (($prefix === '' && !in_array($eventId, [null, false, 0, 0.0, ''], true)) || ($prefix === '1' && $eventId === true)) {
+                throw new \InvalidArgumentException(
+                    "Casting to string failed for value of type: " . get_debug_type($eventId) .
+                    " with value: " . var_export($eventId, true)
+                );
+            }
             $s3 = $this->loadS3Client();
-            $s3->deleteDirectory($eventId);
+            $s3->deleteDirectory($prefix);
         } else {
             App::uses('Folder', 'Utility');
             $dirPath = $this->attachmentDir();


### PR DESCRIPTION
…vents

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2020-05-05: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?
Resolves #10243
Adds functionality to ensure that the eventId submitted to S3 when using the deleteAll function is a String and therefore validated correctly by the S3 sdk.

#### Questions

- [x] Does it require a DB change? NO
- [x] Are you using it in production? YES
- [x] Does it require a change in the API (PyMISP for example)? NO
