### PR TITLE
Fix `searchall` for `/attributes/restSearch`

### DIFF
--- a/app/Controller/Component/RestSearchComponent.php
+++ b/app/Controller/Component/RestSearchComponent.php
@@ -17,6 +17,7 @@ class RestSearchComponent extends Component
             'org_id',
             'orgc_id',
             'tags',
+            'searchall',
             'from',
             'to',
             'last',

--- a/app/webroot/doc/openapi.yaml
+++ b/app/webroot/doc/openapi.yaml
@@ -3610,6 +3610,8 @@ components:
             - $ref: "#/components/schemas/OrganisationName"
         tags:
           $ref: "#/components/schemas/TagsRestSearchFilter"
+        searchall:
+          $ref: "#/components/schemas/SearchAllRestSearchFilter"
         from:
           $ref: "#/components/schemas/DateRestSearchFilter"
         to:


### PR DESCRIPTION
## :bug: Bug Description

The `searchall` parameter does not work for `/attributes/restSearch` on MISP v2.4.218 or v2.5.32.

I'm not certain when this broke but I know it worked on v2.4.169.

### Expected behavior

:+1: A request to `/attributes/restSearch` with a `searchall` parameter (with or without wildcards) should only return attributes that match.

### Actual behavior

:-1: All attributes are returned.

## :thinking: Why?

`searchall` is missing from the [paramArray for **Attribute** in `app/Controller/Component/RestSearchComponent.php`](https://github.com/MISP/MISP/blob/91c5dc368cd57e6c2d0a936def1125f1071bc352/app/Controller/Component/RestSearchComponent.php#L9) so [`_harvestParameters()` removes it](https://github.com/MISP/MISP/blob/91c5dc368cd57e6c2d0a936def1125f1071bc352/app/Controller/AppController.php#L1098-L1100).

This results in a query to the database with no `LIKE` clause, which returns all attributes in the MISP instance.

## :question: Questions

> Does it require a DB change?

No

> Are you using it in production?

No, though it's easy to test locally with `curl "http://localhost/attributes/restSearch" -H "Content-Type: application/json" -H "Authorization: $MISP_API_KEY" --data '{"searchall": "foo"}'`

> Does it require a change in the API (PyMISP for example)?

No, but I did update the OpenAPI specification to include the parameter as well.