### PR TITLE
OpenAPI: refine exportGalaxyClusters description

### DIFF
--- a/app/webroot/doc/openapi.yaml
+++ b/app/webroot/doc/openapi.yaml
@@ -7812,22 +7812,44 @@ components:
                 type: object
                 properties:
                   default:
-                    description: "`true` to filter out galaxy clusters with `default=true` set."
                     type: boolean
+                    description: >
+                      Include default galaxy clusters (`GalaxyCluster.default = true`).
+                      This flag is additive with `custom`. If both are true, both default
+                      and custom clusters are included. If neither is true, no clusters
+                      are returned.
                   custom:
-                    description: "`true` to filter out galaxy clusters with `default=false` set"
                     type: boolean
+                    description: >
+                      Include custom galaxy clusters (`GalaxyCluster.default = false`).
+                      This flag is additive with `default`. If both are true, both default
+                      and custom clusters are included. If neither is true, no clusters
+                      are returned.
                   distribution:
-                    $ref: "#/components/schemas/DistributionLevelId"
+                    description: >
+                      Filter galaxy clusters by exact distribution level.
+                      May be provided as a single distribution ID or as a list of IDs.
+                      When a list is provided, clusters matching any of the given
+                      distribution levels are returned. This parameter is an exact
+                      metadata filter and does not perform access control.
+                    oneOf:
+                      - $ref: "#/components/schemas/DistributionLevelId"
+                      - type: array
+                        items:
+                          $ref: "#/components/schemas/DistributionLevelId"
                   format:
-                    description: "If set to `misp-galaxy` result set is in the misp-galaxy format."
                     type: string
                     enum:
                       - "default"
                       - "misp-galaxy"
+                    description: >
+                      Output format of the export. If set to `misp-galaxy`,
+                      the result set is returned in the canonical misp-galaxy format.
                   download:
-                    description: "`true` returns the response as a json file attachment, `false` returns the response in the response body."
                     type: boolean
+                    description: >
+                      If true, return the response as a downloadable JSON attachment.
+                      If false, return the response body inline.
 
     AttachGalaxyClusterRequest:
       content:


### PR DESCRIPTION
The OpenAPI spec for exportGalaxyClusters previously described the query parameters `default` and `custom` as exclusion filters and limited `distribution` to a scalar value.

This update:
- clarifies API documentation to describe the additive inclusion behaviour implemented in the GalxiesController app/Controller/GalaxiesController.php#L346-L351
  ```php
            if ($this->request->data['default']) {
                $clusterType[] = true;
            }
            if ($this->request->data['custom']) {
                $clusterType[] = false;
            }
  ```
- Highlights the opportunity to specify `distribution` as an array, reflecting CakePHP’s IN query behavior already supported by the endpoint app/Controller/GalaxiesController.php#L352-L358
  ```php
            $options = array(
                'conditions' => array(
                    'GalaxyCluster.galaxy_id' => $galaxyId,
                    'GalaxyCluster.distribution' => $this->request->data['distribution'],
                    'GalaxyCluster.default' => $clusterType
                )
            );
  ```