### PR TITLE
new: [feed] Add TweetFeed community IOC feed

### DIFF
--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -2505,5 +2505,25 @@
       "exportable": true,
       "hide_tag": false
     }
+  },
+  {
+    "Feed": {
+      "name": "TweetFeed",
+      "provider": "tweetfeed.live",
+      "url": "https://tweetfeed.live/misp",
+      "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]}}",
+      "enabled": false,
+      "distribution": "3",
+      "default": false,
+      "source_format": "misp",
+      "fixed_event": false,
+      "delta_merge": false,
+      "publish": false,
+      "override_ids": false,
+      "settings": "{\"csv\":{\"value\":\"\",\"delimiter\":\"\"},\"common\":{\"excluderegex\":\"\"}}",
+      "input_source": "network",
+      "delete_local_file": false,
+      "lookup_visible": false
+    }
   }
 ]


### PR DESCRIPTION
#### What does it do?

Adds [TweetFeed](https://tweetfeed.live) to the default feed list (`app/files/feed-metadata/defaults.json`). Disabled by default, so the administrator opts in. No existing issue.

**What it is**: IOCs (URLs, domains, IPs, MD5, SHA256) that security researchers post publicly on Twitter/X, extracted and deduplicated. Running since August 2021. Licensed **CC0**, no key, no registration.

**Feed details**

- **URL**: `https://tweetfeed.live/misp` — the directory, since `Feed::downloadManifest()` appends `/manifest.json`
- **Format**: MISP feed (`manifest.json`, one JSON file per event, `hashes.csv`)
- **Refresh**: every 15 minutes
- **Organisation**: `TweetFeed`, uuid `76a67249-f941-5bdb-925a-51045a921c1e`
- **Event tags**: `TweetFeed`, `type:OSINT`, `tlp:clear`

Four fixed events, one per rolling window, so the event UUIDs stay stable:

| Window | Attributes (at the time of writing) |
|---|---|
| today | ~280 |
| week | ~2,300 |
| month | ~14,000 |
| year | ~112,500 |

Types in the year window: `url` 54,956 · `domain` 41,498 · `ip-dst` 11,063 · `md5` 2,558 · `sha256` 2,432. All attributes are `to_ids: true`, categorised as Network activity or Payload delivery, and carry per-attribute tags where the reporter used a hashtag (`phishing`, `scam`, malware family names, and so on).

Every attribute's `comment` is the permalink of the tweet it came from, so an analyst can always trace an indicator back to the original public report.

**Notes for reviewers**

- The `year` event is roughly 31 MB and is served as a 302 to the raw file on GitHub. `Feed::getFollowRedirect()` handles it in a single hop, well within the 5 it allows. The other three events are served directly.
- MISP instances are already pulling this feed after finding it on their own; the point of this PR is that it can be selected from the default list rather than typed in by hand.
- `lookup_visible` is `false` on purpose: our `hashes.csv` is not yet in the per-attribute
  format `Feed::getCache()` expects, so the feed cache would be empty. We are fixing the
  generator and will propose flipping it in a follow-up rather than advertise it now.
- The same data is also published as STIX 2.1 bundles, a TAXII 2.1 server, and plain CSV/JSON: <https://tweetfeed.live/api/>

#### Questions

- [ ] Does it require a DB change? — **No.** One entry appended to `defaults.json`.
- [x] Are you using it in production? — **Yes.** We operate the feed, and MISP 2.5 instances are already pulling it.
- [ ] Does it require a change in the API (PyMISP for example)? — **No.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
