### PR TITLE
new: [feeds] add Rectifyq MISP Feeds

### DIFF
--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -2365,5 +2365,53 @@
       "caching_enabled": false,
       "force_to_ids": false
     }
+  },
+  {
+    "Feed": {
+      "name": "Rectifyq - Curated Enriched MISP Threat Information for ICS-OT",
+      "provider": "rectifyq.com",
+      "url": "https://feeds.rectifyq.com/MISP-ICS-OT/",
+      "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]},\"type_attributes\":{\"NOT\":[]},\"type_objects\":{\"NOT\":[]},\"url_params\":\"\"}",
+      "enabled": true,
+      "distribution": "3",
+      "sharing_group_id": "0",
+      "default": false,
+      "source_format": "misp",
+      "fixed_event": true,
+      "delta_merge": false,
+      "publish": false,
+      "override_ids": false,
+      "settings": "{\"disable_correlation\":\"0\",\"unpublish_event\":\"0\",\"csv\":{\"value\":\"\",\"delimiter\":\"\"},\"common\":{\"excluderegex\":\"\"}}",
+      "input_source": "network",
+      "delete_local_file": false,
+      "lookup_visible": true,
+      "headers": "",
+      "caching_enabled": false,
+      "force_to_ids": false
+    }
+  },
+  {
+    "Feed": {
+      "name": "Rectifyq - Curated Enriched MISP Threat Information relevant for Malaysian Context",
+      "provider": "rectifyq.com",
+      "url": "https://feeds.rectifyq.com/MISP-MY/",
+      "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]},\"type_attributes\":{\"NOT\":[]},\"type_objects\":{\"NOT\":[]},\"url_params\":\"\"}",
+      "enabled": true,
+      "distribution": "3",
+      "sharing_group_id": "0",
+      "default": false,
+      "source_format": "misp",
+      "fixed_event": true,
+      "delta_merge": false,
+      "publish": false,
+      "override_ids": false,
+      "settings": "{\"disable_correlation\":\"0\",\"unpublish_event\":\"0\",\"csv\":{\"value\":\"\",\"delimiter\":\"\"},\"common\":{\"excluderegex\":\"\"}}",
+      "input_source": "network",
+      "delete_local_file": false,
+      "lookup_visible": true,
+      "headers": "",
+      "caching_enabled": false,
+      "force_to_ids": false
+    }
   }
 ]


### PR DESCRIPTION
What does it do?
Added Rectifyq MISP Feeds (ICS-OT related feed, Malaysian context related feed)
Refer: https://rectifyq.com/resources

Questions
 Does it require a DB change? No
 Are you using it in production? Yes
 Does it require a change in the API (PyMISP for example)? Not sure