### PR TITLE
fix: [doc:OpenAPI] align sharing group blueprint add sharing_group_id…

### DIFF
--- a/app/webroot/doc/openapi.yaml
+++ b/app/webroot/doc/openapi.yaml
@@ -6005,12 +6005,7 @@ components:
       properties:
         SharingGroupBlueprint:
           allOf:
-            - type: object
-              properties:
-                sharing_group_id:
-                  required: false
-                  type: integer
-                  minimum: 1
+            - $ref: "#/components/schemas/SharingGroupId"
             - $ref: "#/components/schemas/SharingGroupBlueprintEdit"
 
     SharingGroupBlueprintEdit:


### PR DESCRIPTION
… definition

#### What does it do?

As proposed in dev chat.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
