### PR TITLE
Fix: Prevent duplicate tags when updating attribute

### DIFF
--- a/app/Model/MispAttribute.php
+++ b/app/Model/MispAttribute.php
@@ -3191,15 +3191,26 @@ class MispAttribute extends AppModel
                 foreach ($attribute['Tag'] as $tag) {
                     $tag_id = $this->AttributeTag->Tag->captureTag($tag, $user);
                     if ($tag_id) {
-                        $this->AttributeTag->create();
-                        $at = [
-                            'attribute_id' => $this->id,
-                            'event_id' => $eventId,
-                            'tag_id' => $tag_id,
-                            'local' => !empty($tag['local']) ? $tag['local'] : 0,
-                            'relationship_type' => empty($tag['relationship_type']) ? null : $tag['relationship_type']
-                        ];
-                        $this->AttributeTag->save($at);
+                        // NEW: Check if the relationship already exists to prevent duplication
+                        $existingAssociation = $this->AttributeTag->find('count', array(
+                            'conditions' => array(
+                                'attribute_id' => $this->id,
+                                'tag_id' => $tag_id
+                            ),
+                            'recursive' => -1
+                        ));
+
+                        if ($existingAssociation === 0) {
+                            $this->AttributeTag->create();
+                            $at = [
+                                'attribute_id' => $this->id,
+                                'event_id' => $eventId,
+                                'tag_id' => $tag_id,
+                                'local' => !empty($tag['local']) ? $tag['local'] : 0,
+                                'relationship_type' => empty($tag['relationship_type']) ? null : $tag['relationship_type']
+                            ];
+                            $this->AttributeTag->save($at);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
#### What does it do?

Fixes #10804

When updating an existing attribute (e.g., via PyMISP with `break_on_duplicate=False`), if the incoming payload contains tags, the application blindly executes a `create()` loop inside `captureAttribute()`. This causes CakePHP to attempt to insert duplicate rows into the `attribute_tags` pivot table, resulting in either duplicate tags in the UI or 1062 Integrity Constraint violations.

This PR adds a `find('count')` check within the `MispAttribute.php` tag loop to verify if the `$tag_id` and `$attribute_id` relationship already exists. If the association is found, it cleanly skips the creation step, preventing the duplication and any potential subsequent 500 errors.

#### Questions

- [ ] Does it require a DB change? (No)
- [ ] Are you using it in production? (No, local testing on Docker/Ubuntu)
- [ ] Does it require a change in the API (PyMISP for example)? (No)