### PR TITLE
fix(tasks): retain frequency in edit form

### DIFF
--- a/app/Controller/TasksController.php
+++ b/app/Controller/TasksController.php
@@ -154,6 +154,27 @@ class TasksController extends AppController
                         $task['Task']['next_execution_date'] = '';
                         $task['Task']['next_execution_time'] = '';
                     }
+
+                    if (isset($task['Task']['timer']) && $task['Task']['timer'] > 0) {
+                        $timer = (int)$task['Task']['timer'];
+                        $units = [86400, 3600, 60, 1]; // Days, hours, minutes, seconds
+                        foreach ($units as $unit) {
+                            if ($timer >= $unit && $timer % $unit === 0) {
+                                $task['Task']['time_multiplier'] = $timer / $unit;
+                                $task['Task']['time_unit'] = $unit;
+                                break;
+                            }
+                        }
+                        // Fallback if timer doesn't match a unit
+                        if (!isset($task['Task']['time_multiplier'])) {
+                            $task['Task']['time_multiplier'] = $timer;
+                            $task['Task']['time_unit'] = 1; // Default to seconds
+                        }
+                    } else {
+                        $task['Task']['time_multiplier'] = 1;
+                        $task['Task']['time_unit'] = 86400; // Default to 1 day
+                    }
+
                     return $task;
                 },
                 'fields' => ['type', 'action', 'params', 'timer', 'next_execution_time', 'enabled'],

--- a/app/View/Tasks/add.ctp
+++ b/app/View/Tasks/add.ctp
@@ -97,6 +97,7 @@ echo $this->element('genericElements/Form/genericForm', [
                 'class' => 'span2',
                 'stayInLine' => 1,
                 'default' => 1,
+                'value' => isset($edit) && isset($this->request->data['Task']['time_multiplier']) ? $this->request->data['Task']['time_multiplier'] : null,
             ],
             [
                 'field' => 'time_unit',
@@ -110,6 +111,7 @@ echo $this->element('genericElements/Form/genericForm', [
                 'type' => 'dropdown',
                 'class' => 'span2',
                 'default' => 86400,
+                'value' => isset($edit) && isset($this->request->data['Task']['time_unit']) ? $this->request->data['Task']['time_unit'] : null,
                 'placeholder' => __('e.g. 60 for every minute')
             ],
             [


### PR DESCRIPTION
As described in #10471

When editing an existing scheduled task, the frequency configuration resets to Default values, unless explicitly (re)specified/configured

- Updated edit action in `TasksController` to decompose timer into `time_multiplier` and `time_unit` in `afterFind` callback. 
- Modified form in add.ctp to use these values in edit mode, preventi

#### What does it do?

Fixes: #10471