### PR TITLE
fix: [correlation] Add missing org_id guard to object/attribute correlation ACL

### DIFF
--- a/app/Model/Behavior/DefaultCorrelationBehavior.php
+++ b/app/Model/Behavior/DefaultCorrelationBehavior.php
@@ -695,6 +695,7 @@ class DefaultCorrelationBehavior extends ModelBehavior
         // Check if the user can see the object, if we're looking at an object attribute
         if (
             $correlation[$prefix . 'object_id'] &&
+            $correlation[$prefix . 'org_id'] != $user['org_id'] &&
             (
                 $correlation[$prefix . 'object_distribution'] == 0 ||
                 (
@@ -708,6 +709,7 @@ class DefaultCorrelationBehavior extends ModelBehavior
 
         // Check if the user can see the attribute
         if (
+            $correlation[$prefix . 'org_id'] != $user['org_id'] &&
             (
                 $correlation[$prefix . 'distribution'] == 0 ||
                 (


### PR DESCRIPTION
## Summary

**This is a false negative, not a disclosure** — the bug can only ever cause `checkCorrelationACL()` to wrongly *deny* visibility that should have been allowed, never to leak anything it shouldn't. Please don't file this as a security issue.

`DefaultCorrelationBehavior::checkCorrelationACL()` decides whether a given user is allowed to see a correlation row. The event-level check correctly denies only when the correlation belongs to a **different** org **and** has a restrictive distribution:

```php
// app/Model/Behavior/DefaultCorrelationBehavior.php:682-693
if (
    $correlation[$prefix . 'org_id'] != $user['org_id'] &&
    (
        $correlation[$prefix . 'event_distribution'] == 0 ||
        (
            $correlation[$prefix . 'event_distribution'] == 4 &&
            !in_array($correlation[$prefix . 'event_sharing_group_id'], $sgids)
        )
    )
) {
    return false;
}
```

The object-level block and the attribute-level block that immediately follow omit the `org_id` comparison entirely:

```php
// app/Model/Behavior/DefaultCorrelationBehavior.php:696-707 (object-level)
if (
    $correlation[$prefix . 'object_id'] &&
    (
        $correlation[$prefix . 'object_distribution'] == 0 ||
        ...
    )
) {
    return false;
}

// app/Model/Behavior/DefaultCorrelationBehavior.php:710-720 (attribute-level)
if (
    (
        $correlation[$prefix . 'distribution'] == 0 ||
        ...
    )
) {
    return false;
}
```

So these two blocks deny on `distribution == 0` **unconditionally**, even for a user who belongs to the very org that owns the correlated object/attribute. The practical effect: a member of the owning org can be denied visibility of their own org's correlation whenever the correlated object or attribute is separately marked `distribution=0`, even though the org check earlier in the function would have allowed it.

## Fix

Add the same `$correlation[$prefix . 'org_id'] != $user['org_id'] &&` guard used at the event level to both the object-level and attribute-level blocks, so a same-org user is no longer denied purely on `distribution == 0`.

`$prefix . 'org_id'` is the correct field to reuse here — object/attribute correlation rows don't carry a separate org_id of their own; they inherit the owning event's `org_id` (see `createCorrelationEntry()`, which sets `'org_id' => $b['Event']['org_id']` for the whole correlation row), so it's the same value already used by the event-level check just above.

## Testing

- `php -l app/Model/Behavior/DefaultCorrelationBehavior.php` passes.
- These changes cannot be exercised by the tests under `app/Test/`: that directory holds standalone PHPUnit tests that `require_once` a single self-contained `Lib/Tools` class with no CakePHP bootstrap or database, so there's no harness here that can build a `Correlation` row or run `checkCorrelationACL()` against real data.
- The integration test that would prove this: as a member of org A, create an event owned by org A containing an object or attribute with `distribution=0`, then query that event's correlations (e.g. via the attribute/event correlation view or `/attributes/restSearch` with `includeCorrelations`) and assert the same-org correlation is now visible, where before this fix it was hidden.
- A fresh-system install verification was not run.

