### PR TITLE
fix: [taxonomies] update getTagsForNamespace call to prevent OOM error

### DIFF
--- a/app/Model/Taxonomy.php
+++ b/app/Model/Taxonomy.php
@@ -432,7 +432,7 @@ class Taxonomy extends AppModel
         if (empty($taxonomy)) {
             return false;
         }
-        $tags = $this->Tag->getTagsForNamespace($taxonomy['Taxonomy']['namespace']);
+        $tags = $this->Tag->getTagsForNamespace($taxonomy['Taxonomy']['namespace'], false);
         $colours = $paletteTool->generatePaletteFromString($taxonomy['Taxonomy']['namespace'], count($taxonomy['entries']));
         foreach ($taxonomy['entries'] as $k => $entry) {
             $colour = $colours[$k];


### PR DESCRIPTION
#### What does it do?

Fixes #10606.

Prevents PHP out-of-memory when adding a tag via Taxonomies by avoiding eager loading of tag connector relations for an entire taxonomy namespace.

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
