### PR TITLE
Fix OIDC proxy bug with proxy settings

### DIFF
--- a/app/Plugin/OidcAuth/Controller/Component/Auth/OidcAuthenticate.php
+++ b/app/Plugin/OidcAuth/Controller/Component/Auth/OidcAuthenticate.php
@@ -20,6 +20,7 @@ App::uses('Oidc', 'OidcAuth.Lib');
  *  - OidcAuth.check_user_validity (integer, default `0`)
  *  - OidcAuth.update_user_role (boolean, default: true) - if disabled, manually modified role in MISP admin interface will be not changed from OIDC
  *  - OidcAuth.mixedAuth (boolean, default: false) - if enabled, MISP will not automatically redirect to SSO portal and allow other authentication methods
+ *  - OidcAuth.skipProxy (boolean, default: true) - if enabled, MISP will disable global proxy settings for OIDC requests
  */
 class OidcAuthenticate extends BaseAuthenticate
 {

--- a/app/Plugin/OidcAuth/Lib/Oidc.php
+++ b/app/Plugin/OidcAuth/Lib/Oidc.php
@@ -337,7 +337,7 @@ class Oidc
 
         // set proxy
         $proxy = Configure::read('Proxy');
-        if (!empty($proxy['host'])) {
+        if (!$this->getConfig('skipProxy', true) && !empty($proxy['host'])) {
             // construct CURLOPT_PROXY string
             // format from man 3 CURLOPT_PROXY: scheme://username:password@hostname:port
             $proxystr = $proxy['host'];
@@ -350,9 +350,6 @@ class Oidc
                     $proxystr = ":" . $proxy['password'] . $proxystr;
                 }
                 $proxystr = $proxy['username'] . $proxystr;
-            }
-            if (!empty($proxy['method'])) {
-                $proxystr = $proxy['method'] . "://" . $proxystr;
             }
 
             // set in OpenID client

--- a/app/Plugin/OidcAuth/README.md
+++ b/app/Plugin/OidcAuth/README.md
@@ -62,6 +62,9 @@ For avoiding redirect loops when trying to logout, you can configure the `Plugin
 6. Mixed Auth
 Set `OidcAuth.mixedAuth` to `true` to prevent MISP to automatically redirect to your SSO and instead add a `Login with SSO` button in the login page, this allows users to still login with other authentication methods enabled in MISP.
 
+7. Proxy
+Set `OidcAuth.skipProxy` to `false` to use global MISP proxy settings when sending requests to your OIDC provider. By default global proxy settings are ignored. 
+
 ## Caveats
 
 When user is blocked in SSO (IdM), he/she will be not blocked in MISP. He could not log in, but users authentication keys will still work and also he/she will still receive all emails. 


### PR DESCRIPTION
#### What does it do?
* add `OidcAuth.skipProxy` setting, by default it will skip MISP proxy settings for backward compatibility.
* fixes https://github.com/MISP/MISP/issues/10597
* related to https://github.com/MISP/MISP/pull/10551

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
