### PR TITLE
Support for creating locked events on feed pulls

### DIFF
--- a/app/Controller/FeedsController.php
+++ b/app/Controller/FeedsController.php
@@ -280,6 +280,9 @@ class FeedsController extends AppController
                 if (empty($feed['Feed']['lookup_visible'])) {
                     $feed['Feed']['lookup_visible'] = 0;
                 }
+                if (empty($feed['Feed']['lock_events'])) {
+                    $feed['Feed']['lock_events'] = 0;
+                }
                 if (empty($feed['Feed']['input_source'])) {
                     $feed['Feed']['input_source'] = 'network';
                 } else {
@@ -379,7 +382,8 @@ class FeedsController extends AppController
                 'lookup_visible',
                 'headers',
                 'orgc_id',
-                'fixed_event'
+                'fixed_event',
+                'lock_events'
             ],
             'afterFind' => function (array $feed) {
                 $feed['Feed']['settings'] = json_decode($feed['Feed']['settings'], true);

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -95,7 +95,8 @@ class AppModel extends Model
         117 => false, 118 => false, 119 => false, 120 => false, 121 => false, 122 => false,
         123 => false, 124 => false, 125 => false, 126 => false, 127 => false, 128 => false,
         129 => false, 130 => false, 131 => false, 132 => false, 133 => false, 134 => true,
-        135 => false, 136 => true, 137 => false, 138 => false, 139 => false, 140 => false
+        135 => false, 136 => true, 137 => false, 138 => false, 139 => false, 140 => false,
+        141 => false
     );
 
     const ADVANCED_UPDATES_DESCRIPTION = array(
@@ -2479,6 +2480,9 @@ class AppModel extends Model
                 break;
             case 140:
                 $sqlArray[] = "ALTER TABLE `taxii_servers` MODIFY `api_key` TEXT NOT NULL";
+                break;
+            case 141:
+                $sqlArray[] = "ALTER TABLE `feeds` ADD `lock_events` tinyint(1) NOT NULL DEFAULT 0;";
                 break;
             case 'fixNonEmptySharingGroupID':
                 $sqlArray[] = 'UPDATE `events` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -1061,6 +1061,7 @@ class Feed extends AppModel
             } else {
                 $event['Event']['distribution'] = $feed['Feed']['distribution'];
                 $event['Event']['sharing_group_id'] = $feed['Feed']['sharing_group_id'];
+                $event['Event']['lock_events'] = !empty($feed['Feed']['lock_events']) ? 1 : 0;
                 if ($feed['Feed']['sharing_group_id']) {
                     $sg = $this->SharingGroup->find('first', array(
                         'recursive' => -1,

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -1061,7 +1061,7 @@ class Feed extends AppModel
             } else {
                 $event['Event']['distribution'] = $feed['Feed']['distribution'];
                 $event['Event']['sharing_group_id'] = $feed['Feed']['sharing_group_id'];
-                $event['Event']['lock_events'] = !empty($feed['Feed']['lock_events']) ? 1 : 0;
+                $event['Event']['locked'] = !empty($feed['Feed']['lock_events']) ? 1 : 0;
                 if ($feed['Feed']['sharing_group_id']) {
                     $sg = $this->SharingGroup->find('first', array(
                         'recursive' => -1,

--- a/app/View/Feeds/add.ctp
+++ b/app/View/Feeds/add.ctp
@@ -32,6 +32,12 @@ echo $this->element('genericElements/Form/genericForm', [
                 'type' => 'checkbox'
             ],
             [
+                'field' => 'lock_events',
+                'label' => __('Lock events'),
+                'title' => __('Lock events created from this feed (allows sync users to edit them)'),
+                'type' => 'checkbox'
+            ],
+            [
                 'field' => 'name',
                 'label' => __('Name'),
                 'placeholder' => __('Feed name'),

--- a/db_schema.json
+++ b/db_schema.json
@@ -3478,6 +3478,17 @@
                 "column_type": "int(11)",
                 "column_default": "0",
                 "extra": ""
+            },
+            {
+                "column_name": "lock_events",
+                "is_nullable": "NO",
+                "data_type": "tinyint",
+                "character_maximum_length": null,
+                "numeric_precision": "3",
+                "collation_name": null,
+                "column_type": "tinyint(1)",
+                "column_default": "0",
+                "extra": ""
             }
         ],
         "fuzzy_correlate_ssdeep": [
@@ -11028,5 +11039,5 @@
             "uuid": false
         }
     },
-    "db_version": "140"
+    "db_version": "141"
 }


### PR DESCRIPTION
#### What does it do?

Add the ability to create events pulled from a feed in the "locked" state, in order to enable those events to be updated on subsequent pulls from the same feed.  Creates a "141" DB migration.

#### Questions

- [X] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
