### PR TITLE
fix: [api] Repair invalid character class in _harvestParameters wildcard matching

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -1170,7 +1170,7 @@ class AppController extends Controller
                                 $leftover = substr($existingParamKey, strlen($param)-1);
                                 if (
                                     $root == substr($existingParamKey, 0, strlen($root)) &&
-                                    preg_match('/^[\w_-. ]+$/', $leftover) == 1
+                                    preg_match('/^[\w.\- ]+$/', $leftover) == 1
                                 ) {
                                     $data[$existingParamKey] = $temp[$existingParamKey];
                                     break;


### PR DESCRIPTION
The wildcard branch of `AppController::_harvestParameters()` validates the leftover part of a matched parameter name with:

```php
preg_match("/^[\w_-. ]+$/", $leftover) == 1
```

Inside a character class the `-` sits between the two literal characters `_` (0x5F) and `.` (0x2E), so PCRE parses it as a range operator. The range is descending, so the pattern **does not compile**:

```
PHP Warning: preg_match(): Compilation failed: range out of order in character class at offset 6
```

`preg_match()` returns `false` rather than `0` or `1`, and `false == 1` is `false`, so the condition never holds. Every wildcard parameter is silently discarded, and each attempt emits a PHP warning.

**This is reachable, not dead code.** `RestSearchComponent` registers `galaxy.*` in the `Event` scope `paramArray`:

```php
// app/Controller/Component/RestSearchComponent.php:158
'galaxy.*',
```

which is handed to `_harvestParameters()` as `options['paramArray']` for Event restSearch. A request filtering on `galaxy.type` (or any other `galaxy.*` key) therefore has that filter dropped rather than applied, and the search silently returns results that were never narrowed — a wrong-results bug, not just a warning.

**Change**

```diff
-                                    preg_match('/^[\w_-. ]+$/', $leftover) == 1
+                                    preg_match('/^[\w.\- ]+$/', $leftover) == 1
```

Hyphen moved to the end and escaped, making every member of the class literal. `\w` already covers `_`, so no accepted character is lost.

**Verified on PHP 8.5.4**

Before — compile failure:

```
$ php -r 'preg_match("/^[\w_-. ]+$/", "abc");'
PHP Warning:  preg_match(): Compilation failed: range out of order in character class at offset 6
```

After — compiles, and behaves as intended:

| input | result |
|---|---|
| `type` | match |
| `galaxy_name` | match |
| `some.sub` | match |
| `a-b` | match |
| `with space` | match |
| `bad/slash` | no match |
| `semi;colon` | no match |

**Testing**

`php -l` passes, and the regex behaviour above was checked by direct execution rather than inspection. No unit test added: `app/Test/` holds standalone PHPUnit tests that `require_once` a single self-contained `Lib/Tools` class with no CakePHP bootstrap, and `_harvestParameters` is an `AppController` method requiring a request context. The natural coverage is an integration test posting `{"galaxy.type": "..."}` to Event restSearch and asserting the filter survives into the query. I have not run a fresh-system install verification.

Found during a read-only review of the `2.5` tree.
