### PR TITLE
fix: [core] Stop re-including theme files to build theme labels

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -304,25 +304,14 @@ class AppController extends Controller
                     }
                 }
                 $this->set('theme', $currentTheme);
-                $this->set('themes', MispTheme::getAvailableThemes($currentTheme, (bool)Configure::read('debug')));
+                $availableThemes = MispTheme::getAvailableThemes($currentTheme, (bool)Configure::read('debug'));
+                $this->set('themes', $availableThemes);
 
-                $userSetting = ClassRegistry::init('UserSetting');
-                $themes = $userSetting::VALID_SETTINGS['ui_theme']['options'];
-                foreach ($themes as $t) {
-                    if ($t === 'Default') {
+                foreach ($availableThemes as $availableTheme) {
+                    if ($availableTheme->name === 'Default') {
                         continue;
                     }
-                    $themeFile = APP . 'View' . DS . 'Themed' . DS . $t . DS . 'theme.php';
-                    if (file_exists($themeFile)) {
-                        $themeConfig = include $themeFile;
-                        if (!empty($themeConfig['label'])) {
-                            $themeLabels[$t] = $themeConfig['label'];
-                        }
-                    }
-                    if (!isset($themeLabels[$t])) {
-                        $themeLabels[$t] = $t . ' UI';
-
-                    }
+                    $themeLabels[$availableTheme->name] = $availableTheme->label;
                 }
             } else {
                 $this->set('themes', []);


### PR DESCRIPTION
## Summary

`AppController::beforeFilter()` calls `MispTheme::getAvailableThemes()`, which for each non-Default theme already does `file_exists()` + `include $themeFile` (`app/Lib/MispTheme/MispTheme.php:41-43`) and builds a `MispTheme` object per theme that carries `->label`.

Immediately after, the code re-looped the identical theme list and `include`'d the same files again, purely to build a separate `$themeLabels` array, discarding the `MispTheme[]` objects the first call already returned:

```php
// app/Controller/AppController.php (before this change)
$this->set('themes', MispTheme::getAvailableThemes($currentTheme, (bool)Configure::read('debug')));

$userSetting = ClassRegistry::init('UserSetting');
$themes = $userSetting::VALID_SETTINGS['ui_theme']['options'];
foreach ($themes as $t) {
    if ($t === 'Default') {
        continue;
    }
    $themeFile = APP . 'View' . DS . 'Themed' . DS . $t . DS . 'theme.php';
    if (file_exists($themeFile)) {
        $themeConfig = include $themeFile;
        if (!empty($themeConfig['label'])) {
            $themeLabels[$t] = $themeConfig['label'];
        }
    }
    if (!isset($themeLabels[$t])) {
        $themeLabels[$t] = $t . ' UI';
    }
}
```

This is a plain `include` (not `include_once`), so the file's opcodes re-execute on every request even with opcache enabled. MISP ships three non-Default themes, so this was 6 `include`s per non-REST page view (3 inside `getAvailableThemes()`, 3 more in this second loop) to do the same work twice.

I want to be honest about the impact: it's small in absolute terms — the `theme.php` files are short array literals — so this is a minor cleanup, not a meaningful performance fix.

## Fix

Derive `$themeLabels` directly from the `MispTheme[]` objects `getAvailableThemes()` already returned (each carries `->name` and `->label`, with the same `"$name UI"` fallback already applied inside the `MispTheme` constructor), dropping the second include pass entirely:

```php
$availableThemes = MispTheme::getAvailableThemes($currentTheme, (bool)Configure::read('debug'));
$this->set('themes', $availableThemes);

foreach ($availableThemes as $availableTheme) {
    if ($availableTheme->name === 'Default') {
        continue;
    }
    $themeLabels[$availableTheme->name] = $availableTheme->label;
}
```

One behavioral note for reviewers: `getAvailableThemes()` can omit a theme marked `hide_from_users` when it isn't the currently active theme (see its `$hideFromUsers` filtering). The old second loop iterated the full `VALID_SETTINGS['ui_theme']['options']` list unconditionally and would have still produced a label entry for such a theme. After this change, a hidden, non-active theme no longer gets an entry in `$themeLabels`. I checked and `$themeLabels` doesn't currently appear to be read anywhere in `app/View/` — so this shouldn't be user-visible today — but flagging it in case there's a consumer I didn't find.

## Testing

- `php -l app/Controller/AppController.php` passes.
- These changes cannot be exercised by the tests under `app/Test/`: that directory holds standalone PHPUnit tests that `require_once` a single self-contained `Lib/Tools` class with no CakePHP bootstrap or database, so there's no harness here that can run a controller's `beforeFilter()`.
- The integration test that would prove this: load any non-REST page with `MISP.enable_themes` turned on, and assert `$themeLabels` (as set on the view) still maps each non-Default theme name to the same label as before, while confirming (e.g. via an opcache/include profiler) that each theme.php file is now included only once per request instead of twice.
- A fresh-system install verification was not run.

