### PR TITLE
[low] fix: [Collections] delegate CollectionElement::mayView()/mayModify() to Collection

### DIFF
--- a/app/Model/CollectionElement.php
+++ b/app/Model/CollectionElement.php
@@ -132,57 +132,12 @@ class CollectionElement extends AppModel
 
     public function mayModify(int $user_id, int $collection_id)
     {
-        $user = $this->User->getAuthUser($user_id);
-        $collection = $this->find('first', [
-            'recursive' => -1,
-            'conditions' => ['Collection.id' => $collection_id]
-        ]);
-        if ($user['Role']['perm_site_admin']) {
-            return true;
-        }
-        if (empty($user['Role']['perm_modify'])) {
-            return false;
-        }
-        if (!empty($user['Role']['perm_modify_org'])) {
-            if ($user['org_id'] == $collection['Collection']['orgc_id']) {
-                return true;
-            }
-            if ($user['Role']['perm_sync'] && $user['org_id'] == $collection['Collection']['org_id']) {
-                return true;
-            }            
-        }
-        if (!empty($user['Role']['perm_modify']) && $user['id'] === $collection['Collection']['user_id']) {
-            return true;
-        }
-        return false;
+        return $this->Collection->mayModify($user_id, $collection_id);
     }
 
     public function mayView(int $user_id, int $collection_id)
     {
-        $user = $this->User->getAuthUser($user_id);
-        $collection = $this->find('first', [
-            'recursive' => -1,
-            'conditions' => ['Collection.id' => $collection_id]
-        ]);
-        if ($user['Role']['perm_site_admin']) {
-            return true;
-        }
-        if ($collection['Collection']['org_id'] == $user['org_id']) {
-            return true;
-        }
-        if (in_array($collection['Collection']['distribution'], [1,2,3])) {
-            return true;
-        }
-        if ($collection['Collection']['distribution'] === 4) {
-            $SharingGroup = ClassRegistry::init('SharingGroup');
-            $sgs = $this->SharingGroup->fetchAllAuthorised($user, 'uuid');
-            if (isset($sgs[$collection['Collection']['sharing_group_id']])) {
-                return true;
-            } else {
-                return false;
-            }
-        }
-        return false;
+        return $this->Collection->mayView($user_id, $collection_id);
     }
 
     public function deduceType(string $uuid)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `CollectionElement::mayView()` and `mayModify()` are dead copies of `Collection`'s that query the wrong table.

- **Problem** — With `recursive => -1` on `CollectionElement` the `Collection` alias is never joined, so the conditions cannot resolve, and `mayView()` also dereferences a `SharingGroup` association the model does not have. Nothing calls them today — `CollectionElementsController` goes through the association to `Collection`'s own correct methods.
- **Fix** — Replaces both bodies with delegation to `Collection`.
- **Effect** — No runtime behaviour change; it removes a second copy that has to be fixed twice — it has already attracted a duplicated typo fix, and still carries a stale strict distribution comparison corrected upstream.
<!-- /bluf -->

## Problem

`CollectionElement::mayModify()` and `CollectionElement::mayView()` (`app/Model/CollectionElement.php:133-186` before this change) are a copy of `Collection`'s implementations, but they run the lookup against the wrong table:

```php
$collection = $this->find('first', [
    'recursive' => -1,
    'conditions' => ['Collection.id' => $collection_id]
]);
...
$collection['Collection']['org_id']   // read afterwards
```

`$this` is `CollectionElement`, so the `FROM` clause is `collection_elements`. With `recursive => -1` the `belongsTo Collection` association (`app/Model/CollectionElement.php:13-18`) is not joined, so the alias `Collection` is not in scope — `Collection.id` is not a resolvable column and the query cannot succeed. Even if it did, `$collection['Collection']` would never be populated. `mayView()` additionally dereferences `$this->SharingGroup`, which `CollectionElement` does not have.

Nothing calls these today — every real call site goes through the association to `Collection`'s own, schema-correct implementations:

```
app/Controller/CollectionElementsController.php:45,77,103,114,156
    $this->CollectionElement->Collection->mayModify(...)
    $this->CollectionElement->Collection->mayView(...)
```

The reason this is still worth fixing is that the dead copy is being maintained as though it were live: commit `5488f020d` applied the same `Orgc_id`/`Org_id` → `orgc_id`/`org_id` typo fix to *both* `Collection.php` and `CollectionElement.php`, i.e. effort was spent fixing a method nothing calls. `CollectionElement.php` also still carries the strict `=== 4` distribution comparison that was corrected in `Collection.php` by #10927 — a fix that has to be remembered twice.

## Fix

Option 2 from the issue: replace both bodies with delegation to `Collection`.

```php
public function mayModify(int $user_id, int $collection_id)
{
    return $this->Collection->mayModify($user_id, $collection_id);
}
```

Delegation rather than deletion because it preserves the public API — these are public model methods and MISP modules/scripts could conceivably call them — while ending the duplicate-maintenance burden and inheriting the `(int)` cast from #10927 for free. The typed signatures are kept as-is. If maintainers would rather delete the methods outright (option 1 in the issue), I am happy to change the PR to that.

`$this->Collection` is available via the existing `belongsTo` association and is already used the same way by `CollectionElement::touchCollection()` (`app/Model/CollectionElement.php:127`).

## Verified

- `php -l app/Model/CollectionElement.php` — no syntax errors (PHP 8.5).
- Re-grepped the tree: no caller invokes `mayView`/`mayModify` directly on `CollectionElement`, so this change is unreachable-by-construction from existing code paths and cannot regress behaviour.
- Confirmed `Collection::mayModify()`/`mayView()` (`app/Model/Collection.php:107,134`) implement exactly the logic the removed copies intended, against the correct table.

## Not verified

- No runtime execution, no functional or unit test run — this is a static change only.

Fixes #10937

🤖 Generated with [Claude Code](https://claude.com/claude-code)

