### PR TITLE
Update OpenPhish feed URL to new GitHub location

### DIFF
--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -297,7 +297,7 @@
     "Feed": {
       "name": "OpenPhish url list",
       "provider": "openphish.com",
-      "url": "https://openphish.com/feed.txt",
+      "url": "https://raw.githubusercontent.com/openphish/public_feed/refs/heads/main/feed.txt",
       "rules": "",
       "enabled": false,
       "distribution": "3",


### PR DESCRIPTION
#### What does it do?

This PR updates the OpenPhish feed URL to point to their new GitHub-hosted location.

The original feed URL occasionally becomes unavailable, while the GitHub-based feed is now officially listed as a reliable alternative.

Switching to the GitHub feed ensures better reliability and availability of threat intelligence data.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
