### PR TITLE
[high] fix: [export:netfilter] use the loop variable in event scope

### DIFF
--- a/app/Lib/Export/NetfilterExport.php
+++ b/app/Lib/Export/NetfilterExport.php
@@ -36,8 +36,8 @@ class NetfilterExport
         if ($options['scope'] === 'Event') {
             $result = array();
             foreach ($data['Attribute'] as $attribute) {
-                if (in_array($data['Attribute']['type'], array_keys($this->__attributeTypeMappings))) {
-                    $result[] = $this->__convertToRule($data['Attribute'], $action);
+                if (in_array($attribute['type'], array_keys($this->__attributeTypeMappings))) {
+                    $result[] = $this->__convertToRule($attribute, $action);
                 }
             }
             return implode($this->separator(), $result) . "\n";


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `NetfilterExport::handler()` ignores its loop variable, so event-scope netfilter export emits no rules.

- **Problem** — The event-scope branch binds a loop variable and then ignores it, indexing `$data['Attribute']` — the whole list — instead of the current attribute. Every iteration raises an undefined-key warning and the type check never matches, so `restSearch` with `returnFormat=netfilter` returns no rules at all for event scope.
- **Fix** — Uses the loop variable in the two affected lines, mirroring the correct attribute-scope branch immediately above.
- **Effect** — Netfilter export emits the expected iptables rules for events; attribute-scope output is unchanged.
<!-- /bluf -->

## Problem

`NetfilterExport::handler()`'s event-scope branch iterates the attribute list but never uses the loop variable:

```php
foreach ($data['Attribute'] as $attribute) {
    if (in_array($data['Attribute']['type'], array_keys($this->__attributeTypeMappings))) {
        $result[] = $this->__convertToRule($data['Attribute'], $action);
    }
}
```

`$data['Attribute']` is the *list*; `$attribute` is bound and then ignored. So every iteration raises `Undefined array key "type"`, `in_array()` never matches, and **`returnFormat=netfilter` returns no rules at all in event scope**.

The attribute-scope branch immediately above is correct, which suggests this was copied from it without switching to the loop variable. It is the same shape as e06cb68844, which fixed the equivalent bug in `CacheExport`.

## Fix

Use `$attribute` — two lines.

## Verification

Against a running 2.5 instance, for an event with two attributes (`ip-dst 203.0.113.10`, `ip-src 203.0.113.20`):

**Before**
```
Warning: Undefined array key "type"   (x2)
(no rules emitted)
```

**After**
```
iptables -A INPUT -s 203.0.113.10 -j DROP
iptables -A INPUT -s 203.0.113.20 -j DROP
```

Attribute-scope output is unchanged (still 2 rules).

Found while building golden-snapshot coverage of `restSearch` across every `returnFormat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

