### PR TITLE
fix: [GalaxyElements:index] correctly set canModify, to display delet…

### DIFF
--- a/app/Controller/GalaxyElementsController.php
+++ b/app/Controller/GalaxyElementsController.php
@@ -49,7 +49,7 @@ class GalaxyElementsController extends AppController
             'searchall' => isset($filters['searchall']) ? $filters['searchall'] : ''
         ]));
         $cluster = $this->GalaxyElement->GalaxyCluster->fetchIfAuthorized($user, $clusterId, array('edit', 'delete'), false, false);
-        $canModify = !empty($cluster['authorized']);
+        $canModify = !isset($cluster['authorized']) || $cluster['authorized'] === true;
         $this->set('canModify', $canModify);
         if ($filters['context'] === 'JSONView') {
             $expanded = $this->GalaxyElement->getExpandedJSONFromElements($elements);


### PR DESCRIPTION
…e button for those who have the correct privileges

#### What does it do?

Makes the delete button show up correctly (currently it is never shown).

<img width="1918" height="889" alt="image" src="https://github.com/user-attachments/assets/7676e3fa-f3f4-4f90-9432-7e91596dcd37" />


#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
