### PR TITLE
fix: [User] instantiate CryptoGraphicKey correctly for users:getGpgPu…

### DIFF
--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -1370,7 +1370,7 @@ class User extends AppModel
     public function getGpgPublicKey()
     {
         $cryptGpg = $this->initializeGpg();
-        $this->CryptoGraphicKey = ClassRegistry::init('CrytpographicKey');
+        $this->CryptoGraphicKey = ClassRegistry::init('CryptographicKey');
         $fingerprint = $this->CryptoGraphicKey->ingestInstanceKey();
         if (!$fingerprint) {
             return null;


### PR DESCRIPTION
…blicKey

#### What does it do?

Function was giving an internal server error due to a typo in class name.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
