### PR TITLE
Enhanced sorting in generic_picker.ctp

### DIFF
--- a/app/View/Elements/generic_picker.ctp
+++ b/app/View/Elements/generic_picker.ctp
@@ -71,6 +71,43 @@ function setupChosen(id, redrawChosen) {
     var $elem = $('#'+id);
     var chosen_options = <?php echo json_encode($defaults['chosen_options']); ?>;
     $elem.chosen(chosen_options);
+    
+    // Custom sorting to prioritize prefix matches in search results
+    var chosenInstance = $elem.data('chosen');
+    if (chosenInstance && chosenInstance.search_field) {
+        chosenInstance.search_field.on('keyup', function() {
+            setTimeout(function() {
+                var searchTerm = chosenInstance.search_field.val().toLowerCase();
+                if (searchTerm && chosenInstance.search_results) {
+                    var $results = chosenInstance.search_results.find('li.active-result:not(.no-results)');
+                    var items = $results.get();
+                    
+                    // Sort items: prefix matches first, then other matches
+                    items.sort(function(a, b) {
+                        var textA = $(a).text().toLowerCase();
+                        var textB = $(b).text().toLowerCase();
+                        var startsWithA = textA.indexOf(searchTerm) === 0;
+                        var startsWithB = textB.indexOf(searchTerm) === 0;
+                        
+                        if (startsWithA && !startsWithB) return -1;
+                        if (!startsWithA && startsWithB) return 1;
+                        return 0; // Keep original order for same priority
+                    });
+                    
+                    // Re-append sorted items
+                    $.each(items, function(idx, item) {
+                        chosenInstance.search_results.append(item);
+                    });
+                    
+                    // Reset highlighting to first item
+                    chosenInstance.search_results.find('li.highlighted').removeClass('highlighted');
+                    chosenInstance.search_results.find('li.active-result:first').addClass('highlighted');
+                    chosenInstance.result_highlight = chosenInstance.search_results.find('li.active-result:first');
+                }
+            }, 0);
+        });
+    }
+    
     if (!$elem.prop('multiple')) { // not multiple, selection trigger next event
         $elem.change(function(event, selected) {
             var fn = $elem.data('functionname');


### PR DESCRIPTION
Adds better sorting, so the most relevant item ends up at the top of the list.

#### What does it do?

Sorts based on the search string and puts items that starts with the search string on top (instead of sorting the items in alphabetical order)

Example: using Add Object, and searching for the an object template. Typing in "user" in the search field, will sort and highlight "user-account" at the top 
The current behavior puts "ftm-UserAccount" at the top, then "github-user", etc. 

Fixes Issue described in https://github.com/MISP/MISP/issues/10578

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
