### PR TITLE
fix: [Dashboards:EventStreamWidget] Force default columns if only inv…

### DIFF
--- a/app/Lib/Dashboard/EventStreamWidget.php
+++ b/app/Lib/Dashboard/EventStreamWidget.php
@@ -129,6 +129,11 @@ class EventStreamWidget
                 $fields[] = $field_options[$field];
             }
         }
+        if (empty($fields)) {
+            foreach ($this->__default_fields as $field) {
+                $fields[] = $field_options[$field];
+            }
+        }
         // `orgs` no longer passes through to fetchEvent — the canonical
         // adapter has translated the legacy shape into the structured
         // {orgs: [...], match_via: ...} which fetchEvent doesn't accept


### PR DESCRIPTION
…alid 'fields' are requested

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
