### PR TITLE
Fix: Resolve empty baseurl UI bugs for Multi-URL instances

### DIFF
--- a/app/Lib/Dashboard/EventStreamWidget.php
+++ b/app/Lib/Dashboard/EventStreamWidget.php
@@ -85,7 +85,7 @@ class EventStreamWidget
         $field_options = [
             'id' => [
                 'name' => '#',
-                'url' => Configure::read('MISP.baseurl') . '/events/view',
+                'url' => (Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/')) . '/events/view',
                 'element' => 'links',
                 'data_path' => 'Event.id',
                 'url_params_data_paths' => 'Event.id'

--- a/app/Lib/Dashboard/MispCacheStatusWidget.php
+++ b/app/Lib/Dashboard/MispCacheStatusWidget.php
@@ -81,7 +81,7 @@ class MispCacheStatusWidget
 
     private function _hubNode()
     {
-        $baseurl = (string)Configure::read('MISP.baseurl');
+        $baseurl = (Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/'));
         $selfName = (string)Configure::read('MISP.org');
         return array(
             'id' => 'self',

--- a/app/Lib/Dashboard/MispStatusWidget.php
+++ b/app/Lib/Dashboard/MispStatusWidget.php
@@ -28,7 +28,7 @@ class MispStatusWidget
             ),
             'html' => sprintf(
                 ' (<a href="%s">%s</a>)',
-                Configure::read('MISP.baseurl') . '/events/index/timestamp:' . (time() - 86400),
+                (Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/')) . '/events/index/timestamp:' . (time() - 86400),
                 'View'
             )
         );
@@ -42,7 +42,7 @@ class MispStatusWidget
             ),
             'html' => sprintf(
                 ' (<a href="%s">%s</a>)',
-                Configure::read('MISP.baseurl') . '/events/index/published:1/timestamp:' . (time() - 86400),
+                (Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/')) . '/events/index/published:1/timestamp:' . (time() - 86400),
                 'View'
             )
         );
@@ -53,7 +53,7 @@ class MispStatusWidget
                 'value' => $notifications['proposalCount'],
                 'html' => sprintf(
                     ' (<a href="%s">%s</a>)',
-                    Configure::read('MISP.baseurl') . '/shadow_attributes/index/all:0',
+                    (Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/')) . '/shadow_attributes/index/all:0',
                     'View'
                 )
             );
@@ -64,7 +64,7 @@ class MispStatusWidget
                 'value' => $notifications['proposalEventCount'],
                 'html' => sprintf(
                     ' (<a href="%s">%s</a>)',
-                    Configure::read('MISP.baseurl') . '/events/proposalEventIndex',
+                    (Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/')) . '/events/proposalEventIndex',
                     'View'
                 )
             );
@@ -75,7 +75,7 @@ class MispStatusWidget
                 'value' => $notifications['delegationCount'],
                 'html' => sprintf(
                     ' (<a href="%s">%s</a>)',
-                    Configure::read('MISP.baseurl') . '/event_delegations/index/context:pending',
+                    (Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/')) . '/event_delegations/index/context:pending',
                     'View'
                 )
             );

--- a/app/Lib/Dashboard/NewOrgsWidget.php
+++ b/app/Lib/Dashboard/NewOrgsWidget.php
@@ -111,7 +111,7 @@ class NewOrgsWidget
         $field_options = [
             'id' => [
                 'name' => '#',
-                'url' => Configure::read('MISP.baseurl') . '/organisations/view',
+                'url' => (Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/')) . '/organisations/view',
                 'element' => 'links',
                 'data_path' => 'Organisation.id',
                 'url_params_data_paths' => 'Organisation.id'

--- a/app/Lib/Dashboard/NewUsersWidget.php
+++ b/app/Lib/Dashboard/NewUsersWidget.php
@@ -119,7 +119,7 @@ class NewUsersWidget
         $field_options = [
             'id' => [
                 'name' => '#',
-                'url' => empty($user['Role']['perm_site_admin']) ? null : Configure::read('MISP.baseurl') . '/admin/users/view',
+                'url' => empty($user['Role']['perm_site_admin']) ? null : (Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/')) . '/admin/users/view',
                 'element' => 'links',
                 'data_path' => 'User.id',
                 'url_params_data_paths' => 'User.id'

--- a/app/Lib/Dashboard/RecentSightingsWidget.php
+++ b/app/Lib/Dashboard/RecentSightingsWidget.php
@@ -61,7 +61,7 @@ class RecentSightingsWidget
             $data[] = array( 'title' => $type, 'value' => $output, 
                                 'html' => sprintf(
                                     ' (Event <a href="%s%s">%s</a>)',
-                                    Configure::read('MISP.baseurl') . '/events/view/', $event['id'],
+                                    (Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/')) . '/events/view/', $event['id'],
                                     $event['id']
                                 )
                         );

--- a/app/Lib/Dashboard/ThresholdSightingsWidget.php
+++ b/app/Lib/Dashboard/ThresholdSightingsWidget.php
@@ -56,7 +56,7 @@ class ThresholdSightingsWidget
                 $data[] = array( 'title' => __("False positive above threshold"), 'value' => $output, 
                                     'html' => sprintf(
                                         ' (Event <a href="%s%s">%s</a>)',
-                                        Configure::read('MISP.baseurl') . '/events/view/', $s['event_id'],
+                                        (Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/')) . '/events/view/', $s['event_id'],
                                         $s['event_id']
                                     ));
             };

--- a/app/View/Dashboards/index.ctp
+++ b/app/View/Dashboards/index.ctp
@@ -15,7 +15,7 @@
  *   - data-misp-widget-action="*" — clickable widget controls
  *   - data-misp-board-action="*"  — board-level toolbar controls
  */
-$baseurl = Configure::read('MISP.baseurl') ?: '';
+$baseurl = Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/');
 ?>
 <header class="misp-dashboard-header">
     <h1 class="misp-dashboard-title"><?= __('Dashboard') ?></h1>

--- a/app/View/Dashboards/invalidate_user_sessions.ctp
+++ b/app/View/Dashboards/invalidate_user_sessions.ctp
@@ -16,7 +16,7 @@
  *
  * Vars: $userId (int), $email (raw), $count (int), $supported (bool).
  */
-$baseurl = (string)Configure::read('MISP.baseurl');
+$baseurl = (Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/'));
 ?>
 <div class="misp-user-confirm">
 <?php if (empty($supported)): ?>

--- a/app/View/Dashboards/list_templates.ctp
+++ b/app/View/Dashboards/list_templates.ctp
@@ -26,7 +26,7 @@
  * (matches on name + description + uuid via the data-template-
  * search-text attribute the view inlines per card).
  */
-$baseurl = Configure::read('MISP.baseurl') ?: '';
+$baseurl = Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/');
 
 /**
  * Render one card. Inline closure so the per-section loops below

--- a/app/View/Dashboards/save_template.ctp
+++ b/app/View/Dashboards/save_template.ctp
@@ -22,7 +22,7 @@
  *     action attribute and the page title.
  *   - request->data['Dashboard']: pre-fill payload when editing.
  */
-$baseurl = Configure::read('MISP.baseurl') ?: '';
+$baseurl = Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/');
 ?>
 <header class="misp-dashboard-header misp-template-form-header">
     <div class="misp-template-gallery-title-block">

--- a/app/View/Elements/dashboard/Widgets/Button.ctp
+++ b/app/View/Elements/dashboard/Widgets/Button.ctp
@@ -22,7 +22,7 @@
 $url  = isset($data['url'])  ? (string)$data['url']  : '';
 $text = isset($data['text']) ? (string)$data['text'] : '';
 
-$baseurl = (string)Configure::read('MISP.baseurl');
+$baseurl = (Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/'));
 
 $isSafeUrl = function ($url) use ($baseurl) {
     if (!is_string($url) || $url === '') return false;

--- a/app/View/Elements/dashboard/Widgets/EventCards.ctp
+++ b/app/View/Elements/dashboard/Widgets/EventCards.ctp
@@ -37,7 +37,7 @@ if (empty($rows)) {
     return;
 }
 
-$baseurl = (string)Configure::read('MISP.baseurl');
+$baseurl = (Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/'));
 
 /**
  * Same URL safety contract as Index.ctp / SimpleList: relative paths

--- a/app/View/Elements/dashboard/Widgets/Index.ctp
+++ b/app/View/Elements/dashboard/Widgets/Index.ctp
@@ -41,7 +41,7 @@ if (empty($rows)) {
     return;
 }
 
-$baseurl = (string)Configure::read('MISP.baseurl');
+$baseurl = (Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/'));
 
 /**
  * Same URL safety contract as SimpleList: relative paths starting with

--- a/app/View/Elements/dashboard/Widgets/OrgsPictures.ctp
+++ b/app/View/Elements/dashboard/Widgets/OrgsPictures.ctp
@@ -38,7 +38,7 @@ if (empty($orgs)) {
     return;
 }
 
-$baseurl = (string)Configure::read('MISP.baseurl');
+$baseurl = (Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/'));
 $imgDir  = APP . 'files' . DS . 'img' . DS . 'orgs' . DS;
 
 /**

--- a/app/View/Elements/dashboard/Widgets/UserList.ctp
+++ b/app/View/Elements/dashboard/Widgets/UserList.ctp
@@ -75,7 +75,7 @@ if (empty($data)) {
     return;
 }
 
-$baseurl = (string)Configure::read('MISP.baseurl');
+$baseurl = (Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/'));
 $imgDir  = APP . 'files' . DS . 'img' . DS . 'orgs' . DS;
 
 /**

--- a/app/View/Elements/dashboard/save_template_form.ctp
+++ b/app/View/Elements/dashboard/save_template_form.ctp
@@ -11,7 +11,7 @@
  * controller-set view vars ($options, $isSiteAdmin, $isUpdate, $updateRef) —
  * see DashboardsController::saveTemplate (data contract unchanged).
  */
-$baseurl = Configure::read('MISP.baseurl') ?: '';
+$baseurl = Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/');
 $existing = isset($this->request->data['Dashboard'])
     ? $this->request->data['Dashboard']
     : array();

--- a/app/View/Helper/CommandHelper.php
+++ b/app/View/Helper/CommandHelper.php
@@ -13,8 +13,8 @@ App::uses('AppHelper', 'View/Helper');
         private function __buildReplacements() {
             $this->__replacement = array(
                 'link' => array('type' => 'url', 'url' => '$1', 'text' => '$1'),
-                'thread' => array('type' => 'url', 'url' => h(Configure::read('MISP.baseurl')). '/threads/view/$1', 'text' => ' Thread $1'),
-                'event' => array('type' => 'url', 'url' => h(Configure::read('MISP.baseurl')). '/events/view/$1', 'text' => ' Event $1'),
+                'thread' => array('type' => 'url', 'url' => h(Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/')). '/threads/view/$1', 'text' => ' Thread $1'),
+                'event' => array('type' => 'url', 'url' => h(Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/')). '/events/view/$1', 'text' => ' Event $1'),
                 'code' => array('type' => 'replace', 'text' => '<pre>$1</pre>'),
                 'quote' => array('type' => 'replace', 'text' => '<div class="quote">$1</div>')
             );

--- a/app/View/Helper/PivotHelper.php
+++ b/app/View/Helper/PivotHelper.php
@@ -51,9 +51,9 @@ class PivotHelper extends AppHelper
 
         $data[] = '<span class="' . $pivotSpanType . '">';
         if ($pivot['deletable']) {
-            $data[] = '<a class="pivotDelete fa fa-times" href="' . h(Configure::read('MISP.baseurl')) . '/events/removePivot/' . $pivot['id'] . '/' . $currentEventId . '" title="' . __('Remove pivot') . '" aria-label="' . __('Remove pivot') . '"></a>';
+            $data[] = '<a class="pivotDelete fa fa-times" href="' . h(Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/')) . '/events/removePivot/' . $pivot['id'] . '/' . $currentEventId . '" title="' . __('Remove pivot') . '" aria-label="' . __('Remove pivot') . '"></a>';
         }
-        $data[] = '<a class="' . $pivotType . '" href="' . h(Configure::read('MISP.baseurl')) . '/events/view/' . $pivot['id'] . '/1/' . $currentEventId . '" title="' . $info . ' (' . $pivot['date'] . ')">' . $text . '</a>';
+        $data[] = '<a class="' . $pivotType . '" href="' . h(Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/')) . '/events/view/' . $pivot['id'] . '/1/' . $currentEventId . '" title="' . $info . ' (' . $pivot['date'] . ')">' . $text . '</a>';
         $data[] = '</span>';
         if (!empty($pivot['children'])) {
             foreach ($pivot['children'] as $k => $v) {

--- a/app/View/SharingGroups/add.ctp
+++ b/app/View/SharingGroups/add.ctp
@@ -141,7 +141,7 @@
         $server_json = json_encode([[
             'id' => '0',
             'name' => __('Local instance'),
-            'url' => h(Configure::read('MISP.baseurl')),
+            'url' => h(Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/')),
             'all_orgs' => false,
             'removable' => 0
         ]]);

--- a/app/View/SharingGroups/edit.ctp
+++ b/app/View/SharingGroups/edit.ctp
@@ -149,7 +149,7 @@
                     $server_json = json_encode([
                         'id' => $s['server_id'],
                         'name' => 'Local instance',
-                        'url' => empty(Configure::read('MISP.external_baseurl')) ? h(Configure::read('MISP.baseurl')) : h(Configure::read('MISP.external_baseurl')),
+                        'url' => empty(Configure::read('MISP.external_baseurl')) ? h(Configure::read('MISP.baseurl') ?: rtrim(Router::url('/', true), '/')) : h(Configure::read('MISP.external_baseurl')),
                         'all_orgs' => $s['all_orgs'] ? 1 : 0,
                         'removable' => 0
                     ]);


### PR DESCRIPTION
#### What does it do?

Fixes #10813 

When a multi-URL instance intentionally operates with an empty `MISP.baseurl`, several newer components (specifically Dashboard Widgets, Views, and View Helpers) fail to adhere to the dynamic request host. These components were utilizing direct configuration reads (e.g., `(string)Configure::read('MISP.baseurl')`) paired with string concatenation, resulting in orphaned relative paths (e.g., `/events/view/xyz`) that break context.

This PR standardizes the behavior across the UI layer (`app/View/` and `app/Lib/Dashboard/`) by implementing a fallback to CakePHP's HTTP router. When `MISP.baseurl` is empty, the codebase will now safely evaluate to `rtrim(Router::url('/', true), '/')`, ensuring multi-URL environments maintain absolute contextual pathing.

#### Questions

- [ ] Does it require a DB change? (No)
- [ ] Are you using it in production? (No)
- [ ] Does it require a change in the API (PyMISP for example)? (No)