### PR TITLE
fix: [analyst-data] Use passed $fetchRecursive in attachNestedAnalystData

### DIFF
--- a/app/Model/Behavior/AnalystDataParentBehavior.php
+++ b/app/Model/Behavior/AnalystDataParentBehavior.php
@@ -67,7 +67,7 @@ class AnalystDataParentBehavior extends ModelBehavior
         $data = [];
         foreach ($types as $type) {
             $this->{$type} = ClassRegistry::init($type);
-            $this->{$type}->fetchRecursive = !empty($model->includeAnalystDataRecursive);
+            $this->{$type}->fetchRecursive = $fetchRecursive;
             $temp = $this->{$type}->fetchForUuid($object['uuid'], $this->__currentUser);
             if (!empty($temp)) {
                 foreach ($temp as $k => $temp_element) {


### PR DESCRIPTION
## Summary

`attachNestedAnalystData()` in `app/Model/Behavior/AnalystDataParentBehavior.php` (~L65-70) ignores its own `$fetchRecursive` parameter:

```php
private function attachNestedAnalystData(array $object, array $types, $fetchRecursive): array
{
    $data = [];
    foreach ($types as $type) {
        $this->{$type} = ClassRegistry::init($type);
        $this->{$type}->fetchRecursive = !empty($model->includeAnalystDataRecursive);
        ...
```

`$model` is not a parameter of this method, there is no `use (...)` clause bringing it in from an enclosing scope, and `AnalystDataParentBehavior` declares no `$model` property. So `$model` is an undefined variable inside this method: PHP resolves it to `null`, and `!empty(null->includeAnalystDataRecursive)` is always `false` — the expression can never be truthy. Result: recursive Note/Opinion/Relationship fetching never activates on the non-REST (web UI) rendering path, and every call emits an undefined-variable warning followed by a property-access-on-null warning.

The public entry point, `attachAnalystData(Model $model, array $object, array $types)` (~L15-39), already computes the correct value and passes it down:

```php
$fetchRecursive = !empty($model->includeAnalystDataRecursive);
$data = $this->$method($object, $types, $fetchRecursive);
```

The REST-path sibling, `attachFlatAnalystData()` (~L41-63), receives the same parameter and uses it correctly:

```php
$this->{$type}->fetchRecursive = $fetchRecursive;
```

**Fix:** make `attachNestedAnalystData()` use its own `$fetchRecursive` parameter instead of the broken `$model` reference, matching `attachFlatAnalystData()`.

## Testing

- `php -l app/Model/Behavior/AnalystDataParentBehavior.php` passes.
- Not unit-testable in this repo: `app/Test/` only contains standalone PHPUnit tests that `require_once` a single self-contained `Lib/Tools` class with no CakePHP bootstrap or database, so this Behavior fix cannot be exercised there.
  - Integration test that would prove this fix: on the non-REST (web UI) path, fetch an object (e.g. an Attribute or Event) that has a Note attached to a child Relationship/Opinion, with `$model->includeAnalystDataRecursive` set true, and assert the nested analyst data includes the recursively-fetched child instead of stopping one level deep. Before the fix this always behaves as if `fetchRecursive` were `false`, regardless of `$model->includeAnalystDataRecursive`.
- A fresh-system install verification (per the MISP CONTRIBUTING process) was not run.

