### PR TITLE
fix: [collections] Align buildConditions org visibility with mayView

### DIFF
--- a/app/Model/Collection.php
+++ b/app/Model/Collection.php
@@ -168,7 +168,6 @@ class Collection extends AppModel
         if (!$user['Role']['perm_site_admin']) {
             $conditions['OR'] = [
                 [
-                    'Collection.orgc_id' => $user['org_id'],
                     'Collection.org_id' => $user['org_id']
                 ],
                 [


### PR DESCRIPTION
## Problem

`Collection::buildConditions()` (`app/Model/Collection.php:168-184`) builds the visibility filter used by `/collections/index` and the REST index. Its first `OR` branch is:

```php
[
    'Collection.orgc_id' => $user['org_id'],
    'Collection.org_id' => $user['org_id']
],
```

CakePHP ANDs multiple keys inside a single conditions array, so this branch only matches when **both** `orgc_id` and `org_id` equal the caller's org.

Compare `Collection::mayView()` (`app/Model/Collection.php:144`), which grants direct-ID visibility on `org_id` alone:

```php
if ($collection['Collection']['org_id'] == $user['org_id']) {
    return true;
}
```

For a synced-in collection these two fields are intentionally different: `captureCollection()` (~`app/Model/Collection.php:456`) pins `org_id` to the sync user's own org, while `captureOrganisationAndSG()` (~line 562) resolves `orgc_id` to the remote creator org. So a collection synced in from another org, downgraded to `distribution=0`, satisfies none of the three `OR` branches in `buildConditions()` — it isn't in `[1,2,3]` distribution, and it has no sharing group — even though `mayView()` says the same user may view it by `org_id` alone.

Net effect: visible by direct ID (`/collections/view/<id>`), but invisible in both the HTML listing and the REST index for the org that owns it locally.

## Fix

Drop `orgc_id` from the first `OR` branch so listing visibility matches `mayView()`'s policy: membership in `org_id` alone is sufficient.

## Testing

- `php -l app/Model/Collection.php` passes.
- No existing test covers this: `app/Test/CollectionCaptureTest.php` and `app/Test/CollectionPushTest.php` exercise model-level capture/push only, not `buildConditions()`/index visibility. A test that would prove this fix: create a Collection via `captureCollection()` with `org_id` set to the local org and `orgc_id` set to a different (remote) org, downgrade its distribution to 0, then assert it appears in `Collection::indexMinimal()`/`buildConditions()` output for a user in the local org.
- A fresh-system install verification was not run.

