### PR TITLE
fix: [Tasks] use 'validationErrors' instead of 'validationError' in c…

### DIFF
--- a/app/Controller/TasksController.php
+++ b/app/Controller/TasksController.php
@@ -70,7 +70,7 @@ class TasksController extends AppController
             if ($result) {
                 return $this->RestResponse->saveSuccessResponse('Task', 'toggleEnabled', $id, $this->response->type());
             } else {
-                return $this->RestResponse->saveFailResponse('Task', 'toggleEnabled', $id, $this->validationError, $this->response->type());
+                return $this->RestResponse->saveFailResponse('Task', 'toggleEnabled', $id, $this->validationErrors, $this->response->type());
             }
         }
 
@@ -249,7 +249,7 @@ class TasksController extends AppController
                 return;
             } else {
                 if ($this->IndexFilter->isRest()) {
-                    return $this->RestResponse->saveFailResponse('Task', 'forceRunTask', $id, $this->validationError, $this->response->type());
+                    return $this->RestResponse->saveFailResponse('Task', 'forceRunTask', $id, $this->validationErrors, $this->response->type());
                 }
                 $this->Flash->error(__('Failed to force run task: '));
                 $this->redirect(['action' => 'index']);


### PR DESCRIPTION
…ontroller

#### What does it do?

Fixes likely typo.

Didn't test after this change so please check, or let me know if I need to!

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
