### PR TITLE
[OTP/OIDC] Allow otp multiple auth

### DIFF
--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -26,8 +26,6 @@ class UsersController extends AppController
 
     public function beforeFilter()
     {
-        parent::beforeFilter();
-
         // what pages are allowed for non-logged-in users
         $allowedActions = array('login', 'logout', 'getGpgPublicKey', 'logout401', 'otp', 'heartbeat');
         if (!empty(Configure::read('Security.allow_password_forgotten'))) {
@@ -41,6 +39,8 @@ class UsersController extends AppController
             $allowedActions[] = 'register';
         }
         $this->Auth->allow($allowedActions);
+
+        parent::beforeFilter();
     }
 
     public function view($id = null)

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -6942,7 +6942,7 @@ class Server extends AppModel
                 ],
                 'otp_required' => array(
                     'level' => 2,
-                    'description' => __('Require authentication with OTP. Users that do not have (T/H)OTP configured will be forced to create a token at first login. You cannot use it in combination with external authentication plugins.'),
+                    'description' => __('Require authentication with OTP. Users that do not have (T/H)OTP configured will be forced to create a token at first login.'),
                     'value' => false,
                     'test' => 'testBool',
                     'beforeHook' => 'otpBeforeHook',


### PR DESCRIPTION
#### What does it do?

Fixes local auth not working when `OidcAuth.mixedAuth=true` and `Security.otp_required=true`

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
