### PR TITLE
fix: propagate Plugin.<family>_timeout to misp-modules /query payload

### DIFF
--- a/app/Model/Module.php
+++ b/app/Model/Module.php
@@ -283,6 +283,9 @@ class Module extends AppModel
         } else {
             $timeout = Configure::read('Plugin.' . $moduleFamily . '_timeout') ?: 10;
         }
+        if (!isset($postData['timeout'])) {
+            $postData['timeout'] = (int) $timeout;
+        }
         try {
             return $this->sendRequest('/query', $timeout, $postData, $moduleFamily);
         } catch (Exception $e) {


### PR DESCRIPTION
#### Problem
* MISP reads `Plugin.<family>_timeout` (e.g., `Plugin.Action_timeout`) and applies it as the **HTTP client/socket timeout** when calling the module service `/query`.
* However, `misp-modules` enforces the **actual execution timeout** in Tornado using the JSON payload field `timeout` (defaulting to `DEFAULT_TIMEOUT = 300s` when missing).
* Since MISP does not include `timeout` in the `/query` JSON body, long-running Action modules still time out around ~5 minutes even when `Plugin.Action_timeout` is increased.

#### What does it do?
Inject `timeout` into the `/query` JSON payload before calling `sendRequest('/query', ...)`:
This aligns the configured `Plugin.<family>_timeout` with the **Tornado `with_timeout()` enforcement** in `misp-modules`, preventing the default 300s cutoff.

#### Related issues
* #3403 (Tornado timeout on long processing)
* #3404 (misp-modules timeout too low / “Timeout on ocr”)

#### Questions
* [ ] Does it require a DB change?
* [x] Are you using it in production?
* [ ] Does it require a change in the API (PyMISP for example)?