### PR TITLE
Fix: Screenshot preview hidden by modal backdrop

### DIFF
--- a/app/webroot/css/main.css
+++ b/app/webroot/css/main.css
@@ -1100,7 +1100,7 @@ a.black-white:hover {
     top: 100px;
     left: 20px;
     right: 20px;
-    z-index:5;
+    z-index:1060 !important;
     text-align: center;
 }
 


### PR DESCRIPTION
## What does it do?

Fixes #10800.

A comparative analysis of the CSS history between v2.5.35 and v2.5.36 identified a regression where z-index values were globally adjusted, causing the screenshot preview container (`#screenshot_box`) to sit below the Bootstrap modal backdrop (`z-index: 1040`). 

This PR applies a z-index override of `1060` to `#screenshot_box` to ensure the preview layer remains visible above the modal backdrop, restoring the intended UI behavior.

## Questions

- [ ] Does it require a DB change? (No)
- [ ] Are you using it in production? (No)
- [ ] Does it require a change in the API (PyMISP for example)? (No)