### PR TITLE
fix: [Server] Correct typos in default value and description for MISP…

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -6485,8 +6485,8 @@ class Server extends AppModel
                 ],
                 'log_errors_ndjson_path' => [
                     'level' =>  self::SETTING_RECOMMENDED,
-                    'description' => __('Path for the ndjson error log file - defaults to ' . APP . '/app/tmp/logs/error.log.ndjson.'),
-                    'value' => APP . '/tmp/logs/error.log.ndjson',
+                    'description' => __('Path for the ndjson error log file - defaults to ' . APP . 'tmp/logs/error.log.ndjson.'),
+                    'value' => APP . 'tmp/logs/error.log.ndjson',
                     'test' => 'testNDJSONLogPath',
                     'type' => 'string',
                     'cli_only' => true,


### PR DESCRIPTION
….log_errors_ndjson_path

### What does it do
Make it this, which I think is what it was supposed to be:
<img width="2841" height="78" alt="image" src="https://github.com/user-attachments/assets/e417568b-829c-44de-8d99-cff068135acd" />


#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
