### PR TITLE
new: [OIDC] Add `update_user_organization` setting

### DIFF
--- a/app/Plugin/OidcAuth/Controller/Component/Auth/OidcAuthenticate.php
+++ b/app/Plugin/OidcAuth/Controller/Component/Auth/OidcAuthenticate.php
@@ -19,6 +19,7 @@ App::uses('Oidc', 'OidcAuth.Lib');
  *  - OidcAuth.offline_access (boolean, default: false)
  *  - OidcAuth.check_user_validity (integer, default `0`)
  *  - OidcAuth.update_user_role (boolean, default: true) - if disabled, manually modified role in MISP admin interface will be not changed from OIDC
+ *  - OidcAuth.update_user_organization (boolean, default: true) - if disabled, manually modified organisation in MISP admin interface will be not changed from OIDC
  *  - OidcAuth.mixedAuth (boolean, default: false) - if enabled, MISP will not automatically redirect to SSO portal and allow other authentication methods
  *  - OidcAuth.disable_request_object (boolean, default: false) Disable the Request Object approach in authorization requests, allowing users to fallback to plain parameters when needed for compatibility with certain OpenID Connect providers.
  *  - OidcAuth.disable_pushed_authorization_request (boolean, default: false) Disable the use of Pushed Authorization Requests (PAR) and send authorization request parameters directly to the authorization endpoint instead. This can be used for compatibility with OpenID Connect providers where PAR should not be used.

--- a/app/Plugin/OidcAuth/Lib/Oidc.php
+++ b/app/Plugin/OidcAuth/Lib/Oidc.php
@@ -134,7 +134,7 @@ class Oidc
                 $user['email'] = $mispUsername;
             }
 
-            if ($user['org_id'] != $organisationId) {
+            if ($user['org_id'] != $organisationId && $this->getConfig('update_user_organization', true)) {
                 $this->User->updateField($user, 'org_id', $organisationId);
                 $this->log($mispUsername, "User organisation changed from {$user['org_id']} to $organisationId.");
                 $user['org_id'] = $organisationId;
@@ -298,7 +298,7 @@ class Oidc
             }
         }
 
-        if ($update && $user['org_id'] != $organisationId) {
+        if ($update && $user['org_id'] != $organisationId && $this->getConfig('update_user_organization', true)) {
             $this->User->updateField($user, 'org_id', $organisationId);
             $this->log($user['email'], "User organisation changed from {$user['org_id']} to $organisationId.");
         }


### PR DESCRIPTION
#### What does it do?

Adds a new `OidcAuth.update_user_organization` option (boolean, default: `true`) that, when set to `false`, stops OIDC from overwriting a user's organisation on subsequent logins. This mirrors the existing `OidcAuth.update_user_role` option, which already allows the same for roles.

Changes:

- `Oidc.php` — `authenticate()`: the organisation is only updated when `update_user_organization` is enabled.
- `Oidc.php` — `isUserValid()`: same guard, so the organisation is not silently overwritten by the periodic validity check (`check_user_validity` with `offline_access`) either.
- `OidcAuthenticate.php`: documents the new option alongside the other `OidcAuth.*` settings.

The default (`true`) preserves the current behaviour, so existing installs are unaffected.

#### Why?

Our Identity Provider does not populate the organisation claim, and `OidcAuth.default_org` is required for login to succeed. This means every user is provisioned into a single staging organisation, and any organisation an admin later assigns through the MISP UI is reverted back to `default_org` on the user's next login (or at the next validity check).

With `update_user_organization` set to `false`, users can be provisioned into the staging organisation by OIDC and then moved to their real organisation by an admin, with the assignment surviving. Organisation management stays in MISP for setups where the IdP is not authoritative on that attribute — exactly the tradeoff `update_user_role` already offers for roles.

#### Questions

- [ ] Does it require a DB change? No
- [x] Are you using it in production? Yes
- [ ] Does it require a change in the API (PyMISP for example)? No
