### PR TITLE
fix: [Attributes:addTag] allow adding multiple tags at once with list…

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -2698,7 +2698,7 @@ class AttributesController extends AppController
                             } else if(is_numeric($tag_id)){
                                 $tag_id_list[] = $tag_id;
                             } else {
-                                $tagId = $this->Attribute->AttributeTag->Tag->lookupTagIdForUser($this->Auth->user(), trim($tag_id));
+                                $tagId = $this->MispAttribute->AttributeTag->Tag->lookupTagIdForUser($this->Auth->user(), trim($tag_id));
                                 if (empty($tagId)) {
                                     return new CakeResponse(array('body'=> json_encode(array('saved' => false, 'errors' => 'Invalid Tag.')), 'status'=>200, 'type' => 'json'));
                                 }


### PR DESCRIPTION
… of tag strings

#### What does it do?

I suppose this was merged from a fix originally done on 2.4, and didn't have the MispAttribute update

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
