### PR TITLE
Fix: [Decaying Models] Check for undefined array key decay_score

### DIFF
--- a/app/Model/MispAttribute.php
+++ b/app/Model/MispAttribute.php
@@ -2218,7 +2218,7 @@ class MispAttribute extends AppModel
                         $attr['Attribute'] = $this->DecayingModel
                             ->attachScoresToAttribute($user, $attr['Attribute'], $options['decayingModel'], $options['modelOverrides'], $full);
                         unset($attr['Attribute']['AttributeTag'], $attr['Attribute']['EventTag']);
-                        if (!empty($options['excludeDecayed'])) {
+                        if (!empty($options['excludeDecayed']) && isset($attr['Attribute']['decay_score'])) {
                             $allDecayed = true;
                             foreach ($attr['Attribute']['decay_score'] as $ds) {
                                 $allDecayed = $allDecayed && $ds['decayed'];


### PR DESCRIPTION
Check for undefined array key "decay_score".

**What does it do?**
Addresses the error below:
```
Undefined array key "decay_score" in [app/Model/MispAttribute.php, line 2223
Warning: Warning (2): foreach() argument must be of type array|object, null given in [app/Model/MispAttribute.php
```


**Questions**

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
