### PR TITLE
fix: [Warninglist:enableWarninglist] return 'Warninglist disabled' in…

### DIFF
--- a/app/Controller/WarninglistsController.php
+++ b/app/Controller/WarninglistsController.php
@@ -378,7 +378,7 @@ class WarninglistsController extends AppController
         }
         $this->Warninglist->saveField('enabled', $enable);
         $this->Warninglist->regenerateWarninglistCaches($id);
-        if ($enable === 0) {
+        if ($enable === 0 || $enable === '0') {
             $this->Flash->success(__('Warninglist disabled'));
         }
         else {


### PR DESCRIPTION
… flash message when warninglist is disabled by passing 0 as url param

#### What does it do?

/warninglists/enableWarninglist/<id>/0 was correctly disabling a warninglist, but returning "Warninglist enabled" in the response.



Note: it is a bit odd that calling /warninglists/enableWarninglist/<id> actually disables a warninglist (enable param is false by default).

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
