### PR TITLE
fix: [TagCollections] correct permission check in removeTag()

### DIFF
--- a/app/Controller/TagCollectionsController.php
+++ b/app/Controller/TagCollectionsController.php
@@ -407,7 +407,7 @@ class TagCollectionsController extends AppController
             if (empty($tagCollection)) {
                 return new CakeResponse(array('body'=> json_encode(array('saved' => false, 'errors' => __('Invalid tag collection.'))), 'status' => 200, 'type' => 'json'));
             }
-            if ($this->ACL->canModifyTagCollection($this->Auth->user(), $tagCollection)) {
+            if (!$this->ACL->canModifyTagCollection($this->Auth->user(), $tagCollection)) {
                 throw new ForbiddenException(__('You dont have a permission to do that'));
             }
             $found = false;


### PR DESCRIPTION
#### What does it do?

It fixes an existing issue #8706

Fixes the logic error in `TagCollectionsController::removeTag()` that threw
a *ForbiddenException* when the user **had** permission to modify the tag
collection.  Adds the missing negation so only unauthorised users are blocked.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
