### PR TITLE
new: [Bookmarks] allow site admins to create global bookmarks

### DIFF
--- a/app/Controller/BookmarksController.php
+++ b/app/Controller/BookmarksController.php
@@ -37,9 +37,14 @@ class BookmarksController extends AppController
                 $conditions = [
                     'OR' => [
                         'Bookmark.user_id' => $this->Auth->user()['id'],
-                        'AND' => [
-                            'Bookmark.org_id' => $this->Auth->user()['Organisation']['id'],
-                            'Bookmark.exposed_to_org' => true,
+                        [
+                            'AND' => [
+                                'Bookmark.org_id' => $this->Auth->user()['Organisation']['id'],
+                                'Bookmark.exposed_to_org' => true,
+                            ]
+                        ],
+                        [
+                            'Bookmark.exposed_to_all' => true,
                         ],
                     ],
                 ];

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -2195,6 +2195,7 @@ class AppModel extends Model
                     `name` varchar(191) NOT NULL,
                     `url` varchar(255) NOT NULL,
                     `exposed_to_org` tinyint(1) NOT NULL DEFAULT 0,
+                    `exposed_to_all` tinyint(1) NOT NULL DEFAULT 0,
                     PRIMARY KEY (`id`),
                     INDEX `user_id` (`user_id`),
                     INDEX `org_id` (`org_id`),

--- a/app/Model/Bookmark.php
+++ b/app/Model/Bookmark.php
@@ -45,6 +45,7 @@ class Bookmark extends AppModel
         }
         if (empty($this->current_user['Role']['perm_site_admin'])) {
             $this->data['Bookmark']['org_id'] = $this->current_user['Organisation']['id']; // Only site-admins can create Bookmarks for other orgs.
+            $this->data['Bookmark']['exposed_to_all'] = 0; // Only site-admins can create Bookmarks for all users.
         }
         if (empty($this->current_user['Role']['perm_admin'])) {
             $this->data['Bookmark']['exposed_to_org'] = 0; // Only org-admins can create Bookmarks for their own org.
@@ -59,10 +60,13 @@ class Bookmark extends AppModel
             'conditions' => [
                 'OR' => [
                     'Bookmark.user_id' => $user['id'],
-                    'AND' => [
-                        'Bookmark.org_id' => $user['Organisation']['id'],
-                        'Bookmark.exposed_to_org' => true,
+                    [
+                        'AND' => [
+                            'Bookmark.org_id' => $user['Organisation']['id'],
+                            'Bookmark.exposed_to_org' => true,
+                        ]
                     ],
+                    ['Bookmark.exposed_to_all' => true],
                 ],
             ]
         ]);
@@ -118,6 +122,9 @@ class Bookmark extends AppModel
         if ($user['org_id'] == $bookmark['Bookmark']['org_id'] && !empty($bookmark['Bookmark']['exposed_to_org'])) {
             return true;
         }
+        if (!empty($bookmark['Bookmark']['exposed_to_all'])) {
+            return true;
+        }
         return false;
     }
 
@@ -138,6 +145,9 @@ class Bookmark extends AppModel
             return true;
         }
         if ($user['Role']['perm_admin'] && $user['org_id'] == $bookmark['Bookmark']['org_id'] && !empty($bookmark['Bookmark']['exposed_to_org'])) {
+            return true;
+        }
+        if (!empty($bookmark['Bookmark']['exposed_to_all'])) {
             return true;
         }
         return false;

--- a/app/View/Bookmarks/add.ctp
+++ b/app/View/Bookmarks/add.ctp
@@ -21,6 +21,11 @@ $fields = [
         'type' => 'checkbox',
         'label' => __('Should this bookmark be exposed to all users from the organisation'),
     ],
+    [
+        'field' => 'exposed_to_all',
+        'type' => 'checkbox',
+        'label' => __('Should this bookmark be exposed to all users on this instance'),
+    ],
 ];
 echo $this->element('genericElements/Form/genericForm', [
     'data' => [

--- a/app/View/Bookmarks/index.ctp
+++ b/app/View/Bookmarks/index.ctp
@@ -40,6 +40,15 @@
             'colors' => true,
             'class' => 'short',
         ],
+        [
+            'name' => __('Exposed to All Users'),
+            'title' => __('This bookmark is exposed to all users belonging to this MISP instance'),
+            'sort' => 'Bookmark.exposed_to_all',
+            'data_path' => 'Bookmark.exposed_to_all',
+            'element' => 'boolean',
+            'colors' => true,
+            'class' => 'short',
+        ],
     ];
 
     echo $this->element('genericElements/IndexTable/scaffold', [

--- a/app/View/Bookmarks/view.ctp
+++ b/app/View/Bookmarks/view.ctp
@@ -27,6 +27,11 @@ echo $this->element(
                 'type' => 'boolean'
             ],
             [
+                'key' => __('Exposed to All Users'),
+                'path' => 'Bookmark.exposed_to_all',
+                'type' => 'boolean'
+            ],
+            [
                 'key' => __('User'),
                 'path' => 'User.email',
             ],


### PR DESCRIPTION
#### What does it do?

This PR allows site admins to create global bookmarks (exposed to all users on an instance). This feature will be especially beneficial in community instances, allowing site admins to share bookmarks for search queries to view intel specific to an industry, threat actor, threat type, etc. while not requiring the end user to need to create their own.

#### Questions

- [x] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
