### PR TITLE
fix: [Sightings] return saved 'false' on failures

### DIFF
--- a/app/Controller/SightingsController.php
+++ b/app/Controller/SightingsController.php
@@ -187,7 +187,7 @@ class SightingsController extends AppController
             }
         } else {
             if (!isset($id)) {
-                return new CakeResponse(array('body' => json_encode(array('saved' => true, 'errors' => __('Invalid request.'))), 'status' => 200, 'type' => 'json'));
+                return new CakeResponse(array('body' => json_encode(array('saved' => false, 'errors' => __('Invalid request.'))), 'status' => 200, 'type' => 'json'));
             } else {
                 if ($onvalue) {
                     $result = $this->Sighting->add();
@@ -198,7 +198,7 @@ class SightingsController extends AppController
                 if ($result) {
                     return new CakeResponse(array('body' => json_encode(array('saved' => true, 'success' => __('Sighting added.'))), 'status' => 200, 'type' => 'json'));
                 } else {
-                    return new CakeResponse(array('body' => json_encode(array('saved' => true, 'errors' => __('Sighting could not be added'))), 'status' => 200, 'type' => 'json'));
+                    return new CakeResponse(array('body' => json_encode(array('saved' => false, 'errors' => __('Sighting could not be added'))), 'status' => 200, 'type' => 'json'));
                 }
             }
         }
@@ -213,20 +213,20 @@ class SightingsController extends AppController
             $this->render('ajax/quickDeleteConfirmationForm');
         } else {
             if (!isset($id)) {
-                return new CakeResponse(array('body' => json_encode(array('saved' => true, 'errors' => 'Invalid request.')), 'status' => 200, 'type' => 'json'));
+                return new CakeResponse(array('body' => json_encode(array('saved' => false, 'errors' => 'Invalid request.')), 'status' => 200, 'type' => 'json'));
             } else {
                 $sighting = $this->Sighting->find('first', array('conditions' => array('Sighting.id' => $id), 'recursive' => -1));
                 if (empty($sighting)) {
-                    return new CakeResponse(array('body' => json_encode(array('saved' => true, 'errors' => 'Invalid sighting.')), 'status' => 200, 'type' => 'json'));
+                    return new CakeResponse(array('body' => json_encode(array('saved' => false, 'errors' => 'Invalid sighting.')), 'status' => 200, 'type' => 'json'));
                 }
                 if (!$this->ACL->canDeleteSighting($this->Auth->user(), $sighting)) {
-                    return new CakeResponse(array('body' => json_encode(array('saved' => true, 'errors' => 'Invalid sighting.')), 'status' => 200, 'type' => 'json'));
+                    return new CakeResponse(array('body' => json_encode(array('saved' => false, 'errors' => 'Invalid sighting.')), 'status' => 200, 'type' => 'json'));
                 }
                 $result = $this->Sighting->delete($id);
                 if ($result) {
                     return new CakeResponse(array('body' => json_encode(array('saved' => true, 'success' => 'Sighting deleted.')), 'status' => 200, 'type' => 'json'));
                 } else {
-                    return new CakeResponse(array('body' => json_encode(array('saved' => true, 'errors' => 'Sighting could not be deleted')), 'status' => 200, 'type' => 'json'));
+                    return new CakeResponse(array('body' => json_encode(array('saved' => false, 'errors' => 'Sighting could not be deleted')), 'status' => 200, 'type' => 'json'));
                 }
             }
         }


### PR DESCRIPTION
#### What does it do?

Sets saved false for failure cases.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
