### PR TITLE
fix: [collection] Stop swallowing capture failures in CollectionElement

### DIFF
--- a/app/Model/CollectionElement.php
+++ b/app/Model/CollectionElement.php
@@ -246,10 +246,28 @@ class CollectionElement extends AppModel
                 if (empty($element['CollectionElement']['id'])) {
                     $this->create();
                 }
-                try{
-                    $this->save($element);
+                try {
+                    if (!$this->save($element)) {
+                        $this->log(
+                            sprintf(
+                                'Could not save CollectionElement %s for collection %s: %s',
+                                $element['CollectionElement']['uuid'] ?? '',
+                                $data['Collection']['id'],
+                                json_encode($this->validationErrors)
+                            ),
+                            LOG_WARNING
+                        );
+                    }
                 } catch (PDOException $e) {
-                    // duplicate value?
+                    $this->log(
+                        sprintf(
+                            'Could not save CollectionElement %s for collection %s: %s',
+                            $element['CollectionElement']['uuid'] ?? '',
+                            $data['Collection']['id'],
+                            $e->getMessage()
+                        ),
+                        LOG_WARNING
+                    );
                 }
             }
             foreach ($oldElements as $toDelete) {

--- a/app/Model/CollectionElement.php
+++ b/app/Model/CollectionElement.php
@@ -209,6 +209,7 @@ class CollectionElement extends AppModel
         // from the remote by Collection::captureCollection(), so element saves/
         // deletes here must NOT bump it to the local now (D5 / D6 dedup).
         $this->skipCollectionModifiedBump = true;
+        try {
         $temp = $this->find('all', [
             'recursive' => -1,
             'conditions' => ['CollectionElement.collection_id' => $data['Collection']['id']]
@@ -282,8 +283,9 @@ class CollectionElement extends AppModel
                 $data['Collection']['CollectionElement'][] = $element['CollectionElement'];
             }
         }
-
-        $this->skipCollectionModifiedBump = false;
+        } finally {
+            $this->skipCollectionModifiedBump = false;
+        }
         return $data;
     }
 }


### PR DESCRIPTION
## Summary

`CollectionElement::captureElements()` (`app/Model/CollectionElement.php`) has two related silent-failure defects, both introduced by the same method. Two commits, one per fix, so either can be cherry-picked independently.

### 1. Empty catch body swallows every save failure (`app/Model/CollectionElement.php:249-253`, pre-fix)

```php
try{
    $this->save($element);
} catch (PDOException $e) {
    // duplicate value?
}
```

Every `PDOException` thrown by `save()` is discarded with no trace, not just actual duplicate-key violations (the only case the comment guesses at), and the non-exception failure path (`save()` returning `false`) was equally unlogged. `captureElements()` runs per-element across a whole pull batch — `Collection::pullCollectionsInChunks()` processes chunks of 100 — so an element that fails to save just silently disappears from the synced collection, with nothing in the logs to explain a remote instance's element count not matching.

**Fix:** log both failure paths via `$this->log()`, without changing control flow (a failed element still doesn't block the rest of the batch):

```php
try {
    if (!$this->save($element)) {
        $this->log(
            sprintf(
                'Could not save CollectionElement %s for collection %s: %s',
                $element['CollectionElement']['uuid'] ?? '',
                $data['Collection']['id'],
                json_encode($this->validationErrors)
            ),
            LOG_WARNING
        );
    }
} catch (PDOException $e) {
    $this->log(
        sprintf(
            'Could not save CollectionElement %s for collection %s: %s',
            $element['CollectionElement']['uuid'] ?? '',
            $data['Collection']['id'],
            $e->getMessage()
        ),
        LOG_WARNING
    );
}
```

`$this->log()` is the same entry point `AppModel::logException()` already calls internally elsewhere, and matches the precedent at `app/Model/Warninglist.php:203`, which uses `CakeLog::write()` directly for a comparable "something failed, nothing was thrown" case.

### 2. `skipCollectionModifiedBump` can get stuck `true` forever (`app/Model/CollectionElement.php:211`/`268`, pre-fix)

```php
$this->skipCollectionModifiedBump = true;
... // find(), saves, delete()s, find() again
$this->skipCollectionModifiedBump = false;
```

The flag is set at the top of `captureElements()` (to stop sync capture from bumping `Collection.modified` locally — see the comment above it, D5/D6 dedup) and only cleared at the very bottom, with no `try/finally` between the two. If `$this->delete($toDelete['id'])` (culling `$oldElements`) or either `find()` call throws, the reset at the bottom never runs.

`CollectionElement` is a `ClassRegistry`-cached model, so a stuck flag isn't scoped to the current call — it persists for the rest of that worker's lifetime. Every later `CollectionElement` save/delete anywhere in that process stops bumping `Collection.modified`, so remote instances stop seeing those collections as changed. Because `Collection::pullCollectionsInChunks()` reuses the same model instance across chunks of 100 within a single pull, one exception partway through a large pull can silently affect every collection processed afterward in that same run.

**Fix:** wrap the body that runs while the flag is `true` in `try/finally` so the reset always executes, regardless of how the method exits:

```php
$this->skipCollectionModifiedBump = true;
try {
    ...
} finally {
    $this->skipCollectionModifiedBump = false;
}
return $data;
```

This is the standard compensating-flag pattern (set before an operation, guaranteed reset after) that has to hold for any state flag consulted by other code paths — here `CollectionElement::beforeSave()` / `beforeDelete()` at lines 88 and 110 both read `$this->skipCollectionModifiedBump`.

## Testing

- `php -l app/Model/CollectionElement.php` passes.
- MISP's `app/Test/` suite consists of standalone PHPUnit tests that each `require_once` a single self-contained `Lib/Tools` class with no CakePHP bootstrap or database, so this model-layer change cannot be exercised there. The behaviour this fixes would be proven by an integration test that: (1) calls `captureElements()` with a batch containing one element that fails validation/throws, and asserts a log entry is produced instead of nothing; (2) forces an exception inside the delete-cull or refresh `find()` (e.g. a stale/duplicate `CollectionElement.id`), then performs a subsequent unrelated `CollectionElement` save on the same (cached) model instance and asserts `Collection.modified` still gets bumped.
- A fresh-system install verification was not run.

