### PR TITLE
fix: [security] Enforce event modify ACL on attribute enrichment

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -3649,6 +3649,18 @@ class AttributesController extends AppController
         if (!$this->request->is('post') || !$this->_isRest()) {
             throw new MethodNotAllowedException(__('This endpoint allows for API POST requests only.'));
         }
+        // Enrichment persists module-derived attributes into the parent event, so it is a
+        // write on that event, not on the attribute alone. Being able to *view* the attribute
+        // (fetchAttributes uses read scope) is not sufficient; require modify rights on the
+        // event, mirroring EventsController::enrichEvent(). Otherwise any user who can merely
+        // see a cross-org/"all communities" event could inject attributes into it.
+        $event = $this->MispAttribute->Event->fetchSimpleEvent($this->Auth->user(), $attribute['Attribute']['event_id'], ['contain' => ['Orgc']]);
+        if (!$event) {
+            throw new NotFoundException(__('Invalid event'));
+        }
+        if (!$this->__canModifyEvent($event)) {
+            throw new ForbiddenException(__('You do not have permission to do that.'));
+        }
         $modules = [];
         foreach ($this->request->data as $module => $enabled) {
             if ($enabled) {


### PR DESCRIPTION
## Summary

The attribute-level enrichment endpoint (`AttributesController::enrich()`) was missing an event-level
authorization check.

Enrichment persists module-derived attributes into the parent event, so it is a **write** on that event —
but the action only resolved the target attribute through a read-scoped lookup and was otherwise gated by
the `perm_add` ACL alone. The event-level sibling `EventsController::enrichEvent()` already enforces
`__canModifyEvent()`; this entry point did not, so the two paths disagreed on who may trigger enrichment.

## Fix

Add the same `__canModifyEvent()` gate before queueing the enrichment job, following the idiom already
used elsewhere in this controller:

```php
$event = $this->MispAttribute->Event->fetchSimpleEvent($this->Auth->user(), $attribute['Attribute']['event_id'], ['contain' => ['Orgc']]);
if (!$event) {
    throw new NotFoundException(__('Invalid event'));
}
if (!$this->__canModifyEvent($event)) {
    throw new ForbiddenException(__('You do not have permission to do that.'));
}
```

This is the only HTTP entry point reaching attribute-level enrichment, and the check runs before
`enrichmentRouter()`, so every downstream module-output branch is covered by the single gate.

Behaviour for users who may already modify the event is unchanged — verified on a lab instance that
legitimate enrichment by the event owner still succeeds, and that read access to the event is unaffected.

## Notes
- CWE-862 (Missing Authorization).

## Credit

Reported by **Ahmed Ibrahim ([@skeletonsec](https://github.com/skeletonsec)), SkeletonSec.com**
