### PR TITLE
fix: set Security.disable_browser_cache to false in installers and docs

### DIFF
--- a/INSTALL/INSTALL.debian12.sh
+++ b/INSTALL/INSTALL.debian12.sh
@@ -687,7 +687,7 @@ error_check "Background workers setup"
   sudo -u ${APACHE_USER} ${MISP_PATH}/app/Console/cake Admin setSetting "Security.self_registration_message" "If you would like to send us a registration request, please fill out the form below. Make sure you fill out as much information as possible in order to ease the task of the administrators." &>> $logfile
 
   # Appease the security audit, #hardening
-  sudo -u ${APACHE_USER} ${MISP_PATH}/app/Console/cake Admin setSetting "Security.disable_browser_cache" true &>> $logfile
+  sudo -u ${APACHE_USER} ${MISP_PATH}/app/Console/cake Admin setSetting "Security.disable_browser_cache" false &>> $logfile
   sudo -u ${APACHE_USER} ${MISP_PATH}/app/Console/cake Admin setSetting "Security.check_sec_fetch_site_header" true &>> $logfile
   sudo -u ${APACHE_USER} ${MISP_PATH}/app/Console/cake Admin setSetting "Security.csp_enforce" true &>> $logfile
   sudo -u ${APACHE_USER} ${MISP_PATH}/app/Console/cake Admin setSetting "Security.advanced_authkeys" true &>> $logfile

--- a/INSTALL/INSTALL.debian13.sh
+++ b/INSTALL/INSTALL.debian13.sh
@@ -685,7 +685,7 @@ error_check "Background workers setup"
   sudo -u ${APACHE_USER} ${MISP_PATH}/app/Console/cake Admin setSetting "Security.self_registration_message" "If you would like to send us a registration request, please fill out the form below. Make sure you fill out as much information as possible in order to ease the task of the administrators." &>> $logfile
 
   # Appease the security audit, #hardening
-  sudo -u ${APACHE_USER} ${MISP_PATH}/app/Console/cake Admin setSetting "Security.disable_browser_cache" true &>> $logfile
+  sudo -u ${APACHE_USER} ${MISP_PATH}/app/Console/cake Admin setSetting "Security.disable_browser_cache" false &>> $logfile
   sudo -u ${APACHE_USER} ${MISP_PATH}/app/Console/cake Admin setSetting "Security.check_sec_fetch_site_header" true &>> $logfile
   sudo -u ${APACHE_USER} ${MISP_PATH}/app/Console/cake Admin setSetting "Security.csp_enforce" true &>> $logfile
   sudo -u ${APACHE_USER} ${MISP_PATH}/app/Console/cake Admin setSetting "Security.advanced_authkeys" true &>> $logfile

--- a/INSTALL/INSTALL.ubuntu2404.sh
+++ b/INSTALL/INSTALL.ubuntu2404.sh
@@ -723,7 +723,7 @@ set_misp_setting "Security.password_policy_complexity" '/^((?=.*\\d)|(?=.*\\W+))
 set_misp_setting "Security.self_registration_message" "If you would like to send us a registration request, please fill out the form below. Make sure you fill out as much information as possible in order to ease the task of the administrators."
 
 # Appease the security audit, #hardening
-set_misp_setting "Security.disable_browser_cache" true
+set_misp_setting "Security.disable_browser_cache" false
 set_misp_setting "Security.check_sec_fetch_site_header" true
 set_misp_setting "Security.csp_enforce" true
 set_misp_setting "Security.advanced_authkeys" true

--- a/INSTALL/xINSTALL.rhel94.sh
+++ b/INSTALL/xINSTALL.rhel94.sh
@@ -746,7 +746,7 @@ error_check "Background workers setup"
   sudo -u ${APACHE_USER} ${MISP_PATH}/app/Console/cake Admin setSetting "Security.self_registration_message" "If you would like to send us a registration request, please fill out the form below. Make sure you fill out as much information as possible in order to ease the task of the administrators." &>> $logfile
 
   # Appease the security audit, #hardening
-  sudo -u ${APACHE_USER} ${MISP_PATH}/app/Console/cake Admin setSetting "Security.disable_browser_cache" true &>> $logfile
+  sudo -u ${APACHE_USER} ${MISP_PATH}/app/Console/cake Admin setSetting "Security.disable_browser_cache" false &>> $logfile
   sudo -u ${APACHE_USER} ${MISP_PATH}/app/Console/cake Admin setSetting "Security.check_sec_fetch_site_header" true &>> $logfile
   sudo -u ${APACHE_USER} ${MISP_PATH}/app/Console/cake Admin setSetting "Security.csp_enforce" true &>> $logfile
   sudo -u ${APACHE_USER} ${MISP_PATH}/app/Console/cake Admin setSetting "Security.advanced_authkeys" true &>> $logfile

--- a/docs/generic/MISP_CAKE_init.md
+++ b/docs/generic/MISP_CAKE_init.md
@@ -252,7 +252,7 @@ coreCAKE () {
   ${SUDO_WWW} ${RUN_PHP} -- ${CAKE} Admin setSetting "Security.self_registration_message" "If you would like to send us a registration request, please fill out the form below. Make sure you fill out as much information as possible in order to ease the task of the administrators."
 
   # Appease the security audit, #hardening
-  ${SUDO_WWW} ${RUN_PHP} -- ${CAKE} Admin setSetting "Security.disable_browser_cache" true
+  ${SUDO_WWW} ${RUN_PHP} -- ${CAKE} Admin setSetting "Security.disable_browser_cache" false
   ${SUDO_WWW} ${RUN_PHP} -- ${CAKE} Admin setSetting "Security.check_sec_fetch_site_header" true
   ${SUDO_WWW} ${RUN_PHP} -- ${CAKE} Admin setSetting "Security.csp_enforce" true
   ${SUDO_WWW} ${RUN_PHP} -- ${CAKE} Admin setSetting "Security.advanced_authkeys" true


### PR DESCRIPTION
### Motivation
- The installers and init docs were enabling `Security.disable_browser_cache` by default which caused operational issues, so the default should keep browser cache enabled.
- Align installer defaults and the Cake initialization helper with the expected operational behavior to avoid user-facing problems.

### Description
- Changed `Security.disable_browser_cache` from `true` to `false` in the Debian 12 installer (`INSTALL/INSTALL.debian12.sh`).
- Changed `Security.disable_browser_cache` from `true` to `false` in the Debian 13 installer (`INSTALL/INSTALL.debian13.sh`).
- Changed `Security.disable_browser_cache` from `true` to `false` in the Ubuntu 24.04 installer (`INSTALL/INSTALL.ubuntu2404.sh`) and the RHEL 9.4 installer (`INSTALL/xINSTALL.rhel94.sh`).
- Updated the generic Cake initialization documentation (`docs/generic/MISP_CAKE_init.md`) to set `Security.disable_browser_cache` to `false` in the example/init sequence.

### Testing
- Ran the search check with `rg 'setSetting "Security\.disable_browser_cache" true|set_misp_setting "Security\.disable_browser_cache" true|Security\.disable_browser_cache" true' INSTALL docs/generic/MISP_CAKE_init.md` and found no matches, confirming replacements.
- Performed shell syntax checks with `bash -n` on the modified installer scripts which completed without errors.
- Ran `git diff --check` to ensure there are no whitespace or diff issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a50c370cfa88325ac6061d3aef1e1ba)