### PR TITLE
Fix: Category mismatch when using bulk Type change in Freetext Import

### DIFF
--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -2857,7 +2857,9 @@ function changeFreetextImportExecute() {
     $('.typeToggle').each(function() {
         if ($(this).val() === from) {
             if (selectContainsOption("#" + $(this).attr('id'), to)) {
-                $(this).val(to);
+                // Update the value, then manually trigger the 'change' event
+                // so the Category dropdowns update automatically.
+                $(this).val(to).trigger('change');
             }
         }
     });


### PR DESCRIPTION
## What does it do?

Fixes #10799.

When using the Freetext Import bulk "Change all" functionality, the Type dropdowns were updated programmatically using `.val()`, which failed to trigger the necessary JavaScript event listeners. As a result, the Category field remained static and did not re-map to the new Type.

This PR adds `.trigger('change')` to the bulk update loop within `changeFreetextImportExecute()`. This forces the UI to re-evaluate the category-type relationship, ensuring the Category field correctly synchronizes with the newly selected Type.

## Questions

- [ ] Does it require a DB change? (No)
- [ ] Are you using it in production? (No)
- [ ] Does it require a change in the API (PyMISP for example)? (No)