### PR TITLE
Update defaults add reputation SERPRO

### DIFF
--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -2155,5 +2155,30 @@
     "caching_enabled": false,
     "force_to_ids": false
       }
-  }  
+  },
+  "Feed": {
+    "name": "SERPRO: Reputation IP Feed",
+    "provider": "SERPRO",
+    "url": "https://s3.i02.estaleiro.serpro.gov.br/blocklist/blocklist.txt",
+    "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]}}",
+    "enabled": true,
+    "distribution": "3",
+    "default": false,
+    "source_format": "freetext",
+    "fixed_event": false,
+    "delta_merge": true,
+    "publish": true,
+    "override_ids": false,
+    "settings": "{\"csv\":{\"value\":\"\",\"delimiter\":\"\\n\"},\"common\":{\"defaultType\":\"ip-src\",\"excluderegex\":\"\"}}",
+    "input_source": "network",
+    "delete_local_file": false,
+    "lookup_visible": false
+  },
+  "Tag": {
+    "name": "osint:source-type=\"block-or-filter-list\"",
+    "colour": "#004f89",
+    "exportable": true,
+    "hide_tag": false
+  }
+  
 ]


### PR DESCRIPTION
## Pull Request: Add SERPRO Reputation Feed (MISP standard)

## Generic requirements in order to contribute to MISP:

* [x] One Pull Request per fix/feature/change
* [x] Commits squashed into a single commit
* [x] Mergeable with the default branch (2.5)
* [x] CI checks pass (no test changes required)
* [x] No new functionality enabled by default beyond feed addition

---

#### What does it do?

This Pull Request adds a new **SERPRO Reputation IP Feed** following the standard MISP feed format.

The feed provides a curated list of malicious IP addresses used for reputation-based detection and blocking, and is configured as:

* `source_format`: `freetext`
* `defaultType`: `ip-src`
* Network-based input source
* Compatible with delta merge
* Optional OSINT tagging for proper feed classification

The feed definition follows the same structure used by existing community feeds (e.g., CIRCL, ELLIO) and does not modify any core MISP functionality.

---

#### Questions

* [ ] Does it require a DB change?
  **No**

* [x] Are you using it in production?
  **Yes, internally at SERPRO**

* [ ] Does it require a change in the API (PyMISP for example)?
  **No**

---

#### Additional information

* Feed provider: **SERPRO**
* Feed name: **SERPRO: Reputation IP Feed**
* Data type: **IP addresses (`ip-src`)**
* Distribution: **Community / OSINT**
* No breaking changes introduced
