### PR TITLE
Fix/internal sync mirrors local tags after initial sync v2

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -715,7 +715,7 @@ class EventsController extends AppController
     {
         // list the events
         $urlparams = "";
-        $overrideAbleParams = array('all', 'attribute', 'published', 'eventid', 'datefrom', 'dateuntil', 'org', 'eventinfo', 'tag', 'tags', 'distribution', 'sharinggroup', 'analysis', 'threatlevel', 'email', 'hasproposal', 'timestamp', 'publishtimestamp', 'publish_timestamp', 'minimal', 'value', 'is_extension', 'is_extended');
+        $overrideAbleParams = array('all', 'attribute', 'published', 'eventid', 'datefrom', 'dateuntil', 'org', 'eventinfo', 'tag', 'tags', 'distribution', 'sharinggroup', 'analysis', 'threatlevel', 'email', 'hasproposal', 'timestamp', 'publishtimestamp', 'publish_timestamp', 'minimal', 'value', 'is_extension', 'is_extended', 'include_event_tags_fingerprint');
         $paginationParams = array('limit', 'page', 'sort', 'direction', 'order');
         $passedArgs = $this->passedArgs;
 
@@ -845,11 +845,16 @@ class EventsController extends AppController
 
         $fieldNames = $this->Event->schema();
         $minimal = !empty($passedArgs['searchminimal']) || !empty($passedArgs['minimal']);
+        $includeEventTagsFingerprint = !empty($passedArgs['searchinclude_event_tags_fingerprint']) || !empty($passedArgs['include_event_tags_fingerprint']);
         if ($minimal) {
+            $contain = ['Orgc.uuid'];
+            if ($includeEventTagsFingerprint) {
+                $contain[] = 'EventTag';
+            }
             $rules = [
                 'recursive' => -1,
                 'fields' => array('id', 'timestamp', 'sighting_timestamp', 'published', 'uuid', 'protected'),
-                'contain' => array('Orgc.uuid', 'EventTag'),
+                'contain' => $contain,
             ];
         } else {
             // Remove user ID from fetched fields
@@ -922,40 +927,42 @@ class EventsController extends AppController
         $protectedEventsByInstanceKey = array_flip($protectedEventsByInstanceKey);
 
         // Collect all tag IDs that are events
-        $tagIds = [];
-        foreach (array_column($events, 'EventTag') as $eventTags) {
-            foreach (array_column($eventTags, 'tag_id') as $tagId) {
-                $tagIds[$tagId] = true;
-            }
-        }
-
-        if (!empty($tagIds)) {
-            $tags = $this->Event->EventTag->Tag->find('all', [
-                'conditions' => [
-                    'Tag.id' => array_keys($tagIds),
-                    'Tag.exportable' => 1,
-                ],
-                'recursive' => -1,
-                'fields' => ['Tag.id', 'Tag.name', 'Tag.colour', 'Tag.is_galaxy'],
-            ]);
-            unset($tagIds);
-            $tags = array_column(array_column($tags, 'Tag'), null, 'id');
-
-            foreach ($events as $k => $event) {
-                if (empty($event['EventTag'])) {
-                    continue;
+        if (!$minimal || $includeEventTagsFingerprint) {
+            $tagIds = [];
+            foreach (array_column($events, 'EventTag') as $eventTags) {
+                foreach (array_column($eventTags, 'tag_id') as $tagId) {
+                    $tagIds[$tagId] = true;
                 }
-                foreach ($event['EventTag'] as $k2 => $et) {
-                    if (!isset($tags[$et['tag_id']])) {
-                        unset($events[$k]['EventTag'][$k2]); // tag not exists or is not exportable
-                    } else {
-                        $events[$k]['EventTag'][$k2]['Tag'] = $tags[$et['tag_id']];
+            }
+
+            if (!empty($tagIds)) {
+                $tags = $this->Event->EventTag->Tag->find('all', [
+                    'conditions' => [
+                        'Tag.id' => array_keys($tagIds),
+                        'Tag.exportable' => 1,
+                    ],
+                    'recursive' => -1,
+                    'fields' => ['Tag.id', 'Tag.name', 'Tag.colour', 'Tag.is_galaxy'],
+                ]);
+                unset($tagIds);
+                $tags = array_column(array_column($tags, 'Tag'), null, 'id');
+
+                foreach ($events as $k => $event) {
+                    if (empty($event['EventTag'])) {
+                        continue;
                     }
+                    foreach ($event['EventTag'] as $k2 => $et) {
+                        if (!isset($tags[$et['tag_id']])) {
+                            unset($events[$k]['EventTag'][$k2]); // tag not exists or is not exportable
+                        } else {
+                            $events[$k]['EventTag'][$k2]['Tag'] = $tags[$et['tag_id']];
+                        }
+                    }
+                    $events[$k]['EventTag'] = array_values($events[$k]['EventTag']);
                 }
-                $events[$k]['EventTag'] = array_values($events[$k]['EventTag']);
-            }
-            if (!$minimal && !$isCsvResponse) {
-                $events = $this->GalaxyCluster->attachClustersToEventIndex($this->Auth->user(), $events, false);
+                if (!$minimal && !$isCsvResponse) {
+                    $events = $this->GalaxyCluster->attachClustersToEventIndex($this->Auth->user(), $events, false);
+                }
             }
         }
 
@@ -1021,7 +1028,9 @@ class EventsController extends AppController
                 }
                 $event['Event']['orgc_uuid'] = $event['Orgc']['uuid'];
                 unset($event['Event']['protected']);
-                $event['Event']['EventTag'] = $event['EventTag'];
+                if ($includeEventTagsFingerprint) {
+                    $event['Event']['event_tags_fingerprint'] = $this->Event->getTagsFingerprint($event['EventTag']);
+                }
                 $events[$key] = $event['Event'];
             }
             $events = array_values($events);

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -5309,8 +5309,16 @@ class Event extends AppModel
             // edit timestamp newer than existing event timestamp
             if (
                 $force ||
-                !isset($data['Event']['timestamp']) || $data['Event']['timestamp'] > $existingEvent['Event']['timestamp'] ||
-                (!empty($server['Server']['internal']) && $this->areLocalTagsDifferent($existingEvent['EventTag'], $data['Event']['Tag']))
+                !isset($data['Event']['timestamp']) ||
+                $data['Event']['timestamp'] > $existingEvent['Event']['timestamp'] ||
+                (
+                    $data['Event']['timestamp'] == $existingEvent['Event']['timestamp'] &&
+                    !empty($server['Server']['internal']) &&
+                    $this->areLocalTagsDifferent(
+                        $existingEvent['EventTag'],
+                        $data['Event']['Tag']
+                    )
+                )
             ) {
                 if (!isset($data['Event']['timestamp'])) {
                     $data['Event']['timestamp'] = time();
@@ -5557,6 +5565,35 @@ class Event extends AppModel
         $localTagsFromEvent = $normalizeFn($eventTags ?? []);
 
         return $localTagsFromExistingEvent !== $localTagsFromEvent;
+    }
+
+    public function getTagsFingerprint($tags=[]) {
+        $normalizeFn = function (array $tags): array {
+            $result = [];
+
+            foreach ($tags as $tag) {
+                $name = $tag['Tag']['name'] ?? ($tag['name'] ?? null);
+
+                if ($name === null) {
+                    continue;
+                }
+
+                $local = (bool) ($tag['local'] ?? false);
+                $relationship = $tag['relationship_type'] ?? '';
+
+                // build a comparable signature
+                $result[] = $name . '|' . (int)$local . '|' . $relationship;
+            }
+
+            $result = array_values(array_unique($result));
+            sort($result);
+
+            return $result;
+        };
+
+        $normalized = $normalizeFn($tags);
+        $tagsFingerprint = sha1(implode($normalized));
+        return $tagsFingerprint;
     }
 
     // format has to be:

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -977,14 +977,15 @@ class Server extends AppModel
         $localEvents = $reindexed;
         foreach ($events as $k => $event) {
             $uuid = $event['uuid'];
-            $localEventTagsFingerprint = $this->Event->getTagsFingerprint($localEvents[$uuid]['EventTag']);
-            $eventTagsFingerprint = $event['event_tags_fingerprint'] ?? null;
-
+            
             if (isset($localEvents[$uuid])) {
                 $isUnlocked = !$localEvents[$uuid]['locked'];
 
                 $localTs = $localEvents[$uuid]['timestamp'];
                 $incomingTs = $event['timestamp'];
+
+                $localEventTagsFingerprint = $this->Event->getTagsFingerprint($localEvents[$uuid]['EventTag']);
+                $eventTagsFingerprint = $event['event_tags_fingerprint'] ?? null;
 
                 $isInternalSync =
                     $server !== null &&

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -910,6 +910,9 @@ class Server extends AppModel
         }
         $filterRules['minimal'] = 1;
         $filterRules['published'] = 1;
+        if ($serverSync->server()['Server']['internal']) {
+            $filterRules['include_event_tags_fingerprint'] = 1;
+        }
 
         // Fetch event index from cache if exists and is not modified on server
         $redis = RedisTool::init();
@@ -919,6 +922,7 @@ class Server extends AppModel
         } else {
             $cacheEtag = '""';  // Provide empty ETag, so MISP will compute ETag for returned data
         }
+        $cacheEtag = '""';  // Provide empty ETag, so MISP will compute ETag for returned data
 
         $response = $serverSync->eventIndex($filterRules, $cacheEtag);
 
@@ -973,11 +977,34 @@ class Server extends AppModel
         $localEvents = $reindexed;
         foreach ($events as $k => $event) {
             $uuid = $event['uuid'];
-            if (
-                (isset($localEvents[$uuid]) && ($localEvents[$uuid]['timestamp'] >= $event['timestamp'] || !$localEvents[$uuid]['locked'])) &&
-                !($server !== null && !empty($server['Server']['internal']) && $this->Event->areLocalTagsDifferent($localEvents[$uuid]['EventTag'], $event['EventTag']))
-            ) {
-                unset($events[$k]);
+            $localEventTagsFingerprint = $this->Event->getTagsFingerprint($localEvents[$uuid]['EventTag']);
+            $eventTagsFingerprint = $event['event_tags_fingerprint'] ?? null;
+
+            if (isset($localEvents[$uuid])) {
+                $isUnlocked = !$localEvents[$uuid]['locked'];
+
+                $localTs = $localEvents[$uuid]['timestamp'];
+                $incomingTs = $event['timestamp'];
+
+                $isInternalSync =
+                    $server !== null &&
+                    !empty($server['Server']['internal']);
+
+                $sameFingerprint =
+                    $eventTagsFingerprint === null || // If the remote doesn't provide a fingerprint, skip
+                    $localEventTagsFingerprint === $eventTagsFingerprint;
+
+                $shouldDiscard =
+                    $isUnlocked ||
+                    ($localTs > $incomingTs) || // strictly newer local event
+                    (
+                        $localTs === $incomingTs && // same timestamp handling
+                        (!$isInternalSync || $sameFingerprint)
+                    );
+
+                if ($shouldDiscard) {
+                    unset($events[$k]);
+                }
             }
         }
     }


### PR DESCRIPTION
Internal synchronization also propagates local tags if the event was already synced.

- Fix issue introduced in commit the reverted commit https://github.com/MISP/MISP/commit/56f4d02821ba19cb30477bba894c5c3b7372de2d