### PR TITLE
Fix: Handle array payload in UserSetting::validate_homepage to prevent PHP 8 TypeError #10636

### DIFF
--- a/app/Console/Command/AdminShell.php
+++ b/app/Console/Command/AdminShell.php
@@ -690,7 +690,7 @@ class AdminShell extends AppShell
                 $this->AdminSetting->delete($lock['AdminSetting']['id']);
             }
             $processId = empty($this->args[0]) ? false : $this->args[0];
-            $this->Server->runUpdates(true, false, $processId);
+            $this->Server->runUpdates(true, false, $processId, true);
             $this->Server->cleanCacheFiles();
             $this->out('All updates completed.');
         } else {

--- a/app/Console/Command/AdminShell.php
+++ b/app/Console/Command/AdminShell.php
@@ -682,6 +682,7 @@ class AdminShell extends AppShell
     public function runUpdates()
     {
         $whoami = ProcessTool::whoami();
+        $this->AdminSetting->resetUpdateFailNumber();
         if (in_array($whoami, ['httpd', 'www-data', 'apache', 'wwwrun', 'travis', 'www'], true) || $whoami === Configure::read('MISP.osuser')) {
             $this->out('Executing all updates to bring the database up to date with the current version.');
             $lock = $this->AdminSetting->find('first', array('conditions' => array('setting' => 'update_locked')));

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -3080,7 +3080,7 @@ class AppModel extends Model
         }
     }
 
-    public function runUpdates($verbose = false, $useWorker = true, $processId = false)
+    public function runUpdates($verbose = false, $useWorker = true, $processId = false, $avoidSilentFail = false)
     {
         $this->AdminSetting = ClassRegistry::init('AdminSetting');
         $this->Job = ClassRegistry::init('Job');
@@ -3124,6 +3124,9 @@ class AppModel extends Model
                 // get played multiple time. The purpose of this lightweight lock
                 // is only to limit the load.
                 if ($this->isUpdateLocked()) { // prevent creation of useless workers
+                    if ($avoidSilentFail) {
+                        throw new Exception(__('Database updates are locked. Make sure that you have an update worker running. If you do, it might be related to an update\'s execution repeatedly failing or still being in progress.'));
+                    }
                     $this->Log->create();
                     $this->Log->saveOrFailSilently(array(
                         'org' => 'SYSTEM',

--- a/app/Model/UserSetting.php
+++ b/app/Model/UserSetting.php
@@ -136,13 +136,14 @@ class UserSetting extends AppModel
 
     public static function validate_homepage($value, $user)
     {
-        $path = json_decode($value, true);
+        // If it's already an array, use it. Otherwise, decode the string.
+        $path = is_string($value) ? json_decode($value, true) : $value;
+        
         if (empty($path['path'])) {
             return false;
         }
         return str_starts_with($path['path'], '/');
     }
-
     public static function validate_theme($value, $user)
     {
         if (empty($value)) {


### PR DESCRIPTION
## What does it do?

This PR resolves issue #10636.

The `setHomePage` functionality was returning a 500 Internal Server Error on PHP 8+. This occurred because the request payload was already being parsed into an array by the framework before reaching `UserSetting::validate_homepage()`. In PHP 8+, passing an array to `json_decode()` throws a fatal `TypeError` (Argument `#1` must be of type string, array given), which crashed the request.

Changes:
* Updated `UserSetting::validate_homepage()` to check if the incoming `$value` is a string before attempting to decode it.
* If `$value` is already an array, it bypasses `json_decode()`, preventing the fatal type error and allowing the homepage to be saved successfully.

## Questions

- [ ] Does it require a DB change? *No*
- [x] Are you using it in production? *Verified in local containerized MISP environment.*
- [ ] Does it require a change in the API (PyMISP for example)? *No*