### PR TITLE
Add Software Heritage ID section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ The objective of MISP is to foster the sharing of structured information within 
   </tr><tr>
      <td>License</td>
   <td><img src="https://img.shields.io/github/license/MISP/MISP.svg" height="25" /></td>
+    </tr><tr>
+    <td>Software Heritage ID</td>
+  <td> <a href="https://archive.softwareheritage.org/browse/origin/?origin_url=https://github.com/MISP/MISP">
+  <img src="https://archive.softwareheritage.org/badge/origin/https://github.com/MISP/MISP/" alt="Archived | https://github.com/MISP/MISP"/>
+</a> </td>
 </tr>
 </table>
 


### PR DESCRIPTION
Added Software Heritage ID section with badge to README.  as this Repo is being curated and an SWHID has been made,  please let me know if you would also like the SWHID for each build

- Warmax356, Software heritage ambassador (malta)

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2025-09-09: branch 2.5)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

adding the Software heritage badge showcasing that the repo is also curated and backed up. additionally may provide the SWHID, this may be needed with the upcoming SBOMs for CRA compliance.

#### Questions

- [NO ] Does it require a DB change?
- [Yes] Are you using it in production?
- [NO0 ] Does it require a change in the API (PyMISP for example)?
