### PR TITLE
fix: [Bookmarks] use mayView for view() ACL check

### DIFF
--- a/app/Controller/BookmarksController.php
+++ b/app/Controller/BookmarksController.php
@@ -110,7 +110,7 @@ class BookmarksController extends AppController
 
     public function view($id)
     {
-        if (!$this->Bookmark->mayModify($this->Auth->user(), intval($id))) {
+        if (!$this->Bookmark->mayView($this->Auth->user(), intval($id))) {
             throw new MethodNotAllowedException(__('Invalid Bookmark or insufficient privileges'));
         }
         $canSeeUser = false;


### PR DESCRIPTION
#### What does it do?

This has pretty much 0 impact, as org users could still see these properly on index / menu, that's why I'm not flagging it as security fix / reporting that way.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
