### PR TITLE
Fix nids duplicate emails

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -3417,7 +3417,6 @@ class EventsController extends AppController
         if ($this->_isSiteAdmin()) {
             $this->Flash->info(__('Warning, you are logged in as a site admin, any export that you generate will contain the FULL UNRESTRICTED data-set. If you would like to generate an export for your own organisation, please log in with a different user.'));
         }
-        $this->Flash->warning(__('Note: This database export does not include malware samples, as they are stored on the filesystem rather than in the database.'));
         
         // Check if the background jobs are enabled - if not, fall back to old export page.
         if (Configure::read('MISP.background_jobs') && !Configure::read('MISP.disable_cached_exports', true)) {

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -3417,6 +3417,8 @@ class EventsController extends AppController
         if ($this->_isSiteAdmin()) {
             $this->Flash->info(__('Warning, you are logged in as a site admin, any export that you generate will contain the FULL UNRESTRICTED data-set. If you would like to generate an export for your own organisation, please log in with a different user.'));
         }
+        $this->Flash->warning(__('Note: This database export does not include malware samples, as they are stored on the filesystem rather than in the database.'));
+        
         // Check if the background jobs are enabled - if not, fall back to old export page.
         if (Configure::read('MISP.background_jobs') && !Configure::read('MISP.disable_cached_exports', true)) {
             $now = time();

--- a/app/Lib/Export/NidsExport.php
+++ b/app/Lib/Export/NidsExport.php
@@ -168,8 +168,6 @@ abstract class NidsExport
                         break;
                     case 'email':
                         $this->emailSrcRule($ruleFormat, $item['Attribute'], $sid);
-			            $sid++;
-                        $this->emailDstRule($ruleFormat, $item['Attribute'], $sid);
                         break;
                     case 'email-src':
                         $this->emailSrcRule($ruleFormat, $item['Attribute'], $sid);


### PR DESCRIPTION
## What does it do?
This PR fixes duplicate email rules appearing in NIDS export functionality, ensuring clean and accurate export output.

**Changes:**
- Remove duplicate emailDstRule call for generic 'email' case
- Prevents duplicate entries in NIDS export output  
- Generic email attributes now default to source rules only
- Users can still use 'email-dst' for destination-specific rules

**Fixes:** #5095

## Testing
- [ ] NIDS export no longer shows duplicate email rules
- [ ] Generic email attributes export correctly
- [ ] email-dst still works for destination-specific rules