### PR TITLE
fix: [Servers:eventBlockRule] use success response for success, and fail r…

### DIFF
--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -725,9 +725,9 @@ class ServersController extends AppController
             }
             if ($this->_isRest()) {
                 if ($result) {
-                    return $this->RestResponse->saveFailResponse('Servers', 'eventBlockRule', false, $message, $this->response->type());
+                    return $this->RestResponse->saveSuccessResponse('Servers', 'eventBlockRule', false, $message, $this->response->type());
                 } else {
-                    return $this->RestResponse->saveSuccessResponse('Servers', 'eventBlockRule', $message, $this->response->type());
+                    return $this->RestResponse->saveFailResponse('Servers', 'eventBlockRule', $message, $this->response->type());
                 }
             } else {
                 if ($result) {


### PR DESCRIPTION
…esponse for fail

#### What does it do?
Fixes issue with wrong response type being used

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
