### PR TITLE
fix: [Event] Switch Correlation and Warninglist filtering option

### DIFF
--- a/app/View/Elements/Events/View/eventFilteringQueryBuilder.ctp
+++ b/app/View/Elements/Events/View/eventFilteringQueryBuilder.ctp
@@ -158,11 +158,9 @@ function triggerEventFilteringTool(hide) {
                 "id": "correlation",
                 "label": "Correlation",
                 "values": {
-                    0: "All",
-                    1: "Warning only",
-                    2: "Exclude warning",
-                    3: "False positive only",
-                    4: "Known identifier only",
+                    0: "Both",
+                    1: "Correlation only",
+                    2: "Exclude correlation"
                 }
             },
             {
@@ -186,9 +184,11 @@ function triggerEventFilteringTool(hide) {
                 "id": "warning",
                 "label": "Warning",
                 "values": {
-                    0: "Both",
+                    0: "All",
                     1: "Warning only",
-                    2: "Exclude warning"
+                    2: "Exclude warning",
+                    3: "False positive only",
+                    4: "Known identifier only"
                 }
             },
             {


### PR DESCRIPTION
In the Event view, the attribute filtering options on correlations and warninglists have been reversed.
This PR resolves this issue.