### PR TITLE
feat: [settings] environment variables as a third settings source

### DIFF
--- a/app/Console/Command/Task/ConfigLoadTask.php
+++ b/app/Console/Command/Task/ConfigLoadTask.php
@@ -7,5 +7,9 @@ class ConfigLoadTask extends Shell
             App::uses('SystemSetting', 'Model');
             SystemSetting::setGlobalSetting();
         }
+        // Environment variables are the highest priority source, so they are
+        // applied last to override both the config file and the database.
+        App::uses('EnvSetting', 'Tools');
+        EnvSetting::setGlobalSetting();
     }
 }

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -113,6 +113,10 @@ class AppController extends Controller
             App::uses('SystemSetting', 'Model');
             SystemSetting::setGlobalSetting();
         }
+        // Environment variables are the highest priority source, so they are
+        // applied last to override both the config file and the database.
+        App::uses('EnvSetting', 'Tools');
+        EnvSetting::setGlobalSetting();
 
         // Set the baseurl for redirects
         $baseurl = empty(Configure::read('MISP.baseurl')) ? null : Configure::read('MISP.baseurl');

--- a/app/Lib/Tools/EnvSetting.php
+++ b/app/Lib/Tools/EnvSetting.php
@@ -1,0 +1,140 @@
+<?php
+App::uses('SystemSetting', 'Model');
+
+/**
+ * Loads MISP settings from environment variables as a third configuration
+ * source, in addition to the config file and the `system_settings` database
+ * table. This is primarily useful for container and Kubernetes deployments
+ * where settings are injected as environment variables.
+ *
+ * An environment variable is recognised when it starts with the prefix
+ * `MISP_SETTING_`, followed by the setting name with each `.` replaced by a
+ * double underscore `__`. Examples:
+ *
+ *   MISP.baseurl                   -> MISP_SETTING_MISP__baseurl
+ *   Security.salt                  -> MISP_SETTING_Security__salt
+ *   Plugin.Enrichment.services_url -> MISP_SETTING_Plugin__Enrichment__services_url
+ *
+ * Environment provided settings take precedence over both the database and
+ * the config file, so they must be applied after those sources are loaded.
+ * They are read only and cannot be changed from the UI or CLI.
+ *
+ * Values are cast to the most appropriate type: `true`/`false`/`null`, then
+ * integers and floats, then JSON for arrays and objects, falling back to the
+ * raw string. A value that should stay a string but looks numeric (for
+ * example a digit only token) is therefore coerced to a number, so quote or
+ * JSON encode such values if the exact string is required.
+ */
+class EnvSetting
+{
+    const ENV_PREFIX = 'MISP_SETTING_';
+
+    /**
+     * Apply every setting defined via environment variables into the global
+     * Configure store. Must be called after the file and database sources are
+     * loaded so that the environment always wins.
+     *
+     * @return void
+     */
+    public static function setGlobalSetting()
+    {
+        foreach (self::readSettings() as $settingName => $value) {
+            Configure::write($settingName, $value);
+        }
+    }
+
+    /**
+     * Returns the settings provided via environment variables, keyed by their
+     * MISP setting name (e.g. `MISP.baseurl`). Only settings whose top level
+     * category is a known MISP category are returned. Unlike the database
+     * source, sensitive settings are allowed, as environment variables are the
+     * intended channel for injecting secrets.
+     *
+     * @return array
+     */
+    public static function readSettings()
+    {
+        $settings = [];
+        foreach (self::environment() as $name => $value) {
+            if (strpos($name, self::ENV_PREFIX) !== 0) {
+                continue;
+            }
+            $settingName = str_replace('__', '.', substr($name, strlen(self::ENV_PREFIX)));
+            $firstPart = explode('.', $settingName)[0];
+            if (!in_array($firstPart, SystemSetting::ALLOWED_CATEGORIES, true)) {
+                continue;
+            }
+            $settings[$settingName] = self::castValue($value);
+        }
+        return $settings;
+    }
+
+    /**
+     * Whether the given setting is currently provided via an environment
+     * variable. Used to mark such settings as read only.
+     *
+     * @param string $settingName
+     * @return bool
+     */
+    public static function isSetViaEnv($settingName)
+    {
+        return array_key_exists($settingName, self::readSettings());
+    }
+
+    /**
+     * Returns the environment variable name that maps to the given setting.
+     *
+     * @param string $settingName
+     * @return string
+     */
+    public static function envVariableName($settingName)
+    {
+        return self::ENV_PREFIX . str_replace('.', '__', $settingName);
+    }
+
+    /**
+     * Casts a raw environment string into the most appropriate PHP type.
+     * Booleans and null are matched first, since a literal "false" string
+     * would otherwise be truthy, then integers and floats, then JSON for
+     * arrays and objects, falling back to the raw string.
+     *
+     * @param string $value
+     * @return mixed
+     */
+    private static function castValue($value)
+    {
+        $lowered = strtolower($value);
+        if ($lowered === 'true') {
+            return true;
+        }
+        if ($lowered === 'false') {
+            return false;
+        }
+        if ($lowered === 'null') {
+            return null;
+        }
+        if (is_numeric($value)) {
+            return $value == (int)$value ? (int)$value : (float)$value;
+        }
+        $firstChar = isset($value[0]) ? $value[0] : '';
+        if ($firstChar === '{' || $firstChar === '[') {
+            $decoded = json_decode($value, true);
+            if ($decoded !== null) {
+                return $decoded;
+            }
+        }
+        return $value;
+    }
+
+    /**
+     * Returns all environment variables. Uses getenv() so values are read
+     * regardless of the PHP `variables_order` setting.
+     *
+     * @return array
+     */
+    private static function environment()
+    {
+        $env = getenv();
+        return is_array($env) ? $env : [];
+    }
+}

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -2531,6 +2531,10 @@ class Server extends AppModel
         if (!$cli && $cliOnly) {
             return __('This setting can only changed via the CLI. Change request ignored.');
         }
+        App::uses('EnvSetting', 'Tools');
+        if (EnvSetting::isSetViaEnv($setting['name'])) {
+            return __('This setting is set via an environment variable and cannot be changed here. Change request ignored.');
+        }
         $settingSaveResult = $this->serverSettingsSaveValue($setting['name'], $value);
         if ($settingSaveResult) {
             if (SystemSetting::isSensitive($setting['name'])) {


### PR DESCRIPTION
## What does it do?

Fixes #10811

Adds environment variables as a third configuration source alongside `config.php` and the `system_settings` database table. This implementation is explicitly designed for containerized and Kubernetes environments where configuration parameters are dynamically injected at runtime.

* Any configuration parameter can be supplied as an environment variable using the prefix `MISP_SETTING_`.
* The configuration key structure translates dots (`.`) into double underscores (`__`).

### Mapping Examples

| MISP Setting Key | Environment Variable Equivalent |
| --- | --- |
| `MISP.baseurl` | `MISP_SETTING_MISP__baseurl` |
| `Security.salt` | `MISP_SETTING_Security__salt` |
| `Plugin.Enrichment.services_url` | `MISP_SETTING_Plugin__Enrichment__services_url` |

---

## How it works

* **Precedence Chain:** A lightweight `EnvSetting` helper reads matching environment variables and writes them into the `Configure` store. It executes after the flat-file and database bootstrap routines in both `AppController` and the CLI `ConfigLoadTask`. Configuration precedence is resolved as follows:
> **Environment Variables** --> **Database Table** --> **`config.php` File**


* **Immutability (Read-Only):** Environment-provided settings are strictly read-only. The `serverSettingsEditValue` method is updated to reject modification attempts via the UI or API, returning a clear error message in line with how `cli_only` directives are handled.
* **Type Determination:** Values undergo deterministic casting to preserve strict type safety. Literal strings matching `true`, `false`, or `null` are cast to their corresponding primitive types, followed by integer and float checks. Valid JSON strings are parsed into associative arrays/objects; otherwise, the value defaults to a raw string. (Numeric strings intended to remain strings should be quoted or JSON-encoded).
* **Category Scoping & Secrets:** Only known setting categories registered within the MISP schema are parsed and accepted. Unlike the database configuration pipeline, sensitive low-level configurations (such as the application salt or encryption keys) are permitted, as environment injection is the standard practice for secret management in orchestrated infrastructure.
* **Redis Capabilities:** Connection parameters for the Redis backend are supported natively out-of-the-box because they already reside within the centralized settings registry.

---

## Security

* **Header Spoofing Protection:** The `MISP_SETTING_` prefix completely avoids the `HTTP_` namespace defined by CGI/FastCGI implementations. Verification testing on live web servers confirms that a malicious client attempting to send a `MISP_SETTING_...` HTTP request header lands in PHP as `HTTP_MISP_SETTING_...` and is safely ignored by the loader.
* **Privilege Alignment:** Modifying these variables requires process environment control over the underlying container or service execution context, aligning exactly with the trust level required to modify `config.php` on disk.
* **UI Masking:** Sensitive strings remain masked within administrative menus, as data redaction logic hooks directly into the core setting schema definitions rather than evaluating the backend configuration source.

---

## Out of scope

* **`database.php` Adjustments:** Database backend connection parameters utilize a distinct initialization routine that runs prior to the settings registry bootstrap. Because the official MISP Docker stack already handles the dynamic templating of `database.php` from standard environment variables, updating this specific layer has been deferred as a potential downstream enhancement.

---

## Questions

* [ ] Does it require a DB change? *No*
* [ ] Are you using it in production? *Verified in local Docker containerized testing environments.*
* [ ] Does it require a change in the API (PyMISP for example)? *No*

---

## Testing

Validation testing was executed on a local containerized v2.5 stack running under the default configuration baseline.

* **Syntax & Stability:** Verified `php -l` compliance across all modified controllers and components; runtime compilation succeeded without performance degradation.
* **Override Verification:** Passing `MISP_SETTING_MISP__title_text=EnvWins` forces `getSetting MISP.title_text` to correctly return `EnvWins`.
* **Precedence Verification:** Injecting `MISP_SETTING_MISP__redis_database=99` successfully overwrites the disk configuration default of `13`, confirming that environment strings take absolute priority.
* **Type-Casting Integrity:** Validated that literal boolean values (`false`) and explicit digits resolve as primitive booleans and integers rather than truthy strings.
* **Schema Enforcement:** Sensitive keys (`Security.salt`) were successfully parsed and loaded, unregistered structural categories were dropped, and unrelated process environment variables were ignored.
* **Write-Lock Verification:** Attempting a `setSetting` call against an environment-managed variable returns an explicit modification rejection, while unmanaged keys modify normally.
* **Namespace Defense:** Forged client HTTP headers mimicking the configuration layout were rejected cleanly at the application layer.