### PR TITLE
Revert "chg: [upgrade script] Remove MISP updates from upgrade script"

### DIFF
--- a/INSTALL/UPGRADE.ubuntu2404.sh
+++ b/INSTALL/UPGRADE.ubuntu2404.sh
@@ -237,6 +237,11 @@ done
 
 print_ok "MISP database.php file rewritten."
 
+print_status "Running MISP updates"
+
+sudo -u ${APACHE_USER} ${MISP_PATH}/app/Console/cake Admin runUpdates &>> $logfile
+error_check "MISP schema updates"
+
 print_status "Setting up background workers"
 
 sudo -u ${APACHE_USER} ${MISP_PATH}/app/Console/cake Admin setSetting "MISP.redis_serializer" "JSON" &>> $logfile


### PR DESCRIPTION
Since 849c9dcc643348048ab6fd9f9e206d145722b5fc will fail loudly if there is an error during the udpate, it will be nice to have it in the upgrade script to detect quickly if something goes wrong.

#### Questions

- [ ] Does it require a DB change? No
- [ ] Are you using it in production? No
- [ ] Does it require a change in the API (PyMISP for example)? No
