### PR TITLE
Add new feature: display extended event in the index or not

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -761,6 +761,16 @@ class EventsController extends AppController
         $this->set('passedArgsArray', $passedArgsArray);
         $this->set('passedArgs', json_encode($passedArgs));
 
+        $extendedUuids = array_filter(array_map(fn($event) => $event['Event']['extends_uuid'] ?? null, $events));
+
+        if ($extendedUuids) {
+            $extendedEvents = $this->Event->fetchSimpleEvents(
+                $this->Auth->user(),
+                ['conditions' => ['Event.uuid' => $extendedUuids]]
+            );
+            $this->set('extendedEvents', array_column($extendedEvents, 'Event', 'uuid'));
+        }
+
         if ($this->request->is('ajax')) {
             $this->autoRender = false;
             $this->layout = false;
@@ -969,6 +979,8 @@ class EventsController extends AppController
         if ($this->_isSiteAdmin() && !Configure::read('MISP.showorgalternate')) {
             $possibleColumns[] = 'owner_org';
         }
+
+        $possibleColumns[] = 'extended_id';
 
         if (Configure::read('MISP.tagging')) {
             $possibleColumns[] = 'clusters';

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -980,7 +980,7 @@ class EventsController extends AppController
             $possibleColumns[] = 'owner_org';
         }
 
-        $possibleColumns[] = 'extended_id';
+        $possibleColumns[] = 'extending';
 
         if (Configure::read('MISP.tagging')) {
             $possibleColumns[] = 'clusters';

--- a/app/View/Elements/Events/eventIndexTable.ctp
+++ b/app/View/Elements/Events/eventIndexTable.ctp
@@ -58,6 +58,22 @@
         <?php endif; ?>
         <td class="short">
             <span><a href="<?= $baseurl."/events/view/".$eventId ?>" class="dblclickActionElement threat-level-<?= strtolower(h($event['ThreatLevel']['name'])) ?>" title="<?= h($event['Event']['info']) ?>"><?= $eventId ?></a> <?= !empty($event['Event']['protected']) ? sprintf('<i class="fas fa-lock" title="%s"></i>', __('Protected event')) : ''?></span>
+            <?php if (in_array('extended_id', $columns, true)):
+                $extends_uuid = $event['Event']['extends_uuid'] ?? null;
+                $extendedEventsByUuid = array_column($extendedEvents, 'id', 'uuid');
+                $extends_id = $extendedEventsByUuid[$extends_uuid] ?? null;
+                if ($extends_id) {
+                    echo sprintf(
+                        '<div style="padding-left: 1.0em;">
+                            <span class="apply_css_arrow">
+                                <a href="%s/events/view/%s" title="%s" aria-label="%s">%s</a>
+                            </span>
+                        </div>',
+                        h($baseurl), h($extends_id), __('Extend this event'), __('Extend this event'), h($extends_id)
+                    );
+                }
+            ?>
+            <?php endif; ?>
         </td>
         <?php if (in_array('clusters', $columns, true)): ?>
         <td class="short">

--- a/app/View/Elements/Events/eventIndexTable.ctp
+++ b/app/View/Elements/Events/eventIndexTable.ctp
@@ -17,7 +17,7 @@
                 endif;
             $date = time();
             $day = 86400;
-        ?>
+        ?> 
         <?php if (in_array('owner_org', $columns, true)): ?><th class="filter"><?= $this->Paginator->sort('Org.name', __('Owner org')) ?></th><?php endif; ?>
         <th><?= $this->Paginator->sort('id', __('ID'), ['direction' => 'desc']) ?></th>
         <?php if (in_array('clusters', $columns, true)): ?><th><?= __('Clusters') ?></th><?php endif; ?>
@@ -58,22 +58,6 @@
         <?php endif; ?>
         <td class="short">
             <span><a href="<?= $baseurl."/events/view/".$eventId ?>" class="dblclickActionElement threat-level-<?= strtolower(h($event['ThreatLevel']['name'])) ?>" title="<?= h($event['Event']['info']) ?>"><?= $eventId ?></a> <?= !empty($event['Event']['protected']) ? sprintf('<i class="fas fa-lock" title="%s"></i>', __('Protected event')) : ''?></span>
-            <?php if (in_array('extended_id', $columns, true)):
-                $extends_uuid = $event['Event']['extends_uuid'] ?? null;
-                $extendedEventsByUuid = array_column($extendedEvents, 'id', 'uuid');
-                $extends_id = $extendedEventsByUuid[$extends_uuid] ?? null;
-                if ($extends_id) {
-                    echo sprintf(
-                        '<div style="padding-left: 1.0em;">
-                            <span class="apply_css_arrow">
-                                <a href="%s/events/view/%s" title="%s" aria-label="%s">%s</a>
-                            </span>
-                        </div>',
-                        h($baseurl), h($extends_id), __('Extend this event'), __('Extend this event'), h($extends_id)
-                    );
-                }
-            ?>
-            <?php endif; ?>
         </td>
         <?php if (in_array('clusters', $columns, true)): ?>
         <td class="short">
@@ -181,8 +165,40 @@
             <?= $this->Time->time($event['Event']['publish_timestamp']) ?>
         </td>
         <?php endif; ?>
-        <td class="dblclickElement">
+        <?php
+            $extends_uuid = $event['Event']['extends_uuid'] ?? null;
+            $extendedEventsInfoByUuid = array_column($extendedEvents, 'info', 'uuid');
+            $extendedEventsIdByUuid = array_column($extendedEvents, 'id', 'uuid');
+            $extends_info = $extendedEventsInfoByUuid[$extends_uuid] ?? null;
+            $extends_id = $extendedEventsIdByUuid[$extends_uuid] ?? null;
+        ?>
+
+        <td class="dblclickElement" style="min-width: 20vi; white-space: normal;">
             <?= nl2br(h($event['Event']['info']), false) ?>
+
+            <?php if ($extends_info): ?>
+                <?php if (in_array('extending', $columns, true)): ?>
+                    <div style="padding-left: 1em;">
+                        <span class="apply_css_arrow">
+                            <p style="display: inline;">
+                                Extends 
+                                <a href="<?= h($baseurl) ?>/events/view/<?= h($extends_id) ?>" 
+                                title="<?= __('See extended event') ?>" 
+                                aria-label="<?= __('See extended event') ?>">
+                                    <?= h($extends_id)?>
+                                </a>
+                                : <?= h($extends_info) ?>
+                            </p>
+                        </span>
+                    </div>
+                <?php else: ?>
+                    <a href="<?= h($baseurl) ?>/events/view/<?= h($extends_id) ?>" 
+                    title="Extends event <?= h($extends_id) ?>"
+                    aria-label="Extends event <?= h($extends_id) ?>">
+                        <i class="fas fa-external-link-square-alt"></i>
+                    </a>
+                <?php endif; ?>
+            <?php endif; ?>
         </td>
         <td class="short dblclickElement<?php if ($event['Event']['distribution'] == 0) echo ' privateRedText';?>" title="<?= $event['Event']['distribution'] != 3 ? $distributionLevels[$event['Event']['distribution']] : __('All');?>">
             <?php if ($event['Event']['distribution'] == 4):?>

--- a/app/View/Events/index.ctp
+++ b/app/View/Events/index.ctp
@@ -35,7 +35,7 @@
 
         $columnsDescription = [
             'owner_org' => __('Owner org'),
-            'extended_id' => __('Event ID extended'),
+            'extending' => __('Extended event'),
             'attribute_count' => __('Attribute count'),
             'creator_user' => __('Creator user'),
             'tags' => __('Tags'),

--- a/app/View/Events/index.ctp
+++ b/app/View/Events/index.ctp
@@ -35,6 +35,7 @@
 
         $columnsDescription = [
             'owner_org' => __('Owner org'),
+            'extended_id' => __('Event ID extended'),
             'attribute_count' => __('Attribute count'),
             'creator_user' => __('Creator user'),
             'tags' => __('Tags'),


### PR DESCRIPTION
#### What does it do?
Added a feature that indicates in the Info column if an event extends another one.By default, we can consider the extended event option as unchecked, which only puts an icon, indicating the extension, at the end of the event information. If the box is checked then it displays the full description of the extended event.

Modification of the dynamic size of the Info column in the event index to make it easier to read.

![Screenshot from 2025-04-07 15-37-58](https://github.com/user-attachments/assets/8aa73df8-8cef-4f61-a914-bb4070cfc17a)

![Screenshot from 2025-04-07 15-39-29](https://github.com/user-attachments/assets/ec47d715-e838-4abc-b752-388f1facea85)



Related to https://github.com/MISP/MISP/issues/10219

