### PR TITLE
fix: [internal] Fail in case event doesn't contain required field user_id

### DIFF
--- a/app/Controller/Component/ACLComponent.php
+++ b/app/Controller/Component/ACLComponent.php
@@ -1025,6 +1025,9 @@ class ACLComponent extends Component
         if (!isset($event['Event'])) {
             throw new InvalidArgumentException('Passed object does not contain an Event.');
         }
+        if (!isset($event['Event']['user_id'])) {
+            throw new InvalidArgumentException('Passed Event object does not contain `user_id` field.');
+        }
         if ($user['Role']['perm_site_admin']) {
             return true;
         }


### PR DESCRIPTION
#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
