### PR TITLE
new: [Attributes] Add Warninglist in /attributes/search

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -60,6 +60,9 @@ class AttributesController extends AppController
             if ($key === 'to_ids' && $value === '0') {
                 unset($filters[$key]);
             }
+            if ($key === 'warnings' && $value === '0') {
+                unset($filters[$key]);
+            }
             if (is_array($value)) {
                 $filters[$key] = $this->cleanDefaultFormValues($value);
             } elseif ($value === '') {
@@ -82,7 +85,7 @@ class AttributesController extends AppController
         }
         $params['conditions']['AND'][] = $this->Attribute->buildConditions($user);
         $paramArray = [
-            'value' , 'type', 'category', 'org_id', 'tags', 'to_ids', 'first_seen', 'last_seen', 'limit', 'page', 'sort', 'direction'
+            'value' , 'type', 'category', 'org_id', 'tags', 'to_ids', 'first_seen', 'last_seen', 'limit', 'page', 'sort', 'direction' 
         ];
         $filterData = array(
             'request' => $this->request,
@@ -108,6 +111,9 @@ class AttributesController extends AppController
         }
         $this->set('params', $params);
         $conditions = $this->Attribute->buildFilterConditions($user, $filters, false);
+        if (isset($params['warnings'])) {
+            $params_warnings = $params['warnings'];
+        }
         $params = [];
         if (!empty($filters['direction'])) {
             $params['direction'] = $filters['direction'];
@@ -123,6 +129,7 @@ class AttributesController extends AppController
             $params['conditions'] = $conditions;
         }
         $params['flatten'] = 1;
+        $params['includeWarninglistHits'] = 1;
         if ($this->_isRest()) {
             if (!empty($filters['page'])) {
                 $params['page'] = $filters['page'];
@@ -131,11 +138,21 @@ class AttributesController extends AppController
                 $params['limit'] = $filters['limit'];
             }
             $attributes = $this->Attribute->fetchAttributes($user, $params);
+            if (isset($params_warnings)) {
+                $attributes = array_filter($attributes, function($attribute) {
+                    return !isset($attribute['Attribute']['warnings']);
+                });;
+            }
         } else {
             $params['page'] = !empty($filters['page']) ? $filters['page'] : 1;
             $params['limit'] = !empty($filters['limit']) ? $filters['limit'] : 60;
             $this->paginate['conditions'] = $conditions;
             $attributes = $this->Attribute->fetchAttributes($user, $params);
+            if (isset($params_warnings)) {
+                $attributes = array_filter($attributes, function($attribute) {
+                    return !isset($attribute['Attribute']['warnings']);
+                });;
+            }
             App::uses('CustomPaginationTool', 'Tools');
             $customPagination = new CustomPaginationTool();
             $params = $customPagination->createPaginationRules($attributes, $params, $this->modelClass);
@@ -2120,6 +2137,7 @@ class AttributesController extends AppController
             $category = $this->request->data['Attribute']['category'];
             $type = $this->request->data['Attribute']['type'];
             $to_ids = $this->request->data['Attribute']['to_ids'];
+
 
             $oldAttributes = $this->Attribute->find('all', array(
                 'conditions' => array(

--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -112,7 +112,9 @@ class AttributesController extends AppController
         $this->set('params', $params);
         $conditions = $this->Attribute->buildFilterConditions($user, $filters, false);
 
-        $params = isset($params['enforceWarninglist']) ? ['enforceWarninglist' => 1] : [];
+        if (isset($params['enforceWarninglist'])) {
+            $params['enforceWarninglist'] = 1;
+        }
 
         if (!empty($filters['direction'])) {
             $params['direction'] = $filters['direction'];

--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -60,7 +60,7 @@ class AttributesController extends AppController
             if ($key === 'to_ids' && $value === '0') {
                 unset($filters[$key]);
             }
-            if ($key === 'warnings' && $value === '0') {
+            if ($key === 'enforceWarninglist' && $value === '0') {
                 unset($filters[$key]);
             }
             if (is_array($value)) {
@@ -85,7 +85,7 @@ class AttributesController extends AppController
         }
         $params['conditions']['AND'][] = $this->Attribute->buildConditions($user);
         $paramArray = [
-            'value' , 'type', 'category', 'org_id', 'tags', 'to_ids', 'first_seen', 'last_seen', 'limit', 'page', 'sort', 'direction' 
+            'value' , 'type', 'category', 'org_id', 'tags', 'to_ids', 'first_seen', 'last_seen', 'limit', 'page', 'sort', 'direction'
         ];
         $filterData = array(
             'request' => $this->request,
@@ -111,10 +111,9 @@ class AttributesController extends AppController
         }
         $this->set('params', $params);
         $conditions = $this->Attribute->buildFilterConditions($user, $filters, false);
-        if (isset($params['warnings'])) {
-            $params_warnings = $params['warnings'];
-        }
-        $params = [];
+
+        $params = isset($params['enforceWarninglist']) ? ['enforceWarninglist' => 1] : [];
+
         if (!empty($filters['direction'])) {
             $params['direction'] = $filters['direction'];
         }
@@ -138,21 +137,12 @@ class AttributesController extends AppController
                 $params['limit'] = $filters['limit'];
             }
             $attributes = $this->Attribute->fetchAttributes($user, $params);
-            if (isset($params_warnings)) {
-                $attributes = array_filter($attributes, function($attribute) {
-                    return !isset($attribute['Attribute']['warnings']);
-                });;
-            }
         } else {
             $params['page'] = !empty($filters['page']) ? $filters['page'] : 1;
             $params['limit'] = !empty($filters['limit']) ? $filters['limit'] : 60;
             $this->paginate['conditions'] = $conditions;
+
             $attributes = $this->Attribute->fetchAttributes($user, $params);
-            if (isset($params_warnings)) {
-                $attributes = array_filter($attributes, function($attribute) {
-                    return !isset($attribute['Attribute']['warnings']);
-                });;
-            }
             App::uses('CustomPaginationTool', 'Tools');
             $customPagination = new CustomPaginationTool();
             $params = $customPagination->createPaginationRules($attributes, $params, $this->modelClass);

--- a/app/View/Attributes/search.ctp
+++ b/app/View/Attributes/search.ctp
@@ -48,7 +48,7 @@
                 'label' => __('Only find IOCs flagged as to IDS'),
                 'div' => ['style' => 'margin-top:1em'],
             ));
-            echo $this->Form->input('warnings', array(
+            echo $this->Form->input('enforceWarninglist', array(
                 'type' => 'checkbox',
                 'label' => __('Exclude IOCs spotted in a warning list'),
                 'div' => ['style' => 'margin-top:1em'],

--- a/app/View/Attributes/search.ctp
+++ b/app/View/Attributes/search.ctp
@@ -48,6 +48,11 @@
                 'label' => __('Only find IOCs flagged as to IDS'),
                 'div' => ['style' => 'margin-top:1em'],
             ));
+            echo $this->Form->input('warnings', array(
+                'type' => 'checkbox',
+                'label' => __('Exclude IOCs spotted in a warning list'),
+                'div' => ['style' => 'margin-top:1em'],
+            ));
             echo $this->Form->input('first_seen', array(
                 'type' => 'text',
                 'div' => 'input hidden',


### PR DESCRIPTION
**What does it do?**

Added functionality to allow the user to exclude IOCs on a warning list when performing a filter search on attributes.
Added a small indicator in /attributes/index to show whether an attribute is in a warning list.

![Screenshot from 2025-04-16 11-14-51](https://github.com/user-attachments/assets/65f5bfa9-1f20-4a79-814e-7a82a15deae4)

![Screenshot from 2025-04-16 11-18-30](https://github.com/user-attachments/assets/5b1d03af-32ba-4722-88ce-84ec15e721b7)



Related to https://github.com/MISP/MISP/issues/10288