### PR TITLE
Add HoneyLabs default feeds (active exploiters, malware infrastructure)

### DIFF
--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -2453,5 +2453,57 @@
       "delete_local_file": false,
       "lookup_visible": true
     }
+  },
+  {
+    "Feed": {
+      "name": "HoneyLabs active exploiters",
+      "provider": "HoneyLabs",
+      "url": "https://honeylabs.net/feed/exploiters",
+      "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]}}",
+      "enabled": true,
+      "distribution": "0",
+      "default": false,
+      "source_format": "csv",
+      "fixed_event": true,
+      "delta_merge": true,
+      "publish": false,
+      "override_ids": true,
+      "settings": "{\"csv\":{\"value\":\"1\"}}",
+      "input_source": "network",
+      "delete_local_file": false,
+      "lookup_visible": false
+    },
+    "Tag": {
+      "name": "osint:source-type=\"block-or-filter-list\"",
+      "colour": "#004f89",
+      "exportable": true,
+      "hide_tag": false
+    }
+  },
+  {
+    "Feed": {
+      "name": "HoneyLabs malware infrastructure",
+      "provider": "HoneyLabs",
+      "url": "https://honeylabs.net/feed/malware-infrastructure",
+      "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]}}",
+      "enabled": true,
+      "distribution": "0",
+      "default": false,
+      "source_format": "freetext",
+      "fixed_event": true,
+      "delta_merge": true,
+      "publish": false,
+      "override_ids": true,
+      "settings": "{\"csv\":{\"value\":\"\",\"delimiter\":\",\"},\"common\":{\"excluderegex\":\"\"}}",
+      "input_source": "network",
+      "delete_local_file": false,
+      "lookup_visible": false
+    },
+    "Tag": {
+      "name": "osint:source-type=\"block-or-filter-list\"",
+      "colour": "#004f89",
+      "exportable": true,
+      "hide_tag": false
+    }
   }
 ]


### PR DESCRIPTION
This adds two default feeds from HoneyLabs, a network of internet-facing honeypot sensors.

- HoneyLabs active exploiters (CSV): source IPs observed running an exploit or loader command against the sensors in the last 7 days. Known-benign scanners (Censys, Shodan, GreyNoise, Rapid7, Shadowserver and others) are excluded. https://honeylabs.net/feed/exploiters
- HoneyLabs malware infrastructure (freetext): loader and command-and-control URLs extracted from those command-injection payloads over the last 14 days. https://honeylabs.net/feed/malware-infrastructure

Both are free, updated continuously, and built from a redacted view so sensor addresses never appear. Any indicator can be verified at https://honeylabs.net/lookup/<ip>. Method and license are documented at https://honeylabs.net/feed/about

The two entries mirror the existing CSV and freetext blocklist feeds already in this file.