### PR TITLE
Handle Redis BLPOP socket timeouts in mispzmq

### DIFF
--- a/app/files/scripts/mispzmq/mispzmq.py
+++ b/app/files/scripts/mispzmq/mispzmq.py
@@ -4,6 +4,8 @@ from zmq.auth.thread import ThreadAuthenticator
 from zmq.utils.monitor import recv_monitor_message
 import sys
 import redis
+from redis.exceptions import TimeoutError as RedisTimeoutError
+from redis.exceptions import ConnectionError as RedisConnectionError
 import os
 import time
 import threading
@@ -92,7 +94,7 @@ class MispZmq:
             redis_host = redis_host[6:]
         self.redis = redis.StrictRedis(host=redis_host, db=self.settings["redis_database"],
                                    password=self.settings["redis_password"], port=self.settings["redis_port"],
-                                   ssl=redis_ssl)
+                                   ssl=redis_ssl, protocol=2, socket_connect_timeout=5, socket_timeout=30, health_check_interval=30, retry_on_timeout=True)
         self.timestamp_settings = time.time()
         self._logger.debug("Connected to Redis {}:{}/{}".format(self.settings["redis_host"], self.settings["redis_port"],
                                                            self.settings["redis_database"]))
@@ -195,7 +197,16 @@ class MispZmq:
         key_prefix = f"{self.namespace}:".encode("utf-8")
 
         while True:
-            data = self.redis.blpop(lists, timeout=10)
+            try:
+                data = self.redis.blpop(lists, timeout=10)
+            except RedisTimeoutError:
+                self._logger.debug("Redis BLPOP timeout")
+                data = None
+            except RedisConnectionError as e:
+                self._logger.debug("Redis connection error")
+                time.sleep(2)
+                self._setup()
+                data = None
 
             if data is None:
                 # redis timeout expired


### PR DESCRIPTION
#### What does it do?

- Handle Redis BLPOP socket timeouts in mispzmq
- Reconnect on Redis connection errors and
  continue publishing instead of exiting on timeouts

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
