### PR TITLE
feat: [sharing groups] confidential sharing groups: hide member org roster

### DIFF
--- a/INSTALL/MYSQL.sql
+++ b/INSTALL/MYSQL.sql
@@ -1341,6 +1341,7 @@ CREATE TABLE `sharing_groups` (
   `modified` datetime NOT NULL,
   `local` tinyint(1) NOT NULL,
   `roaming` tinyint(1) NOT NULL DEFAULT 0,
+  `confidential` tinyint(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   UNIQUE KEY `uuid` (`uuid`),
   UNIQUE KEY `name` (`name`),

--- a/app/Controller/SharingGroupsController.php
+++ b/app/Controller/SharingGroupsController.php
@@ -22,7 +22,7 @@ class SharingGroupsController extends AppController
         'order' => array(
             'SharingGroup.id' => 'ASC'
         ),
-        'fields' => array('SharingGroup.id', 'SharingGroup.uuid', 'SharingGroup.name', 'SharingGroup.description', 'SharingGroup.releasability', 'SharingGroup.local', 'SharingGroup.active', 'SharingGroup.roaming'),
+        'fields' => array('SharingGroup.id', 'SharingGroup.uuid', 'SharingGroup.name', 'SharingGroup.description', 'SharingGroup.releasability', 'SharingGroup.local', 'SharingGroup.active', 'SharingGroup.roaming', 'SharingGroup.org_id', 'SharingGroup.confidential'),
         'contain' => array(
             'SharingGroupOrg' => array(
                 'Organisation' => array('fields' => array('Organisation.name', 'Organisation.id', 'Organisation.uuid'))
@@ -62,6 +62,9 @@ class SharingGroupsController extends AppController
                     $sg = $this->SharingGroup->fetchAllAuthorised($this->Auth->user(), 'simplified', false, $id);
                     if (!empty($sg)) {
                         $sg = empty($sg) ? array() : $sg[0];
+                        // Confidential SG (#10818): never echo the roster to a
+                        // non-owner/non-admin in the post-save response.
+                        $sg = $this->SharingGroup->obscureConfidentialOrgs($this->Auth->user(), $sg);
                     }
                     return $this->RestResponse->viewData($sg, $this->response->type());
                 } else {
@@ -90,6 +93,7 @@ class SharingGroupsController extends AppController
             }
             $sg['active'] = $sg['active'] ? 1: 0;
             $sg['roaming'] = $sg['roaming'] ? 1: 0;
+            $sg['confidential'] = empty($sg['confidential']) ? 0 : 1;
             $sg['organisation_uuid'] = $this->Auth->user('Organisation')['uuid'];
             $sg['local'] = 1;
             $sg['org_id'] = $this->Auth->user('org_id');
@@ -212,6 +216,9 @@ class SharingGroupsController extends AppController
                 $id = $this->SharingGroup->captureSG($this->request->data, $this->Auth->user());
                 if ($id) {
                     $sg = $this->SharingGroup->fetchAllAuthorised($this->Auth->user(), 'simplified', false, $id);
+                    // Confidential SG (#10818): never echo the roster to a
+                    // non-owner/non-admin in the post-save response.
+                    $sg[0] = $this->SharingGroup->obscureConfidentialOrgs($this->Auth->user(), $sg[0]);
                     return $this->RestResponse->viewData($sg[0], $this->response->type());
                 } else {
                     return $this->RestResponse->saveFailResponse('SharingGroup', 'add', false, 'Could not save sharing group.', $this->response->type());
@@ -220,7 +227,8 @@ class SharingGroupsController extends AppController
                 $json = json_decode($this->request->data['SharingGroup']['json'], true);
                 $sg = $json['sharingGroup'];
                 $sg['id'] = $sharingGroup['SharingGroup']['id'];
-                $fields = array('name', 'releasability', 'description', 'active', 'roaming');
+                $sg['confidential'] = empty($sg['confidential']) ? 0 : 1;
+                $fields = array('name', 'releasability', 'description', 'active', 'roaming', 'confidential');
                 $existingSG = $this->SharingGroup->find('first', array('recursive' => -1, 'conditions' => array('SharingGroup.id' => $sharingGroup['SharingGroup']['id'])));
                 foreach ($fields as $field) {
                     $existingSG['SharingGroup'][$field] = $sg[$field];
@@ -451,6 +459,10 @@ class SharingGroupsController extends AppController
 
             $result[$k]['editable'] = $editable;
             $result[$k]['deletable'] = $deletable;
+            // Confidential SG (#10818): strip the roster for display after
+            // the edit-rights check above, so non-owner members of a
+            // confidential SG never see the other organisations.
+            $result[$k] = $this->SharingGroup->obscureConfidentialOrgs($this->Auth->user(), $result[$k]);
         }
         if ($this->_isRest()) {
             return $this->RestResponse->viewData(['response' => $result], $this->response->type()); // 'response' to keep BC
@@ -524,6 +536,9 @@ class SharingGroupsController extends AppController
             }
         }
         if ($this->_isRest()) {
+            // Confidential SG (#10818): hide the member-org roster from
+            // everyone except the owning org and site admins.
+            $sg = $this->SharingGroup->obscureConfidentialOrgs($this->Auth->user(), $sg);
             return $this->RestResponse->viewData($sg, $this->response->type());
         }
 
@@ -558,6 +573,10 @@ class SharingGroupsController extends AppController
 
         $this->set('mayModify', $this->SharingGroup->checkIfAuthorisedExtend($this->Auth->user(), $sg['SharingGroup']['id']));
         $this->set('id', $sg['SharingGroup']['id']);
+        // Confidential SG (#10818): strip the roster for display after the
+        // edit-rights checks above (which legitimately read it), so a
+        // non-owner member never sees the other organisations.
+        $sg = $this->SharingGroup->obscureConfidentialOrgs($this->Auth->user(), $sg);
         $this->set('sg', $sg);
         $this->set('menuData', ['menuList' => 'globalActions', 'menuItem' => 'viewSG']);
     }

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -98,7 +98,7 @@ class AppModel extends Model
         135 => false, 136 => true, 137 => false, 138 => false, 139 => false, 140 => false,
         141 => false, 142 => false, 143 => false, 144 => false, 145 => false, 146 => false,
         147 => false, 148 => false, 149 => false, 150 => false, 151 => false, 152 => false,
-        153 => false
+        153 => false, 154 => false
     );
 
     const ADVANCED_UPDATES_DESCRIPTION = array(
@@ -2697,6 +2697,9 @@ class AppModel extends Model
                 break;
             case 153:
                 $sqlArray[] = "ALTER TABLE `taxii_servers` ADD `enabled` tinyint(1) NOT NULL DEFAULT 1;";
+                break;
+            case 154:
+                $sqlArray[] = "ALTER TABLE `sharing_groups` ADD `confidential` tinyint(1) NOT NULL DEFAULT 0;";
                 break;
             case 'fixNonEmptySharingGroupID':
                 $sqlArray[] = 'UPDATE `events` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -7287,6 +7287,10 @@ class Event extends AppModel
                         }
                     }
                 }
+                // Confidential SG (#10818): strip the member-org roster
+                // before it rides along with shared events/attributes, so a
+                // non-owner member never learns the other organisations.
+                $v['SharingGroup'] = $this->SharingGroup->obscureConfidentialOrgs($user, $v['SharingGroup']);
                 $sharingGroupData[$v['SharingGroup']['id']] = $v['SharingGroup'];
             }
             if ($useCache) {

--- a/app/Model/SharingGroup.php
+++ b/app/Model/SharingGroup.php
@@ -174,7 +174,10 @@ class SharingGroup extends AppModel
                         'SharingGroup.name',
                         'SharingGroup.releasability',
                         'SharingGroup.description',
-                        'SharingGroup.org_id'
+                        'SharingGroup.org_id',
+                        // needed so confidential-SG roster gating (#10818)
+                        // works if this dormant permission tree is ever used
+                        'SharingGroup.confidential'
                     ),
                     'contain' => array()
                 ),
@@ -200,11 +203,21 @@ class SharingGroup extends AppModel
             $sgs = $this->find('all', array(
                 'contain' => $canSeeOrgs ? ['SharingGroupOrg' => ['org_id']] : [],
                 'conditions' => $conditions,
-                'fields' => ['SharingGroup.id', 'SharingGroup.name', 'SharingGroup.org_id'],
+                // confidential needed for per-SG roster gating (#10818)
+                'fields' => ['SharingGroup.id', 'SharingGroup.name', 'SharingGroup.org_id', 'SharingGroup.confidential'],
                 'order' => 'SharingGroup.name ASC'
             ));
             if ($canSeeOrgs) {
-                return $this->appendOrgsAndServers($sgs, ['id', 'name'], []);
+                $sgs = $this->appendOrgsAndServers($sgs, ['id', 'name'], []);
+                // Confidential SGs (#10818): never expose the member-org list
+                // in the distribution graph to non-owner/non-admin viewers.
+                foreach ($sgs as &$sg) {
+                    if (!$this->canSeeConfidentialOrgs($user, $sg)) {
+                        $sg['SharingGroupOrg'] = [];
+                    }
+                }
+                unset($sg);
+                return $sgs;
             }
             foreach ($sgs as &$sg) {
                 $sg['SharingGroupOrg'] = [];
@@ -554,6 +567,53 @@ class SharingGroup extends AppModel
     }
 
     /**
+     * Whether $user may see the member-org roster of an already-fetched SG.
+     * Confidential sharing groups (#10818) hide their roster from everyone
+     * except the owning org and site admins. The roster still exists at the
+     * data layer for ACL/distribution; this only gates what is shown and
+     * serialized, and is enforced identically on synced peers (the flag
+     * travels with the SG).
+     *
+     * @param array $user
+     * @param array $sg A SG array, either nested (['SharingGroup' => [...]])
+     *                  or a flat SG row.
+     * @return bool
+     */
+    public function canSeeConfidentialOrgs(array $user, array $sg)
+    {
+        $row = isset($sg['SharingGroup']) ? $sg['SharingGroup'] : $sg;
+        if (empty($row['confidential'])) {
+            return true;
+        }
+        if (!empty($user['Role']['perm_site_admin'])) {
+            return true;
+        }
+        return isset($row['org_id'], $user['org_id']) && (int)$row['org_id'] === (int)$user['org_id'];
+    }
+
+    /**
+     * Remove the member-org roster from a fetched SG when $user is not
+     * allowed to see it (confidential SG, #10818). Returns the SG with
+     * SharingGroupOrg / nested Organisation stripped as needed. Safe to
+     * call on any SG shape; a non-confidential SG is returned untouched.
+     *
+     * @param array $user
+     * @param array $sg
+     * @return array
+     */
+    public function obscureConfidentialOrgs(array $user, array $sg)
+    {
+        if ($this->canSeeConfidentialOrgs($user, $sg)) {
+            return $sg;
+        }
+        unset($sg['SharingGroupOrg']);
+        if (isset($sg['SharingGroup']['SharingGroupOrg'])) {
+            unset($sg['SharingGroup']['SharingGroupOrg']);
+        }
+        return $sg;
+    }
+
+    /**
      * Get all organisation ids that can see a SG.
      * @param int $id Sharing group ID
      * @return array|bool
@@ -689,7 +749,7 @@ class SharingGroup extends AppModel
             $isSGOwner = !$user['Role']['perm_sync'] && $existingSG['SharingGroup']['org_id'] == $user['org_id'];
             if ($isUpdatableBySync || $isSGOwner || $user['Role']['perm_site_admin']) {
                 $editedSG = $existingSG['SharingGroup'];
-                $attributes = ['name', 'releasability', 'description', 'created', 'modified', 'roaming', 'active'];
+                $attributes = ['name', 'releasability', 'description', 'created', 'modified', 'roaming', 'active', 'confidential'];
                 foreach ($attributes as $a) {
                     if (isset($sg[$a])) {
                         $editedSG[$a] = $sg[$a];
@@ -754,6 +814,9 @@ class SharingGroup extends AppModel
             'modified' => !isset($sg['modified']) ? $date : $sg['modified'],
             'active' => !isset($sg['active']) ? 1 : $sg['active'],
             'roaming' => !isset($sg['roaming']) ? false : $sg['roaming'],
+            // Confidential SGs hide their member-org roster from non-owner
+            // members (#10818). The flag syncs so peers gate display too.
+            'confidential' => empty($sg['confidential']) ? 0 : 1,
             'local' => 0,
             'sync_user_id' => $user['id'],
             'org_id' => $user['Role']['perm_sync'] ? $this->__retrieveOrgIdFromCapturedSG($user, $sg) : $user['org_id']

--- a/app/View/SharingGroups/add.ctp
+++ b/app/View/SharingGroups/add.ctp
@@ -86,6 +86,10 @@
                 <input type="checkbox" style="float:left;" title="<?php echo __('Enable roaming mode for this sharing group. Roaming mode will allow the sharing group to be passed to any instance where the remote recipient is contained in the organisation list. It is preferred to list the recipient instances instead.');?>" value="1" id="SharingGroupRoaming">
                 <label for="SharingGroupRoaming" style="padding-left:20px;"><?php echo __('<b>Enable roaming mode</b> for this sharing group (pass the event to any connected instance where the sync connection is tied to an organisation contained in the SG organisation list).');?></label>
             </div>
+            <div style="display:block;">
+                <input type="checkbox" style="float:left;" title="<?php echo __('Mark this sharing group as confidential. The list of member organisations will be hidden from everyone except the owner organisation and site admins, on this instance and on synchronised peers.');?>" value="1" id="SharingGroupConfidential">
+                <label for="SharingGroupConfidential" style="padding-left:20px;"><?php echo __('<b>Confidential sharing group</b> (hide the member organisation list from other members; only the owner organisation and site admins can see who is in it).');?></label>
+            </div>
             <div id="serverList">
                 <div class="tabMenuFixedContainer">
                     <span role="button" tabindex="0" aria-label="<?php echo __('Add instance');?>" title="<?php echo __('Add instance');?>" class="tabMenuFixed tabMenuFixedCenter tabMenuSides useCursorPointer" onClick="sharingGroupAdd('server');"><?php echo __('Add instance');?></span>

--- a/app/View/SharingGroups/edit.ctp
+++ b/app/View/SharingGroups/edit.ctp
@@ -90,6 +90,10 @@
                 <input type="checkbox" style="float:left;" title="<?php echo __('Enable roaming mode for this sharing group. Roaming mode will allow the sharing group to be passed to any instance where the remote recipient is contained in the organisation list. It is preferred to list the recipient instances instead.');?>" <?php echo $checked; ?> id="SharingGroupRoaming">
                 <label for="SharingGroupRoaming" style="padding-left:20px;"><?php echo __('<b>Enable roaming mode</b> for this sharing group (pass the event to any connected instance where the sync connection is tied to an organisation contained in the SG organisation list).');?></label>
             </div>
+            <div style="display:block;">
+                <input type="checkbox" style="float:left;" title="<?php echo __('Mark this sharing group as confidential. The list of member organisations will be hidden from everyone except the owner organisation and site admins, on this instance and on synchronised peers.');?>" <?php echo empty($sharingGroup['SharingGroup']['confidential']) ? '' : 'checked'; ?> id="SharingGroupConfidential">
+                <label for="SharingGroupConfidential" style="padding-left:20px;"><?php echo __('<b>Confidential sharing group</b> (hide the member organisation list from other members; only the owner organisation and site admins can see who is in it).');?></label>
+            </div>
             <div id="serverList" <?php echo $serverDivVisibility; ?>>
                 <div class="tabMenuFixedContainer">
                     <span role="button" tabindex="0" aria-label="<?php echo __('Add instance');?>" title="<?php echo __('Add instance');?>" class="tabMenuFixed tabMenuFixedCenter tabMenuSides useCursorPointer" onClick="sharingGroupAdd('server');"><?php echo __('Add instance');?></span>

--- a/app/View/SharingGroups/view.ctp
+++ b/app/View/SharingGroups/view.ctp
@@ -32,6 +32,11 @@ echo $this->element(
                 'type' => 'boolean'
             ],
             [
+                'key' => __('Confidential'),
+                'path' => 'SharingGroup.confidential',
+                'type' => 'boolean'
+            ],
+            [
                 'key' => __('Created by'),
                 'path' => 'Organisation',
                 'type' => 'org'

--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -3514,6 +3514,7 @@ function sgSubmitForm(action) {
             'description': $('#SharingGroupDescription').val(),
             'active': $('#SharingGroupActive').is(":checked"),
             'roaming': $('#SharingGroupRoaming').is(":checked"),
+            'confidential': $('#SharingGroupConfidential').is(":checked"),
         }
     };
     $('#SharingGroupJson').val(JSON.stringify(ajax));
@@ -3573,6 +3574,9 @@ function sharingGroupPopulateFromJson() {
     if (jsonparsed.sharingGroup.roaming == 1) {
         $("#SharingGroupRoaming").prop("checked", true);
         $('#serverList').show();
+    }
+    if (jsonparsed.sharingGroup.confidential == 1) {
+        $("#SharingGroupConfidential").prop("checked", true);
     }
     $('#SharingGroupName').attr('value', jsonparsed.sharingGroup.name);
     $('#SharingGroupReleasability').attr('value', jsonparsed.sharingGroup.releasability);

--- a/db_schema.json
+++ b/db_schema.json
@@ -8141,6 +8141,17 @@
                 "column_type": "tinyint(1)",
                 "column_default": "0",
                 "extra": ""
+            },
+            {
+                "column_name": "confidential",
+                "is_nullable": "NO",
+                "data_type": "tinyint",
+                "character_maximum_length": null,
+                "numeric_precision": "3",
+                "collation_name": null,
+                "column_type": "tinyint(1)",
+                "column_default": "0",
+                "extra": ""
             }
         ],
         "sharing_group_blueprints": [
@@ -11462,5 +11473,5 @@
             "uuid": false
         }
     },
-    "db_version": "153"
+    "db_version": "154"
 }


### PR DESCRIPTION
#### What does it do?

Delivers part 1 of 2 feature request #10818 (the confidential sharing groups part; scoping the multiple sharing groups is next).

- Adds a per-sharing-group `confidential` flag. 
- When set, the member organisation roster is hidden from everyone except the owning organisation and site admins, on this instance and on synchronised peers. 
- Required for NIS2 style sharing where the participant list itself is sensitive. 
- Membership is still stored and used for access control, only its display is hidden, so distribution and sync are unaffected.

Tested on a live `2.5.42` instance with two orgs:
* Roster hidden from member orgs on a confidential SG, shown to owner org and site admins, across the SG view, SG index, shared event/attribute fetch, and the distribution graph
* Roster still shown normally on non-confidential SGs (no regression)
* Member org keeps full access to events shared via a confidential SG (confidentiality hides the roster, not the data)
* Flag persists on create and edit (round-tripped `0` to `1` to `0`) and is included in the sync attribute set
* Migration `154` applied cleanly, schema diagnostics green
* Two leaks caught and fixed during testing: the SG index and the distribution graph were not gating per SG

#### Questions

- [X] Does it require a DB change? (Yes, migration `154` adds `sharing_groups.confidential`)
- [X] Are you using it in production? (No, lab testing)
- [X] Does it require a change in the API (PyMISP for example)? (No)