### PR TITLE
fix: [SharingGroup] correctly allow user without sync perm to update …

### DIFF
--- a/app/Model/SharingGroup.php
+++ b/app/Model/SharingGroup.php
@@ -686,7 +686,7 @@ class SharingGroup extends AppModel
             $isUpdatableBySync = $user['Role']['perm_sync'] && empty($existingSG['SharingGroup']['local']);
             // TODO: reconsider this, org admins will be blocked from legitimate edits if they have sync permissions.
             // We need a mechanism to check whether we're in sync context.
-            $isSGOwner = !$user['Role']['perm_sync'] && $existingSG['org_id'] == $user['org_id'];
+            $isSGOwner = !$user['Role']['perm_sync'] && $existingSG['SharingGroup']['org_id'] == $user['org_id'];
             if ($isUpdatableBySync || $isSGOwner || $user['Role']['perm_site_admin']) {
                 $editedSG = $existingSG['SharingGroup'];
                 $attributes = ['name', 'releasability', 'description', 'created', 'modified', 'roaming', 'active', 'local'];


### PR DESCRIPTION
…own sharing group, using REST api

#### What does it do?

fixes a bug that made it so users with perm_sharing_group but without perm_sync, weren't able to update sharing groups belonging to their org via REST api.

#### Screenshots
##### Before the fix
**Result of query**
<img width="1920" height="1942" alt="owner-cant-edit-sharing-group-without-sync-perm-1" src="https://github.com/user-attachments/assets/243da2b2-39bc-4df6-9c42-ab152cf8844a" />

**User**
<img width="1920" height="1039" alt="owner-cant-edit-sharing-group-without-sync-perm-2" src="https://github.com/user-attachments/assets/0cfd594d-d01e-4858-94e1-044f547db7a4" />

**Org**
<img width="410" height="135" alt="image" src="https://github.com/user-attachments/assets/dbb4c7b9-7c3e-4cfc-92c9-da8d904d1bca" />

**Role**
<img width="1920" height="1039" alt="owner-cant-edit-sharing-group-without-sync-perm-3" src="https://github.com/user-attachments/assets/4ad7cf61-9525-4ed9-b44b-4061612601e6" />


##### After the fix
<img width="1920" height="1942" alt="owner-cant-edit-sharing-group-without-sync-perm-4-after-fix" src="https://github.com/user-attachments/assets/a2a9319e-0bf8-4427-85f1-143b73978e60" />

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
