### PR TITLE
add: [Warninglists] Split Known Identifier from False Positive in the…

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -33,7 +33,7 @@ class AppController extends Controller
 
     public $helpers = array('OrgImg', 'FontAwesome', 'UserName');
 
-    private $__queryVersion = '174';
+    private $__queryVersion = '175';
     public $pyMispVersion = '2.5.10';
     public $phpmin = '8.1';
     public $phprec = '8.2';

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -5266,11 +5266,28 @@ class Event extends AppModel
                 return null;
             }
 
-            if ($filterType['warning'] == 0) { // `both`
-                // pass, do not consider as `both` is selected
-            } else if (!empty($attribute['warnings']) || !empty($attribute['validationIssue'])) { // `include only`
-                $include = $include && ($filterType['warning'] == 1);
-            } else { // `exclude`
+            if ($filterType['warning'] == 0) { // `all`
+                // pass, do not consider as `all` is selected
+            } else if (!empty($attribute['warnings']) || !empty($attribute['validationIssue'])) {
+                $hasFalsePositive = false;
+                $hasKnown = false;
+                if (!empty($attribute['warnings'])) {
+                    foreach ($attribute['warnings'] as $warning) {
+                        if ($warning['warninglist_category'] === 'false_positive') {
+                            $hasFalsePositive = true;
+                        } elseif ($warning['warninglist_category'] === 'known') {
+                            $hasKnown = true;
+                        }
+                    }
+                }
+                if ($filterType['warning'] == 3) { // False positive
+                    $include = $include && $hasFalsePositive;
+                } elseif ($filterType['warning'] == 4) { // Known identifier
+                    $include = $include && $hasKnown;
+                } else {
+                    $include = $include && ($filterType['warning'] == 1); // include only
+                }
+            } else { // exclude
                 $include = $include && ($filterType['warning'] == 2);
             }
 

--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -180,7 +180,12 @@ class Warninglist extends AppModel
                             'warninglist_name' => $warninglists[$warninglistId]['name'],
                             'warninglist_category' => $warninglists[$warninglistId]['category'],
                         ];
-                        $eventWarnings[$warninglistId] = $warninglists[$warninglistId]['name'];
+                        $category = $warninglists[$warninglistId]['category'];
+                        if ($category === "false_positive") {
+                            $eventWarnings["false_positive"][$warninglistId] = $warninglists[$warninglistId]['name'];
+                        } else {
+                            $eventWarnings["known"][$warninglistId] = $warninglists[$warninglistId]['name'];
+                        }
 
                         $store[$warninglistId] = [$match['value'], $match['match']];
                     }
@@ -206,7 +211,12 @@ class Warninglist extends AppModel
                         'warninglist_name' => $warninglists[$warninglistId]['name'],
                         'warninglist_category' => $warninglists[$warninglistId]['category'],
                     ];
-                    $eventWarnings[$warninglistId] = $warninglists[$warninglistId]['name'];
+                    $category = $warninglists[$warninglistId]['category'];
+                    if ($category === "false_positive") {
+                        $eventWarnings["false_positive"][$warninglistId] = $warninglists[$warninglistId]['name'];
+                    } else {
+                        $eventWarnings["known"][$warninglistId] = $warninglists[$warninglistId]['name'];
+                    }
                 }
             }
         }

--- a/app/View/Elements/Events/View/eventFilteringQueryBuilder.ctp
+++ b/app/View/Elements/Events/View/eventFilteringQueryBuilder.ctp
@@ -1,6 +1,9 @@
 <?php
 $warninglistsValues = [];
-foreach ($event['warnings'] as $id => $name) {
+foreach ($event['warnings']['false_positive'] as $id => $name) {
+    $warninglistsValues[] = [(int)$id => h($name)];
+}
+foreach ($event['warnings']['known'] as $id => $name) {
     $warninglistsValues[] = [(int)$id => h($name)];
 }
 $warninglistsValues = json_encode($warninglistsValues, JSON_UNESCAPED_UNICODE);
@@ -151,9 +154,11 @@ function triggerEventFilteringTool(hide) {
                 "id": "correlation",
                 "label": "Correlation",
                 "values": {
-                    0: "Both",
-                    1: "Correlation only",
-                    2: "Exclude correlation"
+                    0: "All",
+                    1: "Warning only",
+                    2: "Exclude warning",
+                    3: "False positive only",
+                    4: "Known identifier only",
                 }
             },
             {

--- a/app/View/Elements/genericElements/SidePanels/Templates/eventWarnings.ctp
+++ b/app/View/Elements/genericElements/SidePanels/Templates/eventWarnings.ctp
@@ -1,27 +1,50 @@
 <?php
-$links = [];
-foreach ($event['warnings'] as $id => $name) {
-    $links[] = sprintf(
-        '<a href="#attributeList" title="%s" onclick="setAttributeFilter(\'warninglistId\', %s)">%s</a> <a href="%s/warninglists/view/%s" class="black fa fa-search" title="%s" aria-label="%s"></a>',
-        __('Show just attributes that have warning from this list'),
-        (int) $id,
-        h($name),
-        $baseurl,
-        (int)$id,
-        __('View warninglist %s', h($name)),
-        __('View warninglist')
+$linksByCategory = [];
+
+foreach ($event['warnings'] as $category => $warnings) {
+    foreach ($warnings as $id => $name) {
+        $linksByCategory[$category][] = sprintf(
+            '<a href="#attributeList" title="%s" onclick="toggleWarningFilter(\'warninglistId:%s\')">%s</a> <a href="%s/warninglists/view/%s" class="black fa fa-search" title="%s" aria-label="%s"></a>',
+            __('Show just attributes that have warning from this list'),
+            (int) $id,
+            h($name),
+            $baseurl,
+            (int)$id,
+            __('View warninglist: %s', h($name)),
+            __('View warninglist')
+        );
+    }
+}
+
+
+if (!empty($linksByCategory['false_positive'])) {
+    echo sprintf(
+        '<div class="warning_container false_positive">%s%s</div>',
+        sprintf(
+            '<h4>%s</h4>',
+            sprintf(
+                '%s <a href="#attributeList" title="%s" onclick="toggleWarningFilter(\'warning:3\');">(%s)</a>',
+                __('Warning: Potential false positives'),
+                __('Show just attributes that have warnings'),
+                __('show')
+            )
+        ),
+        implode('<br>', $linksByCategory['false_positive'])
     );
 }
-echo sprintf(
-    '<div class="warning_container">%s%s</div>',
-    sprintf(
-        '<h4>%s</h4>',
+
+if (!empty($linksByCategory['known'])) {
+    echo sprintf(
+        '<div class="warning_container known_identifier">%s%s</div>',
         sprintf(
-            '%s <a href="#attributeList" title="%s" onclick="toggleBoolFilter(\'warning\');">(%s)</a>',
-            __('Warning: Potential false positives'),
-            __('Show just attributes that have warnings'),
-            __('show')
-        )
-    ),
-    implode('<br>', $links)
-);
+            '<h4>%s</h4>',
+            sprintf(
+                '%s <a href="#attributeList" title="%s" onclick="toggleWarningFilter(\'warning:4\');">(%s)</a>',
+                __('Warning: Potential known identifier'),
+                __('Show just attributes that have warnings'),
+                __('show')
+            )
+        ),
+        implode('<br>', $linksByCategory['known'])
+    );
+}

--- a/app/View/Events/view.ctp
+++ b/app/View/Events/view.ctp
@@ -293,7 +293,7 @@
                 ],
                 [
                     'type' => 'eventWarnings',
-                    'requirement' => !empty($event['warnings'])
+                    'requirement' => !empty($event['warnings']['false_positive']) || !empty($event['warnings']['known'])
                 ]
             ],
             'append' => [

--- a/app/webroot/css/main.css
+++ b/app/webroot/css/main.css
@@ -2095,7 +2095,6 @@ a.discrete {
 }
 
 .warning_container {
-    border: 1px solid red;
     border-radius: 7px;
     padding: 0 10px 10px 10px;
     width: 100%;
@@ -2104,9 +2103,22 @@ a.discrete {
     margin-top: 15px;
 }
 
-.warning_container h4 {
+.false_positive {
+    border: 1px solid red;
+}
+
+.false_positive h4 {
     color: red;
 }
+
+.known_identifier {
+    border: 1px solid orange;
+}
+
+.known_identifier h4 {
+    color: orange;
+}
+
 
 #galaxies_div {
     position: relative;

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -3979,6 +3979,36 @@ function toggleBoolFilter(param) {
     fetchAttributes(currentUri, res);
 }
 
+function toggleWarningFilter(param) { 
+    if (querybuilderTool === undefined) {
+        triggerEventFilteringTool(true); // allows to fetch rules
+    }
+    var rules = querybuilderTool.getRules({ skip_empty: true, allow_invalid: true });
+    var res = cleanRules(rules);
+
+    var [key, value] = param.split(':');
+
+    if (key === "warning" && res["warninglistId"] !== undefined) {
+        res["warninglistId"] = 0;
+        res["warning"] = value;
+    } else if (key === "warninglistId" && res["warning"] !== undefined) {
+        res["warning"] = 0;
+        res["warninglistId"] = value;
+    } else {
+        var current = res[key];
+
+        if (current !== undefined) {
+            res[key] = (current == value) ? 0 : value;
+        } else {
+            res[key] = value;
+        }
+    }
+
+    fetchAttributes(currentUri, res);
+}
+
+
+
 function resetPaginationParameters(currentUri) {
     var newUri = []
     currentUri.split('/').forEach(function(el) {


### PR DESCRIPTION
(re-upload due to a merge conflict with the new release)
**What does it do**

When an attribute is linked to an activated  warninglist, it adapts the message according to the warning category (knowledge identifier or false positive).

Fixed the filtering option from the hyperlinks in the warnings widgets.

![Screenshot from 2025-04-09 15-29-49](https://github.com/user-attachments/assets/7b700605-c95f-40f1-80a7-f6d7e8a07226)
