### PR TITLE
Improve WCAG 2.1 accessibility by adding missing ARIA labels

### DIFF
--- a/app/View/AccessLogs/admin_index.ctp
+++ b/app/View/AccessLogs/admin_index.ctp
@@ -315,13 +315,13 @@
                 </td>
                 <td class="short" data-search="request_method" data-search-value="<?= h($item['AccessLog']['request_method']) ?>">
                     <span title="<?= __("User agent: %s\nRequest ID: %s", h($item['AccessLog']['user_agent']), h($item['AccessLog']['request_id'])) ?>"><?= h($item['AccessLog']['request_method']) ?></span>
-                    <?= in_array($item['AccessLog']['request_method'], ['POST', 'PUT']) ? ' <a href="#" class="far fa-file request" title="' . __('Show HTTP request') . '" data-log-id="' . h($item['AccessLog']['id']) . '"></i>' : '' ?>
+                    <?= in_array($item['AccessLog']['request_method'], ['POST', 'PUT']) ? ' <a href="#" class="far fa-file request" title="' . __('Show HTTP request') . '" aria-label="' . __('Show HTTP request') . '" data-log-id="' . h($item['AccessLog']['id']) . '"></a>' : '' ?>
                 </td>
                 <td class="short" data-search="controller:action" data-search-value="<?= h($item['AccessLog']['controller']) . ':' . h($item['AccessLog']['action']) ?>" title="<?= __('Controller: %s, action: %s', h($item['AccessLog']['controller']), h($item['AccessLog']['action'])) ?>"><?= h($item['AccessLog']['url']) ?></td>
                 <td class="short" data-search="response_code" data-search-value="<?= h($item['AccessLog']['response_code']) ?>"><?= h($item['AccessLog']['response_code']) ?></td>
                 <td class="short"><?= CakeNumber::toReadableSize($item['AccessLog']['memory_usage']) ?></td>
                 <td class="short"><?= $item['AccessLog']['duration'] ?> ms</td>
-                <td class="short"><?= $item['AccessLog']['query_count'] . ($item['AccessLog']['has_query_log'] ? ' <a href="#" class="fas fa-database query-log" title="' . __('Show SQL queries') . '" data-log-id="' . h($item['AccessLog']['id']) . '"></i>' : '') ?>
+                <td class="short"><?= $item['AccessLog']['query_count'] . ($item['AccessLog']['has_query_log'] ? ' <a href="#" class="fas fa-database query-log" title="' . __('Show SQL queries') . '" aria-label="' . __('Show SQL queries') . '" data-log-id="' . h($item['AccessLog']['id']) . '"></a>' : '') ?>
                 </td>
             </tr>
         <?php endforeach; ?>
@@ -380,4 +380,3 @@
     });
 </script>
 <?= $this->element('/genericElements/SideMenu/side_menu', ['menuList' => 'logs', 'menuItem' => 'listAccessLogs']);
-

--- a/app/View/Elements/genericElements/SingleViews/Fields/alignmentField.ctp
+++ b/app/View/Elements/genericElements/SingleViews/Fields/alignmentField.ctp
@@ -11,13 +11,15 @@ if (!empty($field['path'])) {
 if ($field['scope'] === 'individuals') {
     foreach ($extracted['alignments'] as $alignment) {
         $alignments .= sprintf(
-            '<div><span class="font-weight-bold">%s</span> @ %s <a href="#" class="fas fa-trash" onClick="%s"></a></div>',
+            '<div><span class="font-weight-bold">%s</span> @ %s <a href="#" class="fas fa-trash" title="%s" aria-label="%s" onClick="%s"></a></div>',
             h($alignment['type']),
             sprintf(
                 '<a href="/organisations/view/%s">%s</a>',
                 h($alignment['organisation']['id']),
                 h($alignment['organisation']['name'])
             ),
+            __('Delete alignment'),
+            __('Delete alignment'),
             sprintf(
                 "populateAndLoadModal(%s);",
                 sprintf(
@@ -30,13 +32,15 @@ if ($field['scope'] === 'individuals') {
 } else if ($field['scope'] === 'organisations') {
     foreach ($extracted['alignments'] as $alignment) {
         $alignments .= sprintf(
-            '<div>[<span class="font-weight-bold">%s</span>] %s <a href="#" class="fas fa-trash" onClick="%s"></a></div>',
+            '<div>[<span class="font-weight-bold">%s</span>] %s <a href="#" class="fas fa-trash" title="%s" aria-label="%s" onClick="%s"></a></div>',
             h($alignment['type']),
             sprintf(
                 '<a href="/individuals/view/%s">%s</a>',
                 h($alignment['individual']['id']),
                 h($alignment['individual']['email'])
             ),
+            __('Delete alignment'),
+            __('Delete alignment'),
             sprintf(
                 "populateAndLoadModal(%s);",
                 sprintf(

--- a/app/View/Helper/PivotHelper.php
+++ b/app/View/Helper/PivotHelper.php
@@ -51,7 +51,7 @@ class PivotHelper extends AppHelper
 
         $data[] = '<span class="' . $pivotSpanType . '">';
         if ($pivot['deletable']) {
-            $data[] = '<a class="pivotDelete fa fa-times" href="' . h(Configure::read('MISP.baseurl')) . '/events/removePivot/' . $pivot['id'] . '/' . $currentEventId . '" title="' . __('Remove pivot') . '"></a>';
+            $data[] = '<a class="pivotDelete fa fa-times" href="' . h(Configure::read('MISP.baseurl')) . '/events/removePivot/' . $pivot['id'] . '/' . $currentEventId . '" title="' . __('Remove pivot') . '" aria-label="' . __('Remove pivot') . '"></a>';
         }
         $data[] = '<a class="' . $pivotType . '" href="' . h(Configure::read('MISP.baseurl')) . '/events/view/' . $pivot['id'] . '/1/' . $currentEventId . '" title="' . $info . ' (' . $pivot['date'] . ')">' . $text . '</a>';
         $data[] = '</span>';

--- a/app/View/SharingGroupBlueprints/index.ctp
+++ b/app/View/SharingGroupBlueprints/index.ctp
@@ -62,7 +62,9 @@
                                         h($row['SharingGroup']['id']),
                                         h($row['SharingGroup']['name']),
                                         sprintf(
-                                            '<a href="#" class="black fas fa-trash" onClick="openGenericModal(\'%s/sharing_group_blueprints/detach/%s\');"></a>',
+                                            '<a href="#" class="black fas fa-trash" title="%s" aria-label="%s" onClick="openGenericModal(\'%s/sharing_group_blueprints/detach/%s\');"></a>',
+                                            __('Detach sharing group'),
+                                            __('Detach sharing group'),
                                             $baseurl,
                                             h($row['SharingGroupBlueprint']['id'])
                                         )

--- a/app/View/Users/accept_registrations.ctp
+++ b/app/View/Users/accept_registrations.ctp
@@ -7,7 +7,7 @@
             $suggestedOrgText = '<br />&nbsp;&nbsp;<span class="bold red">' . __('Conflicting requirements') . '</span>';
         } else if ($suggestedOrg === -1){
             $suggestedOrgText = sprintf(
-                '<span class="red">%s%s%s</span>%s <a href="%s/admin/organisations/add%s%s%s" class="black fas fa-plus" title="%s"></a>',
+                '<span class="red">%s%s%s</span>%s <a href="%s/admin/organisations/add%s%s%s" class="black fas fa-plus" title="%s" aria-label="%s"></a>',
                 (empty($registration['Inbox']['data']['org_name']) && empty($registration['Inbox']['data']['org_uuid'])) ? h($domain) . ' ' : '',
                 empty($registration['Inbox']['data']['org_name']) ? '' : h($registration['Inbox']['data']['org_name']) . ' ',
                 empty($registration['Inbox']['data']['org_uuid']) ? '' : h($registration['Inbox']['data']['org_uuid']) . ' ',
@@ -16,6 +16,7 @@
                 (empty($registration['Inbox']['data']['org_name']) && empty($registration['Inbox']['data']['org_uuid'])) ? '/name:' . h($domain) : '',
                 empty($registration['Inbox']['data']['org_name']) ? '' : '/name:' . h($registration['Inbox']['data']['org_name']),
                 empty($registration['Inbox']['data']['org_uuid']) ? '' : '/uuid:' . h($registration['Inbox']['data']['org_uuid']),
+                __('Create a new organisation'),
                 __('Create a new organisation')
             );
         } else {

--- a/app/View/Users/view.ctp
+++ b/app/View/Users/view.ctp
@@ -23,9 +23,10 @@ $tableData = [
     array(
         'key' => __('Email'),
         'html' => h($user['User']['email']) . ($admin_view ? sprintf(
-                ' <a class="fas fa-envelope" style="color: #333" href="%s/admin/users/quickEmail/%s" title="%s"></a>',
+                ' <a class="fas fa-envelope" style="color: #333" href="%s/admin/users/quickEmail/%s" title="%s" aria-label="%s"></a>',
                 $baseurl,
                 h($user['User']['id']),
+                __('Send email to user'),
                 __('Send email to user')
             ) : ''),
     ),
@@ -119,12 +120,13 @@ $org_admin_data = array();
 if ($admin_view) {
     foreach ($user['User']['orgAdmins'] as $orgAdminId => $orgAdminEmail) {
         $org_admin_data[] = sprintf(
-            '<a href="%s/admin/users/view/%s">%s</a> <a class="fas fa-envelope" style="color: #333" href="%s/admin/users/quickEmail/%s" title="%s"></a>',
+            '<a href="%s/admin/users/view/%s">%s</a> <a class="fas fa-envelope" style="color: #333" href="%s/admin/users/quickEmail/%s" title="%s" aria-label="%s"></a>',
             $baseurl,
             h($orgAdminId),
             h($orgAdminEmail),
             $baseurl,
             h($orgAdminId),
+            __('Send email to user'),
             __('Send email to user')
         );
     }


### PR DESCRIPTION
### Motivation
- Icon-only interactive controls across several views lacked accessible names, which prevents assistive technologies from conveying control purpose and hinders WCAG 2.1 conformance.
- A short targeted pass was made to ensure non-text controls expose programmatic names and to correct a small HTML issue in access-log icons.

### Description
- Added `aria-label` to icon-only anchor/button controls to provide an accessible name in these files: `app/View/Helper/PivotHelper.php`, `app/View/Users/view.ctp`, `app/View/Users/accept_registrations.ctp`, `app/View/SharingGroupBlueprints/index.ctp`, `app/View/Elements/genericElements/SingleViews/Fields/alignmentField.ctp`, and `app/View/AccessLogs/admin_index.ctp`.
- Added missing `title` attributes where appropriate to align with existing patterns and ensure consistent hover text.
- Corrected malformed closing tags in the access-log icon links (converted stray `</i>` fragments to proper anchor closing) while applying ARIA updates.
- Kept changes minimal and localized to presentation/view code so behavior is unchanged for sighted users.

### Testing
- Searched for icon-only font-awesome anchors missing `aria-label` with `rg` to locate targets and rechecked after changes using `rg -nP '<a(?:(?!aria-label).)*class="[^"]*fa[^"]*"' app/View`.
- Performed PHP syntax checks on all modified files with `php -l` for each modified view/helper, and all reported "No syntax errors detected".
- Verified the modified view files are consistent and the small HTML fixes removed malformed closing tags; no runtime code changes were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e21d9d70e88324bc75e4c9c96b370a)