### PR TITLE
Unset client-supplied id in GalaxyClusterRelation::saveRelation

### DIFF
--- a/app/Model/GalaxyClusterRelation.php
+++ b/app/Model/GalaxyClusterRelation.php
@@ -214,6 +214,7 @@ class GalaxyClusterRelation extends AppModel
             $errors[] = $authorizationCheck['error'];
             return $errors;
         }
+        unset($relation['GalaxyClusterRelation']['id']);
         $relation['GalaxyClusterRelation']['galaxy_cluster_uuid'] = $cluster['uuid'];
 
         $existingRelation = $this->find('first', [


### PR DESCRIPTION
### Motivation
- Prevent a client-supplied `id` from influencing save/update semantics in a create-like flow and avoid potential record-overwrite or integrity issues, mirroring the hardening applied for ShadowAttribute handling.

### Description
- Add `unset($relation['GalaxyClusterRelation']['id']);` at the start of `saveRelation()` in `app/Model/GalaxyClusterRelation.php` so incoming payloads cannot force an `id` into the persisted record.

### Testing
- Ran `php -l app/Model/GalaxyClusterRelation.php` to validate PHP syntax and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dfe167eb48324a27e9b94a8937639)