### PR TITLE
fix: [Galaxy:convertToMISPGalaxyFormat] set initial version correctly…

### DIFF
--- a/app/Model/Galaxy.php
+++ b/app/Model/Galaxy.php
@@ -1392,7 +1392,7 @@ class Galaxy extends AppModel
                     }
                 }
             }
-            $converted['version'] = $converted['version'] > $cluster['GalaxyCluster']['version'];
+            $converted['version'] = max($converted['version'], $cluster['GalaxyCluster']['version']);
             foreach ($cluster['GalaxyCluster']['GalaxyElement'] as $element) {
                 if (isset($values[$i]['meta'][$element['key']])) {
                     if (is_array($values[$i]['meta'][$element['key']])) {


### PR DESCRIPTION
… using max() of cluster version fields

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
