### PR TITLE
fix: [event:graph] honour extended view in event graph

### DIFF
--- a/app/webroot/js/event-graph.js
+++ b/app/webroot/js/event-graph.js
@@ -1413,7 +1413,7 @@ class DataHandler {
         this.mapping_node_to_from_edges = {};
         this.mapping_node_to_to_edges = {};
         this.selected_type_to_display = "";
-        this.extended_event = $('#eventgraph_network').data('is_extended') == 1 ? true : false;
+        this.extended_event = $('#eventgraph_network').data('extended') == 1 ? true : false;
         this.networkHistoryJsonData = new Map();
         this.scope_name;
     }


### PR DESCRIPTION
One line regression from d61dc04c5

#### What does it do?

Shows objects and attributes from extending events in an event's extended view.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
