### PR TITLE
fix: [ShadowAttributesController] harden shadow attribute batch creation workflow

### DIFF
--- a/app/Controller/ShadowAttributesController.php
+++ b/app/Controller/ShadowAttributesController.php
@@ -229,6 +229,7 @@ class ShadowAttributesController extends AppController
                 $this->Flash->error(__('Attribute has not been added: attachments are added by "Add attachment" button', true), 'default', array(), 'error');
                 $this->redirect(array('controller' => 'events', 'action' => 'view', $event['Event']['id']));
             }
+            unset($this->request->data['ShadowAttribute']['id']);
             $this->request->data['ShadowAttribute']['event_id'] = $event['Event']['id'];
             //
             // multiple attributes in batch import


### PR DESCRIPTION
#### What does it do?

This PR hardens the batch import logic in `ShadowAttributesController` to ensure data integrity during bulk operations.

Currently, the batch import loop relies on the model instance state to determine if a record is a new entry. This change explicitly clears the `id` field from the request data within the loop. This ensures that the framework consistently treats every item in a batch import as a new proposal (INSERT) rather than accidentally allowing an update (UPDATE) to existing records.

**Changes:**
- Added `unset($this->request->data['ShadowAttribute']['id'])` within the batch processing loop in `ShadowAttributesController::add()`.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?