### PR TITLE
fix: [attributes] Fix inverted null checks in changeInTagOrCluster flag

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -1645,9 +1645,9 @@ class AttributesController extends AppController
         $clusters_ids_remove = json_decode($requestData['clusters_ids_remove']);
         $clusters_ids_add = json_decode($requestData['clusters_ids_add']);
         $changeInTagOrCluster = ($tags_ids_remove !== null && count($tags_ids_remove) > 0)
-            || ($tags_ids_add === null || count($tags_ids_add) > 0)
-            || ($clusters_ids_remove === null || count($clusters_ids_remove) > 0)
-            || ($clusters_ids_add === null || count($clusters_ids_add) > 0);
+            || ($tags_ids_add !== null && count($tags_ids_add) > 0)
+            || ($clusters_ids_remove !== null && count($clusters_ids_remove) > 0)
+            || ($clusters_ids_add !== null && count($clusters_ids_add) > 0);
 
         $changeInAttribute = ($requestData['to_ids'] != 2) || ($requestData['distribution'] != 6) || ($requestData['comment'] != null) || ($requestData['disable_correlation'] != 2);
 


### PR DESCRIPTION
## Summary

In `AttributesController::editSelected()` (~L1647-1650), `$changeInTagOrCluster` mixes two different comparison shapes across its four operands:

```php
$changeInTagOrCluster = ($tags_ids_remove !== null && count($tags_ids_remove) > 0)
    || ($tags_ids_add === null || count($tags_ids_add) > 0)
    || ($clusters_ids_remove === null || count($clusters_ids_remove) > 0)
    || ($clusters_ids_add === null || count($clusters_ids_add) > 0);
```

Operand 1 uses `!== null &&` (true only when the field is present AND non-empty). Operands 2-4 use `=== null ||` (true whenever the field is simply *absent*, independent of `count(...)`).

Truth table for operand 2 as an example (`$tags_ids_add === null || count($tags_ids_add) > 0`):

| `$tags_ids_add` | `=== null` | short-circuit? | operand 2 result |
|---|---|---|---|
| `null` (field absent from request) | `true` | yes, `count()` never runs | **true** |
| `[]` (present, empty) | `false` | no | `count([]) > 0` = **false** |
| `[1,2]` (present, non-empty) | `false` | no | `count([1,2]) > 0` = **true** |

So operand 2 (and identically, operands 3 and 4) evaluates to `true` whenever that field is simply missing from the request — which is the *normal* case for any bulk-edit request that isn't touching tags/clusters at all. Because the whole expression is an OR chain, a single absent field among `tags_ids_add`, `clusters_ids_remove`, `clusters_ids_add` forces `$changeInTagOrCluster = true` regardless of whether any tag/cluster change was actually requested.

**Impact:** this bypasses the "nothing changed" short-circuit immediately below:

```php
if (!$changeInAttribute && !$changeInTagOrCluster) {
    return new CakeResponse(array('body'=> json_encode(array('saved' => true)), 'status' => 200, 'type' => 'json'));
}
```

and execution reaches the tag/cluster loops (~L1731-1745) with null iterables, e.g. `foreach ($tags_ids_remove as $tag_id)` where `$tags_ids_remove` is `null`. To be precise about the actual runtime effect (not overstating it): on PHP 8 this is a non-fatal `Warning: foreach() argument must be of type array|object, null given` — the loop body is simply skipped, and the request does **not** fail or throw. The real-world cost is: the "nothing to do" fast path never triggers when it should, attribute saves/unpublish/timestamp-bump logic in the `$changeInAttribute` block above runs unnecessarily, and the warning is logged repeatedly.

**Fix:** make operands 2-4 match operand 1's shape — `$field !== null && count($field) > 0` — so `$changeInTagOrCluster` is only true when a field is both present and non-empty.

## Testing

- `php -l app/Controller/AttributesController.php` passes.
- Not unit-testable in this repo: `app/Test/` only contains standalone PHPUnit tests that `require_once` a single self-contained `Lib/Tools` class with no CakePHP bootstrap or database, so this Controller-level fix cannot be exercised there.
  - Integration test that would prove this fix: POST to `attributes/editSelected/{eventId}` with `tags_ids_remove`/`tags_ids_add`/`clusters_ids_remove`/`clusters_ids_add` all omitted (or JSON `null`) and `to_ids`/`distribution`/`comment`/`disable_correlation` left at their "no change" sentinel values, and assert the response returns immediately via the `saved: true` short-circuit with no attribute save, no `unpublishEvent` call, and no PHP warning logged — before the fix, this request instead falls through to the tag/cluster loops.
- A fresh-system install verification (per the MISP CONTRIBUTING process) was not run.

