### PR TITLE
fix: [SharingGroupBlueprint:execute] set correct conditional 'id' val…

### DIFF
--- a/app/Controller/SharingGroupBlueprintsController.php
+++ b/app/Controller/SharingGroupBlueprintsController.php
@@ -197,7 +197,7 @@ class SharingGroupBlueprintsController extends AppController
                 $this->redirect($this->referer());
             }
         } else {
-           $this->set('id', empty($id) ? $id : 'all');
+           $this->set('id', empty($id) ? 'all' : $id);
            $this->set('title', __('Execute Sharing Group Blueprint'));
            $this->set('question', __('Are you sure you want to (re)create a sharing group based on the Sharing Group Blueprint?'));
            $this->set('actionName', __('Execute'));


### PR DESCRIPTION
…ue to send to view

#### What does it do?

swaps the conditional assignment values. When $id is empty -> set to 'all', otherwise to $id.
I don't believe this value is actually used in the view though....

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
