### PR TITLE
Add scheduler for supervisor conf in upgrade

### DIFF
--- a/INSTALL/UPGRADE.ubuntu2404.sh
+++ b/INSTALL/UPGRADE.ubuntu2404.sh
@@ -253,7 +253,7 @@ username=$SUPERVISOR_USER
 password=$SUPERVISOR_PASSWORD" | sudo tee -a /etc/supervisor/supervisord.conf  &>> $logfile
 
 sudo echo "[group:misp-workers]
-programs=default,email,cache,prio,update
+programs=default,email,cache,prio,update,scheduler
 
 [program:default]
 directory=$MISP_PATH
@@ -312,6 +312,18 @@ directory=$MISP_PATH
 command=$MISP_PATH/app/Console/cake start_worker cache
 process_name=%(program_name)s_%(process_num)02d
 numprocs=5
+autostart=true
+autorestart=true
+redirect_stderr=false
+stderr_logfile=$MISP_PATH/app/tmp/logs/misp-workers-errors.log
+stdout_logfile=$MISP_PATH/app/tmp/logs/misp-workers.log
+user=$APACHE_USER
+
+[program:scheduler]
+directory=$MISP_PATH
+command=$MISP_PATH/app/Console/cake scheduler_worker
+process_name=%(program_name)s_%(process_num)02d
+numprocs=1
 autostart=true
 autorestart=true
 redirect_stderr=false


### PR DESCRIPTION
This sync the conf which the install script

#### Questions

- [ ] Does it require a DB change? No
- [ ] Are you using it in production? No
- [ ] Does it require a change in the API (PyMISP for example)? No
