### PR TITLE
fix: [EventReport] allow rendering of mermaid.js diagrams with arrows

### DIFF
--- a/app/webroot/js/markdownEditor/markdownEditor.js
+++ b/app/webroot/js/markdownEditor/markdownEditor.js
@@ -189,7 +189,6 @@ async function doAsyncMermaidRendering(id, code) {
             .replace(/>/g, "&gt;")
             // Quotes need to be preserved for mermaid to parse some diagrams correctly
     }
-    code = partialEscapeHtml(code)
 
     setTimeout(async () => {
         var html = ''
@@ -197,7 +196,7 @@ async function doAsyncMermaidRendering(id, code) {
             var result = await mermaid.mermaidAPI.render('mermaid-graph' + id, code)
             html = '<div class="mermaid">' + (result !== undefined ? result.svg : '- error while parsing mermaid graph -') + '</div>'
         } catch (err) {
-            html = '<pre>' + 'mermaid error:\n' + err.message + '</pre>'
+            html = '<pre>' + 'mermaid error:\n' + partialEscapeHtml(err.message) + '</pre>'
         }
         $('#'+id).html(html)
     }, 1);


### PR DESCRIPTION
#### What does it do?

Fixes the mermaid rendering of diagrams using arrows (e.g. --> or <-->) in event reports.

The XSS for which this partialEscapeHtml was introduced, is only in the error message rendering I believe. The rest should already be fine (famous last words), as mermaid uses DOMPurify.

Of course, review by you true pros is appreciated.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
