### PR TITLE
fix: [restsearch] Honor distribution=0 filter in fetchEvent

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -2994,7 +2994,7 @@ class Event extends AppModel
                 $eventReportCondSelect => $user['org_id']
             );
         }
-        if ($options['distribution']) {
+        if (isset($options['distribution'])) {
             $conditions['AND'][] = array('Event.distribution' => $options['distribution']);
             $conditionsAttributes['AND'][] = array('Attribute.distribution' => $options['distribution']);
             $conditionsObjects['AND'][] = array('Object.distribution' => $options['distribution']);


### PR DESCRIPTION
## Summary

`Event::fetchEvent()` builds the distribution filter condition with a plain truthiness check:

```php
// app/Model/Event.php:2997
if ($options['distribution']) {
    $conditions['AND'][] = array('Event.distribution' => $options['distribution']);
    $conditionsAttributes['AND'][] = array('Attribute.distribution' => $options['distribution']);
    $conditionsObjects['AND'][] = array('Object.distribution' => $options['distribution']);
    $conditionsEventReport['AND'][] = array('EventReport.distribution' => $options['distribution']);
}
```

`distribution` is a documented, accepted REST search filter (see the Event `paramArray` in `RestSearchComponent.php:125`), and `restSearch()` passes filters straight into `fetchEvent($user, $filters, true)` with no normalisation. So a REST query with `"distribution": 0` ("your organisation only") reaches this line unmodified — and because `0` is falsy in PHP, it is silently treated identically to the filter not being supplied at all. None of the Event/Attribute/Object/EventReport distribution conditions get added, so the filter is simply dropped.

This is a broken filter contract, **not a security issue** — the independent ACL block earlier in the same method (`app/Model/Event.php` ~2946-2996) already constrains which events/attributes/objects/reports a given user can see, regardless of this filter. The bug only affects whether the *explicit* `distribution=0` narrowing is honoured on top of that.

## Fix

Switch to `isset()`, matching the pattern already used a few lines below in the same method for `protected` and `published`:

```php
if (isset($options['protected'])) { ... }
if (isset($options['published'])) { ... }
```

`fetchEvent()` defaults every entry in `$this->possibleOptions` (which includes `distribution`) to `null` when the caller didn't supply it (see the `foreach ($this->possibleOptions as $opt)` loop a few lines above), so `isset()` correctly distinguishes "filter not supplied" (null) from "filter supplied as 0" (set, but falsy). This also transparently handles a `"0"` string value coming from a query-string-decoded filter, since `isset("0")` is `true`.

## Testing

- `php -l app/Model/Event.php` passes.
- These changes cannot be exercised by the tests under `app/Test/`: that directory holds standalone PHPUnit tests that `require_once` a single self-contained `Lib/Tools` class with no CakePHP bootstrap or database, so there is no harness here that can instantiate `Event` or run a query against a live schema.
- The integration test that would prove this: a REST `/events/restSearch` (or `/attributes/restSearch`) call as a non-site-admin user, filtering `"distribution": 0` against a mix of events with distribution 0 and >0 visible to that user, asserting only the distribution-0 events are returned before the fix and after.
- A fresh-system install verification was not run.

