### PR TITLE
fix: [SharingGroupOrg] correctly log removed org id, when removing an…

### DIFF
--- a/app/Model/SharingGroupOrg.php
+++ b/app/Model/SharingGroupOrg.php
@@ -75,7 +75,7 @@ class SharingGroupOrg extends AppModel
         // We are left with some "old orgs" that are not in the new list. This means that they can be safely deleted.
         foreach ($old_orgs as $old_org) {
             if ($this->delete($old_org['id'])) {
-                $this->loadLog()->createLogEntry($user, 'delete', 'SharingGroupOrg', $old_org['id'], 'Sharing group (' . $id . '): Removed organisation (' . $old_org['id'] . ').', 'Organisation (' . $org['id'] . ') removed from Sharing group.');
+                $this->loadLog()->createLogEntry($user, 'delete', 'SharingGroupOrg', $old_org['id'], 'Sharing group (' . $id . '): Removed organisation (' . $old_org['org_id'] . ').', 'Organisation (' . $old_org['org_id'] . ') removed from Sharing group.');
             }
         }
     }


### PR DESCRIPTION
… org from a sharing group

#### What does it do?

Makes sure the add and remove logs are aligned:
<img width="1081" height="151" alt="image" src="https://github.com/user-attachments/assets/9b229d73-313f-4e55-a9d0-bc8fccfed1a4" />

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
