### PR TITLE
fix: render domain restrictions line breaks correctly in orgs view

### DIFF
--- a/app/View/Elements/genericElements/IndexTable/Fields/generic_field.ctp
+++ b/app/View/Elements/genericElements/IndexTable/Fields/generic_field.ctp
@@ -6,7 +6,7 @@
     if (is_array($data)) {
         if (count($data) > 1) {
             $implodeGlue = isset($field['array_implode_glue']) ? $field['array_implode_glue'] : ', ';
-            $data = implode($implodeGlue, array_map('h', $data));
+            $data = nl2br(implode($implodeGlue, array_map('h', $data)), false);
         } else {
             if (count($data) > 0) {
                 $data = h($data[0]);

--- a/app/View/Organisations/index.ctp
+++ b/app/View/Organisations/index.ctp
@@ -132,7 +132,7 @@ echo $this->element('/genericElements/IndexTable/index_table', [
                 'name' => __('Restrictions'),
                 'sort' => 'restricted_to_domain',
                 'data_path' => 'Organisation.restricted_to_domain',
-                'array_implode_glue' => '<br>',
+                'array_implode_glue' => "\n",
             ],
         ],
         'actions' => [

--- a/app/View/Organisations/view.ctp
+++ b/app/View/Organisations/view.ctp
@@ -21,8 +21,8 @@
         }
         if (!empty($org['Organisation']['restricted_to_domain'])) {
             $domains = $org['Organisation']['restricted_to_domain'];
-            $domains = implode("<br>", array_map('h', $domains));
-            $table_data[] = array('key' => __('Domain restrictions'), 'html' => $domains);
+            $domains = implode("\n", $domains);
+            $table_data[] = array('key' => __('Domain restrictions'), 'value' => $domains);
         }
         if ($isSiteAdmin) {
             $table_data[] = array('key' => __('Created by'), 'value' => isset($org['Organisation']['created_by_email']) ? $org['Organisation']['created_by_email'] : __("Unknown"));

--- a/app/View/Themed/Overmind/Elements/genericElementsBS5/IndexTable/Fields/generic_field.ctp
+++ b/app/View/Themed/Overmind/Elements/genericElementsBS5/IndexTable/Fields/generic_field.ctp
@@ -6,7 +6,7 @@
     if (is_array($data)) {
         if (count($data) > 1) {
             $implodeGlue = isset($field['array_implode_glue']) ? $field['array_implode_glue'] : ', ';
-            $data = implode($implodeGlue, array_map('h', $data));
+            $data = nl2br(implode($implodeGlue, array_map('h', $data)), false);
         } else {
             if (count($data) > 0) {
                 $data = h($data[0]);


### PR DESCRIPTION
## What does it do?

Fixes #4297

This PR fixes the rendering of domain restrictions in the orgs view.
Instead of showing raw `<br>` text, line breaks are now displayed correctly in the interface.

## Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?