### PR TITLE
[low] test: make code coverage possible (PHPUnit 9.6 + phpunit.xml)

### DIFF
--- a/app/Test/CryptGpgExtendedTest.php
+++ b/app/Test/CryptGpgExtendedTest.php
@@ -53,12 +53,29 @@ class GpgToolTest extends TestCase
     private function init(): CryptGpgExtended
     {
         require_once 'Crypt/GPG.php';
-        include __DIR__ . '/../Config/config.php';
+
+        // A missing or unconfigured GPG setup is an absent precondition, not a
+        // broken suite: skip rather than error, so running the documented
+        // `phpunit app/Test/` on a fresh checkout reports honestly.
+        $configFile = __DIR__ . '/../Config/config.php';
+        if (!is_file($configFile)) {
+            $this->markTestSkipped('app/Config/config.php is absent; GPG tests need a configured instance.');
+        }
+        include $configFile;
+
+        $homedir = $config['GnuPG']['homedir'] ?? '';
+        if ($homedir === '' || !is_dir($homedir)) {
+            $this->markTestSkipped('GnuPG.homedir is not configured; skipping GPG-backed tests.');
+        }
+        $binary = $config['GnuPG']['binary'] ?? '/usr/bin/gpg';
+        if (!is_file($binary)) {
+            $this->markTestSkipped(sprintf('gpg binary not found at %s; skipping GPG-backed tests.', $binary));
+        }
 
         $options = [
-            'homedir' => $config['GnuPG']['homedir'],
+            'homedir' => $homedir,
             'gpgconf' => $config['GnuPG']['gpgconf'] ?? null,
-            'binary' => $config['GnuPG']['binary'] ?? '/usr/bin/gpg',
+            'binary' => $binary,
         ];
         return new CryptGpgExtended($options);
     }

--- a/app/Test/EventTemplateInfoRendererTest.php
+++ b/app/Test/EventTemplateInfoRendererTest.php
@@ -61,7 +61,7 @@ class EventTemplateInfoRendererTest extends TestCase
     public function testDateVariableFallsBackToTodayWhenNoContext(): void
     {
         $out = $this->renderer->render('Today: {{date}}');
-        $this->assertRegExp('/^Today: \d{4}-\d{2}-\d{2}$/', $out);
+        $this->assertMatchesRegularExpression('/^Today: \d{4}-\d{2}-\d{2}$/', $out);
     }
 
     public function testNowVariableUsesContextOverride(): void
@@ -78,7 +78,7 @@ class EventTemplateInfoRendererTest extends TestCase
     {
         $out = $this->renderer->render('At {{now}}');
         // ISO-8601 with timezone offset: 2026-04-23T12:34:56+02:00
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '/^At \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+\-]\d{2}:\d{2}$/',
             $out
         );

--- a/app/Test/WidgetCacheTest.php
+++ b/app/Test/WidgetCacheTest.php
@@ -116,7 +116,7 @@ class WidgetCacheTest extends TestCase
         $this->assertStringStartsWith('misp:custom_geo_key:', $key);
         $hash = substr($key, strlen('misp:custom_geo_key:'));
         $this->assertSame(64, strlen($hash));
-        $this->assertRegExp('/^[0-9a-f]{64}$/', $hash);
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $hash);
     }
 
     public function testFrameworkKeysAreExcludedFromHash()
@@ -178,7 +178,7 @@ class WidgetCacheTest extends TestCase
         // misp:wc_user_scoped_cache:u7:<sha256>
         $this->assertStringStartsWith('misp:wc_user_scoped_cache:u7:', $key);
         $hash = substr($key, strlen('misp:wc_user_scoped_cache:u7:'));
-        $this->assertRegExp('/^[0-9a-f]{64}$/', $hash);
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $hash);
     }
 
     public function testUserScopeDifferentUsersGetDifferentKeys()
@@ -229,7 +229,7 @@ class WidgetCacheTest extends TestCase
         // misp:wc_org_scoped_cache:o5:<sha256>
         $this->assertStringStartsWith('misp:wc_org_scoped_cache:o5:', $key);
         $hash = substr($key, strlen('misp:wc_org_scoped_cache:o5:'));
-        $this->assertRegExp('/^[0-9a-f]{64}$/', $hash);
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $hash);
     }
 
     public function testOrgScopeSameOrgSharesKeyAcrossUsers()

--- a/app/composer.json
+++ b/app/composer.json
@@ -33,7 +33,7 @@
         "Doctrine simple cache no longer supported, switched to scrapbook"
     ],
     "require-dev": {
-        "phpunit/phpunit": "^8",
+        "phpunit/phpunit": "^9.6",
         "php-parallel-lint/php-parallel-lint": "^1.2",
         "cakephp/debug_kit": "^2.2.0"
     },

--- a/app/phpunit.xml
+++ b/app/phpunit.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Enables code coverage, which was previously impossible: the
+  php-code-coverage bundled with PHPUnit 8 refuses to run on PHP 8, while
+  composer.json requires PHP 8.1 or newer.
+
+  Run from the app directory:
+    ./Vendor/bin/phpunit -c phpunit.xml
+    ./Vendor/bin/phpunit -c phpunit.xml  (add a coverage flag for a report)
+
+  The coverage filter excludes vendored CakePHP, Composer packages, and the
+  DebugKit and CakeResque plugins' own test suites, which are third-party
+  test code that would otherwise be counted as MISP source.
+-->
+<phpunit colors="true"
+         convertDeprecationsToExceptions="false"
+         cacheResultFile="tmp/.phpunit.result.cache">
+  <testsuites>
+    <testsuite name="misp">
+      <directory suffix="Test.php">Test</directory>
+    </testsuite>
+  </testsuites>
+  <coverage processUncoveredFiles="false">
+    <include>
+      <directory suffix=".php">Model</directory>
+      <directory suffix=".php">Controller</directory>
+      <directory suffix=".php">Lib</directory>
+      <directory suffix=".php">Console</directory>
+      <directory suffix=".php">Plugin</directory>
+      <directory suffix=".php">View</directory>
+    </include>
+    <exclude>
+      <directory>Lib/cakephp</directory>
+      <directory>Vendor</directory>
+      <directory>Plugin/DebugKit</directory>
+      <directory>Plugin/CakeResque</directory>
+    </exclude>
+  </coverage>
+</phpunit>


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Code coverage cannot run at all: PHPUnit `^8` refuses coverage on PHP 8, which is all MISP supports.

- **Problem** — The pinned `phpunit/phpunit` `^8` brings `php-code-coverage` 7, which refuses to run coverage on PHP 8, while `app/composer.json` requires PHP >= 8.1. There is also no `phpunit.xml` to define a coverage filter.
- **Fix** — Bumps PHPUnit to `^9.6`, adds `app/phpunit.xml` with a filter excluding vendored CakePHP, Composer packages and plugin test suites, updates the five deprecated `assertRegExp` calls, and makes `CryptGpgExtendedTest` skip rather than error when GnuPG is unconfigured.
- **Effect** — The existing phpunit invocation is unchanged and still passes; maintainers gain a working `--coverage-text` number.
- **Cost** — The `phpunit/phpunit` dependency moves from `^8` to `^9.6`.
<!-- /bluf -->

## Problem

`php-code-coverage 7`, bundled with the pinned `phpunit/phpunit: ^8`, aborts with:

```
This version of PHPUnit does not support code coverage on PHP 8
```

while `app/composer.json` requires `"php": ">=8.1.0,<9.0.0"`.

**Code coverage is therefore impossible on every PHP version MISP supports.** There is also no `phpunit.xml`, so there is no coverage filter even in principle. The incompatibility went unnoticed because CI runs `phpunit app/Test/` without a `--coverage-*` flag.

## Changes

- `phpunit/phpunit` `^8` → `^9.6`
- `app/phpunit.xml` — testsuite plus a coverage filter excluding vendored CakePHP, Composer packages, and the DebugKit and CakeResque plugins' *own* test suites (third-party test code that would otherwise be counted as MISP source, ~4,700 statements)
- `assertRegExp()` → `assertMatchesRegularExpression()` at the 5 call sites PHPUnit 9 deprecates
- `CryptGpgExtendedTest` skips instead of erroring when GnuPG is unconfigured

That last one is a small independent fix: running the documented command on a fresh checkout produced **2 errors**, which reads as a broken suite rather than an absent precondition. It now skips with a reason, and still runs normally when `GnuPG.homedir` is configured.

## Verification

The existing invocation is unchanged and still passes — no CI change is needed:

```
$ ./app/Vendor/bin/phpunit app/Test/
Tests: 477, Assertions: 1073, Skipped: 4
```

And coverage now works:

```
$ cd app && ./Vendor/bin/phpunit -c phpunit.xml --coverage-text
Lines: 1.69% (1948/115302)
```

Verified on PHP 8.3.

## Scope

Deliberately minimal: no test restructuring, no new tests, no CI changes. It only makes coverage measurable, so that any later work on the test suite has a number to move.

For context, this came out of a measurement exercise on 2.5. Instrumenting the live Python suite as well as PHPUnit put combined coverage at roughly 20 %, with `Lib/Dashboard` and `Model/WorkflowModules` at 0 % in *both* suites — each suite implicitly assuming the other covered them. Happy to share the full breakdown if it's useful, but that's out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

