### PR TITLE
chg: [Servers] add remote user's org name and uuid to 'view sync user'

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -5341,6 +5341,8 @@ class Server extends AppModel
 
             $results = [
                 __('User') => $user['User']['email'],
+                __('Organisation name') => $user['Organisation']['name'],
+                __('Organisation UUID') => $user['Organisation']['uuid'],
                 __('Role name') => $user['Role']['name'] ?? __('Unknown, outdated instance'),
                 __('Sync flag') => isset($user['Role']['perm_sync']) ? ($user['Role']['perm_sync'] ? __('Yes') : __('No')) : __('Unknown, outdated instance'),
                 __('Sync Internal flag') => isset($user['Role']['perm_sync_internal']) ? ($user['Role']['perm_sync_internal'] ? __('Yes') : __('No')) : __('Unknown, outdated instance'),


### PR DESCRIPTION
#### What does it do?

Fixes #10876 

Example result:
<img width="1653" height="617" alt="image" src="https://github.com/user-attachments/assets/e33088ae-ed71-45de-8fde-0708cd718bbb" />


#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
