### PR TITLE
fix: [Collections] make edits work for collections with sharing group…

### DIFF
--- a/app/Controller/CollectionsController.php
+++ b/app/Controller/CollectionsController.php
@@ -69,6 +69,7 @@ class CollectionsController extends AppController
             throw new MethodNotAllowedException(__('Invalid Collection or insufficient privileges'));
         }
         $params = [];
+        $this->loadModel('Event');
         if ($this->request->is('post') || $this->request->is('put')) {
             $oldCollection = $this->Collection->find('first', [
                 'recursive' => -1,
@@ -106,7 +107,6 @@ class CollectionsController extends AppController
             return $this->restResponsePayload;
         }
         $this->set('menuData', array('menuList' => 'collections', 'menuItem' => 'edit'));
-        $this->loadModel('Event');
         $dropdownData = [
             'types' => array_combine($this->valid_types, $this->valid_types),
             'distributionLevels' => $this->Event->distributionLevels,


### PR DESCRIPTION
… distribution

#### What does it do?

Make sure you don't get error on line 91 (because Event is not loaded at the right spot):
`$canSGBeUsed = $this->Event->SharingGroup->checkIfCanBeUsed($this->Auth->user(), $this->_isRest(), $data, 'Collection');`


To test:
Create a collection with distribution set to a sharing group.
Try editing the name of the collection afterwards -> internal server error
With this fix -> no error

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
