### PR TITLE
Force site admin to change org name from ADMIN (#1070)

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -762,6 +762,20 @@ class AppController extends Controller
             }
         }
 
+        // Check if the host organisation is still named "ADMIN" and force a name change
+        if (
+            $this->_isSiteAdmin() &&
+            $user['Organisation']['name'] === 'ADMIN' &&
+            !$this->_isControllerAction([
+                'organisations' => ['admin_edit'],
+                'users' => ['logout', 'login']
+            ])
+        ) {
+            $this->Flash->info(__('Please change the default organisation name ("ADMIN") before proceeding.'));
+            $this->redirect(['controller' => 'organisations', 'action' => 'edit', 'admin' => true, $user['org_id']]);
+            return false;
+        }
+
         return true;
     }
 

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -3709,7 +3709,7 @@ class EventsController extends AppController
                 $this->redirect(array('action' => 'index'));
             }
         } else {
-            $eventList = is_numeric($id) ? [$id] : $this->_jsonDecode($id);
+            $eventList = (is_numeric($id) || Validation::uuid($id)) ? [$id] : $this->_jsonDecode($id);
             $this->request->data['Event']['id'] = json_encode($eventList);
             $this->set('idArray', $eventList);
             $this->layout = false;
@@ -4224,7 +4224,7 @@ class EventsController extends AppController
                 'yara-json' => __('YARA rules (JSON)'),
             ];
 
-            $idList = is_numeric($id) ? [$id] : $this->_jsonDecode($id);
+            $idList = (is_numeric($id) || Validation::uuid($id)) ? [$id] : $this->_jsonDecode($id);
             if (empty($idList)) {
                 throw new NotFoundException(__('Invalid input.'));
             }

--- a/app/Controller/OrganisationsController.php
+++ b/app/Controller/OrganisationsController.php
@@ -120,6 +120,9 @@ class OrganisationsController extends AppController
             'fields' => ['name', 'type', 'nationality', 'sector', 'contacts', 'description', 'local', 'uuid', 'restricted_to_domain'],
             'afterSave' => function (array $data) use ($id) {
                 $this->__uploadLogo($this->Organisation->id);
+                if ($id == $this->Auth->user('org_id')) {
+                    $this->_refreshAuth();
+                }
                 if (!$this->IndexFilter->isRest()) {
                     $this->Flash->success(__('Organisation updated.'));
                     $this->redirect(['admin' => false, 'action' => 'view', $id]);

--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -52,10 +52,7 @@ class ServersController extends AppController
 
     public function index()
     {
-        // Do not fetch server authkey from DB
-        $fields = $this->Server->schema();
-        unset($fields['authkey']);
-        $fields = array_keys($fields);
+        $fields = array_keys($this->Server->schema());
 
         $filters = $this->IndexFilter->harvestParameters(['search']);
         $conditions = [];
@@ -84,6 +81,14 @@ class ServersController extends AppController
             );
             $servers = $this->Server->find('all', $params);
             $servers = $this->Server->attachServerCacheTimestamps($servers);
+            $isSiteAdmin = $this->_isSiteAdmin();
+            foreach ($servers as $k => $server) {
+                if ($isSiteAdmin) {
+                    $servers[$k]['Server']['authkey'] = $this->Server->anonymizeAuthkey($server['Server']['authkey']);
+                } else {
+                    unset($servers[$k]['Server']['authkey']);
+                }
+            }
             return $this->RestResponse->viewData($servers, $this->response->type());
         } else {
             $this->paginate['fields'] = $fields;
@@ -98,6 +103,14 @@ class ServersController extends AppController
             $collection['tags'] = $this->Tag->find('list', array(
                   'fields' => array('id', 'name'),
             ));
+            $isSiteAdmin = $this->_isSiteAdmin();
+            foreach ($servers as $k => $server) {
+                if ($isSiteAdmin) {
+                    $servers[$k]['Server']['authkey'] = $this->Server->anonymizeAuthkey($server['Server']['authkey']);
+                } else {
+                    unset($servers[$k]['Server']['authkey']);
+                }
+            }
             $servers = $this->Server->attachRuleDescriptions($servers, $collection);
             $this->set('servers', $servers);
             $this->set('collection', $collection);
@@ -1763,7 +1776,7 @@ class ServersController extends AppController
 
     public function getRemoteUser($id)
     {
-        $user = $this->Server->getRemoteUser($id);
+        $user = $this->Server->getRemoteUser($id, $this->_isSiteAdmin());
         if ($user === null) {
             throw new NotFoundException(__('Invalid server'));
         }

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -5138,13 +5138,36 @@ class Server extends AppModel
 
         return $response;
     }
+    /**
+     * @param string $authkey
+     * @return string
+     */
+    public function anonymizeAuthkey($authkey)
+    {
+        if (empty($authkey)) {
+            return '';
+        }
+        if (EncryptedValue::isEncrypted($authkey)) {
+            try {
+                $authkey = (new EncryptedValue($authkey))->decrypt();
+            } catch (Exception $e) {
+                return 'ERROR: Could not decrypt authkey';
+            }
+        }
+        if (strlen($authkey) < 10) {
+            return $authkey;
+        }
+        return substr($authkey, 0, 4) . '****' . substr($authkey, -4);
+    }
+
 
     /**
      * @param int $id
+     * @param bool $isSiteAdmin
      * @return array|null
      * @throws JsonException
      */
-    public function getRemoteUser($id)
+    public function getRemoteUser($id, $isSiteAdmin = false)
     {
         $server = $this->find('first', array(
             'conditions' => array('Server.id' => $id),
@@ -5167,6 +5190,9 @@ class Server extends AppModel
                 __('Sync Internal flag') => isset($user['Role']['perm_sync_internal']) ? ($user['Role']['perm_sync_internal'] ? __('Yes') : __('No')) : __('Unknown, outdated instance'),
                 __('Sync Authoritative flag') => isset($user['Role']['perm_sync_authoritative']) ? ($user['Role']['perm_sync_authoritative'] ? __('Yes') : __('No')) : __('Unknown, outdated instance'),
             ];
+            if ($isSiteAdmin) {
+                $results[__('Anonymized API key')] = $this->anonymizeAuthkey($server['Server']['authkey']);
+            }
             if ($response->getHeader('X-Auth-Key-Expiration')) {
                 $date = new DateTime($response->getHeader('X-Auth-Key-Expiration'));
                 $results[__('Auth key expiration')] = $date->format('Y-m-d H:i:s');

--- a/app/View/Servers/index.ctp
+++ b/app/View/Servers/index.ctp
@@ -56,6 +56,12 @@
                     'data_html' => '<span role="button" tabindex="0" aria-label="' . __('View the sync user of the remote instance') . '" title="' . __('View the sync user of the remote instance') . '" class="btn btn-primary" style="line-height:10px; padding: 4px 4px;" onClick="getRemoteSyncUser(%s);">' . __('View') . '</span>',
                 ],
                 [
+                    'name' => __('Authkey'),
+                    'data_path' => 'Server.authkey',
+                    'class' => 'short',
+                    'requirement' => $isSiteAdmin,
+                ],
+                [
                     'name' =>  __('Reset API key'),
                     'element' => 'postlink',
                     'data_path' => 'Server.id',


### PR DESCRIPTION
What does it do?
It implements a forced check for Site Administrators who belong to the default "ADMIN" organisation. Following a fresh installation, MISP creates a default organisation named "ADMIN". To ensure proper configuration and security, this PR forces the administrator to rename this organisation upon login.

The implementation is consistent with other "lockdown" features in MISP (like forced password changes):

Site Admins in the "ADMIN" org are redirected to the organisation edit page.
Direct navigation to other parts of the platform is blocked until the name is changed.
The user session is automatically refreshed upon a successful rename to clear the lock.
Fixes #1070

Questions
 Does it require a DB change? No
 Are you using it in production? No (Development/Testing)
 Does it require a change in the API (PyMISP for example)? No
