### PR TITLE
fix: add zeromq supervisor setting and status check

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -2591,6 +2591,9 @@ class Server extends AppModel
         // If we are trying to change the enable setting to false, we don't need to test anything, just kill the server and return true.
         if ($setting === 'Plugin.ZeroMQ_enable') {
             if ($value == false || $value == 0) {
+                if (Configure::read('Plugin.ZeroMQ_supervisor_managed')) {
+                    return true;
+                }
                 $this->getPubSubTool()->killService();
                 return true;
             }
@@ -4057,19 +4060,28 @@ class Server extends AppModel
             return 1;
         }
         $pubSubTool = $this->getPubSubTool();
-        try {
-            $isInstalled = $pubSubTool->checkIfPythonLibInstalled();
-        } catch (Exception $e) {
-            $this->logException('ZMQ is not properly installed.', $e, LOG_NOTICE);
-            $diagnostic_errors++;
-            return 2;
-        }
+        if (!Configure::read('Plugin.ZeroMQ_supervisor_managed')) {
+            try {
+                $isInstalled = $pubSubTool->checkIfPythonLibInstalled();
+            } catch (Exception $e) {
+                $this->logException('ZMQ is not properly installed.', $e, LOG_NOTICE);
+                $diagnostic_errors++;
+                return 2;
+            }
 
-        if (!$isInstalled) {
-            $diagnostic_errors++;
-            return 2;
+            if (!$isInstalled) {
+                $diagnostic_errors++;
+                return 2;
+            }
         }
-        if ($pubSubTool->checkIfRunning()) {
+        try {
+            $status = $pubSubTool->statusCheck();
+        } catch (Exception $e) {
+            $this->logException('ZMQ is not running or not responding.', $e, LOG_NOTICE);
+            $diagnostic_errors++;
+            return 3;
+        }
+        if (!empty($status)) {
             return 0;
         }
         $diagnostic_errors++;
@@ -8077,6 +8089,15 @@ class Server extends AppModel
                     'test' => 'testBool',
                     'type' => 'boolean',
                     'afterHook' => 'zmqAfterHook',
+                ),
+                'ZeroMQ_supervisor_managed' => array(
+                    'level' => 2,
+                    'description' => __('Enable this setting if the ZeroMQ server is managed by supervisor.'),
+                    'value' => false,
+                    'test' => 'testBool',
+                    'type' => 'boolean',
+                    'afterHook' => 'zmqAfterHook',
+                    'cli_only' => true,
                 ),
                 'ZeroMQ_host' => array(
                     'level' => 2,


### PR DESCRIPTION
## What does it do?
Adds the missing `Plugin.ZeroMQ_supervisor_managed` server setting as a CLI-only boolean setting, disabled by default.

When ZeroMQ is supervisor-managed, disabling Plugin.ZeroMQ_enable no longer attempts to kill the ZeroMQ process from the web process. This avoids failures in deployments where the ZeroMQ process is owned by an external supervisor; disabling the setting now only stops MISP from publishing messages.

When this setting is enabled, ZeroMQ diagnostics no longer require the local Python ZeroMQ library check from the web process. This supports deployments where web and supervisor processes are not on the same system.

ZeroMQ diagnostics now verify liveness using `PubSubTool::statusCheck()` instead of the PID-file based `checkIfRunning()` check, so diagnostics confirm that the service is actually responding.

### Questions
- [No] Does it require a DB change?
- [No] Are you using it in production?
- [No] Does it require a change in the API (PyMISP for example)?