### PR TITLE
fix: [Servers:saveCert] correct file size check

### DIFF
--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -938,7 +938,7 @@ class ServersController extends AppController
                         $this->redirect(array('action' => 'index'));
                     }
 
-                    if (!$server['Server'][$subm]['size'] > 0) {
+                    if (!($server['Server'][$subm]['size'] > 0)) {
                         $this->Flash->error(__('Incorrect extension or empty file.'));
                         $this->redirect(array('action' => 'index'));
                     }


### PR DESCRIPTION
#### What does it do?

Adds () around the comparison, so the ! is correctly applied

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
