### PR TITLE
Fix Taxii Server view Collections UI element

### DIFF
--- a/app/View/TaxiiServers/view.ctp
+++ b/app/View/TaxiiServers/view.ctp
@@ -61,13 +61,13 @@ echo $this->element(
         ],
         'children' => [
             [
-                'url' => $baseurl . '/taxii_servers/collectionsIndex/{{0}}/',
+                'url' => '/taxii_servers/collectionsIndex/{{0}}/',
                 'url_params' => ['TaxiiServer.id'],
                 'title' => __('Collections'),
                 'elementId' => 'taxii_collections'
             ],
             [
-                'url' => $baseurl . '/taxii_servers/objectsIndex/{{0}}/{{1}}/',
+                'url' => '/taxii_servers/objectsIndex/{{0}}/{{1}}/',
                 'url_params' => ['TaxiiServer.id', 'TaxiiServer.collection'],
                 'title' => __('Objects in selected Collection'),
                 'elementId' => 'taxii_objects'


### PR DESCRIPTION
#### What does it do?

Currently there is a bug in Taxii Server view, selecting collections triggers a malformed request i.e. https://[baseurl]https//[baseurl]/taxii_servers/collectionsIndex/[id]

This PR changes this request to return in the correct format i.e. https://baseurl]/taxii_servers/collectionsIndex/[id] in this view by removing a baseurl prepend in the component definition as this is currently handled in the base Accordion component.

#### Questions

- [ ] Does it require a DB change? No
- [ ] Are you using it in production? No
- [ ] Does it require a change in the API (PyMISP for example)? No
