### PR TITLE
fix: [OrgEventsWidget] Fix target date computation

### DIFF
--- a/app/Lib/Dashboard/OrgEventsWidget.php
+++ b/app/Lib/Dashboard/OrgEventsWidget.php
@@ -156,7 +156,7 @@ class OrgEventsWidget
         for ($i=0; $i < $limit; $i++) {
             $target_month = $current_month - $i;
             $target_year = $current_year;
-            if ($target_month < 1) {
+            while ($target_month < 1) {
                 $target_month += 12;
                 $target_year -= 1;
             }

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1008,7 +1008,9 @@ class Server extends AppModel
         $reindexed = [];
         foreach ($localEvents as $item) {
             $event = $item['Event'];
-            $event['EventTag'] = $item['EventTag'] ?? [];
+            if ($isInternal) {
+                $event['EventTag'] = $item['EventTag'] ?? [];
+            }
             $reindexed[$event['uuid']] = $event;
         }
         $localEvents = $reindexed;
@@ -1018,23 +1020,29 @@ class Server extends AppModel
             if (isset($localEvents[$uuid])) {
                 $isUnlocked = !$localEvents[$uuid]['locked'];
 
-                $localTs = $localEvents[$uuid]['timestamp'];
-                $incomingTs = $event['timestamp'];
+                $localTs = (int)$localEvents[$uuid]['timestamp'];
+                $incomingTs = (int)$event['timestamp'];
 
-                $localEventTagsFingerprint = $this->Event->getTagsFingerprint($localEvents[$uuid]['EventTag']);
-                $eventTagsFingerprint = $event['event_tags_fingerprint'] ?? null;
+                if ($isInternal) {
+                    $localEventTagsFingerprint = $this->Event->getTagsFingerprint($localEvents[$uuid]['EventTag']);
+                    $eventTagsFingerprint = $event['event_tags_fingerprint'] ?? null;
 
-                $sameFingerprint =
-                    $eventTagsFingerprint === null || // If the remote doesn't provide a fingerprint, skip
-                    $localEventTagsFingerprint === $eventTagsFingerprint;
+                    $sameFingerprint =
+                        $eventTagsFingerprint === null || // If the remote doesn't provide a fingerprint, skip
+                        $localEventTagsFingerprint === $eventTagsFingerprint;
 
-                $shouldDiscard =
-                    $isUnlocked ||
-                    ($localTs > $incomingTs) || // strictly newer local event
-                    (
-                        $localTs === $incomingTs && // same timestamp handling
-                        (!$isInternal || $sameFingerprint)
-                    );
+                    $shouldDiscard =
+                        $isUnlocked ||
+                        ($localTs > $incomingTs) || // strictly newer local event
+                        (
+                            $localTs === $incomingTs && // same timestamp handling
+                            $sameFingerprint
+                        );
+                } else {
+                    $shouldDiscard =
+                        $isUnlocked ||
+                        ($localTs >= $incomingTs); // same timestamp handling
+                }
                 if ($shouldDiscard) {
                     unset($events[$k]);
                 }


### PR DESCRIPTION
Computation of the target month and year failed to account for the case where the start date was before January of the previous year. The code considered the case when the target month was below 1, but trying to go back further than (12 + the current month) months resulted in a negative value for the target month. Changing the `if` to a `while` compensates for multiple years.

#### Questions

- [ ] Does it require a DB change?
- [x] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
