### PR TITLE
fix: event delete and restSearchExport fail when MISP.use_uuids_in_urls = true

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -3709,7 +3709,7 @@ class EventsController extends AppController
                 $this->redirect(array('action' => 'index'));
             }
         } else {
-            $eventList = is_numeric($id) ? [$id] : $this->_jsonDecode($id);
+            $eventList = (is_numeric($id) || Validation::uuid($id)) ? [$id] : $this->_jsonDecode($id);
             $this->request->data['Event']['id'] = json_encode($eventList);
             $this->set('idArray', $eventList);
             $this->layout = false;
@@ -4224,7 +4224,7 @@ class EventsController extends AppController
                 'yara-json' => __('YARA rules (JSON)'),
             ];
 
-            $idList = is_numeric($id) ? [$id] : $this->_jsonDecode($id);
+            $idList = (is_numeric($id) || Validation::uuid($id)) ? [$id] : $this->_jsonDecode($id);
             if (empty($idList)) {
                 throw new NotFoundException(__('Invalid input.'));
             }


### PR DESCRIPTION
## Summary

Fixes #10631 — Event deletion (and rest search export) from the UI fails with `405 / Invalid JSON input` when `MISP.use_uuids_in_urls` is set to `true`.

## Root Cause

When `MISP.use_uuids_in_urls` is enabled, the UI sends UUIDs instead of numeric IDs in URL paths. The JavaScript calls `GET /events/delete/<uuid>` to load the delete confirmation popup.

In `EventsController::delete()`, the GET branch (which renders the confirmation form) had:

```php
$eventList = is_numeric($id) ? [$id] : $this->_jsonDecode($id);
