### PR TITLE
fix: [object] Dead first_seen/last_seen condition + null id/uuid in duplicate log

### DIFF
--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -415,16 +415,21 @@ class MispObject extends AppModel
         $newObjectAttributeCount = count($newObjectAttributes);
         if (!empty($this->__objectDuplicationCheckCache['new'][$object['Object']['template_uuid']])) {
             foreach ($this->__objectDuplicationCheckCache['new'][$object['Object']['template_uuid']] as $previousNewObject) {
-                if ($newObjectAttributeCount === count($previousNewObject)) {
-                    if (empty(array_diff($previousNewObject, $newObjectAttributes))) {
-                        $duplicatedObjectId = $previousNewObject['Object']['id'];
-                        $duplicateObjectUuid = $previousNewObject['Object']['uuid'];
+                if ($newObjectAttributeCount === count($previousNewObject['attributes'])) {
+                    if (empty(array_diff($previousNewObject['attributes'], $newObjectAttributes))) {
+                        // In-batch objects typically have no database id yet, only a uuid
+                        $duplicatedObjectId = $previousNewObject['id'];
+                        $duplicateObjectUuid = $previousNewObject['uuid'];
                         return true;
                     }
                 }
             }
         }
-        $this->__objectDuplicationCheckCache['new'][$object['Object']['template_uuid']][] = $newObjectAttributes;
+        $this->__objectDuplicationCheckCache['new'][$object['Object']['template_uuid']][] = array(
+            'attributes' => $newObjectAttributes,
+            'id' => isset($object['Object']['id']) ? $object['Object']['id'] : null,
+            'uuid' => isset($object['Object']['uuid']) ? $object['Object']['uuid'] : null,
+        );
         if (!isset($this->__objectDuplicationCheckCache[$object['Object']['template_uuid']])) {
             $this->__objectDuplicationCheckCache[$object['Object']['template_uuid']] = $this->find('all', array(
                 'recursive' => -1,

--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -1143,13 +1143,13 @@ class MispObject extends AppModel
             // Set seen of object at attribute level
             if (
                 (!array_key_exists('first_seen', $newAttribute) || is_null($newAttribute['first_seen'])) &&
-                (!array_key_exists('first_seen', $object['Object']) && !is_null($object['Object']['first_seen']))
+                (array_key_exists('first_seen', $object['Object']) && !is_null($object['Object']['first_seen']))
             ) {
                 $newAttribute['first_seen'] = $object['Object']['first_seen'];
             }
             if (
                 (!array_key_exists('last_seen', $newAttribute) || is_null($newAttribute['last_seen'])) &&
-                (!array_key_exists('last_seen', $object['Object']) && !is_null($object['Object']['last_seen']))
+                (array_key_exists('last_seen', $object['Object']) && !is_null($object['Object']['last_seen']))
             ) {
                 $newAttribute['last_seen'] = $object['Object']['last_seen'];
             }


### PR DESCRIPTION
## Summary

Two unrelated defects in `app/Model/MispObject.php`, kept as separate commits on this branch so they can be cherry-picked independently.

### Commit 1 — dead condition drops object-level first_seen/last_seen (`deltaMerge()`, ~L1144-1155)

In the `onlyAddNewAttribute` branch:

```php
if (
    (!array_key_exists('first_seen', $newAttribute) || is_null($newAttribute['first_seen'])) &&
    (!array_key_exists('first_seen', $object['Object']) && !is_null($object['Object']['first_seen']))
) {
    $newAttribute['first_seen'] = $object['Object']['first_seen'];
}
```

Truth table for the second clause, `!array_key_exists('first_seen', $object['Object']) && !is_null($object['Object']['first_seen'])`:

| key present? | `!array_key_exists` | `$object['Object']['first_seen']` | `!is_null(...)` | clause result |
|---|---|---|---|---|
| no | `true` | reading a missing key yields `null` | `false` | `true && false` = **false** |
| yes | `false` | (short-circuits on the first operand anyway) | — | **false** |

The clause is `false` in every case, so the outer `&&` is always `false`, and `$newAttribute['first_seen']` is never populated from `$object['Object']['first_seen']` — object-level `first_seen` never propagates to a newly captured attribute. The `last_seen` block immediately below (~L1150-1155) has the identical shape and the identical defect.

Compare the correctly-shaped sibling branch a few dozen lines above (~L1108-1119), which checks `isset($forcedSeenOnElements['first_seen'])` (no stray negation before the existence test), and `syncObjectAndAttributeSeen()` (~L977-1012), which does the same.

**Fix:** drop the stray `!` so the clause reads `array_key_exists('first_seen', $object['Object']) && !is_null($object['Object']['first_seen']))`. Same for `last_seen`.

### Commit 2 — duplicate-object log always reports blank ID/UUID for intra-batch duplicates (`checkForDuplicateObjects()`, ~L403-427)

The intra-batch cache is written as a **flat array of attribute hash strings**:

```php
$this->__objectDuplicationCheckCache['new'][$object['Object']['template_uuid']][] = $newObjectAttributes;
```

but read back a few lines above as though each entry were a full object record:

```php
$duplicatedObjectId = $previousNewObject['Object']['id'];
$duplicateObjectUuid = $previousNewObject['Object']['uuid'];
```

`$previousNewObject` **is** the flat hash array (e.g. `['type:category:value', ...]`), so `$previousNewObject['Object']` never exists — both reads resolve to `null` under CakePHP's array access (PHP itself would emit an undefined-index/key warning if strict, but here it silently reads as null via the implicit array semantics). The duplicate *detection* itself is unaffected — `array_diff()` on the two flat arrays and the `return true` are correct — but both out-parameters end up null, so `captureObject()` (~L1183-1186) logs:

```
Object dropped due to it being a duplicate (ID: , UUID: ) and breakOnDuplicate being requested for Event ...
```

with both fields blank, destroying the audit trail for exactly the intra-batch case this code exists to handle.

**Fix:** cache each batch entry as `['attributes' => $newObjectAttributes, 'id' => ..., 'uuid' => ...]` instead of a bare flat array, and read from that shape. Note that in-batch objects normally have no database id yet (only a uuid) — the fix stores whatever `$object['Object']['id']` is available (typically absent/null at this point) rather than assuming an id exists.

## Testing

- `php -l app/Model/MispObject.php` passes for both commits.
- Not unit-testable in this repo: `app/Test/` only contains standalone PHPUnit tests that `require_once` a single self-contained `Lib/Tools` class with no CakePHP bootstrap or database wiring, so a `Model`-level fix like this has no harness to run against here.
  - Integration test that would prove commit 1: capture an object with `first_seen`/`last_seen` set at the object level and no attribute-level seen values, via the "add new attribute to existing object" delta-merge path (i.e. add a new attribute to an object template that already has other attributes captured, using `breakOnDuplicate`/delta-merge semantics), then assert the newly created attribute row has `first_seen`/`last_seen` populated from the object.
  - Integration test that would prove commit 2: submit two objects with identical attributes and the same template in a single capture batch with `breakOnDuplicate` set, and assert the resulting log entry / duplicate error message contains the actual uuid (and id, if applicable) of the first object rather than empty strings.
- A fresh-system install verification (per the MISP CONTRIBUTING process) was not run.

