### PR TITLE
add-db-export-warning

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -3417,6 +3417,8 @@ class EventsController extends AppController
         if ($this->_isSiteAdmin()) {
             $this->Flash->info(__('Warning, you are logged in as a site admin, any export that you generate will contain the FULL UNRESTRICTED data-set. If you would like to generate an export for your own organisation, please log in with a different user.'));
         }
+        $this->Flash->warning(__('Note: This database export does not include malware samples, as they are stored on the filesystem rather than in the database.'));
+        
         // Check if the background jobs are enabled - if not, fall back to old export page.
         if (Configure::read('MISP.background_jobs') && !Configure::read('MISP.disable_cached_exports', true)) {
             $now = time();

--- a/app/Lib/Export/NidsExport.php
+++ b/app/Lib/Export/NidsExport.php
@@ -168,8 +168,6 @@ abstract class NidsExport
                         break;
                     case 'email':
                         $this->emailSrcRule($ruleFormat, $item['Attribute'], $sid);
-			            $sid++;
-                        $this->emailDstRule($ruleFormat, $item['Attribute'], $sid);
                         break;
                     case 'email-src':
                         $this->emailSrcRule($ruleFormat, $item['Attribute'], $sid);


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:
* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2020-05-05: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config

#### What does it do?

This PR adds a warning message to the database export functionality to inform users that malware samples are not included in database exports since they are stored on the filesystem rather than in the database.

The warning message appears when users access the export function and helps set proper expectations about what will be included in the export. This prevents confusion and ensures users understand that malware samples require separate backup procedures.

Fixes #3101

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?