### PR TITLE
Pass default values to configProxy when not set

### DIFF
--- a/app/Lib/Tools/SyncTool.php
+++ b/app/Lib/Tools/SyncTool.php
@@ -95,7 +95,7 @@ class SyncTool
 
         $proxy = Configure::read('Proxy');
         if (empty($params['skip_proxy']) && isset($proxy['host']) && !empty($proxy['host'])) {
-            $HttpSocket->configProxy($proxy['host'], $proxy['port'], $proxy['method'], $proxy['user'], $proxy['password']);
+            $HttpSocket->configProxy($proxy['host'], $proxy['port'] ?? 3128, $proxy['method'] ?? null, $proxy['user'] ?? null, $proxy['password'] ?? null);
         }
         return $HttpSocket;
     }


### PR DESCRIPTION
Fixes #10413

When using an unauthenticated proxy, SyncTool is writing warnings during run. This change passes configProxy() default values if they are not explicitly set in configs to prevent the extraneous entries in the error log.

https://api.cakephp.org/2.8/class-HttpSocket.html#_configProxy

```
2025-07-02 16:49:13 Warning: Undefined array key "method" in [/var/www/MISP/app/Lib/Tools/SyncTool.php, line 98]
2025-07-02 16:49:13 Warning: Undefined array key "user" in [/var/www/MISP/app/Lib/Tools/SyncTool.php, line 98]
2025-07-02 16:49:13 Warning: Undefined array key "password" in [/var/www/MISP/app/Lib/Tools/SyncTool.php, line 98]
```

#### Questions

- [x] Does it require a DB change? No
- [x] Are you using it in production? Yes
- [x] Does it require a change in the API (PyMISP for example)? No
