### PR TITLE
Add ThreatCluster feeds to default feed metadata

### DIFF
--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -2505,5 +2505,51 @@
       "exportable": true,
       "hide_tag": false
     }
+  },
+  {
+    "Feed": {
+      "name": "ThreatCluster OSINT Feed",
+      "provider": "ThreatCluster",
+      "url": "https://threatcluster.io/misp",
+      "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]}}",
+      "enabled": true,
+      "distribution": "3",
+      "default": false,
+      "source_format": "misp",
+      "fixed_event": false,
+      "delta_merge": false,
+      "publish": false,
+      "override_ids": false,
+      "settings": "{\"csv\":{\"value\":\"\",\"delimiter\":\"\"},\"common\":{\"excluderegex\":\"\"}}",
+      "input_source": "network",
+      "delete_local_file": false,
+      "lookup_visible": false
+    }
+  },
+  {
+    "Feed": {
+      "name": "ThreatCluster IOC Blocklist (network indicators)",
+      "provider": "ThreatCluster",
+      "url": "https://threatcluster.io/api/iocs/public/feed.txt",
+      "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]}}",
+      "enabled": true,
+      "distribution": "0",
+      "default": false,
+      "source_format": "freetext",
+      "fixed_event": true,
+      "delta_merge": true,
+      "publish": false,
+      "override_ids": false,
+      "settings": "{\"csv\":{\"value\":\"\",\"delimiter\":\",\"},\"common\":{\"excluderegex\":\"\"}}",
+      "input_source": "network",
+      "delete_local_file": false,
+      "lookup_visible": false
+    },
+    "Tag": {
+      "name": "osint:source-type=\"block-or-filter-list\"",
+      "colour": "#004f89",
+      "exportable": true,
+      "hide_tag": false
+    }
   }
 ]


### PR DESCRIPTION
This PR adds two feeds from ThreatCluster (https://threatcluster.io), a threat-intelligence platform that clusters reporting from 20,000+ public sources and extracts validated indicators.

**1. ThreatCluster OSINT Feed** — `misp` source format
- Base URL: https://threatcluster.io/misp (serves `manifest.json`, `hashes.csv`, and per-event JSON per the MISP feed spec)
- Daily events with deduplicated attributes (network indicators + file hashes), correlated threat context (actor / malware / CVE galaxy tags where known), `tlp:clear` tagged
- No authentication required

**2. ThreatCluster IOC Blocklist (network indicators)** — `freetext` source format
- URL: https://threatcluster.io/api/iocs/public/feed.txt
- High-confidence malicious domains and IPs from the last 30 days, one per line with `#` comment header
- Indicators pass an automated validation pipeline (allowlist/anti-false-positive checks) before publication; false-positive contact is in the feed header

Both feeds are free for any use, served over HTTPS with no rate limits that would affect normal MISP fetch intervals. Several MISP instances already consume the feed by manual configuration; this adds it to the defaults for discoverability.

Happy to adjust entry fields (distribution, tags, defaults) to whatever the maintainers prefer.
