### PR TITLE
Fix: Correct galaxy distribution schema and v151 migration

### DIFF
--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -2692,7 +2692,7 @@ class AppModel extends Model
                 $sqlArray[] = "ALTER TABLE `galaxy_clusters` MODIFY `description` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;";
                 break;
             case 151:
-                $sqlArray[] = "ALTER TABLE `galaxies` ADD `distribution` tinyint(4) NOT NULL DEFAULT 0;";
+                $sqlArray[] = "ALTER TABLE `galaxies` MODIFY `distribution` tinyint(4) NOT NULL DEFAULT 0;";
                 break;
             case 'fixNonEmptySharingGroupID':
                 $sqlArray[] = 'UPDATE `events` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';

--- a/db_schema.json
+++ b/db_schema.json
@@ -3959,7 +3959,7 @@
                 "numeric_precision": "3",
                 "collation_name": null,
                 "column_type": "tinyint(4)",
-                "column_default": null,
+                "column_default": "0",
                 "extra": ""
             }
         ],


### PR DESCRIPTION
#### What does it do?

Fixes #10815

During the v151 database migration, upgrading an older instance that already contained a `distribution` column in the `galaxies` table (where it allowed `NULL`) resulted in a `1060 Duplicate Column` error. Because this error is intentionally suppressed during upgrades, the `ADD` command was skipped, leaving the existing column with a default of `NULL` instead of the required `0`.

This PR makes two adjustments to resolve the desync:
1. Updates the v151 update script in `AppModel.php` to use `MODIFY` instead of `ADD` for the `galaxies` table's `distribution` column, ensuring existing columns correctly inherit `NOT NULL DEFAULT 0`.
2. Updates `db_schema.json` so the blueprint correctly defines the distribution default as `"0"` instead of `null`, establishing the proper source of truth for the ORM.

#### Questions

- [x] Does it require a DB change? (Yes)
- [ ] Are you using it in production? (No)
- [ ] Does it require a change in the API (PyMISP for example)? (No)