### PR TITLE
fix: [Feed] correct typos in __filterEventsIndex condition

### DIFF
--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -891,7 +891,7 @@ class Feed extends AppModel
                 unset($events[$k]);
                 continue;
             }
-            if (isset($filterRules['orgs']['NO']) && !empty($filterRules['orgs']['NOT']) && in_array($event['Orgc']['name'], $filterRules['orgs']['OR'])) {
+            if (isset($filterRules['orgs']['NOT']) && !empty($filterRules['orgs']['NOT']) && in_array($event['Orgc']['name'], $filterRules['orgs']['NOT'])) {
                 unset($events[$k]);
                 continue;
             }


### PR DESCRIPTION
#### What does it do?

Untested fix.
Suppose it should make the NOT filtering based on creator org work.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
