### PR TITLE
feat(api): Add /attributes/getid endpoint for efficient attribute lookup by value

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -3154,4 +3154,63 @@ class AttributesController extends AppController
         ]);
         return $this->RestResponse->successResponse(0, $result);
     }
+    /**
+     * Get attribute ID and details by attribute value
+     * Searches directly in the database using indexed value1 column for efficiency
+     * 
+     * @param string $base64Value Base64 encoded attribute value to search for
+     * @return CakeResponse
+     * @throws NotFoundException If no matching attribute is found
+     * @throws MethodNotAllowedException If not an API request
+     */
+    public function getid($base64Value)
+    {
+        if (!$this->_isRest()) {
+            throw new MethodNotAllowedException(__("This action is available only via API."));
+        }
+        
+        // Decode the base64 value
+        $decodedValue = base64_decode($base64Value, true);
+        if ($decodedValue === false) {
+            throw new NotFoundException(__("Invalid base64 encoding."));
+        }
+        
+        $user = $this->Auth->user();
+        
+        // Build efficient query conditions - search directly on indexed value1 column
+        // Also check value2 for composite attributes (e.g., ip|port)
+        $conditions = [
+            "AND" => [
+                $this->MispAttribute->buildConditions($user),
+                "Attribute.deleted" => 0,
+                "OR" => [
+                    "Attribute.value1" => $decodedValue,
+                    "Attribute.value2" => $decodedValue,
+                    // For composite values like "ip|port", also search on the virtual value field
+                    "CONCAT(Attribute.value1, '|', Attribute.value2)" => $decodedValue
+                ]
+            ]
+        ];
+        
+        // Fetch attributes with the search conditions
+        $attributes = $this->MispAttribute->fetchAttributes($user, [
+            "conditions" => $conditions,
+            "flatten" => true,
+            "limit" => 100 // Limit results for performance
+        ]);
+        
+        if (empty($attributes)) {
+            throw new NotFoundException(__("Attribute not found."));
+        }
+        
+        // Format response
+        $results = [];
+        foreach ($attributes as $attr) {
+            unset($attr["Attribute"]["value1"]);
+            unset($attr["Attribute"]["value2"]);
+            $results[] = $attr["Attribute"];
+        }
+        
+        return $this->RestResponse->viewData($results, $this->response->type());
+    }
 }

--- a/app/webroot/doc/openapi.yaml
+++ b/app/webroot/doc/openapi.yaml
@@ -450,6 +450,63 @@ paths:
         default:
           $ref: "#/components/responses/ApiErrorResponse"
 
+
+  /attributes/getid/{base64Value}:
+    get:
+      summary: "Get attribute(s) by value"
+      description: |
+        Search for attributes by their value and return full attribute details including ID.
+        This endpoint allows efficient lookup of attributes directly in the database using indexed columns.
+        The attribute value must be base64 encoded in the URL path.
+        
+        **Example usage:**
+        ```bash
+        # Encode the attribute value to base64
+        VALUE="192.168.1.1"
+        BASE64=$(echo -n "$VALUE" | base64 -w0)
+        
+        # Query the API
+        curl -H "Authorization: YOUR_API_KEY" \
+             -H "Accept: application/json" \
+             "https://misp.local/attributes/getid/${BASE64}"
+        ```
+      operationId: getAttributeByValue
+      tags:
+        - Attributes
+      parameters:
+        - name: base64Value
+          in: path
+          description: "Base64 encoded attribute value to search for (use `echo -n 'value' | base64 -w0`)"
+          required: true
+          schema:
+            type: string
+            format: byte
+            example: "MTkyLjE2OC4xLjE="
+      responses:
+        "200":
+          description: "List of matching attributes"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Attribute"
+        "404":
+          description: "Attribute not found or invalid base64 encoding"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "403":
+          $ref: "#/components/responses/UnauthorizedApiErrorResponse"
+        "405":
+          description: "Method not allowed - this endpoint is API only"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        default:
+          $ref: "#/components/responses/ApiErrorResponse"
   /attributes/attributeStatistics/{context}/{percentage}:
     get:
       summary: "Get the count of attributes per category"


### PR DESCRIPTION
## Summary

This PR adds a new API endpoint `/attributes/getid/{base64Value}` that allows users to efficiently search for attributes by their value and retrieve full attribute details including the ID.

## Motivation

Currently, to find an attribute's ID by its value, users need to:
1. Use `/attributes/restSearch` with filters, which can be slow for simple lookups
2. Iterate through all attributes in an event

This new endpoint provides a direct, efficient way to lookup attributes by value, which is useful for:
- Checking if an attribute already exists before adding
- Getting the ID of an attribute for further operations (tagging, deletion, etc.)
- Building automation scripts and integrations

## Implementation Details

### Endpoint
```
GET /attributes/getid/{base64Value}
```

### Parameters
- `base64Value`: Base64 encoded attribute value (use `echo -n 'value' | base64 -w0`)

### Response
Returns an array of matching attributes with full details:
```json
[
    {
        "id": "12345",
        "event_id": "100",
        "type": "ip-src",
        "category": "Network activity",
        "value": "192.168.1.1",
        "uuid": "...",
        ...
    }
]
```

### Example Usage
```bash
VALUE="192.168.1.1"
BASE64=$(echo -n "$VALUE" | base64 -w0)
curl -H "Authorization: YOUR_API_KEY" \
     -H "Accept: application/json" \
     "https://misp.local/attributes/getid/${BASE64}"
```

## Key Features

- **Efficient**: Searches directly on indexed `value1` column in database
- **Access Control**: Respects existing MISP permission system
- **Composite Attributes**: Supports attributes with composite values (e.g., ip|port)
- **API Only**: Endpoint is available via REST API only
- **Documented**: Includes OpenAPI specification

## Changes

- `app/Controller/AttributesController.php`: Added `getid()` function
- `app/webroot/doc/openapi.yaml`: Added OpenAPI documentation for the endpoint

## Testing

Tested with various attribute types:
- IP addresses
- Domains/hostnames  
- Hashes (MD5, SHA256)
- URLs

All tests returned correct attribute details with proper access control enforcement.