### PR TITLE
[Oidc] Move from JakubOnderka to CertMichelin openid-connect-php

### DIFF
--- a/app/Plugin/OidcAuth/Controller/Component/Auth/OidcAuthenticate.php
+++ b/app/Plugin/OidcAuth/Controller/Component/Auth/OidcAuthenticate.php
@@ -20,6 +20,7 @@ App::uses('Oidc', 'OidcAuth.Lib');
  *  - OidcAuth.check_user_validity (integer, default `0`)
  *  - OidcAuth.update_user_role (boolean, default: true) - if disabled, manually modified role in MISP admin interface will be not changed from OIDC
  *  - OidcAuth.mixedAuth (boolean, default: false) - if enabled, MISP will not automatically redirect to SSO portal and allow other authentication methods
+ *  - OidcAuth.disable_request_object (boolean, default: false) Disable the Request Object approach in authorization requests, allowing users to fallback to plain parameters when needed for compatibility with certain OpenID Connect providers.
  */
 class OidcAuthenticate extends BaseAuthenticate
 {

--- a/app/Plugin/OidcAuth/Lib/Oidc.php
+++ b/app/Plugin/OidcAuth/Lib/Oidc.php
@@ -205,7 +205,7 @@ class Oidc
 
         try {
             $oidc->refreshToken($userInfo['refresh_token']);
-        } catch (CertMichelin\ErrorResponse $e) {
+        } catch (CertMichelin\ErrorResponse | JakubOnderka\ErrorResponse $e) {
             if ($e->getError() === 'invalid_grant') {
                 $this->log($user['email'], "Refreshing token is not possible because of `{$e->getMessage()}`, considering user is not valid");
                 return false;
@@ -290,7 +290,7 @@ class Oidc
     }
     
     /**
-     * @return \CertMichelin\OpenIDConnectClient
+     * @return OpenIDConnectClient CertMichelin if available, otherwise JakubOnderka for keeping backward compatibility.
      * @throws Exception
      */
     private function prepareClient()
@@ -306,8 +306,13 @@ class Oidc
 
         if (class_exists("\CertMichelin\OpenIDConnectClient")) {
             $oidc = new \CertMichelin\OpenIDConnectClient($providerUrl, $clientId, $clientSecret, $issuer);
+
+            // Load specific settings for CertMichelin's client.
+            $disable_request_object = $this->getConfig('disable_request_object', false);
+            $oidc->setDisableRequestObject($disable_request_object);
+            
         } else if (class_exists("\JakubOnderka\OpenIDConnectClient")) {
-            throw new Exception("JakubOnderka OIDC implementation is not supported anymore, please use CertMichelin's client");
+            $oidc = new \JakubOnderka\OpenIDConnectClient($providerUrl, $clientId, $clientSecret, $issuer);
         } else if (class_exists("\Jumbojett\OpenIDConnectClient")) {
             throw new Exception("Jumbojett OIDC implementation is not supported anymore, please use JakubOnderka's client");
         } else {
@@ -336,10 +341,6 @@ class Oidc
 
         $oidc->setRedirectURL(Configure::read('MISP.baseurl') . '/users/login');
         $this->oidcClient = $oidc;
-
-        $disable_request_object = $this->getConfig('disable_request_object', false);
-        $oidc->setDisableRequestObject($disable_request_object);
-
 
         // set proxy
         $proxy = Configure::read('Proxy');

--- a/app/Plugin/OidcAuth/Lib/Oidc.php
+++ b/app/Plugin/OidcAuth/Lib/Oidc.php
@@ -205,7 +205,7 @@ class Oidc
 
         try {
             $oidc->refreshToken($userInfo['refresh_token']);
-        } catch (JakubOnderka\ErrorResponse $e) {
+        } catch (CertMichelin\ErrorResponse $e) {
             if ($e->getError() === 'invalid_grant') {
                 $this->log($user['email'], "Refreshing token is not possible because of `{$e->getMessage()}`, considering user is not valid");
                 return false;
@@ -290,7 +290,7 @@ class Oidc
     }
     
     /**
-     * @return \JakubOnderka\OpenIDConnectClient
+     * @return \CertMichelin\OpenIDConnectClient
      * @throws Exception
      */
     private function prepareClient()
@@ -304,8 +304,10 @@ class Oidc
         $clientSecret = $this->getConfig('client_secret');
         $issuer = $this->getConfig('issuer', null, false);
 
-        if (class_exists("\JakubOnderka\OpenIDConnectClient")) {
-            $oidc = new \JakubOnderka\OpenIDConnectClient($providerUrl, $clientId, $clientSecret, $issuer);
+        if (class_exists("\CertMichelin\OpenIDConnectClient")) {
+            $oidc = new \CertMichelin\OpenIDConnectClient($providerUrl, $clientId, $clientSecret, $issuer);
+        } else if (class_exists("\JakubOnderka\OpenIDConnectClient")) {
+            throw new Exception("JakubOnderka OIDC implementation is not supported anymore, please use CertMichelin's client");
         } else if (class_exists("\Jumbojett\OpenIDConnectClient")) {
             throw new Exception("Jumbojett OIDC implementation is not supported anymore, please use JakubOnderka's client");
         } else {
@@ -334,6 +336,10 @@ class Oidc
 
         $oidc->setRedirectURL(Configure::read('MISP.baseurl') . '/users/login');
         $this->oidcClient = $oidc;
+
+        $disable_request_object = $this->getConfig('disable_request_object', false);
+        $oidc->setDisableRequestObject($disable_request_object);
+
 
         // set proxy
         $proxy = Configure::read('Proxy');

--- a/app/Plugin/OidcAuth/README.md
+++ b/app/Plugin/OidcAuth/README.md
@@ -10,7 +10,7 @@ to login with passwords stored in MISP.
 
 ```bash 
 cd app
-php composer.phar require certmichelin/openid-connect-php:1.0.0
+php composer.phar require certmichelin/openid-connect-php:1.3.0
 ```
 
 2. Enable Oidc plugin in `app/Config/bootstrap.php`, add the following line to the end:

--- a/app/Plugin/OidcAuth/README.md
+++ b/app/Plugin/OidcAuth/README.md
@@ -8,11 +8,13 @@ to login with passwords stored in MISP.
 
 1. Install required library using composer
 
-```
+```bash 
 cd app
-php composer.phar require jakub-onderka/openid-connect-php:1.0.0-rc1
+php composer.phar require certmichelin/openid-connect-php:1.0.0
 ```
+
 2. Enable Oidc plugin in `app/Config/bootstrap.php`, add the following line to the end:
+
 ```php
 CakePlugin::load('OidcAuth');
 ```
@@ -44,6 +46,7 @@ $config = array(
             'misp-admin' => 1, // Admin
         ],
         'default_org' => '{{ MISP_ORG }}',
+        'disable_request_object' => true, //Disable the Request Object approach in authorization requests, allowing users to fallback to plain parameters when needed for compatibility with certain OpenID Connect providers. (False by default)
         'scopes' => ['profile', 'email'], // Make sure to add your custom scope here if you set any
     ],
     ...
@@ -52,7 +55,8 @@ $config = array(
 5. Other MISP settings
 
 You might want to change or set the following MISP config values once the single sign on integration works (you can do this via GUI):
-```
+
+```generic
 Security.require_password_confirmation false
 Security.auth_enforced true
 ```
@@ -60,6 +64,7 @@ Security.auth_enforced true
 For avoiding redirect loops when trying to logout, you can configure the `Plugin.CustomAuth_custom_logout` setting with the logout url of your IdP.
 
 6. Mixed Auth
+
 Set `OidcAuth.mixedAuth` to `true` to prevent MISP to automatically redirect to your SSO and instead add a `Login with SSO` button in the login page, this allows users to still login with other authentication methods enabled in MISP.
 
 ## Caveats
@@ -67,6 +72,7 @@ Set `OidcAuth.mixedAuth` to `true` to prevent MISP to automatically redirect to 
 When user is blocked in SSO (IdM), he/she will be not blocked in MISP. He could not log in, but users authentication keys will still work and also he/she will still receive all emails. 
 
 To solve this problem:
+
 1) set `OidcAuth.offline_access` to `true` - with that, IdP will be requested to provide offline access token
 2) set `OidcAuth.check_user_validity` to number of seconds, after which user will be revalidated if he is still active in IdP. Zero means that this functionality is disabled. Recommended value is `300`.
 3) because offline tokens will expire when not used, you can run `cake user check_user_validity` to check all user in one call


### PR DESCRIPTION
This PR integrate a change for the library managing OIDC authentication, as mentioned in #10563.

We had some issues when integrating with Forgerock using the Request Object approach (for example, duplicated scope values between the JWT and POST parameters).

To address this, we added an optional flag that allows enforcing the “legacy” / standard parameter-based flow, even when request_parameter_supported in the .well-known/openid-configuration is set to true.

It introduces an optional configuration attribute (disable_request_object) allowing MISP to disable the Request Object flow and always use standard authorization parameters when needed.

The default behavior remains unchanged, ensuring full backward compatibility. Once this PR will be validated, I will submit a change on Docker integration project.

In addition, this PR improves the CI/CD pipeline and ensures better compatibility with the PHP versions currently supported by MISP.

Thanks in advance for your review !

+++

