### PR TITLE
fix: [TagCollections] correctly set a specific tag when submitting a …

### DIFF
--- a/app/Controller/TagCollectionsController.php
+++ b/app/Controller/TagCollectionsController.php
@@ -224,7 +224,13 @@ class TagCollectionsController extends AppController
                         return new CakeResponse(array('body'=> json_encode(array('saved' => false, 'errors' => 'Invalid Tag(s).')), 'status'=>200, 'type' => 'json'));
                     }
                 } else {
-                    $tag = $this->TagCollection->TagCollectionTag->Tag->find('first', array('recursive' => -1, 'conditions' => $tagConditions));
+                    $tag_lookup = ['OR' => ['LOWER(Tag.name) LIKE' => strtolower(trim($tag_id))]];
+                    $tag = $this->TagCollection->TagCollectionTag->Tag->find('first', array('recursive' => -1, 'conditions' => array(
+                        'AND' => array(
+                            $tagConditions,
+                            $tag_lookup
+                        )
+                    )));
                     if (empty($tag)) {
                         return new CakeResponse(array('body'=> json_encode(array('saved' => false, 'errors' => 'Invalid Tag.')), 'status'=>200, 'type' => 'json'));
                     }


### PR DESCRIPTION
…string like 'tag_name'

#### What does it do?

Submitting something like below currently just adds a tag at random, which is odd. Still not a perfect solution (what's the point of a LIKE to add 1 tag?), but okay.

This function has a bunch of problems, just starting with this.

<img width="1083" height="352" alt="image" src="https://github.com/user-attachments/assets/af18cf28-c8d3-4da9-8f5d-504cb1ac98f8" />


#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
