### PR TITLE
fix: [WarningList:zmq] correct typo that led to missing info i…

### DIFF
--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -894,7 +894,7 @@ class Warninglist extends AppModel
         if ($this->pubToZmq('warninglist')) {
             $warninglist = $this->find('first', [
                 'conditions' => ['id' => $data['Warninglist']['id']],
-                'contains' => ['WarninglistEntry', 'WarninglistType'],
+                'contain' => ['WarninglistEntry', 'WarninglistType'],
             ]);
             $pubSubTool = $this->getPubSubTool();
             $pubSubTool->warninglist_save($warninglist, $created ? 'add' : 'edit');


### PR DESCRIPTION
…n Zmq publication

#### What does it do?
Makes the notification something like this (I tested, WarninglistEntry and WarninglistType were missing without the change):
```
{
	"Warninglist": {
		"id": "92",
		"name": "test",
		"type": "cidr",
		"description": "test",
		"version": "4",
		"enabled": false,
		"default": false,
		"category": "false_positive"
	},
	"WarninglistEntry": [
		{
			"id": "4619164",
			"value": "50.50.50.50",
			"warninglist_id": "92",
			"comment": null
		},
		{
			"id": "4619165",
			"value": "50.50.50.51",
			"warninglist_id": "92",
			"comment": null
		},
		{
			"id": "4619166",
			"value": "50.50.50.52",
			"warninglist_id": "92",
			"comment": null
		}
	],
	"WarninglistType": [
		{
			"id": "633",
			"type": "ip-src",
			"warninglist_id": "92"
		},
		{
			"id": "634",
			"type": "ip-dst",
			"warninglist_id": "92"
		},
		{
			"id": "635",
			"type": "domain|ip",
			"warninglist_id": "92"
		},
		{
			"id": "636",
			"type": "ip-dst|port",
			"warninglist_id": "92"
		},
		{
			"id": "637",
			"type": "ip-src|port",
			"warninglist_id": "92"
		}
	],
	"action": "edit"
}
```

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
