### PR TITLE
fix: [UI:logs] don't try to do weird ajax redirect magic on search, d…

### DIFF
--- a/app/View/Logs/search.ctp
+++ b/app/View/Logs/search.ctp
@@ -92,8 +92,7 @@ echo $this->element('genericElements/Form/genericForm', [
         'title' => __('Search Logs'),
         'fields' => $fields,
         'submit' => [
-            'action' => 'index',
-            'ajaxSubmit' => 'submitGenericFormInPlace();'
+            'action' => 'index'
         ]
     ],
     'formOptions' => [


### PR DESCRIPTION
…isplay result properly

#### What does it do?

Fixes messed up UI on search on /logs/index

Without this fix you get something like this, instead of the index page updating properly:
<img width="1192" height="463" alt="image" src="https://github.com/user-attachments/assets/a8f146ab-bf52-4f15-a4ff-3de1e0923315" />


#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
