### PR TITLE
Fix: Prevent OverCorrelatingValue::truncate() crash on null input

### DIFF
--- a/app/Model/OverCorrelatingValue.php
+++ b/app/Model/OverCorrelatingValue.php
@@ -8,12 +8,14 @@ class OverCorrelatingValue extends AppModel
     /** @var array */
     private $blockedValues = [];
 
-    public static function truncate(string $value): string
+    public static function truncate(?string $value): string
     {
+        if ($value === null) {
+            return '';
+        }
         $value = mb_strtolower($value);
         return mb_substr($value, 0, 191);
     }
-
     public static function truncateValues(array $values): array
     {
         return array_map(function(string $value) {


### PR DESCRIPTION
## What does it do?

Fixes #10763.

The MalwareBazaar MISP-format feed occasionally contains malformed attribute values that result in a `null` value being passed to `OverCorrelatingValue::truncate()`. In PHP 8.3, passing `null` where a `string` is expected causes a fatal `TypeError`, which terminates the entire background feed fetch process.

This PR updates `OverCorrelatingValue::truncate()` to accept a nullable string (`?string`) and adds a defensive guard to return an empty string if the input is `null`. This ensures the deduplication pipeline gracefully handles malformed attributes without crashing the import job.

## Patch Testing
The fix was verified locally inside the MISP core container by isolating the method and simulating a `null` input, confirming the fatal error is successfully bypassed:

```bash
# Executed within the misp-core container
php -r 'class App { public static function uses($c, $t){} } class AppModel{} require "/var/www/MISP/app/Model/OverCorrelatingValue.php"; echo "Result: [" . OverCorrelatingValue::truncate(null) . "]\n";'

# Output confirms null is caught and an empty string is returned:
Result: []
```

## Questions
- [ ] Does it require a DB change? (No)
- [ ] Are you using it in production? (No)
- [ ] Does it require a change in the API (PyMISP for example)? (No)