### PR TITLE
fix: [AttributeValidationTool] add start anchor to uuid validation regex

### DIFF
--- a/app/Lib/Tools/AttributeValidationTool.php
+++ b/app/Lib/Tools/AttributeValidationTool.php
@@ -638,7 +638,7 @@ class AttributeValidationTool
                 }
                 return __('AS number have to be integer between 1 and 4294967295');
             case 'uuid':
-                return preg_match('/[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$/', $value) === 1;
+                return preg_match('/^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$/', $value) === 1;
             case 'chrome-extension-id':
                 return preg_match('/^[a-p]{32}$/', $value) === 1;
             case 'edge-extension-id':


### PR DESCRIPTION
The UUID validation regex was missing a leading `^` anchor, allowing strings with arbitrary prefixes to pass validation. Added `^` to ensure the full value is matched from the start.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
