### PR TITLE
fix(openioc): export suricata attributes using Suricata indicator type

### DIFF
--- a/app/Lib/Export/OpeniocExport.php
+++ b/app/Lib/Export/OpeniocExport.php
@@ -29,7 +29,7 @@ class OpeniocExport
             'user-agent' => array('Network', 'Network/UserAgent', 'string'),
             'regkey' => array('Network', 'RegistryItem/KeyPath', 'string'),
             'snort' => array('Snort', 'Snort/Snort', 'string'),
-            'suricata' => array('Snort', 'Snort/Snort', 'string'),
+            'suricata' => array('Suricata', 'Suricata/Suricata', 'string'),
             'attachment' => array('FileItem', 'FileItem/FileName', 'string'),
             'link' => array('URL', 'UrlHistoryItem/URL', 'md5')
         )

--- a/app/Lib/Tools/IOCExportTool.php
+++ b/app/Lib/Tools/IOCExportTool.php
@@ -96,7 +96,7 @@ class IOCExportTool
                 'user-agent' => array('Network', 'Network/UserAgent', 'string'),
                 'regkey' => array('Network', 'RegistryItem/KeyPath', 'string'),
                 'snort' => array('Snort', 'Snort/Snort', 'string'),
-                'suricata' => array('Snort', 'Snort/Snort', 'string'),
+                'suricata' => array('Suricata', 'Suricata/Suricata', 'string'),
                 'attachment' => array('FileItem', 'FileItem/FileName', 'string'),
                 'link' => array('URL', 'UrlHistoryItem/URL', 'md5')
         )


### PR DESCRIPTION
### Motivation
- The `suricata` attribute type was exported as `Snort/Snort` in OpenIOC exports, which mismatches the importer and can break round-trip export/import and tests that expect a `Suricata/Suricata` indicator path. 

### Description
- Update `app/Lib/Export/OpeniocExport.php` to emit `suricata` attributes as `('Suricata', 'Suricata/Suricata', 'string')` instead of `('Snort', 'Snort/Snort', 'string')`.
- Apply the same mapping fix in `app/Lib/Tools/IOCExportTool.php` to keep both IOC export codepaths consistent.
- No other behavioral changes were made; mappings for `snort` remain unchanged and the import-side handling already supports `Suricata/Suricata`.

### Testing
- Ran `php -l app/Lib/Export/OpeniocExport.php` and it reported no syntax errors.
- Ran `php -l app/Lib/Tools/IOCExportTool.php` and it reported no syntax errors.
- No additional automated test suites were executed in this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec671ccf648324b29a167e62de0ab4)