### PR TITLE
Warn if themes disabled; add theme descriptions; add MispTheme class;…

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -5,6 +5,7 @@ App::uses('File', 'Utility');
 App::uses('RequestRearrangeTool', 'Tools');
 App::uses('BlowfishConstantPasswordHasher', 'Controller/Component/Auth');
 App::uses('BetterCakeEventManager', 'Tools');
+App::uses('MispTheme', 'Lib/MispTheme');
 
 /**
  * Application Controller
@@ -272,30 +273,27 @@ class AppController extends Controller
             }
         }
 
-        if (!$this->_isRest() && Configure::read('MISP.enable_themes')) {
-            if ($this->Auth->user()) {
-                $userTheme = $this->User->UserSetting->getUserTheme($this->Auth->user('id'));
-                if ($userTheme) {
-                    $this->theme = $userTheme;
-                    $this->viewClass = 'Theme';
-                } else {
-                    $default_theme = Configure::read('MISP.default_theme');
-                    if ($default_theme) {
-                        $this->theme = $default_theme;
-                        $this->viewClass = 'Theme';
-                    }
+        if (!$this->_isRest()) {
+            $themesEnabled = (bool)Configure::read('MISP.enable_themes');
+            $currentTheme = 'Default';
+            if ($themesEnabled) {
+                if ($this->Auth->user()) {
+                    $currentTheme = $this->User->UserSetting->getUserTheme($this->Auth->user('id')) ?? 'Default';
                 }
-                $this->set('theme', $userTheme);
-            } else {
-                $default_theme = Configure::read('MISP.default_theme');
-                if ($default_theme) {
-                    $this->theme = $default_theme;
+                if ($currentTheme === 'Default') {
+                    $currentTheme = Configure::read('MISP.default_theme') ?? 'Default';
+                }
+                if (!empty($this->request->params['named']['beta'])) {
+                    $currentTheme = 'UiBeta';
+                }
+                if ($currentTheme !== 'Default') {
+                    $this->theme = $currentTheme;
                     $this->viewClass = 'Theme';
-                    $this->set('theme', $default_theme);
                 }
             }
-            $userSetting = ClassRegistry::init('UserSetting');
-            $this->set('themes', $userSetting::VALID_SETTINGS['ui_theme']['options']);
+            $this->set('theme', $currentTheme);
+            $this->set('themesEnabled', $themesEnabled);
+            $this->set('themes', MispTheme::getAvailableThemes($currentTheme, (bool)Configure::read('debug')));
         }
 
         $user = $this->Auth->user();

--- a/app/Lib/MispTheme/MispTheme.php
+++ b/app/Lib/MispTheme/MispTheme.php
@@ -1,0 +1,58 @@
+<?php
+class MispTheme
+{
+    public $name;
+    public $label;
+    public $description;
+    public $active;
+    public $hideFromUsers;
+
+    public function __construct($name, $label = '', $description = '', $active = false, $hideFromUsers = false)
+    {
+        $this->name = $name;
+        $this->label = !empty($label) ? $label : $name . ' UI';
+        $this->description = $description;
+        $this->active = $active;
+        $this->hideFromUsers = $hideFromUsers;
+    }
+
+    /**
+     * Get all available themes as MispTheme objects
+     *
+     * @param string $currentActiveTheme The name of the currently active theme
+     * @param bool $showHiddenThemes Whether to include hidden themes (e.g. for developers)
+     * @return MispTheme[]
+     */
+    public static function getAvailableThemes($currentActiveTheme = 'Default', $showHiddenThemes = false)
+    {
+        $userSetting = ClassRegistry::init('UserSetting');
+        $themeNames = $userSetting::VALID_SETTINGS['ui_theme']['options'];
+
+        $themes = [];
+        foreach ($themeNames as $name) {
+            $label = '';
+            $description = '';
+            $hideFromUsers = false;
+
+            if ($name === 'Default') {
+                $label = __('Default UI');
+                $description = __('The classic MISP interface.');
+            } else {
+                $themeFile = APP . 'View' . DS . 'Themed' . DS . $name . DS . 'theme.php';
+                if (file_exists($themeFile)) {
+                    $themeConfig = include $themeFile;
+                    $label = !empty($themeConfig['label']) ? $themeConfig['label'] : '';
+                    $description = !empty($themeConfig['description']) ? $themeConfig['description'] : '';
+                    $hideFromUsers = !empty($themeConfig['hide_from_users']) ? (bool)$themeConfig['hide_from_users'] : false;
+                }
+            }
+
+            if ($hideFromUsers && !$showHiddenThemes && $name !== $currentActiveTheme) {
+                continue;
+            }
+
+            $themes[] = new MispTheme($name, $label, $description, $name === $currentActiveTheme, $hideFromUsers);
+        }
+        return $themes;
+    }
+}

--- a/app/View/Elements/global_menu.ctp
+++ b/app/View/Elements/global_menu.ctp
@@ -232,30 +232,56 @@ if (!empty($me)) {
                     'text' => __('My Settings'),
                     'url' => $baseurl . '/user_settings/index/user_id:me'
                 ),
-                array(
-                    'type' => 'group',
-                    'text' => __('Themes'),
-                    'children' => array(
                         array(
-                            'html' => sprintf(
-                                '<span id="betaUiToggle" class="setTheme" style="cursor: pointer;" data-theme="UiBeta"><i class="fas fa-flask"></i> %s <span class="label %s">%s</span></span>',
-                                __('Beta UI'),
-                                'label-default',
-                                __('OFF')
-                            ),
-                            'url' => '#'
-                        ),
-                        array(
-                            'html' => sprintf(
-                                '<span id="OvermindToggle" class="setTheme" style="cursor: pointer;" data-theme="Overmind"><i class="fas fa-flask"></i> %s <span class="label %s">%s</span></span>',
-                                __('Overmind UI'),
-                                'label-default',
-                                __('OFF')
-                            ),
-                            'url' => '#'
-                        ),
-                    ),
-                )
+                            'type' => 'group',
+                            'html' => '<i class="fas fa-palette fa-fw"></i> ' . __('Themes'),
+                            'children' => (function() use ($theme, $themes, $themesEnabled, $baseurl) {
+                                $children = [];
+                                if (!$themesEnabled) {
+                                    $children[] = [
+                                        'html' => sprintf(
+                                            '<div style="padding: 10px 15px; width: 400px; line-height: 1.4; border-bottom: 1px solid #444; margin-bottom: 5px;">' .
+                                            '<span class="text-warning" style="font-weight: bold;"><i class="fas fa-exclamation-triangle"></i> %s</span><br>' .
+                                            '<small style="opacity: 0.8;">%s</small>' .
+                                            '</div>',
+                                            __('Themes are not yet enabled.'),
+                                            __('Contact your MISP administrator to set MISP.enable_themes to 1.')
+                                        ),
+                                        'url' => '#'
+                                    ];
+                                }
+                                $themeItems = array_map(function($tObj) use ($theme, $themesEnabled) {
+                                    $html = sprintf(
+                                        '<span id="%sToggle" class="setTheme style-inline-theme" style="cursor: pointer; display: block; padding: 10px 15px; min-width: 400px; %s" data-theme="%s">',
+                                        strtolower($tObj->name),
+                                        !$themesEnabled ? 'opacity: 0.5; pointer-events: none;' : '',
+                                        h($tObj->name)
+                                    );
+                                    $html .= sprintf(
+                                        '<div style="display: flex; justify-content: space-between; align-items: center;">' .
+                                        '<span style="font-weight: bold;"><i class="fas fa-desktop fa-fw"></i> %s%s</span>' .
+                                        '<span class="label %s">%s</span>' .
+                                        '</div>',
+                                        $tObj->hideFromUsers ? '<span class="text-error">[DEV]</span> ' : '',
+                                        h($tObj->label),
+                                        $theme === $tObj->name ? 'label-success' : 'label-default',
+                                        $theme === $tObj->name ? __('ON') : __('OFF')
+                                    );
+                                    if (!empty($tObj->description)) {
+                                        $html .= sprintf(
+                                            '<div style="font-size: 0.9em; opacity: 0.6; margin-top: 4px; line-height: 1.2; white-space: normal; max-width: 450px; padding-left: 28px;">%s</div>',
+                                            h($tObj->description)
+                                        );
+                                    }
+                                    $html .= '</span>';
+                                    return array(
+                                        'html' => $html,
+                                        'url' => '#'
+                                    );
+                                }, $themes);
+                                return array_merge($children, $themeItems);
+                            })()
+                        )
             ),
             array(
                 'text' => __('Set Setting'),

--- a/app/View/Themed/Overmind/theme.php
+++ b/app/View/Themed/Overmind/theme.php
@@ -1,0 +1,5 @@
+<?php
+return [
+    'label' => __('Overmind UI'),
+    'hide_from_users' => true
+];

--- a/app/View/Themed/UiBeta/Elements/global_menu.ctp
+++ b/app/View/Themed/UiBeta/Elements/global_menu.ctp
@@ -677,67 +677,57 @@ if (!empty($me)) {
                 ),
                 array(
                     'type' => 'group',
-                    'html' => '<i class="fas fa-book fa-fw"></i> ' . __('Themes'),
-                    'children' => array(
-                        array(
-                            'html' => sprintf(
-                                '<span id="defaultUiToggle" class="setTheme" style="cursor: pointer;" data-theme="Default"><i class="fas fa-flask"></i> %s <span class="label %s">%s</span></span>',
-                                __('Default UI'),
-                                'label-default',
-                                __('OFF')
-                            ),
-                            'url' => '#'
-                        ),
-                        array(
-                            'html' => sprintf(
-                                '<span id="OvermindToggle" class="setTheme" style="cursor: pointer;" data-theme="Overmind"><i class="fas fa-flask"></i> %s <span class="label %s">%s</span></span>',
-                                __('Overmind UI'),
-                                'label-default',
-                                __('OFF')
-                            ),
-                            'url' => '#'
-                        ),
-                    )
+                    'html' => '<i class="fas fa-palette fa-fw"></i> ' . __('Themes'),
+                    'children' => (function() use ($theme, $themes, $themesEnabled, $baseurl) {
+                        $children = [];
+                        if (!$themesEnabled) {
+                            $children[] = [
+                                'html' => sprintf(
+                                    '<div style="padding: 10px 15px; width: 400px; line-height: 1.4; border-bottom: 1px solid #444; margin-bottom: 5px;">' .
+                                    '<span class="text-warning" style="font-weight: bold;"><i class="fas fa-exclamation-triangle"></i> %s</span><br>' .
+                                    '<small style="opacity: 0.8;">%s</small>' .
+                                    '</div>',
+                                    __('Themes are not yet enabled.'),
+                                    __('Contact your MISP administrator to set MISP.enable_themes to 1.')
+                                ),
+                                'url' => '#'
+                            ];
+                        }
+                        $themeItems = array_map(function($tObj) use ($theme, $themesEnabled) {
+                            $html = sprintf(
+                                '<span id="%sToggle" class="setTheme style-inline-theme" style="cursor: pointer; display: block; padding: 10px 15px; min-width: 400px; %s" data-theme="%s">',
+                                strtolower($tObj->name),
+                                !$themesEnabled ? 'opacity: 0.5; pointer-events: none;' : '',
+                                h($tObj->name)
+                            );
+                            $html .= sprintf(
+                                '<div style="display: flex; justify-content: space-between; align-items: center;">' .
+                                '<span style="font-weight: bold;"><i class="fas fa-desktop fa-fw"></i> %s%s</span>' .
+                                '<span class="label %s">%s</span>' .
+                                '</div>',
+                                $tObj->hideFromUsers ? '<span class="text-error">[DEV]</span> ' : '',
+                                h($tObj->label),
+                                $theme === $tObj->name ? 'label-success' : 'label-default',
+                                $theme === $tObj->name ? __('ON') : __('OFF')
+                            );
+                            if (!empty($tObj->description)) {
+                                $html .= sprintf(
+                                    '<div style="font-size: 0.9em; opacity: 0.6; margin-top: 4px; line-height: 1.2; white-space: normal; max-width: 450px; padding-left: 28px;">%s</div>',
+                                    h($tObj->description)
+                                );
+                            }
+                            $html .= '</span>';
+                            return array(
+                                'html' => $html,
+                                'url' => '#'
+                            );
+                        }, $themes);
+                        return array_merge($children, $themeItems);
+                    })()
                 )
             )
         )
     );
-    $menu[] = [
-        'type' => 'separator'
-    ];
-    $temp_menu_item = [
-        'html' => '<i class="fas fa-person-digging fa-fw"></i> ' . __('Themes'),
-        'children' => [],
-        'html' => sprintf(
-            '<span id="betaUiToggle" style="cursor: pointer;"><i class="fas fa-person-digging"></i> %s <span class="label label-success">%s</span></span>',
-            __('Beta UI'),
-            'label-success',
-            __('ON')
-        ),
-        'url' => '#'
-    ];
-    $temp_menu_item = [
-    'html' => '<i class="fas fa-flask fa-fw"></i> ' . __('Themes'),
-    'children' => [],
-    'html' => sprintf(
-        '<span id="betaUiToggle" style="cursor: pointer;"><i class="fas fa-flask"></i> %s <span class="label label-success">%s</span></span>',
-        __('Beta UI'),
-        'label-default',
-        __('OFF')
-    ),
-    'url' => '#'
-    ];
-    foreach ($themes as $theme) {
-        $temp_menu_item['children'][] = [
-            'html' => sprintf(
-                '<span class="%s" data-theme="%s">%s</span>',
-                'theme-option',
-                h($theme),
-                h($theme)
-            ),
-            'url' => $baseurl . '/users/setTheme/' . h($theme)
-        ];
-    }
 
     $logo = '<span class="logoBlueStatic bold" id="smallLogo">MISP</span>';
     $today = date('md');

--- a/app/View/Themed/UiBeta/theme.php
+++ b/app/View/Themed/UiBeta/theme.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    'label' => __('Beta UI'),
+    'description' => 'Beta UI to streamline analyst workflow. Current updates: Event List and navigation.',
+    'hide_from_users' => false
+];


### PR DESCRIPTION
#### What does it do?

Various improvements to the new theme system:

* Warn users if themes are disabled and tell them an admin has to enable it
* Add theme descriptions so users can see what a theme does + what is supports
* Create a new MispTheme class to bundle theme metadata
* Add a new hide_from_users in theme.php to hide this theme as a menu option
  * Developers can still enable it via user settings for their own testing
* Always fall back to classic MISP theme if themes become globally disabled

#### Questions

- [No] Does it require a DB change?
- [Not yet] Are you using it in production?
- [No] Does it require a change in the API (PyMISP for example)?
<img width="1346" height="708" alt="image" src="https://github.com/user-attachments/assets/049376fe-8fce-43b6-9396-981e68776c8c" />
<img width="1344" height="706" alt="image" src="https://github.com/user-attachments/assets/24f6e415-ddfa-4bd1-8fc5-f34e836d60dc" />
