### PR TITLE
fix: [collections] Drop stale-modified conflict guard from user edit

### DIFF
--- a/app/Controller/CollectionsController.php
+++ b/app/Controller/CollectionsController.php
@@ -175,12 +175,6 @@ class CollectionsController extends AppController
                 $this->request->data = ['Collection' => $this->request->data];
             }
             $data = $this->request->data;
-            if (
-                isset($data['Collection']['modified']) &&
-                $data['Collection']['modified'] <= $oldCollection['Collection']['modified']
-            ) {
-                throw new ForbiddenException(__('Collection received older or same as local version.'));
-            }
             // The sharing-group authorisation check must run against the EFFECTIVE distribution
             // and sharing group after the edit, not only when 'distribution' is present in the
             // body. CRUDComponent::edit() retains the stored value for any field the request


### PR DESCRIPTION
## Problem

`CollectionsController::edit()` (`app/Controller/CollectionsController.php:178-183`) carries a sync-style conflict guard on the user-facing edit action:

```php
if (
    isset($data['Collection']['modified']) &&
    $data['Collection']['modified'] <= $oldCollection['Collection']['modified']
) {
    throw new ForbiddenException(__('Collection received older or same as local version.'));
}
```

`view()` returns the full record, including `modified`. Any REST client doing the standard GET-then-PUT pattern — the only way to update fields the HTML form doesn't expose, since `add.ctp` only emits `name`/`type`/`description`/`distribution`/`sharing_group_id` — echoes `modified` back unchanged and hits this guard. Because the comparison is `<=` rather than `<`, it fails on **every** edit, including the very first one, with no race condition involved.

This is a sync conflict-resolution pattern, but this endpoint is not part of the sync path. The actual push/pull flow is:

```
ServerSyncTool::pushCollection
  -> CollectionsController::captureCollection()
  -> Collection::captureCollection()   (own D6 conflict rule, ~Collection.php:514)
```

`captureCollection()` never touches `edit()`, so the guard here is a misapplied copy of that pattern, not shared sync logic.

## Fix

Remove the stale-`modified` check from `edit()`. `mayModify()` (checked at the top of the action, line 161) already gates who is allowed to edit a collection at all; treating a client-echoed `modified` timestamp as an authorization signal on this endpoint was incorrect regardless of the `<=` bug.

## Testing

- `php -l app/Controller/CollectionsController.php` passes.
- No existing test covers this: `app/Test/CollectionCaptureTest.php` and `app/Test/CollectionPushTest.php` exercise model-level capture/push only, nothing exercises `CollectionsController::edit()`. A test that would prove this fix: as an authorised user, GET a collection, PUT the identical payload back (including the returned `modified` value) to `edit()`, and assert a 200 rather than a 403.
- A fresh-system install verification was not run.

