### PR TITLE
[API] async support for /servers/updateJSON

### DIFF
--- a/app/Console/Command/AdminShell.php
+++ b/app/Console/Command/AdminShell.php
@@ -381,6 +381,10 @@ class AdminShell extends AppShell
     public function updateJSON()
     {
         $this->out('Updating all JSON structures.');
+
+        $userId = empty($this->args[0])  ? null : $this->args[0];
+        $jobId = empty($this->args[1])  ? null : $this->args[1];
+
         $overallSuccess = true;
         foreach ($this->Server->updateJSON() as $type => $result) {
             $type = Inflector::pluralize(Inflector::humanize($type));
@@ -394,8 +398,15 @@ class AdminShell extends AppShell
         }
         if ($overallSuccess) {
             $this->out('All JSON structures updated. Thank you and have a very safe and productive day.');
+            if (!is_null($jobId)) {
+                $this->Job->saveProgress($jobId, 'All JSON structures updated', 100);
+                $job['Job']['status'] = Job::STATUS_COMPLETED;
+            }
         } else {
             $this->error('Some structure could no be updated');
+            if (!is_null($jobId)) {
+                $this->Job->saveStatus($jobId, false, 'Some JSON structures could not be updated');
+            }
         }
     }
 

--- a/app/Controller/ServersController.php
+++ b/app/Controller/ServersController.php
@@ -2171,12 +2171,42 @@ class ServersController extends AppController
         }
     }
 
-    public function updateJSON()
+public function updateJSON()
     {
         $results = [];
-        foreach ($this->Server->updateJSON() as $type => $result) {
-            $results[$type] = $results['success'];
+
+        $async = Configure::read('MISP.background_jobs') && isset($this->params['named']['async']) ? filter_var($this->params['named']['async'], FILTER_VALIDATE_BOOLEAN) : false;
+
+        if ($async) {
+            $this->loadModel('Job');
+            $jobId = $this->Job->createJob(
+                $this->Auth->user(),
+                Job::WORKER_DEFAULT,
+                'updateJSON',
+                $this->Auth->user('id'),
+                __('Starting server JSON update.')
+            );
+
+            $this->Server->getBackgroundJobsTool()->enqueue(
+                BackgroundJobsTool::DEFAULT_QUEUE,
+                BackgroundJobsTool::CMD_ADMIN,
+                [
+                    'updateJSON',
+                    $this->Auth->user('id'),
+                    $jobId,
+                    $jobId
+                ],
+                true,
+                $jobId
+            );
+
+            $results['message'] = __('Server updateJSON job queued. Job ID: %s', $jobId);
+        } else {
+            foreach ($this->Server->updateJSON() as $type => $result) {
+                $results[$type] = $results['success'];
+            }
         }
+
         return $this->RestResponse->viewData($results, $this->response->type());
     }
 

--- a/app/webroot/doc/openapi.yaml
+++ b/app/webroot/doc/openapi.yaml
@@ -1801,6 +1801,22 @@ paths:
         default:
           $ref: "#/components/responses/ApiErrorResponse"
 
+  /servers/updateJSON:
+    post:
+      summary: "Update server JSON libraries (galaxies, taxonomies, object templates, object relationships, noticelists, warninglists). For async updates, use the /servers/updateJSON/async:1 endpoint instead."
+      operationId: updateServerJSON
+      tags:
+        - Servers
+      responses:
+        "200":
+          $ref: "#/components/responses/UpdateServerJSONResponse"
+        "403":
+          $ref: "#/components/responses/UnauthorizedApiErrorResponse"
+        "404":
+          $ref: "#/components/responses/NotFoundApiErrorResponse"
+        default:
+          $ref: "#/components/responses/ApiErrorResponse"
+
   /servers/cache:
     post:
       summary: "Cache server"
@@ -9890,6 +9906,38 @@ components:
                     - $ref: "#/components/schemas/UpdateServerResultItem"
                     - type: string
                       example: "Update failed, you are not on branch"
+
+    UpdateServerJSONResponse:
+      description: "Update server JSON libraries response. Synchronous updates return the result for each updated library (a value of null indicates the library was up to date and not changed). Asynchronous updates (/servers/updateJSON/async:1) return the queued job information instead."
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - type: object
+                properties:
+                  Galaxy:
+                    type: object
+                    nullable: true
+                  Noticelist:
+                    type: object
+                    nullable: true
+                  Warninglist:
+                    type: object
+                    nullable: true
+                  Taxonomy:
+                    type: object
+                    nullable: true
+                  ObjectTemplate:
+                    type: object
+                    nullable: true
+                  ObjectRelationship:
+                    type: object
+                    nullable: true
+              - type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Server updateJSON job queued. Job ID: 181"
 
     CacheServerResponse:
       description: "Cache server response"


### PR DESCRIPTION
#### What does it do?

allow async updates of JSON libraries via `/servers/updateJSON/async:1` parameter as requested by @rommelfs 

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
