### PR TITLE
fix: [ACLComponent] make canModifyWarninglist return true for roles w…

### DIFF
--- a/app/Controller/Component/ACLComponent.php
+++ b/app/Controller/Component/ACLComponent.php
@@ -1349,8 +1349,8 @@ class ACLComponent extends Component
         if (!empty($user['Role']['perm_site_admin'])) {
             return true;
         }
-        if (!$user['Role']['perm_warninglist']) {
-            return false;
+        if (!empty($user['Role']['perm_warninglist'])) {
+            return true;
         }
         return false;
     }


### PR DESCRIPTION
…ith perm_warninglist

#### What does it do?

Without this change, the edit button doesn't show up on /warnignlists/view/<id> page with overmind theme, for people with perm_warninglist

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
