### PR TITLE
fix: implement includeEventUuid for API /objects/restSearch endpoint

### DIFF
--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -637,6 +637,9 @@ class MispObject extends AppModel
             } else {
                 $fields = array_merge($fields, array('Event.distribution', 'Event.id', 'Event.user_id', 'Event.orgc_id', 'Event.org_id'));
             }
+            if (!empty($options['includeEventUuid']) && !in_array('Event.uuid', $fields)) {
+                $fields[] = 'Event.uuid';
+            }
             $params = array(
                 'fields' => $fields,
                 'conditions' => $this->buildConditions($user),
@@ -662,12 +665,18 @@ class MispObject extends AppModel
                 ),
             );
         } else {
+            $eventFields = isset($options['contain']['Event']['fields'])
+                ? $options['contain']['Event']['fields']
+                : array('id', 'info', 'org_id', 'orgc_id');
+            if (!empty($options['includeEventUuid']) && !in_array('uuid', $eventFields)) {
+                $eventFields[] = 'uuid';
+            }
             $params = array(
                 'conditions' => $this->buildConditions($user),
                 'recursive' => -1,
                 'contain' => array(
                     'Event' => array(
-                        'fields' => isset($options['contain']['Event']['fields']) ? $options['contain']['Event']['fields'] : array('id', 'info', 'org_id', 'orgc_id'),
+                        'fields' => $eventFields,
                     ),
                     'Attribute' => array(
                         'conditions' => $attributeConditions,
@@ -744,6 +753,11 @@ class MispObject extends AppModel
         $results = $this->find('all', $params);
         if ($options['enforceWarninglist'] && !isset($this->Warninglist)) {
             $this->Warninglist = ClassRegistry::init('Warninglist');
+        }
+        if (!empty($options['includeEventUuid'])) {
+            foreach ($results as $key => $object) {
+                $results[$key]['Object']['event_uuid'] = $object['Event']['uuid'];
+            }
         }
         $proposals_block_attributes = Configure::read('MISP.proposals_block_attributes');
         if (empty($options['metadata'])) {


### PR DESCRIPTION
#### What does it do?

The includeEventUuid parameter was accepted and passed through restSearch() into fetchObjects() but fetchObjects() never fetched Event.uuid from the database and never injected event_uuid into the Object output.

Fix DB query paths to include Event.uuid when includeEventUuid is requested, then inject Object.event_uuid from Event.uuid in a post-fetch pass that runs regardless of the metadata flag, mirroring the existing behaviour in MispAttribute::fetchAttributes().

Basically I fixed the stub implementation of this in the objects controller.

#### Questions

- [ ] Does it require a DB change?
No

- [ ] Are you using it in production?
I'm having to make a second call in production to get the event uuid.

- [X] Does it require a change in the API (PyMISP for example)?
kinda, it's already in the spec definition, it just didn't work.  `include_event_uuid` and `includeEventUuid` both exist in the spec definition right now, and `include_event_uuid` just maps to `includeEventUuuid`, so even though legacy will also work now.

```
davidz@ocp:~/stuff/misp-docker$ curl -k -s -H "Authorization: cq1qrY9Dw7B60zPssL43gw9V3kkwbDlbLCbFjdWw" -H "Accept: application/json" -H "Content-Type: application/json" -X POST https://localhost/objects/restSearch -d '{"returnFormat": "json", "includeEventUuid": 1, "limit": 5}'|jq .
```

Before:
```
{
  "response": [
    {
      "Object": {
        "id": "1",
        "name": "file",
        "meta-category": "file",
        "description": "File object describing a file with meta-information",
        "template_uuid": "688c46fb-5edb-40a3-8273-1af7923e2215",
        "template_version": "25",
        "event_id": "1",
        "uuid": "7efd422c-6099-40b1-868e-f494ad93d9c5",
        "timestamp": "1777937653",
        "distribution": "5",
        "sharing_group_id": "0",
        "comment": "",
        "deleted": false,
        "first_seen": null,
        "last_seen": null,
        "Attribute": [
          {
            "id": "14497",
            "event_id": "1",
            "object_id": "1",
            "object_relation": "filename",
            "category": "Payload delivery",
            "type": "filename",
            "value1": "lol.bat",
            "value2": "",
            "to_ids": true,
            "uuid": "39923de3-796c-40a3-929e-e4ea37300403",
            "timestamp": "1777937653",
            "distribution": "5",
            "sharing_group_id": "0",
            "comment": "",
            "deleted": false,
            "disable_correlation": true,
            "first_seen": null,
            "last_seen": null,
            "value": "lol.bat",
            "AttributeTag": []
          }
        ],
        "Event": {
          "distribution": "1",
          "id": "1",
          "user_id": "1",
          "orgc_id": "1",
          "org_id": "1"
        }
      }
    }
  ]
}
```

After:
```
{
  "response": [
    {
      "Object": {
        "id": "1",
        "name": "file",
        "meta-category": "file",
        "description": "File object describing a file with meta-information",
        "template_uuid": "688c46fb-5edb-40a3-8273-1af7923e2215",
        "template_version": "25",
        "event_id": "1",
        "uuid": "7efd422c-6099-40b1-868e-f494ad93d9c5",
        "timestamp": "1777937653",
        "distribution": "5",
        "sharing_group_id": "0",
        "comment": "",
        "deleted": false,
        "first_seen": null,
        "last_seen": null,
        "event_uuid": "077212c3-70c7-4357-9fbe-428f610786ea",
        "Attribute": [
          {
            "id": "14497",
            "event_id": "1",
            "object_id": "1",
            "object_relation": "filename",
            "category": "Payload delivery",
            "type": "filename",
            "value1": "lol.bat",
            "value2": "",
            "to_ids": true,
            "uuid": "39923de3-796c-40a3-929e-e4ea37300403",
            "timestamp": "1777937653",
            "distribution": "5",
            "sharing_group_id": "0",
            "comment": "",
            "deleted": false,
            "disable_correlation": true,
            "first_seen": null,
            "last_seen": null,
            "value": "lol.bat",
            "AttributeTag": []
          }
        ],
        "Event": {
          "distribution": "1",
          "id": "1",
          "user_id": "1",
          "orgc_id": "1",
          "org_id": "1",
          "uuid": "077212c3-70c7-4357-9fbe-428f610786ea"
        }
      }
    }
  ]
}
```
