### PR TITLE
fix: [TagCollections:removeTag] allow removing tags by setting tag_co…

### DIFF
--- a/app/Controller/TagCollectionsController.php
+++ b/app/Controller/TagCollectionsController.php
@@ -342,6 +342,7 @@ class TagCollectionsController extends AppController
             $this->request->data = $RearrangeTool->rearrangeArray($this->request->data, $rearrangeRules);
             if ($id === false) {
                 $id = $this->request->data['tag_collection'];
+                $conditions['TagCollection.id'] = $id;
             }
             if ($tag_id === false) {
                 $tag_id = $this->request->data['tag'];


### PR DESCRIPTION
…llection id in the POST body

#### What does it do?

Allows doing this:
<img width="1082" height="340" alt="image" src="https://github.com/user-attachments/assets/40abcf44-c1a2-41ee-bc19-884dc4d8fdd0" />

without the change, the post body tag_collection id is not used

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
