### PR TITLE
Somes fixes for the Regexp page

### DIFF
--- a/app/Controller/RegexpController.php
+++ b/app/Controller/RegexpController.php
@@ -72,10 +72,13 @@ class RegexpController extends AppController
             unset($this->request->data['Regexp']['id']);
             // If 'all' is set, it overrides all other type settings. Create an attribute with the "all" setting and save it. Also, delete the original(s)
             if ($this->request->data['Regexp']['all'] == 1) {
+                $oldArray = $this->Regexp->find_similar($id);
                 $this->Regexp->create();
-                $this->request->data['Regexp']['type'] = 'ALL';
+                $this->request->data['Regexp']['type'] = 'All';
                 if ($this->Regexp->save($this->request->data)) {
-                    $this->Regexp->find_similar($id, true);
+                    foreach ($oldArray as $old) {
+                        $this->Regexp->delete($old[0]);
+                    }
                     $this->Flash->success('The Regexp has been saved');
                     $this->redirect(array('action' => 'index'));
                 } else {

--- a/app/View/Regexp/admin_add.ctp
+++ b/app/View/Regexp/admin_add.ctp
@@ -7,6 +7,7 @@ foreach ($types as $key => $label) {
         'field' => $key,
         'label' => $label,
         'type' => 'checkbox',
+        'default' => !empty($value[$key]) ? 1 : 0,
         'stayInLine' => true
     ];
 }
@@ -35,7 +36,9 @@ echo $this->element('genericElements/Form/genericForm', [
                 [
                     'field' => 'all',
                     'label' => __('All'),
-                    'type' => 'checkbox'
+                    'type' => 'checkbox',
+                    'data_path' => 'Regexp.id',
+                    'default' => !empty($all) ? 1 : 0
                 ]
             ],
             $typeCheckboxes


### PR DESCRIPTION
## Fix in View

Apply a fix on top of the existing PR
[https://github.com/MISP/MISP/pull/10572](https://github.com/MISP/MISP/pull/10572)

---

## Fix in Controller

Prevent accidental deletion of `Regexp` entries when their type is set to **`All`** during edition.

### Previous behavior

1. Create a new `Regexp` with the type set to **All**
2. Edit this `Regexp` without changing any field
3. Save the form
4. The `Regexp` entry is deleted from the database

This happened because the cleanup logic removed all similar entries after the new `All` entry was created, including the newly created one.

---

### Current behavior

1. Create a new `Regexp` with the type set to **All**
2. Edit this `Regexp` without changing any field
3. Save the form
4. The `Regexp` entry remains correctly stored in the database

NB: The edit operation still follows the existing *delete + recreate* logic, and this behavior has not been modified.
