### PR TITLE
Improved the accessibility of the server settings screens

### DIFF
--- a/app/View/Elements/healthElements/settings_row.ctp
+++ b/app/View/Elements/healthElements/settings_row.ctp
@@ -22,7 +22,13 @@
                 'class' => 'short live_filter_target'
             ),
             'setting' => array(
-                'html' => h($setting['setting']),
+                'html' => sprintf(
+                    '%s<span %s></span>',
+                    h($setting['setting']),
+                    sprintf('role="button" tabindex="0" aria-label="%s" aria-controls="setting_%s_%s_placeholder" onclick="serverSettingsActivateField(\'%s\',\'%s\');"',
+                        h('edit'),
+                        h($subGroup), h($k),
+                        h($setting['setting']), h($k))),
                 'class' => 'short live_filter_target',
                 'ondblclick' => 'serverSettingsActivateField',
                 'ondblclickParams' => array(h($setting['setting']), h($k))


### PR DESCRIPTION
On each setting row, I have added a pure ARIA button (invisible), that switch the cell to edit mode when activating. This avoid having to move the mouse cursor and double-click, which is challenging for screen reader users. 

The behavior for "normal" users should remain unchanged.