### PR TITLE
fix: incorrect html anchor rendering during "populate from template"

### DIFF
--- a/app/View/Templates/ajax/template_choices.ctp
+++ b/app/View/Templates/ajax/template_choices.ctp
@@ -1,43 +1,41 @@
 <div class="popover_choice">
     <legend><?php echo __('Choose element type'); ?></legend>
-    <div class="popover_choice_main" id ="popover_choice_main">
+    <div class="popover_choice_main" id="popover_choice_main">
         <?php foreach ($templates as $k => $template): ?>
-            <?= $this->Html->link(
-                '<div style="float:left;">' .
-                    $this->OrgImg->getOrgImg([
+            <a href="<?= $this->Html->url([
+                            'controller' => 'templates',
+                            'action' => 'populateEventFromTemplate',
+                            $template['Template']['id'],
+                            $id
+                        ]); ?>"
+                class="templateChoiceButton"
+                style="width:100%; display:block;text-decoration:none;"
+                role="button"
+                tabindex="0"
+                aria-label="<?= h($template['Template']['description']); ?>"
+                title="<?= h($template['Template']['description']); ?>">
+                <div style="float:left;">
+                    <?= $this->OrgImg->getOrgImg([
                         'name' => $template['Template']['org'],
                         'size' => 24
-                    ], true) .
-                '</div>' .
-                '<div><span style="position:relative;left:-12px;">' .
-                h($template['Template']['name']) .
-                '&nbsp;</span></div>',
-                [
-                    'controller' => 'templates',
-                    'action' => 'populateEventFromTemplate',
-                    $template['Template']['id'],
-                    $id
-                ],
-                [
-                    'escape'     => false, // allow inner HTML
-                    'class'      => 'templateChoiceButton',
-                    'style'      => 'width:100%; display:block;text-decoration:none;',
-                    'role'       => 'button',
-                    'tabindex'   => 0,
-                    'aria-label' => h($template['Template']['description']),
-                    'title'      => h($template['Template']['description'])
-                ]
-            ); ?>
+                    ], false, true); ?>
+                </div>
+                <div>
+                    <span style="position:relative;left:-12px;">
+                        <?= h($template['Template']['name']); ?>&nbsp;
+                    </span>
+                </div>
+            </a>
         <?php endforeach; ?>
     </div>
-    <div role="button" tabindex="0" aria-label="<?php echo __('Cancel');?>" title="<?php echo __('Cancel');?>" class="templateChoiceButton templateChoiceButtonLast" onClick="cancelPopoverForm();"><?php echo __('Cancel');?></div>
+    <div role="button" tabindex="0" aria-label="<?php echo __('Cancel'); ?>" title="<?php echo __('Cancel'); ?>" class="templateChoiceButton templateChoiceButtonLast" onClick="cancelPopoverForm();"><?php echo __('Cancel'); ?></div>
 </div>
 <script type="text/javascript">
-$(document).ready(function() {
-    resizePopoverBody();
-});
+    $(document).ready(function() {
+        resizePopoverBody();
+    });
 
-$(window).resize(function() {
-    resizePopoverBody();
-});
+    $(window).resize(function() {
+        resizePopoverBody();
+    });
 </script>


### PR DESCRIPTION
#### What does it do?

Populate from templates a rendered incorrectly under some conditions (maybe if the Org don't have a image).

Incorrect generated HTML:
```
<a href="/templates/populateEventFromTemplate/5/778" class="templateChoiceButton" style="width:100%; display:block;text-decoration:none;" role="button" tabindex="0" aria-label="Is this a Bug or a Feature?" title="Is this a Bug or a Feature?"></a>

<div style="float:left;"><a href="/templates/populateEventFromTemplate/5/778" class="templateChoiceButton" style="width:100%; display:block;text-decoration:none;" role="button" tabindex="0" aria-label="Is this a Bug or a Feature?" title="Is this a Bug or a Feature?"></a><a href="https://sample-misp/organisations/view/Sample"><span class="welcome">Sample</span></a></div> <div><span style="position:relative;left:-12px;">This tastes like a Bug&nbsp;</span></div>
```

All the `<div>` are outside the `<a>`.

#### Questions

- [no] Does it require a DB change?
- [yes] Are you using it in production?
- [no] Does it require a change in the API (PyMISP for example)?
