### PR TITLE
fix(task-ui): typo - missing parenthesis

### DIFF
--- a/app/View/Tasks/add.ctp
+++ b/app/View/Tasks/add.ctp
@@ -104,7 +104,7 @@ echo $this->element('genericElements/Form/genericForm', [
                 'options' => [
                     1 => __('second(s)'),
                     60 => __('minute(s)'),
-                    3600 => __('hour(s'),
+                    3600 => __('hour(s)'),
                     86400 => __('day(s)'),
                 ],
                 'type' => 'dropdown',


### PR DESCRIPTION
Fixes minor typo in the UI for creating tasks: the hour option for the `time_unit` field  (Period) was missing a closing parenthesis:
 `hour(s` -> `hour(s)`