### PR TITLE
fix: [Model:ObjectReference] correct 'assignment instead of compariso…

### DIFF
--- a/app/Model/ObjectReference.php
+++ b/app/Model/ObjectReference.php
@@ -177,7 +177,7 @@ class ObjectReference extends AppModel
             } elseif (!empty($data[$side]) && $side == 'referenced') {
                 $referenced_id = $data[$side]['Object']['id'];
                 $referenced_type = 1;
-            } elseif (!empty($data[$side]) && $side = 'object') {
+            } elseif (!empty($data[$side]) && $side == 'object') {
                 $object_id = $data[$side]['Object']['id'];
             } else {
                 return 'Invalid ' . $side . ' uuid';


### PR DESCRIPTION
…n' bug in smartSave()

#### What does it do?
Not 100% sure about impact of the bug and the fix, but does look wrong hence the PR.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
