### PR TITLE
Add hideNseek LAB Threat Intelligence Feeds

### DIFF
--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -2175,5 +2175,77 @@
     "caching_enabled": false,
     "force_to_ids": false
       }
-  }  
+  },
+  {
+  "Feed": {
+    "name": "hideNseek LAB - Threat Intelligence JSON",
+    "provider": "hideNseek LAB",
+    "url": "https://data.hidenseek.dev/download/cti/hns_cti.json",
+    "rules": "",
+    "enabled": false,
+    "distribution": "3",
+    "default": false,
+    "source_format": "freetext",
+    "fixed_event": true,
+    "delta_merge": false,
+    "publish": false,
+    "override_ids": false,
+    "settings": "{\"csv\":{\"value\":\"\",\"delimiter\":\",\"},\"common\":{\"excluderegex\":\"^#\"}}",
+    "input_source": "network",
+    "delete_local_file": false,
+    "lookup_visible": true,
+    "headers": "",
+    "caching_enabled": true,
+    "force_to_ids": false,
+    "orgc_id": "0"
+      }
+  },
+  {
+  "Feed": {
+    "name": "hideNseek LAB - CSV Threat Feed",
+    "provider": "hideNseek LAB",
+    "url": "https://data.hidenseek.dev/download/cti/hns_cti.csv",
+    "rules": "",
+    "enabled": false,
+    "distribution": "3",
+    "default": false,
+    "source_format": "csv",
+    "fixed_event": true,
+    "delta_merge": false,
+    "publish": false,
+    "override_ids": false,
+    "settings": "{\"csv\":{\"value\":\"1\",\"delimiter\":\",\"},\"common\":{\"excluderegex\":\"\"}}",
+    "input_source": "network",
+    "delete_local_file": false,
+    "lookup_visible": true,
+    "headers": "",
+    "caching_enabled": true,
+    "force_to_ids": false,
+    "orgc_id": "0"
+      }
+  },
+  {
+  "Feed": {
+    "name": "hideNseek LAB - IP Blocklist",
+    "provider": "hideNseek LAB",
+    "url": "https://data.hidenseek.dev/download/cti/hns_blocklist.txt",
+    "rules": "",
+    "enabled": false,
+    "distribution": "3",
+    "default": false,
+    "source_format": "freetext",
+    "fixed_event": true,
+    "delta_merge": false,
+    "publish": false,
+    "override_ids": false,
+    "settings": "{\"csv\":{\"value\":\"\",\"delimiter\":\",\"},\"common\":{\"excluderegex\":\"^#\"}}",
+    "input_source": "network",
+    "delete_local_file": false,
+    "lookup_visible": true,
+    "headers": "",
+    "caching_enabled": true,
+    "force_to_ids": false,
+    "orgc_id": "0"
+      }
+  }
 ]


### PR DESCRIPTION
This commit adds three hideNseek LAB threat intelligence feeds:

- hideNseek LAB JSON: AI-enriched threat data
- hideNseek LAB CSV: Detailed threat feed with 20 columns
- hideNseek LAB IP Blocklist: Plain text IP list with comments

All feeds are updated daily at 23:00 UTC.
Source: https://data.hidenseek.dev/