### PR TITLE
Add selectable cache time window for server attribute caching

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -4888,6 +4888,10 @@ class Server extends AppModel
                     'page' => $i,
                     'limit' => $chunk_size,
                 ];
+                $cacheFilterRules = $this->filterRuleToParameter($server['Server']['pull_rules']);
+                if (!empty($cacheFilterRules['timestamp'])) {
+                    $rules['timestamp'] = $cacheFilterRules['timestamp'];
+                }
                 try {
                     $data = $serverSync->attributeSearch($rules)->body();
                 } catch (Exception $e) {

--- a/app/View/Elements/serverRuleElements/pull.ctp
+++ b/app/View/Elements/serverRuleElements/pull.ctp
@@ -75,7 +75,18 @@
         <div class="bold green">
             <?= __('Additional sync parameters (based on the event index filters)'); ?>
         </div>
-        <div style="display: flex;">
+        <div style="display: flex; flex-direction: column; gap: 6px;">
+            <label for="cachePeriodPreset" style="font-weight: bold; margin: 0;"><?= __('Attribute cache period'); ?></label>
+            <select id="cachePeriodPreset" style="max-width: 340px;">
+                <option value=""><?= __('No period filter'); ?></option>
+                <option value="30d"><?= __('Last 30 days'); ?></option>
+                <option value="90d"><?= __('Last 90 days'); ?></option>
+                <option value="180d"><?= __('Last 6 months'); ?></option>
+                <option value="365d"><?= __('Last year'); ?></option>
+                <option value="730d"><?= __('Last 2 years'); ?></option>
+                <option value="custom"><?= __('Custom / keep manual JSON'); ?></option>
+            </select>
+            <small><?= __('This sets url_params.timestamp in the JSON below, used for cache retrieval when supported.'); ?></small>
             <textarea style="width:100%;" placeholder='{"timestamp": "30d"}' type="text" value="" id="urlParams" data-original-title="" title="" rows="3"><?= !empty($ruleUrlParams) ? json_encode(h($ruleUrlParams), JSON_PRETTY_PRINT) : '' ?></textarea>
         </div>
     </div>
@@ -124,6 +135,10 @@ echo $this->element('genericElements/assetLoader', array(
             addPullFilteringRulesToPicker()
         <?php endif; ?>
         setupCodeMirror()
+        syncCachePeriodPresetFromJson()
+        $('#cachePeriodPreset').on('change', function() {
+            applyCachePeriodPreset($(this).val())
+        })
         <?php if (empty($attributeTypeBlockRules) && empty($objectTypeBlockRules)) : ?>
             $('div.server-rule-container-pull .type-filtering-subcontainer').hide()
         <?php else : ?>
@@ -224,6 +239,44 @@ echo $this->element('genericElements/assetLoader', array(
                 from: CodeMirror.Pos(cur.line, token.start + 1),
                 to: CodeMirror.Pos(cur.line, token.end)
             }
+        }
+
+        function syncCachePeriodPresetFromJson() {
+            var knownPresets = ['30d', '90d', '180d', '365d', '730d']
+            var raw = $('#urlParams').val().trim()
+            if (!raw) {
+                $('#cachePeriodPreset').val('')
+                return
+            }
+            try {
+                var parsed = JSON.parse(raw)
+                if (parsed.timestamp && knownPresets.indexOf(parsed.timestamp) !== -1) {
+                    $('#cachePeriodPreset').val(parsed.timestamp)
+                } else {
+                    $('#cachePeriodPreset').val('custom')
+                }
+            } catch (e) {
+                $('#cachePeriodPreset').val('custom')
+            }
+        }
+
+        function applyCachePeriodPreset(period) {
+            if (!period || period === 'custom') {
+                return
+            }
+            var raw = $('#urlParams').val().trim()
+            var params = {}
+            if (raw) {
+                try {
+                    params = JSON.parse(raw)
+                } catch (e) {
+                    params = {}
+                }
+            }
+            params.timestamp = period
+            var value = JSON.stringify(params, null, 4)
+            cm.setValue(value)
+            $('#urlParams').val(value)
         }
 
         function setupCodeMirror() {


### PR DESCRIPTION
### Motivation
- Remote-server attribute caching can time out when fetching the full attribute set for large instances, so limiting the scope to a recent time window reduces response size and improves reliability. 
- Provide an easy UI for operators to pick common time windows (e.g. last year) instead of requiring manual JSON edits.
- Ensure the selected window is actually applied by the backend when performing attribute-based cache fetches.

### Description
- Added an "Attribute cache period" preset selector above the existing `url_params` JSON editor in the server pull-rule modal (`app/View/Elements/serverRuleElements/pull.ctp`) with options like `30d`, `90d`, `180d`, `365d`, `730d`, and a `custom` mode. 
- Implemented frontend JS handlers (`syncCachePeriodPresetFromJson` and `applyCachePeriodPreset`) that initialize the selector from existing `url_params.timestamp`, mark non-matching values as `custom`, and update the CodeMirror JSON editor when a preset is selected (`app/View/Elements/serverRuleElements/pull.ctp`).
- Updated server-side caching logic to read `timestamp` from `pull_rules.url_params` (via `filterRuleToParameter`) and pass it to `attributeSearch` when performing non-fast caching, so the timestamp filter is used during cache population (`app/Model/Server.php`).
- Kept backward compatibility: if no timestamp is set the behavior is unchanged, and fast-caching remains unaffected.

### Testing
- Ran PHP syntax checks with `php -l` on modified files and both returned no syntax errors for `app/Model/Server.php` and `app/View/Elements/serverRuleElements/pull.ctp` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15888f471c8324b0ac55ed5c6baf9a)