### PR TITLE
Add SiberKapan to default feeds

### DIFF
--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -2433,5 +2433,25 @@
       "delete_local_file": false,
       "lookup_visible": true
     }
+  },
+    {
+    "Feed": {
+      "name": "SiberKapan",
+      "provider": "siberkapan.org",
+      "url": "https://siberkapan.org/misp-feed/",
+      "rules": "",
+      "enabled": false,
+      "distribution": "3",
+      "default": false,
+      "source_format": "misp",
+      "fixed_event": false,
+      "delta_merge": false,
+      "publish": false,
+      "override_ids": false,
+      "settings": "{\"csv\":{\"value\":\"\",\"delimiter\":\"\"},\"common\":{\"excluderegex\":\"\"}}",
+      "input_source": "network",
+      "delete_local_file": false,
+      "lookup_visible": true
+    }
   }
 ]


### PR DESCRIPTION
Adds SiberKapan (https://siberkapan.org), a Turkey-focused threat intelligence platform, as a default MISP feed. The feed is served in MISP format at https://siberkapan.org/misp-feed/ and aggregates data from a custom honeypot network, Fail2ban, and FortiGate Security Fabric automation, cross-referenced with AbuseIPDB.

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2025-09-09: branch 2.5)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

If it fixes an existing issue, please use github syntax: `#<IssueID>`

#### Questions

- [x] Does it require a DB change? No — this only adds a JSON entry to the default feed metadata file.
- [x] Are you using it in production? Yes — SiberKapan is a live platform; the feed endpoint (https://siberkapan.org/misp-feed/) is publicly accessible and serves real, continuously updated threat data.
- [x] Does it require a change in the API (PyMISP for example)? No.