### PR TITLE
Replace deprecated apt-key

### DIFF
--- a/INSTALL/old/xINSTALL.debian8-postgresql.txt
+++ b/INSTALL/old/xINSTALL.debian8-postgresql.txt
@@ -67,8 +67,15 @@ sudo apt-get remove mysql-server mysql-client mariadb-client mariadb-server php5
 ### MIGRATION from MySQL/MariaDB
 # migration of data is done using latest "pgloader" release (3.2.2 at the time of writing)
 
+# install some dependencies
+sudo apt-get install wget ca-certificates
+
+# add repository signing key
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
+gpg --dearmor --yes --output /usr/share/keyrings/pgsql-ACCC4CF8.gpg
+
 # add official postgres repository to apt sources
-sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+sudo sh -c 'echo "deb [signed-by=/usr/share/keyrings/pgsql-ACCC4CF8.gpg] http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 
 # make sure packages from official postgres repository aren't used by default, only when explicitly specifying it
 sudo cat <<EOF > /etc/apt/preferences.d/pgdg.pref
@@ -76,12 +83,6 @@ Package: *
 Pin: release o=apt.postgresql.org
 Pin-Priority: 200
 EOF
-
-# install some dependencies
-sudo apt-get install wget ca-certificates
-
-# add repository signing key
-wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 
 # update cache
 sudo apt-get update

--- a/docs/archive/xINSTALL.debian9-postgresql.md
+++ b/docs/archive/xINSTALL.debian9-postgresql.md
@@ -69,8 +69,15 @@ sudo apt-get remove mysql-server mysql-client mariadb-client mariadb-server php5
 ### MIGRATION from MySQL/MariaDB
 # migration of data is done using latest "pgloader" release (3.2.2 at the time of writing)
 
+# install some dependencies
+sudo apt-get install wget ca-certificates
+
+# add repository signing key
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
+gpg --dearmor --yes --output /usr/share/keyrings/pgsql-ACCC4CF8.gpg
+
 # add official postgres repository to apt sources
-sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+sudo sh -c 'echo "deb [signed-by=/usr/share/keyrings/pgsql-ACCC4CF8.gpg] http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 
 # make sure packages from official postgres repository aren't used by default, only when explicitly specifying it
 sudo cat <<EOF > /etc/apt/preferences.d/pgdg.pref
@@ -78,12 +85,6 @@ Package: *
 Pin: release o=apt.postgresql.org
 Pin-Priority: 200
 EOF
-
-# install some dependencies
-sudo apt-get install wget ca-certificates
-
-# add repository signing key
-wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 
 # update cache
 sudo apt-get update


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2020-05-05: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

##### `apt-key` is deprecated

... instead you should be writing a pair of files:
... * the gpg key added to a distinct key ring file based on your project/distro/key...
... * the sources.list in a district file -- not simply appended to `/etc/apt/sources.list` -- (there is a newer format [DEB822](https://manpages.debian.org/bookworm/dpkg-dev/deb822.5.en.html)) that references the gpg key.
Consider:
````sh
curl http://download.something.example.com/$DISTRO/Release.key | \
gpg --dearmor --yes --output /usr/share/keyrings/something-distro.gpg
echo "deb [signed-by=/usr/share/keyrings/something-distro.gpg] http://download.something.example.com/repositories/home:/$DISTRO ./" \
>> /etc/apt/sources.list.d/something-distro.list
````


#### Questions

- [x] Does it require a DB change? No
- [x] Are you using it in production? No
- [x] Does it require a change in the API (PyMISP for example)? No
