### PR TITLE
[Security] Prevent deletion 500 error caused by 4-byte UTF-8 characters

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -370,15 +370,22 @@ class Event extends AppModel
         if (Configure::read('MISP.enableEventBlocklisting') !== false && empty($this->skipBlocklist)) {
             $this->EventBlocklist = ClassRegistry::init('EventBlocklist');
             $orgc = $this->Orgc->find('first', array('conditions' => array('Orgc.id' => $this->data['Event']['orgc_id']), 'recursive' => -1, 'fields' => array('Orgc.name')));
+            
+            // FIX: Scrub 4-byte UTF-8 characters (like emojis) to prevent PDOExceptions 
+            // on database tables using legacy 3-byte utf8 encoding.
+            $eventInfo = $this->data['Event']['info'];
+            if (!empty($eventInfo)) {
+                $eventInfo = preg_replace('/[\x{10000}-\x{10FFFF}]/u', '', $eventInfo);
+            }
+
             $this->EventBlocklist->create();
             $this->EventBlocklist->save(array(
                 'event_uuid' => $this->data['Event']['uuid'],
-                'event_info' => $this->data['Event']['info'],
+                'event_info' => $eventInfo,
                 'event_orgc' => $orgc['Orgc']['name'],
                 'comment' => __('Automatically blocked by deleting event'),
             ));
         }
-
         if (!empty($this->data['Event']['id'])) {
             if ($this->pubToZmq('event')) {
                 $pubSubTool = $this->getPubSubTool();


### PR DESCRIPTION
#### What does it do?

This PR improves the stability of the event deletion process by ensuring better handling of multi-byte character encoding between different database tables.

**Technical Details:**
In some environments, a mismatch can occur between the character encoding supported by the primary `events` table and the `event_blocklists` metadata table. Specifically, when deleting an event that contains 4-byte UTF-8 characters (such as certain emojis or mathematical symbols), the transition to the blocklist logic can trigger a database-level exception if the target table is using a 3-byte configuration.

Because this exception occurs during the `beforeDelete` lifecycle hook, it interrupts the transaction, resulting in a 500 error and preventing the event from being removed through the standard interface.

**The Fix:**
Added a sanitization step to the `beforeDelete` function in `app/Model/Event.php` to filter character sequences that exceed the 3-byte limit before metadata is processed for blocklisting. This ensures that the deletion process remains functional and robust across various database configurations and legacy environments.

#### Questions

* [ ] Does it require a DB change? **No**
* [ ] Are you using it in production? **Verified in a containerized development environment.**
* [ ] Does it require a change in the API (PyMISP for example)? **No**