### PR TITLE
chg: [freetext] added browser extension id extraction.

### DIFF
--- a/app/Lib/Tools/ComplexTypeTool.php
+++ b/app/Lib/Tools/ComplexTypeTool.php
@@ -335,6 +335,10 @@ class ComplexTypeTool
 
         $input = ['raw' => $raw_input];
 
+        if ($result = $this->__checkForBrowserExtensionIDs($input)) {
+            return $result;
+        }
+
         // Check hashes before refang and port extracting, it is not necessary for hashes. This speedups parsing
         // freetexts or CSVs with a lot of hashes.
         if ($result = $this->__checkForHashes($input)) {
@@ -374,6 +378,18 @@ class ComplexTypeTool
             return [
                 'types' => ['btc'],
                 'default_type' => 'btc',
+                'value' => $input['raw'],
+            ];
+        }
+        return false;
+    }
+
+    private function __checkForBrowserExtensionIDs($input)
+    {
+        if (preg_match('/^[a-p]{32}$/', $input['raw'])) {
+            return [
+                'types' => ['chrome-extension-id'],
+                'default_type' => 'chrome-extension-id',
                 'value' => $input['raw'],
             ];
         }


### PR DESCRIPTION
#### What does it do?
This PR adds a new feature to the `freetextimport` process to automatically extract **browser extension IDs**.

Since **Chrome and Edge extension IDs consist of a fixed-length string of 32 alphabetic characters**, they are highly suitable for automated extraction. While MD5 hashes share the same length (32 characters), they can be distinguished from extension IDs because MD5 includes numeric digits (0-9), whereas extension IDs use only lowercase letters (a-p).
- https://support.google.com/chrome/a/answer/7532015?hl=en
- https://learn.microsoft.com/en-us/microsoft-edge/extensions/developer-guide/alternate-distribution-options#gather-initial-information

Browser extension IDs are frequently listed as Indicators of Compromise (IoCs) in threat research reports. Adding this extraction logic allows users to quickly import these IDs from blog posts or security alerts.
- https://www.koi.ai/blog/4-million-browsers-infected-inside-shadypanda-7-year-malware-campaign
- https://www.obsidiansecurity.com/resource/obsidian-security-customer-alert-on-malicious-chrome-extension
- https://layerxsecurity.com/blog/silent-takeover-how-purchased-chrome-extensions-became-remote-controlled-webpage-manipulation-tools/

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

Thank you for your time.