### PR TITLE
add: support for memberOf type query in LdapAuth plugin

### DIFF
--- a/app/Plugin/LdapAuth/Controller/Component/Auth/LdapAuthenticate.php
+++ b/app/Plugin/LdapAuth/Controller/Component/Auth/LdapAuthenticate.php
@@ -50,6 +50,7 @@ class LdapAuthenticate extends BaseAuthenticate
             'ldapTlsProtocolMin' => Configure::read('LdapAuth.ldapTlsProtocolMin') ?? LDAP_OPT_X_TLS_PROTOCOL_TLS1_2,
             'ldapEscape' => Configure::read('LdapAuth.ldapEscape') ?? false,
             'ldapEscapeIgnoreChars' => Configure::read('LdapAuth.ldapEscapeIgnoreChars') ?? "",
+            'ldapUseMemberOf' => Configure::read('LdapAuth.ldapUseMemberOf') ?? false,
         ];
 
         if (self::$conf['ldapEscape'] && self::$conf['ldapSearchFilter']) {
@@ -120,8 +121,12 @@ class LdapAuthenticate extends BaseAuthenticate
 
     private function getUserMemberships($ldapconn, $ldapUserData)
     {
+        if (self::$conf['ldapUseMemberOf']) {
+            return $this->getUserMembershipsFromMemberOf($ldapconn, $ldapUserData);
+        }
+
         $groups = [];
-        if (Configure::read('LdapAuth.ldapEscape')) {
+        if (self::$conf['ldapEscape']) {
             $ldapUserData[0]['dn'] = ldap_escape($ldapUserData[0]['dn'], self::$conf['ldapEscapeIgnoreChars'], LDAP_ESCAPE_FILTER);
         }
         $filter = '(member=' . $ldapUserData[0]['dn'] . ')';
@@ -136,6 +141,29 @@ class LdapAuthenticate extends BaseAuthenticate
             }
         }
 
+        return $groups;
+    }
+
+    // Reads the user's `memberOf` attribute directly (AD-style lookup).
+    // Returns full group DNs, so ldapDefaultRoleId keys must be DNs when this path is enabled.
+    private function getUserMembershipsFromMemberOf($ldapconn, $ldapUserData)
+    {
+        $groups = [];
+        $userDn = $ldapUserData[0]['dn'];
+        $result = ldap_read($ldapconn, $userDn, '(objectClass=*)', ['memberOf']);
+        if (!$result) {
+            CakeLog::error("[LdapAuth] LDAP memberOf read failed: " . ldap_error($ldapconn));
+            return $groups;
+        }
+
+        $entries = ldap_get_entries($ldapconn, $result);
+        if (empty($entries[0]['memberof']['count'])) {
+            return $groups;
+        }
+
+        for ($i = 0; $i < $entries[0]['memberof']['count']; $i++) {
+            $groups[] = $entries[0]['memberof'][$i];
+        }
         return $groups;
     }
 
@@ -272,10 +300,16 @@ class LdapAuthenticate extends BaseAuthenticate
                 }
             }
 
-            // Disable user if no valid role is found
-            if ($user && !$roleId) {
-                CakeLog::debug("[LdapAuth] User has no valid role anymore, disabling user.");
-                $this->disableUser($mispUsername);
+            // Refuse login when no mapped role matches the user's groups.
+            // For existing users we also disable the account; for new users we just refuse
+            // so we never hit the INSERT with a NULL role_id.
+            if (!$roleId) {
+                if ($user) {
+                    CakeLog::debug("[LdapAuth] User has no valid role anymore, disabling user.");
+                    $this->disableUser($mispUsername);
+                } else {
+                    CakeLog::error("[LdapAuth] No matching role for user's LDAP groups, refusing login.");
+                }
                 throw new UnauthorizedException(__('User could not be authenticated by LDAP.'));
             }
         } else {

--- a/app/Plugin/LdapAuth/README.md
+++ b/app/Plugin/LdapAuth/README.md
@@ -170,6 +170,12 @@ Each setting is stored in the `LdapAuth` configuration array and can be customiz
 - **Default**: `""`
 - **Example**: `" "`
 
+### `ldapUseMemberOf`
+- **Description**: When enabled, group membership is resolved by reading the `memberOf` attribute directly from the user entry instead of searching for groups whose `member` attribute contains the user DN. Recommended for Microsoft Active Directory. When enabled, keys in `ldapDefaultRoleId` must be the full group DN (e.g. `CN=MISP Admins,OU=Groups,DC=example,DC=com`) rather than the group CN.
+- **Type**: `boolean`
+- **Default**: `false`
+- **Example**: `true`
+
 
 ## Example Usage
 


### PR DESCRIPTION
#### What does it do?

add new LdapAuth setting `ldapUseMemberOf` for an alternative method of querying ldap based on `ldap_read/memberOf` instead of `ldap_search`.

fixes https://github.com/MISP/MISP/issues/10633


#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
