### PR TITLE
chg: [Feeds] remove redundant tags query in edit

### DIFF
--- a/app/Controller/FeedsController.php
+++ b/app/Controller/FeedsController.php
@@ -474,11 +474,6 @@ class FeedsController extends AppController
         if (empty(Configure::read('Security.disable_local_feed_access'))) {
             $inputSources['local'] = 'Local';
         }
-        $tags = $this->Event->EventTag->Tag->find('all', [
-            'recursive' => -1,
-            'fields' => ['Tag.name', 'Tag.id'],
-            'order' => ['lower(Tag.name) asc']
-        ]);
         $tags = $this->Event->EventTag->Tag->find('list', array('fields' => array('Tag.name'), 'order' => array('lower(Tag.name) asc')));
         $tags[0] = 'None';
         $this->loadModel('TagCollection');


### PR DESCRIPTION
#### What does it do?

Removes a redundant db query / assignment.
Not sure which one of the 2 should be kept, so leaving the one that ended up being used at the moment.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
