### PR TITLE
fix: [logging] warning on remote server version during sync

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -2969,7 +2969,7 @@ class Server extends AppModel
         if ($response === false && $localVersion['hotfix'] < $remoteVersion[2]) {
             $response = "Sync to Server ('{$server['Server']['id']}') initiated, but the remote instance is a few hotfixes ahead. Make sure you keep your instance up to date!";
         }
-        if (empty($response) && $remoteVersion[2] < 111) {
+        if (empty($response) && $remoteVersion[1] <= 4 && $remoteVersion[2] < 111) {
             $response = "Sync to Server ('{$server['Server']['id']}') initiated, but version 2.4.111 is required in order to be able to pull proposals from the remote side.";
         }
 


### PR DESCRIPTION
#### What does it do?
The following log line is created in application logs:
`Warning: Sync to Server ('2') initiated, but version 2.4.111 is required in order to be able to pull proposals from the remote side.`
Both local and remote is running v2.5.6
Related to #10021 


#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
