### PR TITLE
Add Object faster workflow

### DIFF
--- a/app/Controller/ObjectTemplatesController.php
+++ b/app/Controller/ObjectTemplatesController.php
@@ -90,6 +90,7 @@ class ObjectTemplatesController extends AppController
         $this->set('options', array(
             'functionName' => 'redirectAddObject',
             'multiple' => -1,
+            'auto_open' => true,
             'select_options' => array(
                 'additionalData' => array('event_id' => $event_id),
             ),

--- a/app/Controller/ObjectTemplatesController.php
+++ b/app/Controller/ObjectTemplatesController.php
@@ -89,7 +89,7 @@ class ObjectTemplatesController extends AppController
         $this->set('items', $items);
         $this->set('options', array(
             'functionName' => 'redirectAddObject',
-            'multiple' => 0,
+            'multiple' => -1,
             'select_options' => array(
                 'additionalData' => array('event_id' => $event_id),
             ),

--- a/app/Controller/ObjectTemplatesController.php
+++ b/app/Controller/ObjectTemplatesController.php
@@ -89,7 +89,7 @@ class ObjectTemplatesController extends AppController
         $this->set('items', $items);
         $this->set('options', array(
             'functionName' => 'redirectAddObject',
-            'multiple' => -1,
+            'multiple' => 0,
             'auto_open' => true,
             'select_options' => array(
                 'additionalData' => array('event_id' => $event_id),

--- a/app/View/Elements/genericElements/SideMenu/side_menu.ctp
+++ b/app/View/Elements/genericElements/SideMenu/side_menu.ctp
@@ -109,7 +109,7 @@ $divider = '<li class="divider"></li>';
                             'text' => __('Add Object'),
                             'onClick' => array(
                                 'function' => 'popoverPopup',
-                                'params' => array('this', $eventId, 'objectTemplates', 'objectMetaChoice')
+                                'params' => array('this', $eventId, 'objectTemplates', 'objectChoice')
                             ),
                         ));
                         echo $this->element('/genericElements/SideMenu/side_menu_link', array(

--- a/app/View/Elements/generic_picker.ctp
+++ b/app/View/Elements/generic_picker.ctp
@@ -25,6 +25,7 @@
         'flag_redraw_chosen' => false, // should chosen picker be redraw at drawing time
         'redraw_debounce_time' => 200,
         'autofocus' => true,
+        'auto_open' => false, // whether to automatically open dropdown for single-select on autofocus
     );
     /**
     * Supported default option in <Option> fields:
@@ -109,7 +110,8 @@ function setupChosen(id, redrawChosen) {
     if ($elem.prop('multiple')) {
         $elem.filter('[autofocus]').trigger('chosen:open');
     } else {
-        $elem.filter('[autofocus]').trigger('chosen:activate');
+        var autoOpen = <?php echo json_encode($defaults['auto_open']); ?>;
+        $elem.filter('[autofocus]').trigger(autoOpen ? 'chosen:open' : 'chosen:activate');
     }
 
     // Hide popover when pressing ESC on closed chosen


### PR DESCRIPTION
#### What does it do?

Addresses Issue https://github.com/MISP/MISP/issues/10580 

I makes the Add Object jump into the search bar directly, so the user don't have to click several times, first to select ("meta")category of templates (or All Object, which I think most users uses anyway) and another click to open the search for template to select. 

#### Questions

- [ ] Does it require a DB change? 
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
