### PR TITLE
fix: [sync:SharingGroup] do not overwrite local flag on syncing of edits

### DIFF
--- a/app/Model/SharingGroup.php
+++ b/app/Model/SharingGroup.php
@@ -689,7 +689,7 @@ class SharingGroup extends AppModel
             $isSGOwner = !$user['Role']['perm_sync'] && $existingSG['org_id'] == $user['org_id'];
             if ($isUpdatableBySync || $isSGOwner || $user['Role']['perm_site_admin']) {
                 $editedSG = $existingSG['SharingGroup'];
-                $attributes = ['name', 'releasability', 'description', 'created', 'modified', 'roaming', 'active', 'local'];
+                $attributes = ['name', 'releasability', 'description', 'created', 'modified', 'roaming', 'active'];
                 foreach ($attributes as $a) {
                     if (isset($sg[$a])) {
                         $editedSG[$a] = $sg[$a];


### PR DESCRIPTION
#### What does it do?

fixes #10616

Please note I **only** tested pull sync update at the moment

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
