### PR TITLE
Fix: Workflow 'add tag' fails on events without existing tags

### DIFF
--- a/app/Model/WorkflowModules/WorkflowBaseModule.php
+++ b/app/Model/WorkflowModules/WorkflowBaseModule.php
@@ -540,7 +540,7 @@ class WorkflowBaseActionModule extends WorkflowBaseModule
     {
         if ($scope == 'event') {
             if ($operation == 'add') {
-                $newTagList = array_merge($rData['Event']['Tag'], $tags);
+                $newTagList = array_merge(is_array($rData['Event']['Tag']) ? $rData['Event']['Tag'] : [], $tags);
             } else {
                 $newTagList = $this->getNewTagList(
                     $rData['Event']['Tag'],


### PR DESCRIPTION
When pulling events from remote servers, the workflow's 'add tag' function could fail if the incoming event JSON lacked an existing 'Tag' array. This resulted in `array_merge()` receiving `null` instead of an array, causing a fatal error during event synchronization.

This commit modifies `WorkflowBaseModule.php` to ensure that `$rData['Event']['Tag']` is always treated as an array (or an empty array if null), preventing `array_merge()` errors and ensuring workflow jobs complete successfully for events without pre-existing tags.

#### What does it do?

This PR fixes an issue where the workflow's "add tag" action would fail when processing events pulled from remote servers if those events did not originally contain any tags. The `array_merge()` function was receiving `null` instead of an array, leading to a fatal error.

```
2025-07-11 17:14:53 Warning: Undefined array key "Tag" in [/data/www/MISP/app/Model/WorkflowModules/WorkflowBaseModule.php, line 543]
Error: array_merge(): Argument #1 must be of type array, null given
#0 /data/www/MISP/app/Model/WorkflowModules/WorkflowBaseModule.php(543): array_merge()
#1 /data/www/MISP/app/Model/WorkflowModules/WorkflowBaseModule.php(531): WorkflowBaseActionModule->_handleTag()
#2 /data/www/MISP/app/Model/WorkflowModules/action/Module_tag_operation.php(175): WorkflowBaseActionModule->_addTag()
#3 /data/www/MISP/app/Model/WorkflowModules/action/Module_tag_operation.php(122): Module_tag_operation->__addTagsToEvent()
#4 /data/www/MISP/app/Model/Workflow.php(813): Module_tag_operation->exec()
#5 /data/www/MISP/app/Model/Workflow.php(734): Workflow->executeNode()
#6 /data/www/MISP/app/Model/Workflow.php(670): Workflow->walkGraph()
#7 /data/www/MISP/app/Model/Workflow.php(614): Workflow->__runWorkflow()
#8 /data/www/MISP/app/Model/Workflow.php(580): Workflow->executeWorkflowForTrigger()
#9 /data/www/MISP/app/Model/AppModel.php(4190): Workflow->executeWorkflowForTriggerRouter()
#10 /data/www/MISP/app/Model/Event.php(5081): AppModel->executeTrigger()
#11 /data/www/MISP/app/Model/Event.php(4591): Event->publish()
#12 /data/www/MISP/app/Model/Server.php(527): Event->_edit()
#13 /data/www/MISP/app/Model/Server.php(586): Server->__checkIfPulledEventExistsAndAddOrUpdate()
#14 /data/www/MISP/app/Model/Server.php(682): Server->__pullEvent()
#15 /data/www/MISP/app/Console/Command/ServerShell.php(152): Server->pull()
#16 /data/www/MISP/app/Lib/cakephp/lib/Cake/Console/Shell.php(459): ServerShell->pull()
#17 /data/www/MISP/app/Lib/cakephp/lib/Cake/Console/ShellDispatcher.php(222): Shell->runCommand()
#18 /data/www/MISP/app/Lib/cakephp/lib/Cake/Console/ShellDispatcher.php(66): ShellDispatcher->dispatch()
#19 /data/www/MISP/app/Console/cake.php(47): ShellDispatcher::run()
#20 {main}
```

It specifically addresses the `array_merge()` argument type error on line 543 of `/data/www/MISP/app/Model/WorkflowModules/WorkflowBaseModule.php`.

The change is from:
```php
$newTagList = array_merge($rData['Event']['Tag'], $tags);
````

to:

```php
$newTagList = array_merge(is_array($rData['Event']['Tag']) ? $rData['Event']['Tag'] : [], $tags);
```

This ensures that `$rData['Event']['Tag']` is always an array (even if empty) before being passed to `array_merge()`, thus preventing the runtime error during event synchronization.

#### Questions

  - [ ] Does it require a DB change? 
  - [x] Are you using it in production? 
  - [ ] Does it require a change in the API (PyMISP for example)? 