### PR TITLE
fix: [background_jobs] Check $this->error, not the unset $stderr variable

### DIFF
--- a/app/Lib/Tools/BackgroundJobs/BackgroundJob.php
+++ b/app/Lib/Tools/BackgroundJobs/BackgroundJob.php
@@ -91,7 +91,7 @@ class BackgroundJob implements JsonSerializable
 
         $this->pool($process, $pipes, $runningCallback);
 
-        if ($this->returnCode === 0 && empty($stderr)) {
+        if ($this->returnCode === 0 && empty($this->error)) {
             $this->setStatus(BackgroundJob::STATUS_COMPLETED);
             $this->setProgress(100);
         } else {


### PR DESCRIPTION
## Summary

`BackgroundJob::run()` at `app/Lib/Tools/BackgroundJobs/BackgroundJob.php:94` tests a variable that is never assigned anywhere in the class:

```php
if ($this->returnCode === 0 && empty($stderr)) {
    $this->setStatus(BackgroundJob::STATUS_COMPLETED);
    $this->setProgress(100);
} else {
    $this->setStatus(BackgroundJob::STATUS_FAILED);
}
```

`$stderr` is a bare local variable, not `$this->error`. The class actually accumulates stderr output into `$this->error`:

- declared at `app/Lib/Tools/BackgroundJobs/BackgroundJob.php:46`
- initialized in `pool()` at line 114 (`$this->error = '';`)
- appended from the stderr pipe at lines 133 and 145 (`$this->error .= stream_get_contents($pipes[2]);`)

Since the local `$stderr` is always undefined, `empty($stderr)` is always `true` in PHP (undefined variables are `empty()`), so the whole condition collapses to just `$this->returnCode === 0`. A worker that exits `0` while still writing to stderr — exactly the case this check exists to catch — gets recorded as `STATUS_COMPLETED` at progress 100 instead of `STATUS_FAILED`.

## Fix

```php
if ($this->returnCode === 0 && empty($this->error)) {
```

One-token change: check the property `pool()` actually populates instead of the unset variable.

## Behavior change — please read before merging

Any worker that legitimately writes non-fatal warnings to stderr while still exiting `0` will now be marked `STATUS_FAILED` instead of `STATUS_COMPLETED`. That is the intended effect of the check as originally written — return code alone was evidently judged insufficient, or this condition wouldn't exist — but it means previously-"passing" workers with noisy-but-harmless stderr output on success will start failing until they stop writing to stderr when they succeed. Flagging this explicitly since it's a real behavior change, not just a bugfix with no externally visible effect.

## Testing

- `php -l app/Lib/Tools/BackgroundJobs/BackgroundJob.php` passes.
- MISP's `app/Test/` suite consists of standalone PHPUnit tests that each `require_once` a single self-contained `Lib/Tools` class with no CakePHP bootstrap or database. `BackgroundJob` itself has no bootstrap/DB dependency, so a targeted unit test is actually feasible here (unlike the model-layer fixes in the other two PRs from this review): instantiate `BackgroundJob`, drive it through a command that exits `0` but writes to stderr (e.g. `php -r 'fwrite(STDERR, "warn\n"); exit(0);'` if `run()`'s command construction is made testable, or by exercising `pool()` directly with a real `proc_open()` of such a command), and assert the resulting status is `STATUS_FAILED`, not `STATUS_COMPLETED`. I did not add this test in this PR since `run()` currently hardcodes the `cake` console command rather than accepting an arbitrary command, which would need a small seam change to test in isolation — flagging that as a possible follow-up rather than bundling it into this fix.
- A fresh-system install verification was not run.

