### PR TITLE
fix: [collections] Compare distribution numerically in Collection::mayView

### DIFF
--- a/app/Model/Collection.php
+++ b/app/Model/Collection.php
@@ -147,7 +147,7 @@ class Collection extends AppModel
         if (in_array($collection['Collection']['distribution'], [1,2,3])) {
             return true;
         }
-        if ($collection['Collection']['distribution'] === 4) {
+        if ((int)$collection['Collection']['distribution'] === 4) {
             $SharingGroup = ClassRegistry::init('SharingGroup');
             $sgs = $this->SharingGroup->fetchAllAuthorised($user, 'uuid');
             if (isset($sgs[$collection['Collection']['sharing_group_id']])) {


### PR DESCRIPTION
`Collection::mayView()` gates the sharing-group case on a strict comparison:

```php
if ($collection['Collection']['distribution'] === 4) {
```

The value comes straight from `find('first')` with no cast, and `app/Config/database.default.php` sets

```php
'flags' => [
    PDO::ATTR_STRINGIFY_FETCHES => true
]
```

described in that file as *"required for compatibility with the MISP standard / pre 2.5 behaviour"*. Every integer column therefore comes back as a PHP string, `'4' === 4` is `false`, and the entire sharing-group branch is unreachable.

**Effect.** Execution falls past the dead branch to the closing `return false`, so a `distribution = 4` collection is refused to exactly the users it exists to be shared with — members of an authorised sharing group outside the owning org. Site admins and same-org users still get in, because they match the earlier checks, which is what masks the bug in everyday use.

There is a second symptom that makes it look inconsistent rather than simply broken: `buildConditions()` **does** list these collections (it matches `sharing_group_id` against the authorised ids), so an affected user sees the collection in the index and then gets *"Invalid Collection or insufficient privileges"* on opening it.

**Why the neighbouring lines are fine**

| Line | Comparison | Affected? |
|---|---|---|
| 144 | `==` | no — loose |
| 147 | `in_array($v, [1,2,3])` | no — non-strict |
| 150 | `=== 4` | **yes** |

**Change**

```diff
-        if ($collection['Collection']['distribution'] === 4) {
+        if ((int)$collection['Collection']['distribution'] === 4) {
```

The `(int)` cast matches how this column is handled elsewhere in the same file (lines 468, 477) and in `Event.php:2027`.

**Deliberately not included**

`app/Model/CollectionElement.php:176` has the identical `=== 4`, but it sits inside that class's own `mayView()`/`mayModify()`, which are unreachable (every call site goes through `CollectionElement->Collection->may*`) and would fail anyway — they query `Collection.id` against the `collection_elements` table with `recursive => -1`, so the aliased column is not in scope. Patching the comparison there would suggest those methods work. They look like they want deleting or replacing with a delegation, but that felt like a separate call for a maintainer to make.

**Testing**

`php -l` passes. No unit test added: `app/Test/` holds standalone PHPUnit tests that `require_once` a single self-contained `Lib/Tools` class with no CakePHP bootstrap or database, and this needs a `Collection` fixture, a sharing group, and a user — the integration suite, not the unit suite. Worth noting a test here must use the **string** `'4'` to reproduce, since a fixture with an int would pass even against the unpatched code. Nothing in `app/Test/` currently references `mayView` or `mayModify`. I have not run a fresh-system install verification.

Found during a read-only review of the `2.5` tree.
