### PR TITLE
fix: [Collections] correct typo preventing users belonging to the cre…

### DIFF
--- a/app/Model/Collection.php
+++ b/app/Model/Collection.php
@@ -110,10 +110,10 @@ class Collection extends AppModel
             return false;
         }
         if (!empty($user['Role']['perm_modify_org'])) {
-            if ($user['org_id'] == $collection['Collection']['Orgc_id']) {
+            if ($user['org_id'] == $collection['Collection']['orgc_id']) {
                 return true;
             }
-            if ($user['Role']['perm_sync'] && $user['org_id'] == $collection['Collection']['Org_id']) {
+            if ($user['Role']['perm_sync'] && $user['org_id'] == $collection['Collection']['org_id']) {
                 return true;
             }            
         }

--- a/app/Model/CollectionElement.php
+++ b/app/Model/CollectionElement.php
@@ -85,10 +85,10 @@ class CollectionElement extends AppModel
             return false;
         }
         if (!empty($user['Role']['perm_modify_org'])) {
-            if ($user['org_id'] == $collection['Collection']['Orgc_id']) {
+            if ($user['org_id'] == $collection['Collection']['orgc_id']) {
                 return true;
             }
-            if ($user['Role']['perm_sync'] && $user['org_id'] == $collection['Collection']['Org_id']) {
+            if ($user['Role']['perm_sync'] && $user['org_id'] == $collection['Collection']['org_id']) {
                 return true;
             }            
         }


### PR DESCRIPTION
…ating/syncing user's org, from modifying data

#### What does it do?

These typos prevented users from the same organization as the creator, that were not the creator, from editing data.
Something similar for sync users, but that part I didn't test/verify. I don't think collections even sync yet though.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
