### PR TITLE
CI: Fix PHP version in GitHub Actions matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}a
+          php-version: ${{ matrix.php }}
           extensions: mysql, mbstring, xml, opcache, readline, redis, gd, apcu
 
       - name: Initialize variables


### PR DESCRIPTION
## What does it do?

Fixes a typo in the GitHub Actions workflow where `setup-php` receives an invalid PHP version (`${{ matrix.php }}a`).

#### Change
- Use the matrix value directly:
  - `php-version: ${{ matrix.php }}`

#### Why
The extra trailing character makes the version string invalid (e.g., `8.1a`, `8.3a`) and can cause CI setup to fail or behave unexpectedly.

#### Notes
No product/runtime code changes; workflow-only fix.

## Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
