### PR TITLE
fix: [TaxiiServers] correct saveFailResponse action name for getColle…

### DIFF
--- a/app/Controller/TaxiiServersController.php
+++ b/app/Controller/TaxiiServersController.php
@@ -183,7 +183,7 @@ class TaxiiServersController extends AppController
             return $this->RestResponse->viewData($results, 'json');
         } else {
             return $this->RestResponse->saveFailResponse(
-                'TaxiiServers', 'getRoot', null, $result, $this->response->type()
+                'TaxiiServers', 'getCollections', null, $result, $this->response->type()
             );  
         }
     }


### PR DESCRIPTION
…ctions

#### What does it do?

Corrects a copy pasta error. Sets the correct action name for the getCollections saveFailResponse

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
