### PR TITLE
fix: [feed, object] Check saveMany() result before acting on delete cascades

### DIFF
--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -1423,8 +1423,8 @@ class Feed extends AppModel
                     $attributesToDelete[$k]['Attribute']['deleted'] = 1;
                     unset($attributesToDelete[$k]['Attribute']['timestamp']);
                 }
-                $this->Event->Attribute->saveMany($attributesToDelete); // We need to trigger callback methods
-                if (!empty($attributesToDelete)) {
+                $saved = $this->Event->Attribute->saveMany($attributesToDelete); // We need to trigger callback methods
+                if (!empty($attributesToDelete) && $saved) {
                     $this->Event->unpublishEvent($feed['Feed']['event_id']);
                 }
             }

--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -325,7 +325,15 @@ class MispObject extends AppModel
                 $attribute_to_delete['Attribute']['deleted'] = 1;
                 unset($attribute_to_delete['Attribute']['timestamp']);
             }
-            $this->Attribute->saveMany($attributes_to_delete);
+            if (!$this->Attribute->saveMany($attributes_to_delete) && !empty($attributes_to_delete)) {
+                $this->log(
+                    sprintf(
+                        'Could not cascade delete to all Attributes of Object %s: some attributes may remain visible (not deleted).',
+                        $this->id
+                    ),
+                    LOG_WARNING
+                );
+            }
         }
         $workflowErrors = [];
         $logging = [


### PR DESCRIPTION
## Summary

Two occurrences of the same defect class: a `saveMany()` cascade whose return value is discarded, followed by code that acts as if the cascade always succeeded. CakePHP 2's `saveMany()` defaults to atomic transactions, so a single bad row rolls back the whole batch — but both call sites kept treating the *input* array as proof the *save* happened.

### 1. `app/Model/Feed.php:1426` — event stays published after a failed delete cascade

```php
$this->Event->Attribute->saveMany($attributesToDelete); // We need to trigger callback methods
if (!empty($attributesToDelete)) {
    $this->Event->unpublishEvent($feed['Feed']['event_id']);
}
```

`saveFreetextFeedData()`'s `delta_merge` path builds `$attributesToDelete` from attributes no longer present upstream, marks them `deleted = 1`, and calls `saveMany()` to persist that — the comment even notes this is "to trigger callback methods". But the `if` right after only checks whether `$attributesToDelete` was non-empty *before* the save, not whether the save succeeded. If `saveMany()` fails partway through the batch (atomic by default), the transaction rolls back, none of the attributes end up marked deleted, and `unpublishEvent()` still fires. The event's published state now disagrees with its attribute content, with no error surfaced anywhere.

**Fix:** capture `saveMany()`'s return value and require it to be truthy before unpublishing:

```php
$saved = $this->Event->Attribute->saveMany($attributesToDelete); // We need to trigger callback methods
if (!empty($attributesToDelete) && $saved) {
    $this->Event->unpublishEvent($feed['Feed']['event_id']);
}
```

This mirrors how the main chunked save loop a few lines below (`app/Model/Feed.php:1450`) is written to have its result matter to the caller.

### 2. `app/Model/MispObject.php:328` — soft-deleted Object leaves live Attributes behind, silently

```php
$this->Attribute->saveMany($attributes_to_delete);
```

`MispObject::afterSave()` cascades a soft-delete on an Object to its Attributes the same way, also with no return check. If the batch fails (e.g. `MispAttribute::beforeValidateMassage()`'s `runRegexp()` rejects a previously-valid stored value because an org admin later added an import regexp filter), the Object ends up with `deleted = 1` while its Attributes stay `deleted = 0`. Content the user believes they deleted keeps appearing in exports, feeds, and correlation — and there is no exception and no log entry to reveal it happened.

**Fix:** check the return value and log a warning when the cascade doesn't fully save, instead of forcing the delete or silently swallowing the failure inside `afterSave()` (either of those would be a materially bigger and riskier change for this PR):

```php
if (!$this->Attribute->saveMany($attributes_to_delete) && !empty($attributes_to_delete)) {
    $this->log(
        sprintf(
            'Could not cascade delete to all Attributes of Object %s: some attributes may remain visible (not deleted).',
            $this->id
        ),
        LOG_WARNING
    );
}
```

`$this->log()` is the same logging entry point `AppModel::logException()` already calls internally elsewhere in this codebase — this just uses it directly for a plain (non-exception) failure, the same way `CakeLog::write()` is used directly in `app/Model/Warninglist.php:203` for a comparable "something failed, no exception was thrown" case.

## Why one PR

Both are the same defect shape (unchecked `saveMany()` cascade, decision made on the pre-save array instead of the save result) reported together. Each fix is its own commit so either can be cherry-picked independently.

## Testing

- `php -l app/Model/Feed.php` and `php -l app/Model/MispObject.php` both pass.
- MISP's `app/Test/` suite consists of standalone PHPUnit tests that each `require_once` a single self-contained `Lib/Tools` class with no CakePHP bootstrap or database, so this model-layer change cannot be exercised there. The behaviour this fixes would be proven by an integration test that: (1) for Feed.php, configures a `delta_merge` feed, seeds an event with an attribute that will be marked for deletion, injects a row that fails validation into the same batch, runs the feed fetch, and asserts the event stays published; (2) for MispObject.php, soft-deletes an Object whose Attributes include one that a `beforeValidateMassage()` regexp filter will now reject, and asserts either the cascade fully applies or a log entry is emitted — today neither happens.
- A fresh-system install verification was not run.

