### PR TITLE
Fix: Handle Em Space (U+2003) and Unicode separators in FreeText import

### DIFF
--- a/app/Lib/Tools/ComplexTypeTool.php
+++ b/app/Lib/Tools/ComplexTypeTool.php
@@ -310,8 +310,7 @@ class ComplexTypeTool
     {
         // convert non breaking space to normal space and all unicode chars from "other" category
         $input = preg_replace("/\p{C}+|\xc2\xa0/u", ' ', $input);
-        $iocArray = preg_split("/\r\n|\n|\r|\s|\s+|,|<|>|;/", $input);
-
+        $iocArray = preg_split("/\r\n|\n|\r|\s|\p{Z}+|,|<|>|;/u", $input);
         preg_match_all('/\"([^\"]+)\"/', $input, $matches);
         array_push($iocArray, ...$matches[1]);
 


### PR DESCRIPTION
## What does it do?
This PR resolves issue #10716. 

The FreeText import parser was previously using `\s` for whitespace detection, which is limited to ASCII characters. This caused it to fail when encountering Unicode whitespace characters like the Em Space (U+2003), often found when copying IOCs from threat intelligence reports. This resulted in filenames and hashes being incorrectly concatenated together.

**Changes:**
- Updated the regex in `ComplexTypeTool::parseFreetext` to include `\p{Z}+` (the Unicode separator character class).
- Added the `/u` (Unicode) modifier to the `preg_split` pattern to ensure the string is treated as UTF-8.
- This ensures that various Unicode spaces are correctly treated as delimiters, significantly improving the robustness of the FreeText import for real-world analyst data.

## Questions
- [ ] Does it require a DB change? *No*
- [ ] Are you using it in production? *Verified in local containerized MISP environment with reproduction test strings.*
- [ ] Does it require a change in the API (PyMISP for example)? *No*