### PR TITLE
fix: [collections] Check Event visibility before collection attachment

### DIFF
--- a/app/Controller/CollectionsController.php
+++ b/app/Controller/CollectionsController.php
@@ -136,6 +136,20 @@ class CollectionsController extends AppController
 
     private function __attachElementToCollection($collectionId, $elementType, $elementUuid)
     {
+        if ($elementType === 'Event') {
+            // Mirror CollectionElementsController::addElementToCollection()'s visibility
+            // check: without it, a user could attach a UUID they cannot see to a
+            // collection they control, and probe for the existence of arbitrary event
+            // UUIDs (view() only ever renders ACL-filtered fetchSimpleEvents() output,
+            // so this does not itself grant read access to the event's content).
+            $this->loadModel('Event');
+            $event = $this->Event->fetchSimpleEvent($this->Auth->user(), $elementUuid, [
+                'fields' => ['Event.id']
+            ]);
+            if (empty($event)) {
+                throw new NotFoundException(__('Invalid event or not authorized.'));
+            }
+        }
         $this->Collection->CollectionElement->create();
         try {
             $this->Collection->CollectionElement->save([


### PR DESCRIPTION
## Problem

`CollectionsController::__attachElementToCollection()` (`app/Controller/CollectionsController.php:137-155`, invoked from `add()`'s `afterSave` hook when a caller passes `_attach_element_type`/`_attach_element_uuid`) saves a `CollectionElement` row with no existence or visibility check on the referenced element. The only validation applied before that point is format-level, in `__getAttachTargetFromRequest()`: the type must be one of `CollectionElement::valid_types` (`Event`, `GalaxyCluster`), and the UUID must pass `Validation::uuid()`.

The sibling action, `CollectionElementsController::addElementToCollection()` (`app/Controller/CollectionElementsController.php:164-173`), already performs this check for Events:

```php
if ($element_type === 'Event') {
    $this->loadModel('Event');
    foreach ($elementUuids as $currentElementUuid) {
        $event = $this->Event->fetchSimpleEvent($this->Auth->user(), $currentElementUuid, [
            'fields' => ['Event.id']
        ]);
        if (empty($event)) {
            throw new NotFoundException(__('Invalid event or not authorized.'));
        }
    }
}
```

`CollectionsController`'s attach-on-create path bypassed this entirely.

**Precise impact** (please read this before triaging severity): an attacker does **not** gain read access to the referenced event's content. `CollectionsController::view()` only ever renders element display data through ACL-filtered `fetchSimpleEvents()`/`fetchGalaxyClusters()`, so a viewer without access to the underlying event still sees only the raw type+uuid pair for an element attached to a collection they can see. What is actually gained without this check:

1. Attaching a UUID the attacker cannot see to a collection they control.
2. An existence oracle for arbitrary event UUIDs (the save succeeds/fails predictably depending on whether the UUID exists at all, independent of access).

## Fix

Mirror the sibling's `fetchSimpleEvent` visibility check inside `__attachElementToCollection()` for the `'Event'` element type, throwing `NotFoundException` when it comes back empty — same behavior, same message, as `CollectionElementsController::addElementToCollection()`.

**Scope note:** `GalaxyCluster` attachments remain unchecked in *both* controllers after this fix — `CollectionElementsController` never validated GalaxyCluster visibility either, so that gap is pre-existing and is not addressed here. Flagging it explicitly rather than overstating what this PR covers.

## Testing

- `php -l app/Controller/CollectionsController.php` passes.
- No existing test covers this: `app/Test/CollectionCaptureTest.php` and `app/Test/CollectionPushTest.php` exercise model-level capture/push only, nothing exercises the `add()` attach-on-create path. A test that would prove this fix: as a user without access to a given event, POST to `collections/add` with `_attach_element_type=Event` and `_attach_element_uuid=<uuid of an event outside the user's ACL>`, and assert a `NotFoundException` (404) rather than a successful attach.
- A fresh-system install verification was not run.

