### PR TITLE
fix: Do not fetch users associated objects recursive for audit logging

### DIFF
--- a/app/Model/AuditLog.php
+++ b/app/Model/AuditLog.php
@@ -312,6 +312,7 @@ class AuditLog extends AppModel
                 $userFromDb = $this->User->find('first', [
                     'conditions' => ['User.id' => $currentUserId],
                     'fields' => ['User.org_id'],
+                    'recursive' => -1,
                 ]);
                 $this->user['org_id'] = $userFromDb['User']['org_id'];
             }


### PR DESCRIPTION
#### What does it do?
Currently users are fetched with all associated events for audit logging, but only `org_id` is used.
If the user is associated with many events, this might take much time.
If only the user instance, without associated objects is fetched, audit logging is much faster.

If it fixes an existing issue, please use github syntax: #10264

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
