### PR TITLE
fix: [internal] Serialise validation errors before throwing in AuditLog::insert

### DIFF
--- a/app/Model/AuditLog.php
+++ b/app/Model/AuditLog.php
@@ -347,7 +347,7 @@ class AuditLog extends AppModel
             return; // Table is missing when updating, so this is intentional
         }
         if ($this->save(['AuditLog' => $data], ['atomic' => false]) === false) {
-            throw new Exception($this->validationErrors);
+            throw new Exception("Could not save audit log because of validation errors: " . JsonTool::encode($this->validationErrors));
         }
     }
 


### PR DESCRIPTION
AuditLog::insert() passes `$this->validationErrors` — an array — straight to `Exception::__construct()`, whose signature is `__construct(string $message = "", ...)`.

On PHP 8 that raises

```
TypeError: Exception::__construct(): Argument #1 ($message) must be of type string, array given
```

instead of the intended exception. The error path masks the very validation failure it was written to report, so whatever save actually failed is hidden behind a type error from the throw itself.

**Why this is the right shape of fix**

Every other model in the tree that throws on its own `validationErrors` serialises them first:

| File | Line | Call |
|---|---|---|
| `app/Model/Log.php` | 347 | `json_encode($this->validationErrors)` |
| `app/Model/Warninglist.php` | 403 | `json_encode($this->validationErrors)` |
| `app/Model/SystemSetting.php` | 120 | `JsonTool::encode($this->validationErrors)` |

`AuditLog` is the only one handing the raw array to the constructor. This change brings it in line and adds the same descriptive prefix the siblings use.

`JsonTool` is already used in this same file at lines 157 and 186, and is loaded application-wide via `app/Model/AppModel.php:27`, so no new import is needed.

**Change**

```diff
-            throw new Exception($this->validationErrors);
+            throw new Exception("Could not save audit log because of validation errors: " . JsonTool::encode($this->validationErrors));
```

One file, one line.

**Testing**

`php -l` passes. I have not added a unit test: `app/Test/` consists of standalone PHPUnit tests that `require_once` a single self-contained `Lib/Tools` class with no CakePHP bootstrap or database, and `AuditLog` is a model requiring both. Reaching this line also requires forcing a save-time validation failure on the `audit_logs` table, which needs the integration suite rather than the unit suite. I have not run a fresh-system install verification.

Found during a read-only review of the `2.5` tree; reported alongside several other issues.
