### PR TITLE
Scheduled taxii push

### DIFF
--- a/app/Console/Command/SchedulerWorkerShell.php
+++ b/app/Console/Command/SchedulerWorkerShell.php
@@ -8,7 +8,7 @@ App::uses('Worker', 'Tools/BackgroundJobs');
 
 class SchedulerWorkerShell extends AppShell
 {
-    public $uses = ['Task', 'Feed', 'Server', 'Job', 'User'];
+    public $uses = ['Task', 'Feed', 'Server', 'TaxiiServer', 'Job', 'User'];
 
     /** @var Worker */
     private $worker;
@@ -108,6 +108,13 @@ class SchedulerWorkerShell extends AppShell
                 $this->logMessage('error', $task['id'], "unknown action for Feed: {$task['action']}");
                 return;
             }
+        } elseif ($task['type'] == 'TAXII') {
+            if ($task['action'] !== 'push') {
+                $this->logMessage('error', $task['id'], "unknown action for TAXII: {$task['action']}");
+                return;
+            }
+
+            $this->runTaxiiPushTask($task);
         } elseif ($task['type'] == 'Workflow') {
             $this->runWorkflowAdHoc($task);
         } elseif ($task['type'] == 'Periodic Summary') {
@@ -436,6 +443,60 @@ class SchedulerWorkerShell extends AppShell
         ]);
 
         $this->logMessage('info', $task['id'], "enqueued cache for Feed with scope: {$scope}.");
+    }
+
+    private function runTaxiiPushTask($task)
+    {
+        $taxiiServerId = $task['params'];
+
+        if (!is_numeric($taxiiServerId) && $taxiiServerId !== 'all') {
+            $this->logMessage('error', $task['id'], "invalid parameters: expected numeric TAXII server ID or 'all'.");
+            return;
+        }
+
+        $user = $this->User->getAuthUser($task['user_id']);
+        if (empty($user)) {
+            $this->logMessage('error', $task['id'], "user ID do not match an existing user.");
+            return;
+        }
+
+        if (is_numeric($taxiiServerId) && !$this->TaxiiServer->hasAny([
+            'TaxiiServer.id' => $taxiiServerId,
+            'TaxiiServer.enabled' => 1,
+        ])) {
+            $this->logMessage('error', $task['id'], "TAXII server is not found or not enabled: {$taxiiServerId}.");
+            return;
+        }
+
+        $jobId = $this->Job->createJob(
+            $user,
+            Job::WORKER_DEFAULT,
+            'push_taxii',
+            'TAXII Server: ' . $taxiiServerId,
+            __('Starting TAXII push.')
+        );
+
+        $this->getBackgroundJobsTool()->enqueue(
+            BackgroundJobsTool::DEFAULT_QUEUE,
+            BackgroundJobsTool::CMD_SERVER,
+            [
+                'push_taxii',
+                $user['id'],
+                $taxiiServerId,
+                $jobId
+            ],
+            true,
+            $jobId
+        );
+
+        $this->Task->save([
+            'id' => $task['id'],
+            'last_job_id' => $jobId,
+            'message' => 'Enqueued',
+            'last_run_at' => time()
+        ]);
+
+        $this->logMessage('info', $task['id'], "enqueued TAXII Push for TAXII Server ID: {$taxiiServerId}.");
     }
 
     public function runWorkflowAdHoc($task)

--- a/app/Console/Command/ServerShell.php
+++ b/app/Console/Command/ServerShell.php
@@ -830,18 +830,44 @@ class ServerShell extends AppShell
         if (empty($this->args[0]) || empty($this->args[1])) {
             die('Usage: ' . $this->Server->command_line_functions['console_automation_tasks']['data']['Push Taxii'] . PHP_EOL);
         }
-        
+
         $userId = $this->args[0];
         $user = $this->getUser($userId);
-        $serverId = $this->args[1];
+        $taxiiServerId = $this->args[1];
         if (!empty($this->args[2])) {
             $jobId = $this->args[2];
         } else {
-            $jobId = $this->Job->createJob($user, Job::WORKER_DEFAULT, 'push_taxii', 'Server: ' . $serverId, 'Pushing.');
+            $jobId = $this->Job->createJob($user, Job::WORKER_DEFAULT, 'push_taxii', 'TAXII Server: ' . $taxiiServerId, 'Pushing.');
         }
         $this->Job->read(null, $jobId);
 
-        $result = $this->TaxiiServer->push($serverId, $user, $jobId);
+        if ($taxiiServerId === 'all') {
+            $taxiiServerIds = $this->TaxiiServer->find('column', [
+                'fields' => ['TaxiiServer.id'],
+                'conditions' => ['TaxiiServer.enabled' => 1],
+            ]);
+
+            $successes = 0;
+            $fails = 0;
+            $total = count($taxiiServerIds);
+            foreach ($taxiiServerIds as $k => $taxiiServerId) {
+                $this->Job->saveProgress($jobId, 'Pushing TAXII server: ' . $taxiiServerId, $total > 0 ? 100 * $k / $total : 100);
+                $result = $this->TaxiiServer->push($taxiiServerId, $user, $jobId);
+                if ($result === true || is_array($result)) {
+                    $successes++;
+                } else {
+                    $fails++;
+                    CakeLog::error('TAXII push failed for server ' . $taxiiServerId . ': ' . $result);
+                }
+            }
+
+            $message = 'Job done. ' . $successes . ' TAXII servers pushed successfully, ' . $fails . ' TAXII servers could not be pushed.';
+            $this->Job->saveStatus($jobId, $fails === 0, $message);
+            echo $message . PHP_EOL;
+            return;
+        }
+
+        $result = $this->TaxiiServer->push($taxiiServerId, $user, $jobId);
         if ($result !== true && !is_array($result)) {
             $message = 'Job failed. Reason: ' . $result;
             $this->Job->saveStatus($jobId, false, $message);

--- a/app/Controller/TasksController.php
+++ b/app/Controller/TasksController.php
@@ -132,6 +132,8 @@ class TasksController extends AppController
                             if ($task['Task']['action'] === 'pull') {
                                 $task['Task']['server_technique'] = $params[1];
                             }
+                        } elseif ($task['Task']['type'] === 'TAXII') {
+                            $task['Task']['taxii_server_id'] = $params[0];
                         } elseif ($task['Task']['type'] === 'Feed') {
                             $task['Task']['feed_action'] = $task['Task']['action'];
                             if ($task['Task']['action'] === 'fetch') {
@@ -326,6 +328,7 @@ class TasksController extends AppController
         $this->Server = ClassRegistry::init('Server');
         $this->Feed = ClassRegistry::init('Feed');
         $this->Workflow = ClassRegistry::init('Workflow');
+        $this->TaxiiServer = ClassRegistry::init('TaxiiServer');
 
         $workflows = $this->Workflow->find('all', [
             'order' => ['Workflow.name' => 'ASC'],
@@ -362,6 +365,11 @@ class TasksController extends AppController
                 'order' => ['Feed.name' => 'ASC']
             ]),
             'workflows' => $dropdownWorkflows,
+            'taxii_servers' => ['all' => __('All enabled TAXII servers')] + $this->TaxiiServer->find('list', [
+                'fields' => ['TaxiiServer.id', 'TaxiiServer.name'],
+                'conditions' => ['TaxiiServer.enabled' => 1],
+                'order' => ['TaxiiServer.name' => 'ASC']
+            ]),
         ];
 
         return $dropdownData;
@@ -416,6 +424,21 @@ class TasksController extends AppController
                 return;
             }
             $data['Task']['params'] = $data['Task']['workflow'];
+        } elseif ($data['Task']['type'] === 'TAXII') {
+            $data['Task']['action'] = 'push';
+
+            if (!isset($data['Task']['taxii_server_id']) || empty($data['Task']['taxii_server_id'])) {
+                $this->Flash->error(__('Please select a TAXII server.'));
+                return;
+            }
+            if ($data['Task']['taxii_server_id'] !== 'all' && !$this->TaxiiServer->hasAny([
+                'TaxiiServer.id' => $data['Task']['taxii_server_id'],
+                'TaxiiServer.enabled' => 1,
+            ])) {
+                $this->Flash->error(__('Please select an enabled TAXII server.'));
+                return;
+            }
+            $data['Task']['params'] = $data['Task']['taxii_server_id'];
         } elseif ($data['Task']['type'] === 'Periodic Summary') {
             $data['Task']['action'] = 'send';
         } elseif ($data['Task']['type'] === 'Admin') {

--- a/app/Controller/TaxiiServersController.php
+++ b/app/Controller/TaxiiServersController.php
@@ -111,6 +111,9 @@ class TaxiiServersController extends AppController
         if (empty($taxii_server)) {
             throw new NotFoundException(__('Invalid Taxii Server ID provided.'));
         }
+        if (empty($taxii_server['TaxiiServer']['enabled'])) {
+            throw new MethodNotAllowedException(__('TAXII server is disabled.'));
+        }
 
         if ($this->request->is('post')) {
             $result = $this->TaxiiServer->pushRouter($taxii_server['TaxiiServer']['id'], $this->Auth->user());

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -97,7 +97,8 @@ class AppModel extends Model
         129 => false, 130 => false, 131 => false, 132 => false, 133 => false, 134 => true,
         135 => false, 136 => true, 137 => false, 138 => false, 139 => false, 140 => false,
         141 => false, 142 => false, 143 => false, 144 => false, 145 => false, 146 => false,
-        147 => false, 148 => false, 149 => false, 150 => false, 151 => false, 152 => false
+        147 => false, 148 => false, 149 => false, 150 => false, 151 => false, 152 => false,
+        153 => false
     );
 
     const ADVANCED_UPDATES_DESCRIPTION = array(
@@ -2693,6 +2694,9 @@ class AppModel extends Model
                 break;
             case 151:
                 $sqlArray[] = "ALTER TABLE `galaxies` MODIFY `distribution` tinyint(4) NOT NULL DEFAULT 0;";
+                break;
+            case 153:
+                $sqlArray[] = "ALTER TABLE `taxii_servers` ADD `enabled` tinyint(1) NOT NULL DEFAULT 1;";
                 break;
             case 'fixNonEmptySharingGroupID':
                 $sqlArray[] = 'UPDATE `events` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';

--- a/app/Model/TaxiiServer.php
+++ b/app/Model/TaxiiServer.php
@@ -33,10 +33,16 @@ class TaxiiServer extends AppModel
         if (!isset($this->data['TaxiiServer']['skip_proxy'])) {
             $this->data['TaxiiServer']['skip_proxy'] = false;
         }
+        if (!isset($this->data['TaxiiServer']['enabled']) && empty($this->id)) {
+            $this->data['TaxiiServer']['enabled'] = true;
+        }
 
         // Validate skip_proxy as a boolean
         if (isset($this->data['TaxiiServer']['skip_proxy']) && !is_bool($this->data['TaxiiServer']['skip_proxy'])) {
             $this->data['TaxiiServer']['skip_proxy'] = $this->data['TaxiiServer']['skip_proxy'] ? true : false; // Convert to boolean
+        }
+        if (isset($this->data['TaxiiServer']['enabled']) && !is_bool($this->data['TaxiiServer']['enabled'])) {
+            $this->data['TaxiiServer']['enabled'] = $this->data['TaxiiServer']['enabled'] ? true : false;
         }
         return true;
     }
@@ -73,6 +79,12 @@ class TaxiiServer extends AppModel
             'recursive' => -1,
             'conditions' => ['TaxiiServer.id' => $id]
         ]);
+        if (empty($taxii_server)) {
+            return __('Invalid TAXII server.');
+        }
+        if (empty($taxii_server['TaxiiServer']['enabled'])) {
+            return __('TAXII server is disabled.');
+        }
         $filters = $this->__setPushFilters($taxii_server);
         $elementCounter = 0;
         $eventid = $this->Event->filterEventIds($user, $filters, $elementCounter);

--- a/app/View/Tasks/add.ctp
+++ b/app/View/Tasks/add.ctp
@@ -12,6 +12,7 @@ echo $this->element('genericElements/Form/genericForm', [
                     'Feed' => 'Feed',
                     'Workflow' => 'Workflow',
                     'Periodic Summary' => 'Periodic Summary',
+                    'TAXII' => 'TAXII',
                     'Admin' => 'Admin'
                 ],
                 'type' => 'dropdown',
@@ -100,6 +101,18 @@ echo $this->element('genericElements/Form/genericForm', [
                 ],
                 'class' => 'span6',
                 'div' => ['id' => 'Workflow', 'style' => 'display:none', 'class' => 'optionalField'],
+            ],
+            [
+                'field' => 'taxii_server_id',
+                'label' => __('TAXII Server'),
+                'options' => $dropdownData['taxii_servers'],
+                'type' => 'dropdown',
+                'picker' => true,
+                '_chosenOptions' => [
+                    'width' => '460px',
+                ],
+                'class' => 'span6',
+                'div' => ['id' => 'TaxiiServer', 'style' => 'display:none', 'class' => 'optionalField'],
             ],
             [
                 'field' => 'admin_action',
@@ -205,14 +218,22 @@ echo $this->Js->writeBuffer();
 
 <script type="text/javascript">
     $(document).ready(function() {
+        function refreshTaskForm() {
+            taskFormUpdate();
+            if ($("#TaskType").val() === "TAXII") {
+                $("#TaxiiServer").show();
+            }
+            $("#TaxiiServer select, #Workflow select, #Server select, #Feed select").trigger("chosen:updated");
+        }
+
         $(".datepicker").datepicker({
             preventMultipleSet: true,
             format: 'yyyy-mm-dd',
             todayHighlight: true
         });
-        taskFormUpdate();
+        refreshTaskForm();
         $("#TaskType, #TaskRunAfterCreation, #TaskFeedAction, #TaskServerAction, #TaskFeedId").change(function() {
-            taskFormUpdate();
+            refreshTaskForm();
         });
     });
 </script>

--- a/app/View/TaxiiServers/add.ctp
+++ b/app/View/TaxiiServers/add.ctp
@@ -20,6 +20,12 @@ $fields = [
         'default' => false
     ],
     [
+        'field' => 'enabled',
+        'label' => __('Enabled'),
+        'type' => 'checkbox',
+        'default' => !$edit
+    ],
+    [
         'field' => 'api_key',
         'label' => 'API Key',
         'type' => 'text',

--- a/app/View/TaxiiServers/index.ctp
+++ b/app/View/TaxiiServers/index.ctp
@@ -55,6 +55,12 @@
                         'element' => 'boolean'
                     ],
                     [
+                        'name' => __('Enabled'),
+                        'sort' => 'TaxiiServer.enabled',
+                        'data_path' => 'TaxiiServer.enabled',
+                        'element' => 'boolean'
+                    ],
+                    [
                         'name' => __('API root'),
                         'sort' => 'TaxiiServer.api_root',
                         'data_path' => 'TaxiiServer.api_root'
@@ -96,7 +102,10 @@
                         ),
                         'onclick_params_data_path' => 'TaxiiServer.id',
                         'title' => __('Push all filtered data to TAXII server'),
-                        'icon' => 'upload'
+                        'icon' => 'upload',
+                        'complex_requirement' => function ($row) {
+                            return !empty($row['TaxiiServer']['enabled']);
+                        }
                     ],
                     [
                         'onclick' => sprintf(

--- a/app/View/TaxiiServers/view.ctp
+++ b/app/View/TaxiiServers/view.ctp
@@ -23,6 +23,11 @@ echo $this->element(
                 'type' => 'json'
             ],
             [
+                'key' => __('Enabled'),
+                'path' => 'TaxiiServer.enabled',
+                'type' => 'json'
+            ],
+            [
                 'key' => __('Discovery URL'),
                 'path' => 'TaxiiServer.discovery_url'
             ],

--- a/app/View/Themed/Overmind/Elements/TaxiiServers/View/taxiiServers_actions.ctp
+++ b/app/View/Themed/Overmind/Elements/TaxiiServers/View/taxiiServers_actions.ctp
@@ -1,5 +1,6 @@
 <?php
 $taxiiServerId = h($data['TaxiiServer']['id']);
+$taxiiServerEnabled = !empty($data['TaxiiServer']['enabled']);
 
 $actions = [];
 
@@ -10,12 +11,14 @@ if ($isSiteAdmin) {
         'icon' => 'fas fa-pen',
         'label' => __('Edit Server')
     ];
-    $actions[] = [
-        'url' => "$baseurl/taxiiServers/push/$taxiiServerId",
-        'onclick' => "event.preventDefault(); openModal('$baseurl/taxiiServers/push/$taxiiServerId', 'sm');",
-        'icon' => 'fas fa-arrow-circle-up',
-        'label' => __('Push data to TAXII server')
-    ];
+    if ($taxiiServerEnabled) {
+        $actions[] = [
+            'url' => "$baseurl/taxiiServers/push/$taxiiServerId",
+            'onclick' => "event.preventDefault(); openModal('$baseurl/taxiiServers/push/$taxiiServerId', 'sm');",
+            'icon' => 'fas fa-arrow-circle-up',
+            'label' => __('Push data to TAXII server')
+        ];
+    }
     $actions[] = [
         'url' => "$baseurl/taxiiServers/delete/$taxiiServerId",
         'onclick' => "event.preventDefault(); openModal('$baseurl/taxiiServers/deleteSelection/$taxiiServerId', 'sm');",

--- a/app/View/Themed/Overmind/Elements/TaxiiServers/View/taxiiServers_general.ctp
+++ b/app/View/Themed/Overmind/Elements/TaxiiServers/View/taxiiServers_general.ctp
@@ -27,7 +27,7 @@
         <div class="row g-3">
 
             <!-- ID -->
-            <div class="col-md-4">
+            <div class="col-md-3">
                 <div class="text-muted small text-uppercase fw-bold mb-1">
                     ID
                 </div>
@@ -37,7 +37,7 @@
             </div>
 
             <!-- OWNER -->
-            <div class="col-md-4">
+            <div class="col-md-3">
                 <div class="text-muted small text-uppercase fw-bold mb-1"><?= __('Owner') ?></div>
                 <div class="d-flex align-items-center bg-light rounded px-2 py-1 border">
                     <div class="bg-primary text-white rounded-circle d-flex align-items-center justify-content-center me-3 shadow-sm" style="width: 25px; height: 25px;">
@@ -48,15 +48,31 @@
             </div>
 
             <!-- PROXY -->
-            <div class="col-md-4">
+            <div class="col-md-3">
                 <div class="text-muted small text-uppercase fw-bold mb-1">
                     <?= __('Skip Proxy') ?>
                 </div>
 
-                <div class="d-flex align-items-center py-2"">
+                <div class="d-flex align-items-center py-2">
                     <?= $this->element('genericElementsBS5/Badges/boolean', [
                         'boolean' => $data['TaxiiServer']['skip_proxy'],
                         'full' => false
+                    ]); ?>
+                </div>
+            </div>
+
+            <!-- ENABLED -->
+            <div class="col-md-3">
+                <div class="text-muted small text-uppercase fw-bold mb-1">
+                    <?= __('Enabled') ?>
+                </div>
+
+                <div class="d-flex align-items-center py-2">
+                    <?= $this->element('genericElementsBS5/Badges/boolean', [
+                        'boolean' => $data['TaxiiServer']['enabled'],
+                        'full' => false,
+                        'true' => __('Enabled'),
+                        'false' => __('Disabled')
                     ]); ?>
                 </div>
             </div>

--- a/app/View/Themed/Overmind/TaxiiServers/add.ctp
+++ b/app/View/Themed/Overmind/TaxiiServers/add.ctp
@@ -1,5 +1,9 @@
 <?php
 $edit = $this->request->params['action'] === 'edit';
+$enabledOptions = ['class' => 'form-check-input'];
+if (!$edit && !isset($this->request->data['TaxiiServer']['enabled'])) {
+    $enabledOptions['checked'] = true;
+}
 
 echo $this->Form->create('TaxiiServer', [
     'class' => 'needs-validation',
@@ -100,6 +104,11 @@ echo $this->Form->create('TaxiiServer', [
                         'class' => 'form-check-input',
                     ]) ?>
                     <?= $this->Form->label('skip_proxy', __('Skip Proxy'), ['class' => 'form-check-label']) ?>
+                </div>
+
+                <div class="form-check form-switch mb-4">
+                    <?= $this->Form->checkbox('enabled', $enabledOptions) ?>
+                    <?= $this->Form->label('enabled', __('Enabled'), ['class' => 'form-check-label']) ?>
                 </div>
 
                 <!-- ACTIONS -->

--- a/app/View/Themed/Overmind/TaxiiServers/index.ctp
+++ b/app/View/Themed/Overmind/TaxiiServers/index.ctp
@@ -79,6 +79,14 @@ $fields = [
         'display_in' => ['table', 'card']
     ],
     [
+        'name' => __('Enabled'),
+        'sort' => 'TaxiiServer.enabled',
+        'data_path' => 'TaxiiServer.enabled',
+        'element' => 'enabled',
+        'card_section' => 'top',
+        'display_in' => ['table', 'card']
+    ],
+    [
         'name' => __('Actions'),
         'element' => 'row_actions',
         'data_path' => 'TaxiiServer.id',
@@ -108,14 +116,18 @@ $fields = [
             [
                 'type' => 'divider',
                 'url' => '#',
-                'requirement' => $isSiteAdmin
+                'requirement' => function (array $row) use ($isSiteAdmin) {
+                    return $isSiteAdmin && !empty($row['TaxiiServer']['enabled']);
+                }
             ],
             [
                 'type' => 'modal',
                 'label' => __('Push all filtered data to TAXII server'),
                 'icon' => 'arrow-circle-up',
                 'url' => $baseurl . '/taxiiServers/push/%id%',
-                'requirement' => $isSiteAdmin
+                'requirement' => function (array $row) use ($isSiteAdmin) {
+                    return $isSiteAdmin && !empty($row['TaxiiServer']['enabled']);
+                }
             ]
         ]
     ]

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -5984,6 +5984,9 @@ function taskFormUpdate() {
         case 'Workflow':
             $('#Workflow').show();
             break;
+        case 'TAXII':
+            $('#TaxiiServer').show();
+            break;
         case 'Admin':
             $('#AdminAction').show();
             break;

--- a/db_schema.json
+++ b/db_schema.json
@@ -9102,6 +9102,17 @@
                 "column_type": "tinyint(1)",
                 "column_default": "0",
                 "extra": ""
+            },
+            {
+                "column_name": "enabled",
+                "is_nullable": "NO",
+                "data_type": "tinyint",
+                "character_maximum_length": null,
+                "numeric_precision": "3",
+                "collation_name": null,
+                "column_type": "tinyint(1)",
+                "column_default": "1",
+                "extra": ""
             }
         ],
         "taxonomies": [
@@ -11451,5 +11462,5 @@
             "uuid": false
         }
     },
-    "db_version": "152"
+    "db_version": "153"
 }


### PR DESCRIPTION
  - add TAXII as a scheduled task type with single-server and all-enabled push modes
  - enqueue TAXII pushes through the scheduler worker and server shell
  - add an enabled flag for TAXII servers, defaulting enabled for upgrades and new records
  - block manual and scheduled pushes for disabled TAXII servers
  - expose TAXII enabled state in default and Overmind add/index/view UI
  - filter scheduled TAXII task selection to enabled servers

#### Questions

- [Yes] Does it require a DB change?
- [No] Are you using it in production?
- [No?] Does it require a change in the API (PyMISP for example)?
