### PR TITLE
add: [LdapAuth] configuration option to escape ldap filters

### DIFF
--- a/app/Plugin/LdapAuth/Controller/Component/Auth/LdapAuthenticate.php
+++ b/app/Plugin/LdapAuth/Controller/Component/Auth/LdapAuthenticate.php
@@ -1,5 +1,7 @@
 <?php
 
+use PSpell\Config;
+
 App::uses('BaseAuthenticate', 'Controller/Component/Auth');
 
 class LdapAuthenticate extends BaseAuthenticate
@@ -46,7 +48,13 @@ class LdapAuthenticate extends BaseAuthenticate
             'ldapTlsCustomCaCert' => Configure::read('LdapAuth.ldapTlsCustomCaCert') ?? false,
             'ldapTlsCrlCheck' => Configure::read('LdapAuth.ldapTlsCrlCheck') ?? LDAP_OPT_X_TLS_CRL_PEER,
             'ldapTlsProtocolMin' => Configure::read('LdapAuth.ldapTlsProtocolMin') ?? LDAP_OPT_X_TLS_PROTOCOL_TLS1_2,
+            'ldapEscape' => Configure::read('LdapAuth.ldapEscape') ?? false,
+            'ldapEscapeIgnoreChars' => Configure::read('LdapAuth.ldapEscapeIgnoreChars') ?? "",
         ];
+
+        if (self::$conf['ldapEscape'] && self::$conf['ldapSearchFilter']) {
+            self::$conf['ldapSearchFilter'] = ldap_escape(self::$conf['ldapSearchFilter'], self::$conf['ldapEscapeIgnoreChars'], LDAP_ESCAPE_FILTER);
+        }
     }
 
     public function authenticate(CakeRequest $request, CakeResponse $response)
@@ -113,7 +121,10 @@ class LdapAuthenticate extends BaseAuthenticate
     private function getUserMemberships($ldapconn, $ldapUserData)
     {
         $groups = [];
-        $filter = '(member= ' . $ldapUserData[0]['dn'] . ')';
+        if (Configure::read('LdapAuth.ldapEscape')) {
+            $ldapUserData[0]['dn'] = ldap_escape($ldapUserData[0]['dn'], self::$conf['ldapEscapeIgnoreChars'], LDAP_ESCAPE_FILTER);
+        }
+        $filter = '(member=' . $ldapUserData[0]['dn'] . ')';
         $ldapUserMemberships = ldap_search($ldapconn, self::$conf['ldapDn'], $filter, ['cn']);
 
         if ($ldapUserMemberships) {

--- a/app/Plugin/LdapAuth/README.md
+++ b/app/Plugin/LdapAuth/README.md
@@ -156,14 +156,27 @@ Each setting is stored in the `LdapAuth` configuration array and can be customiz
 - **Default**: `LDAP_OPT_X_TLS_PROTOCOL_TLS1_2`
 - **Example**: `LDAP_OPT_X_TLS_PROTOCOL_SSL3`
 
-See also: https://www.php.net/manual/en/ldap.constants.php
+* See also: https://www.php.net/manual/en/ldap.constants.php
+
+### `ldapEscape`
+- **Description**: Escapes filters sent to ldap_search.
+- **Type**: `boolean`
+- **Default**: `false`
+- **Example**: `true`
+
+### `ldapEscapeIgnoreChars`
+- **Description**: Characters to ignore when escaping .
+- **Type**: `string`
+- **Default**: `""`
+- **Example**: `" "`
+
 
 ## Example Usage
 
 To configure these settings in your application, ensure each setting is defined in your configuration file as follows:
 
 ```php
-'LdapAuth', [
+'LdapAuth' => [
     'ldapServer' => 'ldap://ldap.example.com',
     'ldapDn' => 'dc=example,dc=com',
     'ldapReaderUser' => 'cn=reader,dc=example,dc=com',
@@ -179,7 +192,7 @@ To configure these settings in your application, ensure each setting is defined 
     'ldapDefaultOrg' => 1,
     'ldapDefaultRoleId' => 3,
     'updateUser' => true
-];
+]
 ```
 
 Adjust the values as needed based on your LDAP server setup.


### PR DESCRIPTION
#### What does it do?

Add `ldapEscape` and `ldapEscapeIgnoreChars` options to `LdapAuth` plugin.

Fixes: https://github.com/MISP/MISP/issues/10291

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
