### PR TITLE
update Cerebrate UI components and respect `skip_proxy` flag 

### DIFF
--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -3510,16 +3510,21 @@ class AppModel extends Model
         return true;
     }
 
-    public function setupHttpSocket($server, $HttpSocket = null, $timeout = false)
+    public function setupHttpSocket($server, $HttpSocket = null, $timeout = false, $model = null)
     {
         if (empty($HttpSocket)) {
             App::uses('SyncTool', 'Tools');
             $syncTool = new SyncTool();
-            $HttpSocket = $syncTool->setupHttpSocket($server, $timeout);
+
+            if ($model !== null) {
+                $HttpSocket = $syncTool->setupHttpSocket($server, $timeout, $model);
+            } else {
+                $HttpSocket = $syncTool->setupHttpSocket($server, $timeout);
+            }
         }
         return $HttpSocket;
     }
-
+    
     /**
      * @param array $server
      * @param string $model

--- a/app/Model/Cerebrate.php
+++ b/app/Model/Cerebrate.php
@@ -36,7 +36,7 @@ class Cerebrate extends AppModel
         $url = $options['cerebrate']['Cerebrate']['url'] . $options['path'];
         $url_params = [];
 
-        $HttpSocket = $this->setupHttpSocket($options['cerebrate']);
+        $HttpSocket = $this->setupHttpSocket($options['cerebrate'], null, false, 'Cerebrate');
         $request = $this->setupSyncRequest($options['cerebrate'], 'Cerebrate');
         try {
             if (!empty($options['type']) && $options['type'] === 'post') {

--- a/app/Model/Cerebrate.php
+++ b/app/Model/Cerebrate.php
@@ -52,7 +52,7 @@ class Cerebrate extends AppModel
                 return json_decode($response->body, true);
             }
         } catch (SocketException $e) {
-            throw new BadRequestException(__('Something went wrong. Error returned: %s', $e->getMessage));
+            throw new BadRequestException(__('Something went wrong. Error returned: %s', $e->getMessage()));
         }
         if ($response->code === 403 || $response->code === 401) {
             throw new ForbiddenException(__('Authentication failed.'));

--- a/app/View/Cerebrates/add.ctp
+++ b/app/View/Cerebrates/add.ctp
@@ -28,6 +28,12 @@ $fields = [
         'class' => 'input span6'
     ],
     [
+        'field' => 'skip_proxy',
+        'label' => 'Skip Proxy (if applicable)',
+        'type' => 'checkbox',
+        'default' => false
+    ],
+    [
         'field' => 'pull_orgs',
         'label' => __('Pull Organisations'),
         'type' => 'checkbox',

--- a/app/View/Cerebrates/index.ctp
+++ b/app/View/Cerebrates/index.ctp
@@ -27,6 +27,12 @@
             'data_path' => 'Cerebrate.description'
         ],
         [
+            'name' => __('Skip Proxy'),
+            'sort' => 'Cerebrate.skip_proxy',
+            'data_path' => 'Cerebrate.skip_proxy',
+            'element' => 'boolean'
+        ],
+        [
             'name' => __('Pull Orgs'),
             'sort' => 'Cerebrate.pull_orgs',
             'data_path' => 'Cerebrate.pull_orgs',

--- a/app/View/Cerebrates/view.ctp
+++ b/app/View/Cerebrates/view.ctp
@@ -20,6 +20,11 @@ echo $this->element(
                 'url_vars' => ['Cerebrate.url']
             ],
             [
+                'key' => __('Skip Proxy'),
+                'path' => 'Cerebrate.skip_proxy',
+                'type' => 'json'
+            ],
+            [
                 'key' => __('Owner Organisation'),
                 'path' => 'Cerebrate.org_id',
                 'pathName' => 'Organisation.name',


### PR DESCRIPTION
- The `skip_proxy` setting is now fully supported in the Cerebrate UI, including:
  - View: Displays current proxy status.
  - Edit: Allows users to update the setting.
  - Index: Shows the proxy configuration per Cerebrate entry.

This also ensures the `skip_proxy` setting is properly respected in HTTP requests made via `SyncTool::setupHttpSocket()`. Previously, the method defaulted to using the 'Server' model key, which caused it to overlook `skip_proxy` and other configuration values when used by models like 'Cerebrate'.

To resolve this:
- `AppModel::setupHttpSocket()` was extended to accept an optional `$model` parameter. If provided, it is passed through to `SyncTool::setupHttpSocket()` to ensure the correct settings are used.
- Backward compatibility is maintained for other subclasses of `AppModel` that do not yet pass a model identifier.

Tested and confirmed working in production with `skip_proxy` enabled.