### PR TITLE
fix: [UI] screenshot_box popup display issue when opening images atta…

### DIFF
--- a/app/webroot/css/main.css
+++ b/app/webroot/css/main.css
@@ -1100,7 +1100,7 @@ a.black-white:hover {
     top: 100px;
     left: 20px;
     right: 20px;
-    z-index:5;
+    z-index: 21;
     text-align: center;
 }
 


### PR DESCRIPTION
#### What does it do?

Fixed an issue causing the popup to appear behind the gray overlay when opening an image attached to an event

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
