### PR TITLE
fix: [validation] use is_numeric and filter_var to validate integer a…

### DIFF
--- a/app/Lib/Tools/AttributeValidationTool.php
+++ b/app/Lib/Tools/AttributeValidationTool.php
@@ -567,8 +567,10 @@ class AttributeValidationTool
                   }
                 return true;*/
             case 'integer':
-                if (is_int($value)) {
-                    return true;
+                if (is_numeric($value)) {
+                    if (filter_var($value, FILTER_VALIDATE_INT)) {
+                        return true;
+                    }
                 }
                 return __('The value has to be an integer value.');
             case 'iban':


### PR DESCRIPTION
…ttribute type

Fixes #10259 

Please test. I'm not properly setup for MISP development or automated testing. I've done some basic testing by modifying the source code of a docker instance and testing with various inputs. Also did basic testing with PyMISP.

#### Questions

- [ ] Does it require a DB change? NO
- [ ] Are you using it in production? Tested on docker instance
- [ ] Does it require a change in the API (PyMISP for example)? No
