### PR TITLE
Make UI theme list dynamically populate from available options

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -295,7 +295,25 @@ class AppController extends Controller
                 }
             }
             $userSetting = ClassRegistry::init('UserSetting');
-            $this->set('themes', $userSetting::VALID_SETTINGS['ui_theme']['options']);
+            $themes = $userSetting::VALID_SETTINGS['ui_theme']['options'];
+            $themeLabels = ['Default' => __('Default UI')];
+            foreach ($themes as $t) {
+                if ($t === 'Default') {
+                    continue;
+                }
+                $themeFile = APP . 'View' . DS . 'Themed' . DS . $t . DS . 'theme.php';
+                if (file_exists($themeFile)) {
+                    $themeConfig = include $themeFile;
+                    if (!empty($themeConfig['label'])) {
+                        $themeLabels[$t] = $themeConfig['label'];
+                    }
+                }
+                if (!isset($themeLabels[$t])) {
+                    $themeLabels[$t] = $t . ' UI';
+                }
+            }
+            $this->set('themes', $themes);
+            $this->set('themeLabels', $themeLabels);
         }
 
         $user = $this->Auth->user();

--- a/app/View/Elements/global_menu.ctp
+++ b/app/View/Elements/global_menu.ctp
@@ -232,30 +232,24 @@ if (!empty($me)) {
                     'text' => __('My Settings'),
                     'url' => $baseurl . '/user_settings/index/user_id:me'
                 ),
-                array(
-                    'type' => 'group',
-                    'text' => __('Themes'),
-                    'children' => array(
                         array(
-                            'html' => sprintf(
-                                '<span id="betaUiToggle" class="setTheme" style="cursor: pointer;" data-theme="UiBeta"><i class="fas fa-flask"></i> %s <span class="label %s">%s</span></span>',
-                                __('Beta UI'),
-                                'label-default',
-                                __('OFF')
-                            ),
-                            'url' => '#'
-                        ),
-                        array(
-                            'html' => sprintf(
-                                '<span id="OvermindToggle" class="setTheme" style="cursor: pointer;" data-theme="Overmind"><i class="fas fa-flask"></i> %s <span class="label %s">%s</span></span>',
-                                __('Overmind UI'),
-                                'label-default',
-                                __('OFF')
-                            ),
-                            'url' => '#'
-                        ),
-                    ),
-                )
+                            'type' => 'group',
+                            'html' => '<i class="fas fa-palette fa-fw"></i> ' . __('Themes'),
+                            'children' => array_map(function($t) use ($theme, $themeLabels) {
+                                $label = isset($themeLabels[$t]) ? $themeLabels[$t] : $t . ' UI';
+                                return array(
+                                    'html' => sprintf(
+                                        '<span id="%sToggle" class="setTheme" style="cursor: pointer;" data-theme="%s"><i class="fas fa-brush"></i> %s <span class="label %s">%s</span></span>',
+                                        strtolower($t),
+                                        h($t),
+                                        $label,
+                                        $theme === $t ? 'label-success' : 'label-default',
+                                        $theme === $t ? __('ON') : __('OFF')
+                                    ),
+                                    'url' => '#'
+                                );
+                            }, $themes)
+                        )
             ),
             array(
                 'text' => __('Set Setting'),

--- a/app/View/Themed/Overmind/theme.php
+++ b/app/View/Themed/Overmind/theme.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'label' => __('Overmind UI')
+];

--- a/app/View/Themed/UiBeta/Elements/global_menu.ctp
+++ b/app/View/Themed/UiBeta/Elements/global_menu.ctp
@@ -677,67 +677,25 @@ if (!empty($me)) {
                 ),
                 array(
                     'type' => 'group',
-                    'html' => '<i class="fas fa-book fa-fw"></i> ' . __('Themes'),
-                    'children' => array(
-                        array(
+                    'html' => '<i class="fas fa-palette fa-fw"></i> ' . __('Themes'),
+                    'children' => array_map(function($t) use ($theme, $themeLabels) {
+                        $label = isset($themeLabels[$t]) ? $themeLabels[$t] : $t . ' UI';
+                        return array(
                             'html' => sprintf(
-                                '<span id="defaultUiToggle" class="setTheme" style="cursor: pointer;" data-theme="Default"><i class="fas fa-flask"></i> %s <span class="label %s">%s</span></span>',
-                                __('Default UI'),
-                                'label-default',
-                                __('OFF')
+                                '<span id="%sToggle" class="setTheme" style="cursor: pointer;" data-theme="%s"><i class="fas fa-brush"></i> %s <span class="label %s">%s</span></span>',
+                                strtolower($t),
+                                h($t),
+                                $label,
+                                $theme === $t ? 'label-success' : 'label-default',
+                                $theme === $t ? __('ON') : __('OFF')
                             ),
                             'url' => '#'
-                        ),
-                        array(
-                            'html' => sprintf(
-                                '<span id="OvermindToggle" class="setTheme" style="cursor: pointer;" data-theme="Overmind"><i class="fas fa-flask"></i> %s <span class="label %s">%s</span></span>',
-                                __('Overmind UI'),
-                                'label-default',
-                                __('OFF')
-                            ),
-                            'url' => '#'
-                        ),
-                    )
+                        );
+                    }, $themes)
                 )
             )
         )
     );
-    $menu[] = [
-        'type' => 'separator'
-    ];
-    $temp_menu_item = [
-        'html' => '<i class="fas fa-person-digging fa-fw"></i> ' . __('Themes'),
-        'children' => [],
-        'html' => sprintf(
-            '<span id="betaUiToggle" style="cursor: pointer;"><i class="fas fa-person-digging"></i> %s <span class="label label-success">%s</span></span>',
-            __('Beta UI'),
-            'label-success',
-            __('ON')
-        ),
-        'url' => '#'
-    ];
-    $temp_menu_item = [
-    'html' => '<i class="fas fa-flask fa-fw"></i> ' . __('Themes'),
-    'children' => [],
-    'html' => sprintf(
-        '<span id="betaUiToggle" style="cursor: pointer;"><i class="fas fa-flask"></i> %s <span class="label label-success">%s</span></span>',
-        __('Beta UI'),
-        'label-default',
-        __('OFF')
-    ),
-    'url' => '#'
-    ];
-    foreach ($themes as $theme) {
-        $temp_menu_item['children'][] = [
-            'html' => sprintf(
-                '<span class="%s" data-theme="%s">%s</span>',
-                'theme-option',
-                h($theme),
-                h($theme)
-            ),
-            'url' => $baseurl . '/users/setTheme/' . h($theme)
-        ];
-    }
 
     $logo = '<span class="logoBlueStatic bold" id="smallLogo">MISP</span>';
     $today = date('md');

--- a/app/View/Themed/UiBeta/theme.php
+++ b/app/View/Themed/UiBeta/theme.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'label' => __('Beta UI')
+];


### PR DESCRIPTION
#### What does it do?

* Make the list of themes in the UI dynamically populated from `ui_theme['options']` in UserSetting.php
* Allow each theme to have a label for itself in `Themed/[Theme name]/theme.php` as a config variable
* Show the currently set theme with "On" next to it in the menu UI.
* Change the menu icon for theme settings in the menu UI.

#### Questions

- [ No] Does it require a DB change?
- [ Not yet ] Are you using it in production?
- [ No ] Does it require a change in the API (PyMISP for example)?

<img width="523" height="280" alt="image" src="https://github.com/user-attachments/assets/007a13a7-fd61-45dd-9371-6d905afb7f7f" />
