### PR TITLE
fix(users-view): correct action name in server link

### DIFF
--- a/app/View/Users/view.ctp
+++ b/app/View/Users/view.ctp
@@ -42,7 +42,7 @@ $tableData = [
 if (!empty($user['Server']['id'])) {
     $tableData[] = [
         'key' => __('Bound Server'),
-        'html' => $this->Html->link($user['Server']['name'], ['controller' => 'servers', 'action' => 'view', $user['Server']['id']]),
+        'html' => $this->Html->link($user['Server']['name'], ['controller' => 'servers', 'action' => 'previewIndex', $user['Server']['id']]),
     ];
 }
 


### PR DESCRIPTION
#### What does it do?

Changed the link action from 'view' to 'previewIndex' in app/View/Users/view.ctp to fix navigation to the correct "Bound Server" see #10468 
