### PR TITLE
fix: [collections] Fix NOT-rule-only orgc_name filter dropping all rows

### DIFF
--- a/app/Controller/AnalystDataController.php
+++ b/app/Controller/AnalystDataController.php
@@ -477,7 +477,15 @@ class AnalystDataController extends AppController
                 $orgcNames = [$orgcNames];
             }
             $filterName = 'orgc_uuid';
+            // Track whether an OR-rule (allow-list) was supplied separately from
+            // whether it resolved: a NOT-rule against an org that doesn't exist
+            // locally should impose no restriction, not exclude everything. Only
+            // "caller asked for specific orgs, none exist" should return nothing.
+            $hasOrRule = false;
             foreach ($orgcNames as $orgcName) {
+                if (!is_string($orgcName) || $orgcName === '') {
+                    continue;
+                }
                 if ($orgcName[0] === '!') {
                     $orgc = $this->AnalystData->Orgc->fetchOrg(substr($orgcName, 1));
                     if ($orgc === false) {
@@ -485,6 +493,7 @@ class AnalystDataController extends AppController
                     }
                     $options[]['AND'][] = ["{$filterName} !=" => $orgc['uuid']];
                 } else {
+                    $hasOrRule = true;
                     $orgc = $this->AnalystData->Orgc->fetchOrg($orgcName);
                     if ($orgc === false) {
                         continue;
@@ -493,7 +502,7 @@ class AnalystDataController extends AppController
                 }
             }
 
-            if (empty($options)) {
+            if ($hasOrRule && empty($options['OR'])) {
                 return $this->RestResponse->viewData([], $this->response->type());
             }
         }

--- a/app/Controller/CollectionsController.php
+++ b/app/Controller/CollectionsController.php
@@ -456,7 +456,15 @@ class CollectionsController extends AppController
             if (!is_array($orgcNames)) {
                 $orgcNames = [$orgcNames];
             }
+            // Track whether an OR-rule (allow-list) was supplied separately from
+            // whether it resolved: a NOT-rule against an org that doesn't exist
+            // locally should impose no restriction, not exclude everything. Only
+            // "caller asked for specific orgs, none exist" should return nothing.
+            $hasOrRule = false;
             foreach ($orgcNames as $orgcName) {
+                if (!is_string($orgcName) || $orgcName === '') {
+                    continue;
+                }
                 // Collections key the creator org by integer FK (orgc_id), not the
                 // orgc_uuid string column that analyst data filters on — resolve the
                 // name to a local org id before building the condition.
@@ -467,6 +475,7 @@ class CollectionsController extends AppController
                     }
                     $options[]['AND'][] = ['Collection.orgc_id !=' => $orgc['id']];
                 } else {
+                    $hasOrRule = true;
                     $orgc = $this->Organisation->fetchOrg($orgcName);
                     if ($orgc === false) {
                         continue;
@@ -474,7 +483,7 @@ class CollectionsController extends AppController
                     $options['OR'][] = ['Collection.orgc_id' => $orgc['id']];
                 }
             }
-            if (empty($options)) {
+            if ($hasOrRule && empty($options['OR'])) {
                 return $this->RestResponse->viewData([], $this->response->type());
             }
         }


### PR DESCRIPTION
## Problem

`CollectionsController::indexMinimal()` (`app/Controller/CollectionsController.php:459-479`) and its verbatim duplicate `AnalystDataController::indexMinimal()` (`app/Controller/AnalystDataController.php:480-498`) build an orgc_name OR/NOT pull-rule filter for sync with two defects, present identically in both:

**1. Missing type/emptiness guard.** `$orgcName[0]` is read directly:

```php
foreach ($orgcNames as $orgcName) {
    if ($orgcName[0] === '!') {
```

An empty string, or a malformed nested array element, raises a PHP 8 warning ("Uninitialized string offset 0" for the empty-string case, or a type-juggling issue for a nested array) instead of being skipped cleanly.

**2. NOT-rule-only requests return zero rows instead of everything.** When every supplied `orgc_name` entry is a NOT-rule (`!org`) and none of them resolve locally (`fetchOrg()` returns `false` for all of them), `$options` never gets an `'OR'` key — every loop iteration hits `continue` — and the old guard:

```php
if (empty($options)) {
    return $this->RestResponse->viewData([], $this->response->type());
}
```

returns **zero** rows. But a NOT-rule against an org that doesn't exist locally should impose *no* restriction, not exclude every row — the caller said "don't give me org X", and there is no local data belonging to org X to exclude in the first place.

`app/Test/CollectionPushTest.php:551 testPushRulesNotMissAllows()` already documents this exact "NOT-rule miss allows" semantic at the model layer (`ServerSyncTool`/push-rule evaluation); these two controller endpoints contradicted it. Only the OR-only-unresolved case — the caller asked for specific orgs by allow-list and *none* of them exist locally — should legitimately return nothing, since there is nothing left to match.

## Fix

Two commits, one per controller (verbatim duplicate, so each stands alone and can be cherry-picked independently):

1. `CollectionsController::indexMinimal()`
2. `AnalystDataController::indexMinimal()`

Both commits:
- Guard the loop body with `is_string($orgcName) && $orgcName !== ''`, skipping anything else.
- Track `$hasOrRule` (whether any allow-list entry was supplied at all) separately from whether the OR-set resolved to anything (`empty($options['OR'])`), and only short-circuit to an empty result when `$hasOrRule && empty($options['OR'])`.

## Testing

- `php -l` passes for both touched files.
- No existing test covers either controller path: `app/Test/CollectionCaptureTest.php` and `app/Test/CollectionPushTest.php` exercise model-level capture/push and push-rule evaluation only, nothing calls `CollectionsController::indexMinimal()` or `AnalystDataController::indexMinimal()` directly. A test that would prove each fix: POST `{"orgc_name": ["!nonexistent-org"]}` to the respective `indexMinimal` action and assert the full unfiltered result set comes back rather than an empty array.
- A fresh-system install verification was not run.

