### PR TITLE
Correlation - fix ipv4-mapped ipv6 address handling

### DIFF
--- a/app/Model/Correlation.php
+++ b/app/Model/Correlation.php
@@ -768,7 +768,7 @@ class Correlation extends AppModel
             $ip_version = filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ? 4 : 6;
             $cidrList = $this->getCidrList();
             foreach ($cidrList as $cidr) {
-                if (str_contains($cidr, '.')) {
+                if (filter_var(explode("/",$cidr)[0], FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
                     if ($ip_version === 4 && $this->__ipv4InCidr($ip, $cidr)) {
                         $ipValues[] = $cidr;
                     }


### PR DESCRIPTION
#### What does it do?

Correlations break when encountering an ipv4-mapped ipv6 address of the form `::ffff::a.b.c.d/ZZ` since the test simply checks for the presence or absence of `.` characters, leading to an ipv6 address with an embedded ipv4 address being mishandled as an ipv4 address.  

This culminates in an exception when trying to shift left by a negative number (since these CIDRs typically have prefix lengths of 96 or greater, and the netmask handling code assumes 32 or less.)  Ultimately, this behaviour leads to the inability to add `ip-addr` attributes to any event.


#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
