### PR TITLE
fix: [analyst_data:blocklists] use correct controller name for redire…

### DIFF
--- a/app/Controller/AnalystDataBlocklistsController.php
+++ b/app/Controller/AnalystDataBlocklistsController.php
@@ -80,7 +80,7 @@ class AnalystDataBlocklistsController extends AppController
                     return $this->RestResponse->saveSuccessResponse('AnalystDataBlocklist', 'Deleted', $ids, $this->response->type());
                 } else {
                     $this->Flash->success('Blocklist entry removed');
-                    $this->redirect(array('controller' => 'AnalystDataBlocklist', 'action' => 'index'));
+                    $this->redirect(array('controller' => 'AnalystDataBlocklists', 'action' => 'index'));
                 }
             } else {
                 $error = __('Failed to delete Analyst Data from AnalystDataBlocklist. Error: ') . PHP_EOL . h($result);


### PR DESCRIPTION
#### What does it do?

Just aligns with line 91, this should be the correct controller name I think.

I am not sure this code is callable in any way using the GUI at the moment (so I couldn't test), but perhaps @mokaddem can confirm.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
