### PR TITLE
fix: [dashboard] Pass full Server record to sync test widget

### DIFF
--- a/app/Lib/Dashboard/MispAdminSyncTestWidget.php
+++ b/app/Lib/Dashboard/MispAdminSyncTestWidget.php
@@ -20,7 +20,6 @@ class MispAdminSyncTestWidget
     {
         $this->Server = ClassRegistry::init('Server');
         $servers = $this->Server->find('all', array(
-            'fields' => array('id', 'url', 'name', 'pull', 'push', 'caching_enabled', 'authkey', 'cert_file', 'client_cert_file', 'self_signed'),
             'conditions' => array('OR' => array('pull' => 1, 'push' => 1, 'caching_enabled' => 1)),
             'recursive' => -1
         ));


### PR DESCRIPTION
fix: [dashboard] Pass full Server record to sync test widget

The `MISP Sync Test` dashboard widget rendered every sync peer as a red "Server unreachable" node, while the very same peers tested green from the Sync Actions → Remote Servers page and from `cake Server test <id>`. 

The widget restricted the columns fetched for each `Server` row and then handed that partial record to `Server::runConnectionTest()`, which builds the sync HTTP socket directly off it, so any column left out of the selection silently changed the behaviour of the connection test itself.

This commit removes the `fields` restriction from the widget's `find('all')`, so `runConnectionTest()` receives a complete `Server` record, consistent with the two other callers of that method (`ServersController::testConnection()` and `ServerShell::test()`), both of which already pass an unfiltered record.

#### What does it do?

This PR fixes an issue where the "MISP Sync Test" widget of the new dashboard reported all sync servers as unreachable even though the connection tests were succeeding everywhere else.

The widget's payload showed every node as failed:

```json
{"nodes":[
  {"id":"self","name":"MyOrg","status":"self","message":"Current instance (sync root)."},
  {"id":"srv-5","name":"#5 MISP1","status":"error","message":"Server unreachable"},
  {"id":"srv-12","name":"#12 MISP2","status":"error","message":"Server unreachable"}
]}
```

while the CLI reported the same servers as reachable:

```
$ sudo -u apache /var/www/MISP/app/Console/cake Server test 5
{
    "status": 1,
    "info": {
        "version": "2.5.44",
        "perm_sync": true,
        "perm_sighting": true,
        "perm_galaxy_editor": true,
        "perm_analyst_data": true,
        ...
    },
    "client_certificate": null
}

$ sudo -u apache /var/www/MISP/app/Console/cake Server test 12
{
    "status": 1,
    "info": {
        "version": "2.5.44",
        "perm_sync": false,
        "perm_sighting": false,
        "perm_galaxy_editor": false,
        "perm_analyst_data": false,
        ...
    },
    "client_certificate": null
}
```

Logging the widget's own result confirmed it was getting a different outcome from the exact same method:

```
2026-07-14 17:07:19 Debug: SERVER 5 -> {"status":2,"client_certificate":null}
2026-07-14 17:07:19 Debug: SERVER 12 -> {"status":2,"client_certificate":null}
```

Status `2` maps to `Server unreachable` in `Server::$syncTestErrorCodes` and is returned by the generic `catch (Exception $e)` branch of `runConnectionTest()` (`app/Model/Server.php:3090`).

**Root cause.** The widget's `fields` list did not include `skip_proxy`. `runConnectionTest()` passes the record straight to `SyncTool::setupHttpSocket()`, which reads that column:

```php
if (!empty($server[$model]['skip_proxy'])) {
    $params['skip_proxy'] = 1;
}
```

With the column absent from the record the check is always false, so on an instance with `Proxy.host` configured the socket is built with the proxy enabled (`app/Lib/Tools/SyncTool.php:96`) and the request to an internal peer fails, throws, and is reported as `Server unreachable`. The Servers page and the CLI pass the full record, keep `skip_proxy = 1`, bypass the proxy, and succeed — hence the contradiction.

The same class of failure applies to any column that this call chain — `runConnectionTest()` → `setupSyncRequest()` → `SyncTool::setupHttpSocket()` / `getServerClientCertificateInfo()` — reads now or may read in the future. Fetching the whole row removes that implicit coupling instead of re-encoding it in the widget, and the cost is negligible: this widget's runtime is dominated by one HTTPS round-trip per server, not by the width of a handful of rows read with `recursive => -1`.

The change is from:

```php
$servers = $this->Server->find('all', array(
    'fields' => array('id', 'url', 'name', 'pull', 'push', 'caching_enabled', 'authkey', 'cert_file', 'client_cert_file', 'self_signed'),
    'conditions' => array('OR' => array('pull' => 1, 'push' => 1, 'caching_enabled' => 1)),
    'recursive' => -1
));
```

to:

```php
$servers = $this->Server->find('all', array(
    'conditions' => array('OR' => array('pull' => 1, 'push' => 1, 'caching_enabled' => 1)),
    'recursive' => -1
));
```

Nothing else in `handler()` changes — `id`, `name` and `url` are still the only columns read for the node payload, and the existing status mapping already behaves correctly once `runConnectionTest()` is given a valid record:

* green (`ok`) — connected, all sync permissions present (e.g. server 5);
* amber (`warn`) — connected, but missing `perm_sync` / `perm_sighting` / `perm_analyst_data` (e.g. server 12, "Remote user not a sync user");
* red (`error`) — the connection test genuinely failed.

#### Questions

  - [ ] Does it require a DB change?
  - [x] Are you using it in production?
  - [ ] Does it require a change in the API (PyMISP for example)?