### PR TITLE
fix: [Galaxy:detachCluster] set correct orgc id for attributes

### DIFF
--- a/app/Model/Galaxy.php
+++ b/app/Model/Galaxy.php
@@ -879,7 +879,7 @@ class Galaxy extends AppModel
             }
             $event = $event[0];
             $org_id = $event['Event']['org_id'];
-            $orgc_id = $event['Event']['org_id'];
+            $orgc_id = $event['Event']['orgc_id'];
         } elseif ($target_type === 'tag_collection') {
             $target = $this->Tag->TagCollectionTag->TagCollection->fetchTagCollection($user, array('conditions' => array('TagCollection.id' => $target_id)));
             if (empty($target)) {


### PR DESCRIPTION
#### What does it do?

Fixes a likely typo.
I don't think it has an impact at the moment (because it is not used anywhere in a way that could lead to abuse), but it could lead to ACL issue later on, so probably better to fix.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
