### PR TITLE
fix: [dashboard] Add missing BenchmarkTool import in BenchmarkTopListWidget

### DIFF
--- a/app/Lib/Dashboard/BenchmarkTopListWidget.php
+++ b/app/Lib/Dashboard/BenchmarkTopListWidget.php
@@ -1,5 +1,6 @@
 <?php
 
+App::uses('BenchmarkTool', 'Tools');
 
 class BenchmarkTopListWidget
 {


### PR DESCRIPTION
## fix: [dashboard] Add missing BenchmarkTool import in BenchmarkTopListWidget

#### What does it do?

The `BenchmarkTopListWidget` dashboard widget fails to render with an HTTP 500 error. `getData()` instantiates `new BenchmarkTool($this->User)`, but the class is never imported, so CakePHP's autoloader cannot find it.

Fix: add the missing `App::uses('BenchmarkTool', 'Tools');` at the top of the file (line 3) — the same import pattern already used in `AppController`, `BenchmarksController` and `AppShell`. 

**Error (`app/tmp/logs/error.log`):**

```
2026-07-21 19:16:14 Error: [Error] Class "BenchmarkTool" not found
Request URL: /dashboards/renderWidget/w_7
Error in: /data/www/MISP/app/Lib/Dashboard/BenchmarkTopListWidget.php, Line: 97
Stack Trace:
#0 /data/www/MISP/app/Lib/Dashboard/BenchmarkTopListWidget.php(68): BenchmarkTopListWidget->getData()
#1 /data/www/MISP/app/Controller/DashboardsController.php(572): BenchmarkTopListWidget->handler()
#2 /data/www/MISP/app/Lib/Dashboard/Tools/WidgetCache.php(86): DashboardsController->{closure}()
#3 /data/www/MISP/app/Controller/DashboardsController.php(571): WidgetCache::remember()
#4 [internal function]: DashboardsController->renderWidget()
#5 /data/www/MISP/app/Lib/cakephp/lib/Cake/Controller/Controller.php(500): ReflectionMethod->invokeArgs()
#6 /data/www/MISP/app/Lib/cakephp/lib/Cake/Routing/Dispatcher.php(193): Controller->invokeAction()
#7 /data/www/MISP/app/Lib/cakephp/lib/Cake/Routing/Dispatcher.php(167): Dispatcher->_invoke()
#8 /data/www/MISP/app/webroot/index.php(107): Dispatcher->dispatch()
#9 {main}
```

**Widget error on dashboard:**

<img width="455" height="160" alt="Screenshot 2026-07-21 191629" src="https://github.com/user-attachments/assets/235d21c3-79bc-4df7-9baa-0070d7bf58e2" />


#### Questions

  - [ ] Does it require a DB change?
  - [x] Are you using it in production?
  - [ ] Does it require a change in the API (PyMISP for example)?