### PR TITLE
fix: [ServersController] correct CSP report size validation to 1KB

### DIFF
--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -2330,8 +2330,8 @@ class ServersController extends AppController
             $message .= ' from IP ' . $remoteIp;
         }
         $report = JsonTool::encode($report['csp-report'], true);
-        if (strlen($report) > 1024 * 1024) { // limit report to 1 kB
-            $report = substr($report, 0, 1024 * 1024) . '...';
+        if (strlen($report) > 1024) { // limit report to 1 kB
+            $report = substr($report, 0, 1024) . '...';
         }
         $this->log("$message: $report");
 


### PR DESCRIPTION
#### What does it do?

This PR corrects a mathematical oversight in the `cspReport` validation logic within `ServersController.php`. 

The current implementation contains a typo that sets the maximum size of incoming CSP reports to 1 Megabyte, despite the internal code comments indicating an intended limit of 1 Kilobyte. This discrepancy can lead to significantly larger log files than intended during standard browser telemetry collection.

**Changes:**
- Updated the length check in `app/Controller/ServersController.php` to accurately reflect the 1KB limit.
- Synchronized the `substr()` truncation logic to match the corrected 1KB boundary, ensuring consistent log formatting and resource management.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?