### PR TITLE
new: [feed] Add PrecisionSec OSINT Threat Intelligence default feed

### DIFF
--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -2365,5 +2365,25 @@
       "caching_enabled": false,
       "force_to_ids": false
     }
+  },
+  {
+    "Feed": {
+      "name": "PrecisionSec OSINT Threat Intelligence",
+      "provider": "precisionsec.com",
+      "url": "https://misp-osint.precisionsec.com/",
+      "rules": "",
+      "enabled": true,
+      "distribution": "3",
+      "default": false,
+      "source_format": "misp",
+      "fixed_event": false,
+      "delta_merge": false,
+      "publish": false,
+      "override_ids": false,
+      "settings": "{\"csv\":{\"value\":\"\",\"delimiter\":\"\"},\"common\":{\"excluderegex\":\"\"}}",
+      "input_source": "network",
+      "delete_local_file": false,
+      "lookup_visible": true
+    }
   }
 ]


### PR DESCRIPTION
#### What does it do?

Adds the PrecisionSec OSINT Threat Intelligence feed to the default feed metadata (`app/files/feed-metadata/defaults.json`). Single additive, schema-conformant entry; consumers opt in by enabling it.

- Provider: precisionsec.com
- URL: https://misp-osint.precisionsec.com/
- Format: MISP, distribution 3 (all communities)

#### Questions

- [ ] Does it require a DB change? No
- [x] Are you using it in production? Yes
- [ ] Does it require a change in the API (PyMISP for example)? No