### PR TITLE
fix: [event] add redirects non-Overmind themes to missing view2 (#10839)

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -3336,7 +3336,11 @@ class EventsController extends AppController
                     } else {
                         // redirect to the view of the newly created event
                         $this->Flash->success(__('The event has been saved'));
-                        $this->redirect(array('action' => 'view2', $this->Event->getID()));
+                        if ($this->theme === "Overmind") {
+                            $this->redirect(array('action' => 'view2', $this->Event->getID()));
+                        } else {
+                            $this->redirect(array('action' => 'view', $this->Event->getID()));
+                        }
                     }
                 } else {
                     if ($this->_isRest()) { // TODO return error if REST


### PR DESCRIPTION
## What does it do?

Fixes #10839.

Previously, submitting the Add Event form always redirected users to `/events/view2/{id}`. The `view2` action only ships a themed template (Overmind, EventTest) and lacks a default template at `app/View/Events/view2.ctp`. On the default theme, this redirect lands on a view that does not exist, causing CakePHP to throw a `MissingViewException` (*"View file Events/view2.ctp is missing"*). While the event is successfully created in the database, the user is presented with a 500 error page instead of the new event.

This PR guards the `view2` redirect behind the Overmind theme check and falls back to the standard `view` action for all other themes.

## How it works

The change introduces a single conditional statement within `EventsController::add()`. It mirrors the pattern already utilized in `AttributesController` and elsewhere in `EventsController`, where `view2` redirects are explicitly gated on `$this->theme === "Overmind"` with a fallback to `view`. Overmind users retain the new event view layout, while all other users are safely routed back to the working `view` action.

**Regression Source:** Introduced in commit `a6a06665f` (*"new: [Overmind] Start the migration of Event View"*), which swapped this post-create redirect from `view` to `view2` without providing a baseline default template.

## Questions

* [ ] Does it require a DB change? No
* [ ] Are you using it in production? Verified in local containerized MISP environment / test instance.
* [ ] Does it require a change in the API (PyMISP for example)? No

## Testing

Verified on a local MISP v2.5.40 instance with `MISP.default_theme = Default` and `MISP.enable_themes = false` (matching the exact conditions from the issue report):

* **Before the fix:** Creating an event redirects to `/events/view2/{id}`, which returns an HTTP 500 error due to `MissingViewException` (Verified on `.210` via redirect to `/events/view2/32`).
* **After the fix:** Creating an event redirects to `/events/view/{id}`, which returns a clean HTTP 200 OK and properly renders the new event (Verified on `.210` via redirect to `/events/view/33`).
* **Behavior Breakdown:** `/events/view/{id}` functions flawlessly for the default theme; `/events/view2/{id}` is now exclusively hit under the Overmind theme, which provides its own template files.ent-add-view2-redirect`