### PR TITLE
Improve Authentication Flows for TAXII Server Push Configuration

### DIFF
--- a/app/Controller/TaxiiServersController.php
+++ b/app/Controller/TaxiiServersController.php
@@ -185,8 +185,17 @@ class TaxiiServersController extends AppController
             if (!empty($caPath)) {
                 $request['ssl_cafile'] = $caPath;
             }
-            if (!empty($this->request->data['api_key'])) {
-                $request['header']['Authorization'] = 'Basic ' . $this->request->data['api_key'];
+            if (!empty($this->request->data['api_key']) || (!empty($this->request->data['auth_type']) && $this->request->data['auth_type'] === 'basic' && !empty($this->request->data['username']))) {
+                $authMethod = 'Basic ';
+                if (isset($this->request->data['auth_type']) && $this->request->data['auth_type'] === 'bearer') {
+                    $authMethod = 'Bearer ';
+                }
+
+                $apiKey = $this->request->data['api_key'];
+                if ($authMethod === 'Basic ' && !empty($this->request->data['username']) && !empty($this->request->data['password'])) {
+                    $apiKey = base64_encode($this->request->data['username'] . ':' . $this->request->data['password']);
+                }
+                $request['header']['Authorization'] = $authMethod . $apiKey;
             }
             
             // 3. Unified Error Handling to prevent differential responses

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -98,7 +98,7 @@ class AppModel extends Model
         135 => false, 136 => true, 137 => false, 138 => false, 139 => false, 140 => false,
         141 => false, 142 => false, 143 => false, 144 => false, 145 => false, 146 => false,
         147 => false, 148 => false, 149 => false, 150 => false, 151 => false, 152 => false,
-        153 => false
+        153 => false, 154 => false
     );
 
     const ADVANCED_UPDATES_DESCRIPTION = array(
@@ -2697,6 +2697,9 @@ class AppModel extends Model
                 break;
             case 153:
                 $sqlArray[] = "ALTER TABLE `taxii_servers` ADD `enabled` tinyint(1) NOT NULL DEFAULT 1;";
+                break;
+            case 154:
+                $sqlArray[] = "ALTER TABLE `taxii_servers` ADD `auth_type` VARCHAR(255) DEFAULT 'basic' AFTER `api_key`;";
                 break;
             case 'fixNonEmptySharingGroupID':
                 $sqlArray[] = 'UPDATE `events` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';

--- a/app/Model/TaxiiServer.php
+++ b/app/Model/TaxiiServer.php
@@ -191,6 +191,17 @@ class TaxiiServer extends AppModel
         return new File($temporaryFolder . '/' . $random . '.json', true, 0644);
     }
 
+    public function beforeSave($options = array())
+    {
+        parent::beforeSave($options);
+        if (isset($this->data['TaxiiServer']['auth_type']) && $this->data['TaxiiServer']['auth_type'] === 'basic') {
+            if (!empty($this->data['TaxiiServer']['username']) && !empty($this->data['TaxiiServer']['password'])) {
+                $this->data['TaxiiServer']['api_key'] = base64_encode($this->data['TaxiiServer']['username'] . ':' . $this->data['TaxiiServer']['password']);
+            }
+        }
+        return true;
+    }
+
     public function queryInstance($options)
     {
         $url = $options['TaxiiServer']['api_root'] . $options['TaxiiServer']['path'];
@@ -213,9 +224,12 @@ class TaxiiServer extends AppModel
                 'Content-type' => 'application/taxii+json;version=2.1'
             ]
         ];
-        error_log($options['TaxiiServer']['api_key']);
         if (!empty($options['TaxiiServer']['api_key'])) {
-            $request['header']['Authorization'] = 'Basic ' . $options['TaxiiServer']['api_key'];
+            $authMethod = 'Basic ';
+            if (isset($options['TaxiiServer']['auth_type']) && $options['TaxiiServer']['auth_type'] === 'bearer') {
+                $authMethod = 'Bearer ';
+            }
+            $request['header']['Authorization'] = $authMethod . $options['TaxiiServer']['api_key'];
         }
         try {
             if (!empty($options['type']) && $options['type'] === 'post') {

--- a/app/View/Elements/genericElements/SingleViews/Fields/genericField.ctp
+++ b/app/View/Elements/genericElements/SingleViews/Fields/genericField.ctp
@@ -4,6 +4,13 @@ if (isset($field['raw'])) {
 } else {
     $value = Hash::get($data, $field['path']);
     $string = empty($value) ? '' : h($value);
+    if (!empty($field['privacy'])) {
+        $string = sprintf(
+            '<span class="privacy-value quickSelect" data-hidden-value="%s">****************************************</span>&nbsp;<i class="privacy-toggle fas fa-eye useCursorPointer" title="%s"></i>',
+            $string,
+            __('Reveal hidden value')
+        );
+    }
 }
 if (!empty($field['url'])) {
     if (!empty($field['url_vars'])) {

--- a/app/View/TaxiiServers/add.ctp
+++ b/app/View/TaxiiServers/add.ctp
@@ -26,10 +26,30 @@ $fields = [
         'default' => !$edit
     ],
     [
+        'field' => 'auth_type',
+        'label' => 'Authentication Type',
+        'type' => 'select',
+        'options' => ['basic' => 'Basic', 'bearer' => 'Bearer'],
+        'default' => 'basic',
+        'class' => 'span6'
+    ],
+    [
+        'field' => 'username',
+        'label' => 'Username',
+        'type' => 'text auth-basic-field',
+        'class' => 'input span6 auth-basic-field'
+    ],
+    [
+        'field' => 'password',
+        'label' => 'Password',
+        'type' => 'password auth-basic-field',
+        'class' => 'input span6 auth-basic-field'
+    ],
+    [
         'field' => 'api_key',
-        'label' => 'API Key',
-        'type' => 'text',
-        'class' => 'input span6'
+        'label' => 'Bearer Token',
+        'type' => 'text auth-bearer-field',
+        'class' => 'input span6 auth-bearer-field'
     ],
     [
         'field' => 'api_root',
@@ -40,6 +60,9 @@ $fields = [
             'uri' => '/taxii_servers/getRoot',
             'body' => [
                 'discovery_url' => '{{#TaxiiServerDiscoveryUrl}}',
+                'auth_type' => '{{#TaxiiServerAuthType}}',
+                'username' => '{{#TaxiiServerUsername}}',
+                'password' => '{{#TaxiiServerPassword}}',
                 'api_key' => '{{#TaxiiServerApiKey}}'
             ],
             'type' => 'POST'
@@ -53,6 +76,9 @@ $fields = [
         'populateAction' => json_encode([
             'uri' => '/taxii_servers/getCollections',
             'body' => [
+                'auth_type' => '{{#TaxiiServerAuthType}}',
+                'username' => '{{#TaxiiServerUsername}}',
+                'password' => '{{#TaxiiServerPassword}}',
                 'api_key' => '{{#TaxiiServerApiKey}}',
                 'api_root' => '{{#TaxiiServerApiRoot}}'
             ],
@@ -83,7 +109,13 @@ echo $this->element('genericElements/Form/genericForm', [
         ]
     ]
 ]);
-
+?>
+<script>
+$(document).ready(function() {
+    $('#TaxiiServerAuthType').trigger('change');
+});
+</script>
+<?php
 if (!$ajax) {
     echo $this->element('/genericElements/SideMenu/side_menu', $menuData);
 }

--- a/app/View/TaxiiServers/index.ctp
+++ b/app/View/TaxiiServers/index.ctp
@@ -77,7 +77,13 @@
                         'type' => 'json'
                     ],
                     [
-                        'name' => __('api_key'),
+                        'name' => __('Auth Type'),
+                        'sort' => 'TaxiiServer.auth_type',
+                        'data_path' => 'TaxiiServer.auth_type',
+                        'callback' => 'ucfirst'
+                    ],
+                    [
+                        'name' => __('API key'),
                         'sort' => 'TaxiiServer.api_key',
                         'data_path' => 'TaxiiServer.api_key'
                     ],

--- a/app/View/TaxiiServers/index.ctp
+++ b/app/View/TaxiiServers/index.ctp
@@ -83,11 +83,6 @@
                         'callback' => 'ucfirst'
                     ],
                     [
-                        'name' => __('API key'),
-                        'sort' => 'TaxiiServer.api_key',
-                        'data_path' => 'TaxiiServer.api_key'
-                    ],
-                    [
                         'name' => __('Description'),
                         'sort' => 'TaxiiServer.description',
                         'data_path' => 'TaxiiServer.description'

--- a/app/View/TaxiiServers/view.ctp
+++ b/app/View/TaxiiServers/view.ctp
@@ -61,7 +61,7 @@ echo $this->element(
                 'callback' => 'ucfirst'
             ],
             [
-                'key' => __('API key'),
+                'key' => __('Token'),
                 'path' => 'TaxiiServer.api_key',
                 'privacy' => true
             ],

--- a/app/View/TaxiiServers/view.ctp
+++ b/app/View/TaxiiServers/view.ctp
@@ -56,6 +56,11 @@ echo $this->element(
                 'model' => 'organisations'
             ],
             [
+                'key' => __('Authentication Type'),
+                'path' => 'TaxiiServer.auth_type',
+                'callback' => 'ucfirst'
+            ],
+            [
                 'key' => __('API key'),
                 'path' => 'TaxiiServer.api_key'
             ],

--- a/app/View/TaxiiServers/view.ctp
+++ b/app/View/TaxiiServers/view.ctp
@@ -62,7 +62,8 @@ echo $this->element(
             ],
             [
                 'key' => __('API key'),
-                'path' => 'TaxiiServer.api_key'
+                'path' => 'TaxiiServer.api_key',
+                'privacy' => true
             ],
             [
                 'key' => __('Description'),

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -5771,6 +5771,17 @@ function redirectIdSelection(scope, action) {
     }
 }
 
+$(document.body).on('change', '#TaxiiServerAuthType', function() {
+    var authType = $(this).val();
+    if (authType == 'basic') {
+        $('.auth-basic-field').closest('.input, .row').show();
+        $('.auth-bearer-field').closest('.input, .row').hide();
+    } else if (authType == 'bearer') {
+        $('.auth-basic-field').closest('.input, .row').hide();
+        $('.auth-bearer-field').closest('.input, .row').show();
+    }
+});
+
 $(document.body).on('click', '.populateActionTrigger', function() {
     var populate_script = $(this).data('request-script');
     populate_script = atob(populate_script);

--- a/db_schema.json
+++ b/db_schema.json
@@ -9082,6 +9082,17 @@
                 "extra": ""
             },
             {
+                "column_name": "auth_type",
+                "is_nullable": "YES",
+                "data_type": "varchar",
+                "character_maximum_length": "255",
+                "numeric_precision": null,
+                "collation_name": "utf8mb4_unicode_ci",
+                "column_type": "varchar(255)",
+                "column_default": "basic",
+                "extra": ""
+            },
+            {
                 "column_name": "collection",
                 "is_nullable": "YES",
                 "data_type": "varchar",
@@ -11372,6 +11383,7 @@
             "id": true
         },
         "taxii_servers": {
+            "auth_type": false,
             "discovery_url": false,
             "id": true,
             "name": false,
@@ -11462,5 +11474,5 @@
             "uuid": false
         }
     },
-    "db_version": "153"
+    "db_version": "154"
 }


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2025-09-09: branch 2.5)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

Allows TAXII Server Push to be configured with Bearer Token authentication.
Streamlines existing TAXII Basic auth flow to generate basic auth hash from user+pass.
Obfuscates TAXII authentication tokens in UI.
Migration retains existing configurations for TAXII Push.

#### Questions

- [x] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
