### PR TITLE
fix: [TaxiiServer] use correct casing for 'Basic' authorization header

### DIFF
--- a/app/Model/TaxiiServer.php
+++ b/app/Model/TaxiiServer.php
@@ -179,7 +179,7 @@ class TaxiiServer extends AppModel
             ]
         ];
         if (!empty($options['TaxiiServer']['api_key'])) {
-            $request['header']['Authorization'] = 'basic ' . $options['TaxiiServer']['api_key'];
+            $request['header']['Authorization'] = 'Basic ' . $options['TaxiiServer']['api_key'];
         }
         try {
             if (!empty($options['type']) && $options['type'] === 'post') {


### PR DESCRIPTION
#### What does it do?

Upercases the B in Basic, as per https://datatracker.ietf.org/doc/html/rfc7617#section-1.1

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
