### PR TITLE
fix: [UI] Return and use updated last_login time, opposed to 2nd last_login

### DIFF
--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -1290,7 +1290,7 @@ class UsersController extends AppController
         if (empty($authUser['disabled'])) {
             $this->User->extralog($authUser, "login");
         }
-        
+
         $this->User->Behaviors->disable('SysLogLogable.SysLogLogable');
         $user = $this->User->find('first', array(
             'conditions' => array(
@@ -1301,10 +1301,14 @@ class UsersController extends AppController
         ));
         // update login timestamp and welcome user
         if (empty($authUser['disabled'])) {
-            $this->User->updateLoginTimes($user['User']);
+            $updatedUser = $this->User->updateLoginTimes($user['User']);
+            if ($updatedUser) {
+                $user['User'] = $updatedUser['User'];
+            }
         }
         $this->User->Behaviors->enable('SysLogLogable.SysLogLogable');
 
+        // Show the last login timestamp (which was updated by updateLoginTimes)
         $lastUserLogin = $user['User']['last_login'];
         if ($lastUserLogin) {
             $readableDatetime = (new DateTime())->setTimestamp($lastUserLogin)->format('D, d M y H:i:s O'); // RFC822
@@ -2111,7 +2115,7 @@ class UsersController extends AppController
         $stats['analyst_data_count'] = $this->Note->find('count', array('recursive' => -1)) +
             $this->Opinion->find('count', array('recursive' => -1)) +
             $this->Relationship->find('count', array('recursive' => -1));
-        $stats['analyst_data_count_month'] = $this->Note->find('count', array('conditions' => array('Note.modified >' => $this_month), 'recursive' => -1)) + 
+        $stats['analyst_data_count_month'] = $this->Note->find('count', array('conditions' => array('Note.modified >' => $this_month), 'recursive' => -1)) +
             $this->Opinion->find('count', array('conditions' => array('Opinion.modified >' => $this_month), 'recursive' => -1)) +
             $this->Relationship->find('count', array('conditions' => array('Relationship.modified >' => $this_month), 'recursive' => -1));
 


### PR DESCRIPTION
#### What does it do?

Fixes #10487. Code was not actually using the last_login updated by `updateLoginTimes` (the old current_login). Instead, it was using the previous value, meaning the last_login was 1 behind the true value.

Simply leveraging the return from updateLoginTimes to update the user to show the correct date.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
