### PR TITLE
Update LdapAuthenticate.php to escape characters when searching for member groups

### DIFF
--- a/app/Plugin/LdapAuth/Controller/Component/Auth/LdapAuthenticate.php
+++ b/app/Plugin/LdapAuth/Controller/Component/Auth/LdapAuthenticate.php
@@ -113,7 +113,7 @@ class LdapAuthenticate extends BaseAuthenticate
     private function getUserMemberships($ldapconn, $ldapUserData)
     {
         $groups = [];
-        $filter = '(member= ' . $ldapUserData[0]['dn'] . ')';
+        $filter = '(member=' . ldap_escape($ldapUserData[0]['dn'], "", LDAP_ESCAPE_FILTER) . ')';
         $ldapUserMemberships = ldap_search($ldapconn, self::$conf['ldapDn'], $filter, ['cn']);
 
         if ($ldapUserMemberships) {


### PR DESCRIPTION
Resolves #10291 