### PR TITLE
chg: [Event] ensure galaxy cluster uniqueness in event view, even in extended events

### DIFF
--- a/app/View/Elements/galaxyQuickViewNew.ctp
+++ b/app/View/Elements/galaxyQuickViewNew.ctp
@@ -84,6 +84,7 @@ $generatePopover = function (array $cluster) use ($normalizeKey) {
 ?>
 <?php if (!empty($data)): ?>
 <div class="galaxyQuickView">
+<?php $data = array_values(array_combine(array_column($data, 'id'), $data)); ?>
 <?php foreach ($data as $galaxy): ?>
     <h3 title="<?= isset($galaxy['description']) ? h($galaxy['description']) : h($galaxy['name']) ?>">
         <?= h($galaxy['name']) ?>


### PR DESCRIPTION
#### What does it do?
Modified the **Extended Event view to ensure Galaxy Clusters are not displayed redundantly** when attached to multiple child events. Removing duplicate Galaxy Clusters will enhance context visibility and clarity compared to showing redundant entries multiple times.

Screenshots showing the changes are attached below.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

Thank you for your time.