### PR TITLE
fix: [installer] correct cake Admin quoting in INSTALL.ubuntu2404.sh (#10919)

### DIFF
--- a/INSTALL/INSTALL.ubuntu2404.sh
+++ b/INSTALL/INSTALL.ubuntu2404.sh
@@ -464,8 +464,8 @@ error_check "Ensure redis is running"
 
 print_status "Running MISP updates"
 
-sudo -u "${APACHE_USER}" "${MISP_PATH}/app/Console/cake Admin" setSetting "MISP.osuser" "${APACHE_USER}" &>>$logfile
-sudo -u "${APACHE_USER}" "${MISP_PATH}/app/Console/cake Admin" runUpdates &>>$logfile
+sudo -u "${APACHE_USER}" "${MISP_PATH}/app/Console/cake" Admin setSetting "MISP.osuser" "${APACHE_USER}" &>>$logfile
+sudo -u "${APACHE_USER}" "${MISP_PATH}/app/Console/cake" Admin runUpdates &>>$logfile
 MISP_USER_KEY_FILE="$(mktemp)"
 sudo -u "${APACHE_USER}" "${MISP_PATH}/app/Console/cake" User init >"${MISP_USER_KEY_FILE}"
 MISP_USER_KEY="$(tr -d '\n' <"${MISP_USER_KEY_FILE}")"


### PR DESCRIPTION
Fixes #10919.

Diagnosis and diff are @jjfz123's from the issue report - this PR is their proposed change, verified end to end.

### Problem

- `INSTALL/INSTALL.ubuntu2404.sh` lines 467-468 quote the binary and the shell name as one token: `"${MISP_PATH}/app/Console/cake Admin"`.
- sudo therefore looks for a file literally named `cake Admin`, which does not exist, and both commands fail with `command not found` on every fresh install.
- Both calls redirect to `$logfile` and neither is followed by `error_check`, so the failure is silent: the installer reports success while `MISP.osuser` was never set and the initial `Admin runUpdates` never ran.
- These are the only two occurrences in the script. Every other cake invocation, including `User init` and `User change_pw` on the very next lines, already uses the correct form. `UPGRADE.ubuntu2404.sh` is unaffected.

### Fix

- Quote only the binary path, so the subcommand is passed as its own argument.
- Two lines, matching the form used everywhere else in the script.

### Testing

Reproduced and verified against a 2.5.44 install, running the invocations exactly as the script does:

- Before, broken form: `sudo: /var/www/MISP/app/Console/cake Admin: command not found`, exit 1, nothing written to the logfile.
- After, fixed form: both commands exit 0, and the logfile contains `Setting "MISP.osuser" changed to "www-data"` and `All updates completed.`
- `bash -n` on the modified script passes, and no occurrence of the bad pattern remains.

### Questions

- Does it require a DB change? No
- Are you using it in production? No, verified on a 2.5.44 test instance
- Does it require a change in the API (PyMISP for example)? No
