### PR TITLE
fix: [SharingGroups:removeServer] use correct SharingGroupServer ID f…

### DIFF
--- a/app/Controller/SharingGroupsController.php
+++ b/app/Controller/SharingGroupsController.php
@@ -597,7 +597,7 @@ class SharingGroupsController extends AppController
         if (!empty($sg['SharingGroupServer'])) {
             foreach ($sg['SharingGroupServer'] as $sgs) {
                 if ($sgs['server_id'] == $server['Server']['id']) {
-                    $removeServer = $server['Server']['id'];
+                    $removeServer = $sgs['id'];
                     break;
                 }
             }


### PR DESCRIPTION
…or deletion

#### What does it do?

Fixes a logic error. The function was:

1. Searching for a SharingGroupServer in the SharingGroup which had a matching server ID to the one provided as param
2. Then deleting the SharingGroupServer with ID equal to the server ID provided as param (not the matching SharingGroupServer ID)


Basically: the wrong SharingGroupServer was getting deleted, if there happened to be a coincidental match.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
