### PR TITLE
fix: allow editing protected event flag on sync and consider it a sig…

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -4421,7 +4421,7 @@ class Event extends AppModel
             $changed = false;
             // If a field is not set in the request, just reuse the old value
             // Also, compare the event to the existing event and see whether this is a meaningful change
-            $recoverFields = array('analysis', 'threat_level_id', 'info', 'distribution', 'date', 'org_id');
+            $recoverFields = array('analysis', 'threat_level_id', 'info', 'distribution', 'date', 'org_id', 'protected');
             foreach ($recoverFields as $rF) {
                 if (!isset($data['Event'][$rF])) {
                     $data['Event'][$rF] = $existingEvent['Event'][$rF];
@@ -4454,7 +4454,8 @@ class Event extends AppModel
             'timestamp',
             'sharing_group_id',
             'disable_correlation',
-            'extends_uuid'
+            'extends_uuid',
+            'protected'
         );
         $saveResult = $this->save(array('Event' => $data['Event']), array('fieldList' => $fieldList));
         if ($saveResult) {


### PR DESCRIPTION
…nificant change

#### What does it do?

Fixes an issue with unprotected events to protected changes not syncing properly.

e.g.:
1. Create event -> sync it (pull)
2. Turn the event into protected mode -> sync it (pull) -> crypto keys got added but the event wasn't flagged as protected

To be verified together with a to be done fix to protected event pull sync (which is currently broken).

Also:
Sorry for missing the meeting today! I won't make it a habit!

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
