### PR TITLE
new: [feed] APTtrail - APT indicators with MITRE ATT&CK attribution

### DIFF
--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -2505,5 +2505,31 @@
       "exportable": true,
       "hide_tag": false
     }
+  },
+  {
+    "Feed": {
+      "name": "APTtrail: APT indicators with MITRE ATT&CK attribution",
+      "provider": "APTtrail",
+      "url": "https://trilwu.github.io/apttrail/misp-feed",
+      "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]}}",
+      "enabled": false,
+      "distribution": "3",
+      "default": true,
+      "source_format": "misp",
+      "fixed_event": false,
+      "delta_merge": false,
+      "publish": false,
+      "override_ids": false,
+      "settings": "{\"csv\":{\"value\":\"\",\"delimiter\":\"\"},\"common\":{\"excluderegex\":\"\"}}",
+      "input_source": "network",
+      "delete_local_file": false,
+      "lookup_visible": false
+    },
+    "Tag": {
+      "name": "osint:source-type=\"automated-analysis\"",
+      "colour": "#004f89",
+      "exportable": true,
+      "hide_tag": false
+    }
   }
 ]


### PR DESCRIPTION
## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2025-09-09: branch 2.5)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

Adds APTtrail to the default feed list: a MISP feed of ~167,000 APT indicators
derived from Maltrail, published as **one event per actor** rather than one
event with 167,000 attributes — so a correlation hit pivots straight to that
actor's full infrastructure rather than into a single undifferentiated event.

* **340 events**, one per tracked group. 124 of them resolve onto **97 MITRE
  ATT&CK intrusion sets** and carry the `misp-galaxy:mitre-intrusion-set` tag,
  so an event links to the actor cluster.
* Event and attribute UUIDs are **deterministic** (UUIDv5 over a fixed
  namespace), so re-fetching updates events in place rather than duplicating
  them.
* Attributes carry `to_ids`; events carry `tlp:clear` and `apt:<group>`.
* Every indicator also carries the date it first appeared upstream and the
  report that published it (167,134 of 167,135 name a source report).
* Rebuilt hourly by a scheduled GitHub Action from a public upstream; the whole
  generator is in the repository. Feed URL is a static GitHub Pages path — no
  key, no account, no rate limit.

Feed: https://trilwu.github.io/apttrail/misp-feed/manifest.json
Source and generator: https://github.com/trilwu/apttrail

`enabled` is set to `false` so instances opt in rather than having a new
third-party feed switch itself on; happy to flip it if you would prefer.

Scope, stated plainly: attribution is inherited from Maltrail and the MISP
galaxy rather than independently assessed, and these are historical indicators
— a hit is a lead to triage, not proof of compromise. 216 of the 340 groups are
Mandiant UNC designations, malware names or catch-all buckets that ATT&CK does
not track; those ship with their upstream name and no `Gxxxx` id rather than a
guess.

The change is a single 26-line addition to
`app/files/feed-metadata/defaults.json`; no existing entry is touched and the
file still parses.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
