### PR TITLE
new: [OidcAuth] configurable login button text

### DIFF
--- a/app/Plugin/OidcAuth/README.md
+++ b/app/Plugin/OidcAuth/README.md
@@ -48,6 +48,7 @@ $config = array(
         'default_org' => '{{ MISP_ORG }}',
         'disable_request_object' => true, //Disable the Request Object approach in authorization requests, allowing users to fallback to plain parameters when needed for compatibility with certain OpenID Connect providers. (False by default)
         'scopes' => ['profile', 'email'], // Make sure to add your custom scope here if you set any
+        'login_button_text' => 'Login with OIDC', // Optional, custom label for the login button shown when `mixedAuth` is enabled (defaults to "Login with OIDC")
     ],
     ...
 ```
@@ -69,6 +70,10 @@ Set `OidcAuth.mixedAuth` to `true` to prevent MISP to automatically redirect to 
 
 7. Proxy
 Set `OidcAuth.skipProxy` to `false` to use global MISP proxy settings when sending requests to your OIDC provider. By default global proxy settings are ignored. 
+
+8. Custom login button text
+
+When `OidcAuth.mixedAuth` is enabled, a login button is shown on the login page. Set `OidcAuth.login_button_text` to customise its label (for example `Login with Authentik` or `Login with Company SSO`). If unset or empty, it defaults to `Login with OIDC`.
 
 ## Caveats
 

--- a/app/View/Themed/Overmind/Users/login.ctp
+++ b/app/View/Themed/Overmind/Users/login.ctp
@@ -208,8 +208,14 @@
 
                 <?php if (Configure::read('OidcAuth') && Configure::read('OidcAuth.mixedAuth')): ?>
                     <div class="d-grid mb-3">
+                            <?php
+                                $oidcLoginText = Configure::read('OidcAuth.login_button_text');
+                                if (empty($oidcLoginText)) {
+                                    $oidcLoginText = __('Login with OIDC');
+                                }
+                            ?>
                             <?= $this->Html->link(
-                                '<i class="fa-solid fa-id-badge text-warning me-2"></i>' . __('Login with OIDC'),
+                                '<i class="fa-solid fa-id-badge text-warning me-2"></i>' . h($oidcLoginText),
                                 [
                                     'controller' => 'users',
                                     'action' => 'login',

--- a/app/View/Users/login.ctp
+++ b/app/View/Users/login.ctp
@@ -82,7 +82,11 @@
                 echo '<div class="clear" style="margin-top: 5px;"></div><a class="btn btn-info" href="/users/login?AzureAD=enable">Login with AzureAD</a>';
             }
             if (Configure::read('OidcAuth') == true && Configure::read('OidcAuth.mixedAuth') == true) {
-                echo '<div class="clear" style="margin-top: 5px;"></div><a class="btn btn-info" href="/users/login?OidcAuth=enable">Login with OIDC</a>';
+                $oidcLoginText = Configure::read('OidcAuth.login_button_text');
+                if (empty($oidcLoginText)) {
+                    $oidcLoginText = __('Login with OIDC');
+                }
+                echo '<div class="clear" style="margin-top: 5px;"></div><a class="btn btn-info" href="/users/login?OidcAuth=enable">' . h($oidcLoginText) . '</a>';
             }
         ?>
     </td>


### PR DESCRIPTION
#### What does it do?

Adds an optional `OidcAuth.login_button_text` setting to customise the label of the OIDC login button shown on the login page when `OidcAuth.mixedAuth` is enabled.

Falls back to `Login with OIDC` when the setting is unset or empty, so behaviour is unchanged for existing installs (the feature is effectively opt-in / off by default). The configured value is HTML-escaped via `h()` when rendered.

Changes:
- `app/View/Users/login.ctp` — render the OIDC button label from `OidcAuth.login_button_text`, with a safe default.
- `app/Plugin/OidcAuth/README.md` — document the new setting (config example + usage section).

Companion change: the paired PR MISP/misp-docker#422 adds an `OIDC_LOGIN_TEXT` environment variable that writes this `OidcAuth.login_button_text` setting (consistent with the other `OIDC_*` env vars in `configure_misp.sh`), so Docker users can set the label via env. That PR is a no-op until this one merges and a new `misp-core` image is built.

Not linked to an existing issue.

#### Questions

- [ ] Does it require a DB change? — No. It only reads a `Configure` setting (set via `config.php` / settings); no schema change or migration.
- [ ] Are you using it in production? — Not yet (new feature; default behaviour is unchanged).
- [ ] Does it require a change in the API (PyMISP for example)? — No. Login-view only; no API surface is affected.

---

Compliance with the generic contribution requirements:

- One PR, one feature — single change, configurable OIDC button label.
- Minimal commits — one commit; squash-ready if amended.
- Mergeable into the default branch — branched off `2.5`, 10-line diff across 2 files.
- Disabled by default — defaults to `Login with OIDC`, so existing installs behave identically unless the setting is explicitly configured.
- Travis CI — no test cases exist for this view; the change is a string/config read with a safe default, so nothing to update.

