### PR TITLE
fix: [events] Avoid recursive read in generateCount bulk update

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -8479,9 +8479,10 @@ class EventsController extends AppController
             'order' => array('Attribute.event_id ASC'),
         ));
         foreach ($events as $k => $event) {
-            $this->Event->read(null, $event['Attribute']['event_id']);
-            $this->Event->set('attribute_count', $event[0]['attribute_count']);
-            $this->Event->save();
+            $this->Event->updateAll(
+                array('Event.attribute_count' => (int)$event[0]['attribute_count']),
+                array('Event.id' => $event['Attribute']['event_id'])
+            );
         }
         $this->Flash->success(__('All done. attribute_count generated from scratch for ' . (isset($k) ? $k : 'no') . ' events.'));
         $this->redirect(array('controller' => 'pages', 'action' => 'display', 'administration'));


### PR DESCRIPTION
## Summary

`EventsController::generateCount()` (the "Reset the attribute counts" admin action, triggered manually from `app/View/Pages/administration.ctp`, site-admin only) computes counts with one efficient `GROUP BY` query, then updates each event with:

```php
// app/Controller/EventsController.php:8481-8485
foreach ($events as $k => $event) {
    $this->Event->read(null, $event['Attribute']['event_id']);
    $this->Event->set('attribute_count', $event[0]['attribute_count']);
    $this->Event->save();
}
```

`Event` has no `public $recursive` override, so `read()` here runs at CakePHP's default `recursive = 1`, eager-loading every `hasMany` association on the event — including all of that event's own attribute rows — just to overwrite a single integer column. On an instance with many events and many attributes per event, this is a lot of unnecessary I/O for what should be a plain `UPDATE`.

Impact is bounded and I don't want to overstate it: this action is site-admin-only (its ACL entry is an empty array, which falls through to the `perm_site_admin` branch) and has no cron caller — it only runs when an admin manually clicks "Reset the attribute counts."

## Fix

Replace the per-event `read()`/`set()`/`save()` with a single `updateAll()` call per event, avoiding the recursive read entirely:

```php
foreach ($events as $k => $event) {
    $this->Event->updateAll(
        array('Event.attribute_count' => (int)$event[0]['attribute_count']),
        array('Event.id' => $event['Attribute']['event_id'])
    );
}
```

This mirrors the existing pattern in `MispAttribute::__alterAttributeCount()` (`app/Model/MispAttribute.php:611-628`), which already updates `Event.attribute_count` via `updateAll()` without a full model read, for exactly the same field.

## Testing

- `php -l app/Controller/EventsController.php` passes.
- These changes cannot be exercised by the tests under `app/Test/`: that directory holds standalone PHPUnit tests that `require_once` a single self-contained `Lib/Tools` class with no CakePHP bootstrap or database, so there's no harness here that can hit a controller action or a live schema.
- The integration test that would prove this: as a site admin, POST to `/events/generateCount` against a database with events that have attributes, and assert (a) `attribute_count` is still correctly set per event afterward, and (b) the query log / profiler no longer shows a recursive `Attribute` (and other hasMany) load per event.
- A fresh-system install verification was not run.

