### PR TITLE
fix: [security] OIDC authentication bypass under certain insecure IdP…

### DIFF
--- a/app/Plugin/OidcAuth/Controller/Component/Auth/OidcAuthenticate.php
+++ b/app/Plugin/OidcAuth/Controller/Component/Auth/OidcAuthenticate.php
@@ -22,6 +22,8 @@ App::uses('Oidc', 'OidcAuth.Lib');
  *  - OidcAuth.mixedAuth (boolean, default: false) - if enabled, MISP will not automatically redirect to SSO portal and allow other authentication methods
  *  - OidcAuth.disable_request_object (boolean, default: false) Disable the Request Object approach in authorization requests, allowing users to fallback to plain parameters when needed for compatibility with certain OpenID Connect providers.
  *  - OidcAuth.skipProxy (boolean, default: true) - if enabled, MISP will disable global proxy settings for OIDC requests
+ *  - OidcAuth.allow_email_linking (boolean, default: false) - allow OIDC to link to an existing local user (sub IS NULL) by matching the `email` claim. Off by default; enable only when the IdP is trusted to assert ownership of the email claim, otherwise a token holder may take over any local account sharing the email.
+ *  - OidcAuth.require_email_verified (boolean, default: true) - when linking is allowed, also require the token's `email_verified` claim to be true. Disable only on IdPs that do not issue the claim and where ownership of the email is enforced by other means.
  */
 class OidcAuthenticate extends BaseAuthenticate
 {

--- a/app/Plugin/OidcAuth/Lib/Oidc.php
+++ b/app/Plugin/OidcAuth/Lib/Oidc.php
@@ -42,9 +42,29 @@ class Oidc
 
         if (!$user) { // User by sub not found, try to find by email
             $user = $this->_findUser($settings, ['User.email' => $mispUsername]);
-            if ($user && $user['sub'] !== null && $user['sub'] !== $sub) {
-                $this->log($mispUsername, "User sub doesn't match ({$user['sub']} != $sub), could not login.", LOG_ERR);
-                return false;
+            if ($user) {
+                if ($user['sub'] !== null && $user['sub'] !== $sub) {
+                    $this->log($mispUsername, "User sub doesn't match ({$user['sub']} != $sub), could not login.", LOG_ERR);
+                    return false;
+                }
+                if ($user['sub'] === null) {
+                    $allowLink = (bool)$this->getConfig('allow_email_linking', false, false);
+                    $requireVerified = (bool)$this->getConfig('require_email_verified', true, false);
+                    $rawEmailVerified = $claims->email_verified ?? null;
+                    $isVerified = ($rawEmailVerified === true || $rawEmailVerified === 'true');
+                    if (!$allowLink || ($requireVerified && !$isVerified)) {
+                        $this->log(
+                            $mispUsername,
+                            "Refusing to link OIDC identity to existing user with NULL sub " .
+                            "(allow_email_linking=" . var_export($allowLink, true) .
+                            ", require_email_verified=" . var_export($requireVerified, true) .
+                            ", email_verified=" . var_export($rawEmailVerified, true) . "). " .
+                            "Set OidcAuth.allow_email_linking=true to permit migration; the IdP must also issue email_verified=true unless OidcAuth.require_email_verified is set to false.",
+                            LOG_ERR
+                        );
+                        return false;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
#### What does it do?

Prevent automatic account link from IdP with users with a NULL `sub` property with non-verified emails, ensure secure defaults.

> [!WARNING]  
> May break existing OIDC installations with non-secure IdP configurations (no verified email claim).

Credit:     "Discovered by Ali Ganiyev (security researcher)".

#### Questions 

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
