### PR TITLE
Add composite indexes on default_correlations for events index performance

### DIFF
--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -96,7 +96,8 @@ class AppModel extends Model
         123 => false, 124 => false, 125 => false, 126 => false, 127 => false, 128 => false,
         129 => false, 130 => false, 131 => false, 132 => false, 133 => false, 134 => true,
         135 => false, 136 => true, 137 => false, 138 => false, 139 => false, 140 => false,
-        141 => false, 142 => false, 143 => false, 144 => false, 145 => false, 146 => false
+        141 => false, 142 => false, 143 => false, 144 => false, 145 => false, 146 => false,
+        147 => false
     );
 
     const ADVANCED_UPDATES_DESCRIPTION = array(
@@ -2574,6 +2575,12 @@ class AppModel extends Model
                 break;
             case 146:
                 $sqlArray[] = "ALTER TABLE `bookmarks` MODIFY `url` TEXT NOT NULL;";
+                break;
+            case 147:
+                $sqlArray[] = "ALTER TABLE `default_correlations` ADD INDEX `idx_event_1event` (`event_id`, `1_event_id`);";
+                $sqlArray[] = "ALTER TABLE `default_correlations` ADD INDEX `idx_1event_event` (`1_event_id`, `event_id`);";
+                $sqlArray[] = "ALTER TABLE `no_acl_correlations` ADD INDEX `idx_event_1event` (`event_id`, `1_event_id`);";
+                $sqlArray[] = "ALTER TABLE `no_acl_correlations` ADD INDEX `idx_1event_event` (`1_event_id`, `event_id`);";
                 break;
             case 'fixNonEmptySharingGroupID':
                 $sqlArray[] = 'UPDATE `events` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';

--- a/db_schema.json
+++ b/db_schema.json
@@ -11237,5 +11237,5 @@
             "uuid": false
         }
     },
-    "db_version": "146"
+    "db_version": "147"
 }


### PR DESCRIPTION
## Summary
- Add composite indexes `(event_id, 1_event_id)` and `(1_event_id, event_id)` on `default_correlations` and `no_acl_correlations` tables
- Turns slow full-scan correlation queries into covering index scans
- Measured improvement: **43s → 0.12s** per query

## Problem
The events index page runs queries like:
```sql
SELECT DISTINCT `1_event_id` FROM `default_correlations` WHERE `event_id` = ?
```
With only single-column indexes on `event_id` and `1_event_id`, MariaDB/MySQL must look up each matching row to retrieve the other column, then sort for DISTINCT.

For high-correlation events (e.g. the default IPsum feed with 2M attributes and 1.87M correlation rows), this takes **43+ seconds per query**. Since the events index page runs this for multiple events, all PHP-FPM workers get stuck waiting on these queries, exhausting the worker pool and causing **504 Gateway Timeouts**.

## Fix
Composite indexes `(event_id, 1_event_id)` and `(1_event_id, event_id)` allow MariaDB to answer the query entirely from the index (`EXPLAIN` shows "Using index for group-by") without touching the table data.

**Before** (single-column index on `event_id`):
```
type: ref | key: event_id | rows: 1871260 | Extra: Using temporary
→ 43 seconds
```

**After** (composite index):
```
type: range | key: idx_1event_event | rows: 102095 | Extra: Using index for group-by
→ 0.12 seconds
```

The migration is idempotent — duplicate index errors (1061) are silently accepted by MISP's migration framework.

## Related issues
- #4356 — MISP slow with highly correlated index page
- #4801 — Multiple SQL correlations requests launch simultaneously
- #7396 — Login slowness and a lot of correlations
- #10239 — PHP-FPM pm.max_children exhaustion
- #9614 — 504 timeouts after upgrade with large OSINT feeds

## Test plan
- [x] Verified on production MISP 2.5.35 instance with 16M correlation rows
- [x] `EXPLAIN` confirms "Using index for group-by" on correlation queries
- [x] Events index page loads in < 1s with IPsum feed (2M attributes)
- [ ] Verify migration 147 runs without errors on fresh and existing instances
- [ ] Verify `no_acl_correlations` indexes are also applied correctly