### PR TITLE
fix: keep blocked background publish fully unpublished

### DIFF
--- a/app/Console/Command/EventShell.php
+++ b/app/Console/Command/EventShell.php
@@ -434,14 +434,19 @@ class EventShell extends AppShell
         $job['Job']['progress'] = 100;
         $job['Job']['status'] = Job::STATUS_COMPLETED;
         $job['Job']['date_modified'] = date("Y-m-d H:i:s");
-        if ($result) {
+        $isSuccess = $result === true || is_array($result);
+        if ($isSuccess) {
             $job['Job']['message'] = 'Event published.';
         } else {
-            $job['Job']['message'] = 'Event published, but the upload to other instances may have failed.';
+            $job['Job']['message'] = is_string($result) ? sprintf('Event publication blocked: %s', $result) : 'Event publication failed.';
         }
         $this->Job->save($job);
         $log = ClassRegistry::init('Log');
-        $log->createLogEntry($user, 'publish', 'Event', $id, 'Event (' . $id . '): published.', 'published () => (1)');
+        if ($isSuccess) {
+            $log->createLogEntry($user, 'publish', 'Event', $id, 'Event (' . $id . '): published.', 'published () => (1)');
+        } else {
+            $log->createLogEntry($user, 'publish', 'Event', $id, 'Event (' . $id . '): publication blocked.', is_string($result) ? $result : '');
+        }
     }
 
     public function publish_sightings()

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -5102,14 +5102,6 @@ class Event extends AppModel
     public function publishRouter($id, $passAlong = null, $user)
     {
         if (Configure::read('MISP.background_jobs')) {
-            //Tentatively set the publish flag to 1
-            $event = $this->find('first', array(
-                'conditions' => array('Event.id' => $id),
-                'recursive' => -1
-            ));
-            $event['Event']['published'] = 1;
-            $event['Event']['publish_timestamp'] = time();
-            $this->save($event);
             /** @var Job $job */
             $job = ClassRegistry::init('Job');
             $jobId = $job->createJob($user, Job::WORKER_PRIO, 'publish_event', "Event ID: $id", 'Publishing.');
@@ -5221,6 +5213,17 @@ class Event extends AppModel
             $success = $this->executeTrigger('event-publish', $fullEvent[0], $workflowErrors, $logging);
             if (empty($success)) {
                 $errorMessage = implode(', ', $workflowErrors);
+                if (Configure::read('MISP.background_jobs') && !empty($event['Event']['published'])) {
+                    // If blocking workflow stops publication, make sure event stays unpublished.
+                    $this->save([
+                        'Event' => [
+                            'id' => $event['Event']['id'],
+                            'published' => 0,
+                        ],
+                    ], [
+                        'fieldList' => ['id', 'published'],
+                    ]);
+                }
 
                 return $errorMessage;
             }


### PR DESCRIPTION
  ## What does it do?

  Fixes #10690 (blocking `event-publish` workflow in 2.5 background publish flow).

  ### Changes

  - Removed tentative `published=1` update from `Event::publishRouter()` when `MISP.background_jobs=true`.
    - Prevents transient "published" UI flicker before workflow decision.
    - Prevents accidental `publish_timestamp` updates for blocked publish attempts.
  - In `Event::publish()`, when `event-publish` trigger blocks execution, explicitly keep event unpublished (`published=0`).
  - In `EventShell::publish()`, string return values from `Event::publish()` are now treated as blocked/failed publication (instead of success), with accurate job/log messages.

  ### Why

  In background publish mode, event state was being set optimistically before workflow blocking result was known.
  This caused inconsistent publication state and misleading status/log output.

  ### Target branch

  - `2.5`

  ## Questions

  - [x] Does it require a DB change?
    - No.
  - [ ] Are you using it in production?
  - [x] Does it require a change in the API (PyMISP for example)?
    - No.