### PR TITLE
feat: add OpenAPI documentation for job management endpoints

### DIFF
--- a/app/webroot/doc/openapi.yaml
+++ b/app/webroot/doc/openapi.yaml
@@ -138,7 +138,10 @@ tags:
       url: https://www.circl.lu/doc/misp/taxonomy/#taxonomies
   - name: Event Report
     description: "Event reports can contain text under the markdown format and are stored inside an event. They can be used to describe events or processes in a readable way."
-
+  - name: Jobs
+    description: "Background jobs management."
+    externalDocs:
+      url: https://www.circl.lu/doc/misp/administration/#background-processing
 
 paths:
   /analystData/add/{analystType}/{analystObjectUUID}/{analystObjectType}:
@@ -1285,6 +1288,100 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/RestoreGalaxyClusterResponse"
+        "403":
+          $ref: "#/components/responses/UnauthorizedApiErrorResponse"
+        "404":
+          $ref: "#/components/responses/NotFoundApiErrorResponse"
+        default:
+          $ref: "#/components/responses/ApiErrorResponse"
+
+  /jobs/index:
+    get:
+      summary: "List jobs"
+      operationId: indexJobs
+      tags:
+        - Jobs
+      responses:
+        "200":
+          description: "Successful response"
+          content:
+            application/json:
+              schema:
+                type: object
+        "403":
+          $ref: "#/components/responses/UnauthorizedApiErrorResponse"
+        "404":
+          $ref: "#/components/responses/NotFoundApiErrorResponse"
+        default:
+          $ref: "#/components/responses/ApiErrorResponse"
+
+  /jobs/getProgress/{id}:
+    get:
+      summary: "Get job progress"
+      operationId: getJobProgress
+      tags:
+        - Jobs
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: "Job ID"
+      responses:
+        "200":
+          description: "Successful response"
+          content:
+            application/json:
+              schema:
+                type: object
+        "403":
+          $ref: "#/components/responses/UnauthorizedApiErrorResponse"
+        "404":
+          $ref: "#/components/responses/NotFoundApiErrorResponse"
+        default:
+          $ref: "#/components/responses/ApiErrorResponse"
+
+  /jobs/getError/{id}:
+    get:
+      summary: "Get job error"
+      operationId: getJobError
+      tags:
+        - Jobs
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: "Job ID"
+      responses:
+        "200":
+          description: "Successful response"
+          content:
+            application/json:
+              schema:
+                type: object
+        "403":
+          $ref: "#/components/responses/UnauthorizedApiErrorResponse"
+        "404":
+          $ref: "#/components/responses/NotFoundApiErrorResponse"
+        default:
+          $ref: "#/components/responses/ApiErrorResponse"
+
+  /jobs/clearJobs:
+    post:
+      summary: "Clear all jobs"
+      operationId: clearJobs
+      tags:
+        - Jobs
+      responses:
+        "200":
+          description: "Successful response"
+          content:
+            application/json:
+              schema:
+                type: object
         "403":
           $ref: "#/components/responses/UnauthorizedApiErrorResponse"
         "404":


### PR DESCRIPTION
This PR adds and updates the OpenAPI (`openapi.yaml`) documentation for the MISP Background Jobs management API (`/jobs` and `/servers`). 

The goal of this update is to ensure that the API contract is accurately reflected for users and integrations, especially in light of the new Supervisor-based `SimpleBackgroundJobs` implementation introduced in `2.4.151`.

### Changes Included:
* **Added `/jobs` Endpoints**: Documented `/jobs/index`, `/jobs/getProgress/{id}`, `/jobs/getError/{id}`, and `/jobs/clearJobs`.

### Notes for Reviewers:
* **ID Handling**: Depending on the backend endpoint, `{id}` handles both numeric database primary keys (for `getProgress`) and UUID string tokens (for `getError`). The OpenAPI schema utilizes `type: string` to flexibly accommodate both.
* **`killAllWorkers` behavior**: The documentation maps `/servers/killAllWorkers`. Please note that currently, this endpoint behaves as a no-op for the Supervisor backend, as it strictly instantiates `ResqueStatus` and targets CakeResque workers. This may need to be addressed in a future PR to reflect the move to the new Backend or documented otherwise.

---

> 🤖 **Disclaimer:** The OpenAPI YAML modifications and this Pull Request description were partially generated with the assistance of an AI coding assistant. All changes have been manually reviewed for accuracy against the MISP codebase and the `SimpleBackgroundJobs` migration guide.