### PR TITLE
fix: [Export] Remove stray leading newlines from module export files

### DIFF
--- a/app/Model/EventReport.php
+++ b/app/Model/EventReport.php
@@ -1,5 +1,3 @@
-
-
 <?php
 App::uses('AppModel', 'Model');
 App::uses('SyncTool', 'Tools');


### PR DESCRIPTION
#### What does it do?
Fixes an issue introduced in 2.5.40 - when exporting a MISP event through a MISP module, the file would always begin with two line feeds. This would corrupt, for example, an XML file.

The fix has been tested locally.

#### Questions

- [ ] Does it require a DB change? No
- [ ] Are you using it in production? No
- [ ] Does it require a change in the API (PyMISP for example)? No
