### PR TITLE
feat: [sharing groups] multiple sharing groups per event for read access

### DIFF
--- a/INSTALL/MYSQL.sql
+++ b/INSTALL/MYSQL.sql
@@ -471,6 +471,20 @@ CREATE TABLE `event_locks` (
   KEY `timestamp` (`timestamp`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `event_sharing_groups`
+--
+
+CREATE TABLE `event_sharing_groups` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `event_id` int(11) NOT NULL,
+  `sharing_group_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `event_id` (`event_id`),
+  KEY `sharing_group_id` (`sharing_group_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `event_reports` (

--- a/app/Controller/Component/ACLComponent.php
+++ b/app/Controller/Component/ACLComponent.php
@@ -320,6 +320,8 @@ class ACLComponent extends Component
         'events' => array(
             'add' => array('perm_add'),
             'addIOC' => array('perm_add'),
+            'addSharingGroup' => array('perm_add'),
+            'removeSharingGroup' => array('perm_add'),
             'addTag' => array('perm_tagger'),
             'add_misp_export' => array('perm_modify'),
             'alert' => array('perm_publish'),

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -5510,6 +5510,79 @@ class EventsController extends AppController
         $this->set('count', $count);
     }
 
+    /**
+     * Multiple sharing groups (#10818): attach an additional sharing group
+     * to an event, granting its members read access on top of the event's
+     * own distribution. Requires edit rights on the event and access to the
+     * sharing group being attached.
+     */
+    public function addSharingGroup($event_id = false, $sharing_group_id = false)
+    {
+        return $this->__modifyEventSharingGroup($event_id, $sharing_group_id, 'add');
+    }
+
+    /**
+     * Multiple sharing groups (#10818): detach an additional sharing group
+     * from an event.
+     */
+    public function removeSharingGroup($event_id = false, $sharing_group_id = false)
+    {
+        return $this->__modifyEventSharingGroup($event_id, $sharing_group_id, 'remove');
+    }
+
+    private function __modifyEventSharingGroup($event_id, $sharing_group_id, $mode)
+    {
+        if (!$this->request->is('post') && !$this->request->is('delete')) {
+            throw new MethodNotAllowedException(__('This endpoint expects a POST request.'));
+        }
+        $event = $this->Event->find('first', [
+            'recursive' => -1,
+            'conditions' => Validation::uuid($event_id) ? ['Event.uuid' => $event_id] : ['Event.id' => $event_id],
+        ]);
+        if (empty($event)) {
+            throw new NotFoundException(__('Invalid event.'));
+        }
+        if (!$this->__canModifyEvent($event)) {
+            throw new ForbiddenException(__('You do not have permission to modify this event.'));
+        }
+        // Resolve and authorise the sharing group. A user may only attach a
+        // sharing group they themselves have access to, so they cannot widen
+        // an event to an arbitrary group.
+        $sg = $this->Event->SharingGroup->find('first', [
+            'recursive' => -1,
+            'fields' => ['SharingGroup.id'],
+            'conditions' => Validation::uuid($sharing_group_id) ? ['SharingGroup.uuid' => $sharing_group_id] : ['SharingGroup.id' => $sharing_group_id],
+        ]);
+        if (empty($sg) || !$this->Event->SharingGroup->checkIfAuthorised($this->Auth->user(), $sg['SharingGroup']['id'])) {
+            throw new ForbiddenException(__('Invalid sharing group or you do not have access to it.'));
+        }
+        $eventId = (int)$event['Event']['id'];
+        $sgId = (int)$sg['SharingGroup']['id'];
+        $existing = $this->Event->EventSharingGroup->find('first', [
+            'recursive' => -1,
+            'conditions' => ['EventSharingGroup.event_id' => $eventId, 'EventSharingGroup.sharing_group_id' => $sgId],
+        ]);
+        if ($mode === 'add') {
+            if (empty($existing)) {
+                $this->Event->EventSharingGroup->create();
+                if (!$this->Event->EventSharingGroup->save(['event_id' => $eventId, 'sharing_group_id' => $sgId])) {
+                    throw new InternalErrorException(__('Could not attach the sharing group.'));
+                }
+            }
+            $message = __('Sharing group attached to event.');
+        } else {
+            if (!empty($existing)) {
+                $this->Event->EventSharingGroup->delete($existing['EventSharingGroup']['id']);
+            }
+            $message = __('Sharing group detached from event.');
+        }
+        if ($this->_isRest()) {
+            return $this->RestResponse->saveSuccessResponse('Events', $mode . 'SharingGroup', $eventId, false, $message);
+        }
+        $this->Flash->success($message);
+        $this->redirect(['action' => 'view', $eventId]);
+    }
+
     public function addTag($id = false, $tag_id = false)
     {
         $rearrangeRules = array(

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -98,7 +98,7 @@ class AppModel extends Model
         135 => false, 136 => true, 137 => false, 138 => false, 139 => false, 140 => false,
         141 => false, 142 => false, 143 => false, 144 => false, 145 => false, 146 => false,
         147 => false, 148 => false, 149 => false, 150 => false, 151 => false, 152 => false,
-        153 => false
+        153 => false, 154 => false
     );
 
     const ADVANCED_UPDATES_DESCRIPTION = array(
@@ -2697,6 +2697,20 @@ class AppModel extends Model
                 break;
             case 153:
                 $sqlArray[] = "ALTER TABLE `taxii_servers` ADD `enabled` tinyint(1) NOT NULL DEFAULT 1;";
+                break;
+            case 154:
+                // Multiple sharing groups (#10818): additional sharing groups
+                // that grant read access to an event, on top of its primary
+                // distribution. Purely additive; the event keeps its own
+                // sharing_group_id.
+                $sqlArray[] = "CREATE TABLE IF NOT EXISTS `event_sharing_groups` (
+                    `id` int(11) NOT NULL AUTO_INCREMENT,
+                    `event_id` int(11) NOT NULL,
+                    `sharing_group_id` int(11) NOT NULL,
+                    PRIMARY KEY (`id`),
+                    KEY `event_id` (`event_id`),
+                    KEY `sharing_group_id` (`sharing_group_id`)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;";
                 break;
             case 'fixNonEmptySharingGroupID':
                 $sqlArray[] = 'UPDATE `events` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -348,6 +348,11 @@ class Event extends AppModel
             'className' => 'EventReport',
             'dependent' => true,
         ),
+        // Additional sharing groups granting read access (#10818).
+        'EventSharingGroup' => array(
+            'className' => 'EventSharingGroup',
+            'dependent' => true,
+        ),
         'CryptographicKey' => [
             'foreignKey' => 'parent_id',
             'conditions' => [
@@ -1473,11 +1478,50 @@ class Event extends AppModel
                     ]
                 ]
             ];
+            // Multiple sharing groups (#10818): grant access if the event is
+            // shared with any sharing group the user is authorised for via
+            // the event_sharing_groups link table. Additive only.
+            $additionalSgCondition = $this->additionalSharingGroupAccessCondition($sgids, $unpublishedPrivate);
+            if ($additionalSgCondition !== null) {
+                $conditions['AND']['OR'][] = $additionalSgCondition;
+            }
             if (!$skip_own_event_rule) {
                 $conditions['AND']['OR'][] = ['Event.org_id' => $user['org_id']];
             }
         }
         return $conditions;
+    }
+
+    /**
+     * Multiple sharing groups (#10818): build the condition that grants
+     * read access to events shared with any of $sgids via the
+     * event_sharing_groups link table. Returns null when the user has no
+     * authorised sharing groups (nothing extra to grant), so callers add
+     * the branch only when it can match. Additive only: this never
+     * restricts access, it only ORs in another way to be allowed.
+     *
+     * @param array $sgids Authorised sharing group ids for the user.
+     * @param bool $unpublishedPrivate
+     * @return array|null
+     */
+    public function additionalSharingGroupAccessCondition(array $sgids, $unpublishedPrivate = false)
+    {
+        if (empty($sgids)) {
+            return null;
+        }
+        $subQuery = $this->subQueryGenerator(
+            $this->EventSharingGroup,
+            [
+                'fields' => ['EventSharingGroup.event_id'],
+                'conditions' => ['EventSharingGroup.sharing_group_id' => $sgids],
+            ],
+            'Event.id'
+        );
+        $condition = ['AND' => [$subQuery[0]]];
+        if ($unpublishedPrivate) {
+            $condition['AND']['Event.published'] = 1;
+        }
+        return $condition;
     }
 
     public function set_filter_wildcard(&$params, $conditions, $options)

--- a/app/Model/EventSharingGroup.php
+++ b/app/Model/EventSharingGroup.php
@@ -1,0 +1,34 @@
+<?php
+App::uses('AppModel', 'Model');
+
+/**
+ * Multiple sharing groups (#10818).
+ *
+ * Join between an event and the *additional* sharing groups it is shared
+ * with, on top of the event's own primary distribution / sharing_group_id.
+ * Membership in any of these sharing groups grants read access to the
+ * event. Purely additive: it never removes access the event already had.
+ *
+ * @property Event $Event
+ * @property SharingGroup $SharingGroup
+ */
+class EventSharingGroup extends AppModel
+{
+    public $actsAs = array('Containable');
+
+    public $belongsTo = array(
+        'Event',
+        'SharingGroup',
+    );
+
+    public $validate = array(
+        'event_id' => array(
+            'rule' => 'numeric',
+            'required' => true,
+        ),
+        'sharing_group_id' => array(
+            'rule' => 'numeric',
+            'required' => true,
+        ),
+    );
+}

--- a/app/Model/MispAttribute.php
+++ b/app/Model/MispAttribute.php
@@ -1930,14 +1930,26 @@ class MispAttribute extends AppModel
                 $eventLaxCondition['Event.published'] = 1;
                 $eventSgCondition['Event.published'] = 1;
             }
+            // Multiple sharing groups (#10818): an event shared with any of
+            // the user's authorised sharing groups via the event_sharing_groups
+            // link grants event-level access too. Additive only; the attribute
+            // distribution rules below still apply.
+            $eventAccessOr = [
+                $eventLaxCondition,
+                $eventSgCondition,
+            ];
+            $eventAdditionalSgCondition = $this->Event->additionalSharingGroupAccessCondition(
+                $sgids,
+                Configure::read('MISP.unpublishedprivate')
+            );
+            if ($eventAdditionalSgCondition !== null) {
+                $eventAccessOr[] = $eventAdditionalSgCondition;
+            }
             $conditions = [
                 'OR' => [
                     ['Event.org_id' => $user['org_id']],
                     'AND' => [
-                        'OR' => [
-                            $eventLaxCondition,
-                            $eventSgCondition,
-                        ],
+                        'OR' => $eventAccessOr,
                         [
                             'OR' => [
                                 'Attribute.distribution'

--- a/db_schema.json
+++ b/db_schema.json
@@ -10835,6 +10835,41 @@
                 "column_default": "NULL",
                 "extra": ""
             }
+        ],
+        "event_sharing_groups": [
+            {
+                "column_name": "id",
+                "is_nullable": "NO",
+                "data_type": "int",
+                "character_maximum_length": null,
+                "numeric_precision": "10",
+                "collation_name": null,
+                "column_type": "int(11)",
+                "column_default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "column_name": "event_id",
+                "is_nullable": "NO",
+                "data_type": "int",
+                "character_maximum_length": null,
+                "numeric_precision": "10",
+                "collation_name": null,
+                "column_type": "int(11)",
+                "column_default": null,
+                "extra": ""
+            },
+            {
+                "column_name": "sharing_group_id",
+                "is_nullable": "NO",
+                "data_type": "int",
+                "character_maximum_length": null,
+                "numeric_precision": "10",
+                "collation_name": null,
+                "column_type": "int(11)",
+                "column_default": null,
+                "extra": ""
+            }
         ]
     },
     "indexes": {
@@ -11460,7 +11495,12 @@
             "name": false,
             "timestamp": false,
             "uuid": false
+        },
+        "event_sharing_groups": {
+            "event_id": false,
+            "id": true,
+            "sharing_group_id": false
         }
     },
-    "db_version": "153"
+    "db_version": "154"
 }


### PR DESCRIPTION
#### What does it do?

Delivers the multiple sharing groups part of #10818

* **Core Change:** Adds an `event_sharing_groups` link table to grant secondary read access to an event and its event-level attributes.
* **New Endpoints:** Adds `addSharingGroup` and `removeSharingGroup`.
* **Security:** Purely additive `OR` logic. It never loosens existing checks. Attribute visibility stays fail-closed, so org-only attributes remain hidden from secondary group members.

**Scope & Notes:**
* Sync, UI visibility, and attribute-level inheritance are excluded from this initial slice.
* Uses migration 154. If the first half of #10818 merges first, this will need renumbering.
* I read "multiple sharing groups" as one event shared with several groups at once. Please let me know if that needs to be reworked.

**Tested on a live 2.5.42 instance:**
* Link grants read access; removal revokes it immediately.
* Org-only attributes stay hidden from additional-group members.
* Behaviour is consistent across event view, index, and attribute `restSearch`.
* Write path successfully blocks attaching groups the user cannot access.

#### Questions

- [X] Does it require a DB change? (Yes, migration 154)
- [X] Are you using it in production? (No, lab testing)
- [X] Does it require a change in the API (PyMISP for example)? (Yes, new endpoints)