### PR TITLE
fix: [freetext import] keep valid category on type change (#10873)

### DIFF
--- a/app/View/Events/resolved_attributes.ctp
+++ b/app/View/Events/resolved_attributes.ctp
@@ -282,9 +282,15 @@
                 }
                 */
                 var $categorySelect = $('#' + currentId);
+                var previousCategory = $categorySelect.val();
                 $categorySelect.empty();
                 for (var category in currentOptions) {
                     $categorySelect.append(new Option(category, category));
+                }
+                // Keep the user's current category if it is still valid for the
+                // newly selected type, otherwise fall back to the default one.
+                if (previousCategory && currentOptions && currentOptions.hasOwnProperty(previousCategory)) {
+                    $categorySelect.val(previousCategory);
                 }
             });
         <?php


### PR DESCRIPTION
Fixes #10873. 

On type change in Freetext Import, keep the current category if it's still valid for the new type instead of always resetting to the default.

  - DB change? No
  - Used in production? No
  - API change? No
