### PR TITLE
fix: [Servers] use 'validationErrors' instead of 'validationError'

### DIFF
--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -566,7 +566,7 @@ class ServersController extends AppController
 
                             if (!$orgSave) {
                                 if ($this->_isRest()) {
-                                    return $this->RestResponse->saveFailResponse('Servers', 'edit', false, $this->Server->Organisation->validationError, $this->response->type());
+                                    return $this->RestResponse->saveFailResponse('Servers', 'edit', false, $this->Server->Organisation->validationErrors, $this->response->type());
                                 } else {
                                     $this->Flash->error(__('Couldn\'t save the new organisation, are you sure that the uuid is in the correct format?.'));
                                 }
@@ -612,7 +612,7 @@ class ServersController extends AppController
                     }
                 } else {
                     if ($this->_isRest()) {
-                        return $this->RestResponse->saveFailResponse('Servers', 'edit', false, $this->Server->validationError, $this->response->type());
+                        return $this->RestResponse->saveFailResponse('Servers', 'edit', false, $this->Server->validationErrors, $this->response->type());
                     } else {
                         $this->Flash->error(__('The server could not be saved. Please, try again.'));
                     }


### PR DESCRIPTION
#### What does it do?

Fixes likely typo.

Didn't test after this change so please check, or let me know if I need to!

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
