### PR TITLE
fix: [dashboard] NewUsersWidget - enforce permissions and org scope

### DIFF
--- a/app/Lib/Dashboard/NewUsersWidget.php
+++ b/app/Lib/Dashboard/NewUsersWidget.php
@@ -116,6 +116,14 @@ class NewUsersWidget
     public function handler($user, $options = array())
     {
         $this->User = ClassRegistry::init('User');
+        // Site admins (or instances that explicitly opt in) may see and
+        // query e-mail addresses; everyone else has the column redacted
+        // AND is barred from filtering on it - otherwise the filter still
+        // works as an address-existence oracle even with the column hidden.
+        $redactEmails = (
+            empty($user['Role']['perm_site_admin']) &&
+            !Configure::read('Security.disclose_user_emails')
+        );
         $field_options = [
             'id' => [
                 'name' => '#',
@@ -148,6 +156,9 @@ class NewUsersWidget
         ];
         if (!empty($options['filter']) && is_array($options['filter'])) {
             foreach ($this->validFilterKeys as $filterKey) {
+                if ($filterKey === 'email' && $redactEmails) {
+                    continue;
+                }
                 if (!empty($options['filter'][$filterKey])) {
                     if (!is_array($options['filter'][$filterKey])) {
                         $options['filter'][$filterKey] = [$options['filter'][$filterKey]];
@@ -171,13 +182,17 @@ class NewUsersWidget
         if ($timeConditions) {
             $params['conditions']['AND'][] = $timeConditions;
         }
-        
+
+        // Org admins are scoped to their own organisation, mirroring the
+        // /admin/users boundary. Site admins (checkPermissions has already
+        // barred everyone else) see across all organisations.
+        if (empty($user['Role']['perm_site_admin'])) {
+            $params['conditions']['AND'][] = ['User.org_id' => $user['org_id']];
+        }
+
         // redact e-mails for non site admins unless specifically allowed
-        if (
-            empty($user['Role']['perm_site_admin']) &&
-            !Configure::read('Security.disclose_user_emails')
-        ) {
-                unset($field_options['email']);
+        if ($redactEmails) {
+            unset($field_options['email']);
         }
 
         $fields = [];
@@ -215,5 +230,18 @@ class NewUsersWidget
             'fields' => $fields,
             'description' => $this->tableDescription
         ];
+    }
+
+    /**
+     * Restrict this widget to users who are allowed to see the user
+     * directory at all - mirroring the /admin/users boundary, which
+     * requires org-admin (perm_admin) or site-admin (perm_site_admin).
+     * Org admins are further scoped to their own organisation in
+     * handler(). Regular and read-only users get the widget hidden.
+     */
+    public function checkPermissions($user)
+    {
+        return !empty($user['Role']['perm_site_admin'])
+            || !empty($user['Role']['perm_admin']);
     }
 }


### PR DESCRIPTION
 ## What does it do?

Brings the **New Users** dashboard widget in line with the access model already used by the user directory (`/admin/users`). Previously the widget's data scope and load permission didn't match that boundary; this PR makes them consistent.

  - The widget now requires `perm_admin` or `perm_site_admin` to load, the same as the user-administration views.
  - For org admins, results are scoped to their own organisation (site admins are unchanged and still see all orgs).
  - The `email` filter key is dropped when the e-mail column is redacted, so filtering behaviour matches what's actually displayed.

## How it works

The change is implemented entirely within the existing widget class.

  - A `checkPermissions($user)` method is added; `Dashboard::loadWidget()` already enforces this hook, so non-admin roles no longer receive the widget.
  - `handler()` adds a `User.org_id` condition for non-site-admins, mirroring the org-admin scoping in `UsersController`.
  - The existing e-mail redaction flag is reused to also exclude `email` from the filter key list, keeping the query consistent with the rendered columns.
  - Site-admin behaviour (cross-org listing, e-mail visibility) is unchanged.

 ## Questions
  - Does it require a DB change? **No**
  - Are you using it in production? **Local docker / test instance**
  - Does it require a change in the API (PyMISP for example)? **No**

 ## Testing

  Verified on a local MISP v2.5.40 instance:
  - Site admin: widget loads and lists users across all organisations as before.
  - Org admin: widget loads, results limited to the admin's own organisation.
  - Regular / read-only user: widget is not served.
  - Filter behaviour matches the displayed columns for non-site-admin viewers.
