### PR TITLE
Update "Rösti - Repackaged Öpen Source Threat Intelligence" feed URL

### DIFF
--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -2064,7 +2064,7 @@
   "Feed": {
     "name": "Rösti - Repackaged Öpen Source Threat Intelligence",
     "provider": "bin.re",
-    "url": "https://rosti.64617461.xyz/downloads/misp/",
+    "url": "https://misp.rosti.dev",
     "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]},\"type_attributes\":{\"NOT\":[]},\"type_objects\":{\"NOT\":[]},\"url_params\":\"\"}",
     "enabled": true,
     "distribution": "3",


### PR DESCRIPTION
#### What does it do?

The URL for the "Rösti - Repackaged Öpen Source Threat Intelligence" default feed appears to have changed to:

https://misp.rosti.dev/

#### Questions

- [ ] Does it require a DB change?
- [X ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
