### PR TITLE
Fix: Add destructor to TmpFileTool to prevent unmanaged temporary file leaks

### DIFF
--- a/app/Lib/Tools/TmpFileTool.php
+++ b/app/Lib/Tools/TmpFileTool.php
@@ -249,8 +249,10 @@ class TmpFileTool
             throw new Exception('Temporary file is already closed.');
         }
     }
-    public function __destruct()
-    {
-        $this->close();
+    public function close() {
+        if (is_resource($this->tmpfile)) {
+            fclose($this->tmpfile);
+        }
+        $this->tmpfile = null;
     }
 }

--- a/app/Lib/Tools/TmpFileTool.php
+++ b/app/Lib/Tools/TmpFileTool.php
@@ -228,16 +228,19 @@ class TmpFileTool
     }
 
     /**
+     * Close the underlying temporary file handle and free the resource.
+     * Idempotent: safe to call multiple times (e.g. explicitly and again from
+     * the destructor) and safe to call when the file was never opened.
      * @return bool
      */
     public function close()
     {
-        if ($this->tmpfile) {
+        $result = true;
+        if (is_resource($this->tmpfile)) {
             $result = fclose($this->tmpfile);
-            $this->tmpfile = null;
-            return $result;
         }
-        return true;
+        $this->tmpfile = null;
+        return $result;
     }
 
     /**
@@ -249,10 +252,16 @@ class TmpFileTool
             throw new Exception('Temporary file is already closed.');
         }
     }
-    public function close() {
-        if (is_resource($this->tmpfile)) {
-            fclose($this->tmpfile);
-        }
-        $this->tmpfile = null;
+
+    /**
+     * Ensure the temporary file handle is released when the object goes out of
+     * scope. Without this, the php://temp stream backing file in the system tmp
+     * directory could be left dangling until process exit, filling up disk on
+     * long-running workers (see issue #10828). close() is idempotent, so this is
+     * safe even when close() was already called explicitly.
+     */
+    public function __destruct()
+    {
+        $this->close();
     }
 }

--- a/app/Lib/Tools/TmpFileTool.php
+++ b/app/Lib/Tools/TmpFileTool.php
@@ -249,4 +249,8 @@ class TmpFileTool
             throw new Exception('Temporary file is already closed.');
         }
     }
+    public function __destruct()
+    {
+        $this->close();
+    }
 }


### PR DESCRIPTION
#### What does it do?

Fixes #10828

This PR addresses a disk-space exhaustion bug where large JSON sync/manifest responses were leaving unmanaged `phpXXXX` temporary files in the `/tmp` directory, eventually crashing the host OS. 

**Root Cause:** `app/Lib/Tools/TmpFileTool.php` opens `php://temp` streams to handle large payloads that exceed PHP's memory limits. However, the class lacked a `__destruct()` method. When the script finished, PHP's garbage collector destroyed the object but left the underlying physical file handles dangling, preventing the OS from deleting the temporary files.

**Fix:** Added a `__destruct()` magic method to `TmpFileTool` that explicitly calls `$this->close()`. This ensures that `fclose()` is triggered the moment the object goes out of scope, allowing PHP to natively and immediately delete the physical temporary file from the disk.

#### Questions

- [ ] Does it require a DB change? No
- [ ] Are you using it in production? Local docker
- [ ] Does it require a change in the API (PyMISP for example)? No