### PR TITLE
fix: [schema] remove incorrect requirement for sharing_group

### DIFF
--- a/format/2.5/schema.json
+++ b/format/2.5/schema.json
@@ -102,10 +102,7 @@
         "required": [
           "uuid"
         ]
-      },
-      "required": [
-        "uuid"
-      ]
+      }
     },
     "sharing_group_org": {
       "type": "object",


### PR DESCRIPTION
#### What does it do?

Fixes duplicate / incorrect UUID requirement in the sharing_group part of the schema definition.

I wasn't sure if the same should be done for 2.4, as I suppose that one is obsolete.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
