### PR TITLE
fix: [dashboard] searchGalaxyClusters - apply cluster ACL

### DIFF
--- a/app/Controller/DashboardsController.php
+++ b/app/Controller/DashboardsController.php
@@ -899,6 +899,16 @@ class DashboardsController extends AppController
             $cleanQ = str_replace(['%', '_'], '', $q);
             $conditions['GalaxyCluster.value LIKE'] = '%' . $cleanQ . '%';
         }
+        // Scope to clusters the requesting user is allowed to see. Unlike
+        // organisation names, cluster values are distribution-controlled
+        // (org-private clusters are distribution=0), so this picker must
+        // honour the same ACL as every other cluster read path. Site
+        // admins get [] (no restriction); everyone else is limited to
+        // own-org / shared / authorised sharing-group clusters.
+        $acl = $this->GalaxyCluster->buildConditions($this->Auth->user());
+        if (!empty($acl)) {
+            $conditions[] = $acl;
+        }
         $rows = $this->GalaxyCluster->find('all', [
             'recursive' => -1,
             'fields' => ['GalaxyCluster.tag_name', 'GalaxyCluster.value', 'GalaxyCluster.uuid'],


### PR DESCRIPTION
 ## What does it do?

Brings the dashboard galaxy-cluster typeahead (`searchGalaxyClusters`) in line with the access model used by every other galaxy-cluster read path. Previously the picker's query scope didn't match that boundary; this PR makes them consistent.

Unlike the organisation-name picker next to it (org names are not access-controlled), galaxy cluster values are distribution-controlled, org-private clusters use `distribution = 0`. The typeahead was filtering only by galaxy type and value substring, so its results could include clusters outside the requesting user's visibility. This change applies the standard cluster ACL to the query.

## How it works

The change is confined to the existing `searchGalaxyClusters()` action.

  - The query now includes `GalaxyCluster::buildConditions($user)`, the same ACL builder used by `fetchGalaxyClusters()` and the recent-clusters widget, AND-combined with the existing type/value conditions.
  - Site admins get an empty restriction set (unchanged — they see everything).
  - All other users are scoped to own-org clusters, shared clusters (distribution 1–3), and clusters in sharing groups their organisation is authorised for.
  - The 50-row limit, value-substring matching, and response shape are unchanged.

## Questions
  - Does it require a DB change? **No**
  - Are you using it in production? **Local docker / test instance**
  - Does it require a change in the API (PyMISP for example)? **No**

## Testing

  Verified on a local MISP v2.5.40 instance:
  - Site admin: typeahead returns matching clusters across all organisations, as before.
  - Regular / read-only user: typeahead returns own-org and shared clusters, and no longer surfaces another organisation's org-private (`distribution = 0`) clusters, consistent with what `/galaxy_clusters/view` and `/galaxy_clusters/index` already enforce for that user.
  - Substring search and result limit behave identically to before for in-scope clusters.
