### PR TITLE
fix: fill attribute search form inputs with values from named  url parameters

### DIFF
--- a/app/View/Attributes/search.ctp
+++ b/app/View/Attributes/search.ctp
@@ -7,15 +7,42 @@
         <?= __('For string searches (such as searching for an expression, tags, etc) - lookups are simple string matches. If you want a substring match encapsulate the lookup string between "%" characters.'); ?>
         <br><br>
         <?php
-            echo $this->Form->input('value', array('type' => 'textarea', 'rows' => 2, 'label' => __('Containing the following expressions'), 'div' => 'clear', 'class' => 'input-xxlarge', 'required' => false));
-            echo $this->Form->input('tags', array('type' => 'textarea', 'rows' => 2, 'label' => __('Having tag or being an attribute of an event having the tag'), 'div' => 'clear', 'class' => 'input-xxlarge', 'required' => false));
-            echo $this->Form->input('uuid', array('type' => 'textarea', 'rows' => 2, 'maxlength' => false, 'label' => __('Being attributes of the following event IDs, event UUIDs or attribute UUIDs'), 'div' => 'clear', 'class' => 'input-xxlarge', 'required' => false));
+            echo $this->Form->input('value', array(
+                'type' => 'textarea',
+                'rows' => 2,
+                'label' => __('Containing the following expressions'),
+                'div' => 'clear',
+                'class' => 'input-xxlarge',
+                'required' => false,
+                'value' => isset($this->request->params['named']['value']) ? $this->request->params['named']['value'] : ''
+            ));
+
+            echo $this->Form->input('tags', array(
+                'type' => 'textarea', 
+                'rows' => 2, 
+                'label' => __('Having tag or being an attribute of an event having the tag'), 
+                'div' => 'clear', 
+                'class' => 'input-xxlarge', 
+                'required' => false,
+                'value' => isset($this->request->params['named']['tags']) ? $this->request->params['named']['tags'] : ''
+            ));
+            echo $this->Form->input('uuid', array(
+                'type' => 'textarea', 
+                'rows' => 2, 
+                'maxlength' => false, 
+                'label' => __('Being attributes of the following event IDs, event UUIDs or attribute UUIDs'), 
+                'div' => 'clear', 
+                'class' => 'input-xxlarge', 
+                'required' => false,
+                'value' => isset($this->request->params['named']['uuid']) ? $this->request->params['named']['uuid'] : ''
+            ));
             echo $this->Form->input('org', array(
                 'type' => 'textarea',
                 'label' => __('From the following organisation(s)'),
                 'div' => 'input clear',
                 'rows' => 2,
-                'class' => 'input-xxlarge'
+                'class' => 'input-xxlarge',
+                'value' => isset($this->request->params['named']['org']) ? $this->request->params['named']['org'] : ''
             ));
             echo $this->Form->input('object_relation', array(
                 'type' => 'textarea',
@@ -23,7 +50,8 @@
                 'div' => 'input clear',
                 'rows' => 2,
                 'class' => 'input-xxlarge',
-                'required' => false
+                'required' => false,
+                'value' => isset($this->request->params['named']['object_relation']) ? $this->request->params['named']['object_relation'] : ''
             ));
             $typeFormInfo = $this->element('genericElements/Form/formInfo', [
                 'field' => [
@@ -36,6 +64,7 @@
                 'div' => 'input clear',
                 'required' => false,
                 "label" => __("Type") . " " . $typeFormInfo,
+                'value' => isset($this->request->params['named']['type']) ? $this->request->params['named']['type'] : ''
             ));
             $categoryFormInfo = $this->element('genericElements/Form/formInfo', [
                 'field' => [
@@ -47,6 +76,7 @@
             echo $this->Form->input('category', array(
                 'required' => false,
                 "label" => __("Category") . " " . $categoryFormInfo,
+                'value' => isset($this->request->params['named']['category']) ? $this->request->params['named']['category'] : ''
             ));
         ?>
             <div class="input clear"></div>
@@ -55,21 +85,25 @@
                 'type' => 'checkbox',
                 'label' => __('Only find IOCs flagged as to IDS'),
                 'div' => ['style' => 'margin-top:1em'],
+                'checked' => isset($this->request->params['named']['to_ids']) ? $this->request->params['named']['to_ids'] : false
             ));
             echo $this->Form->input('enforceWarninglist', array(
                 'type' => 'checkbox',
                 'label' => __('Exclude IOCs spotted in a warning list'),
                 'div' => ['style' => 'margin-top:1em'],
+                'checked' => isset($this->request->params['named']['enforceWarninglist']) ? $this->request->params['named']['enforceWarninglist'] : false
             ));
             echo $this->Form->input('first_seen', array(
                 'type' => 'text',
                 'div' => 'input hidden',
                 'required' => false,
+                'value' => isset($this->request->params['named']['first_seen']) ? $this->request->params['named']['first_seen'] : ''
             ));
             echo $this->Form->input('last_seen', array(
                 'type' => 'text',
                 'div' => 'input hidden',
                 'required' => false,
+                'value' => isset($this->request->params['named']['last_seen']) ? $this->request->params['named']['last_seen'] : ''
             ));
         ?>
         <div class="clear">


### PR DESCRIPTION



#### What does it do?
When searching for related events from a specific attribute in an event,
<img width="1370" height="385" alt="image" src="https://github.com/user-attachments/assets/0f116b87-d827-412b-9cbc-abead7e45090" />

a URL gets generated like this: https://mispbasedomain/attributes/search/value:d729fbb50665932fe529f7073acca9c1

Currently MISP does not seem to do anything with these named parameters. This PR fills in the values from the named parameters in their respective fields:
<img width="1086" height="1015" alt="image" src="https://github.com/user-attachments/assets/00230b8c-8446-464f-8e1d-614aa3d2aa2c" />


#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
