### PR TITLE
[high] fix: [AnalystData] Relationship::getRelatedElement() called undefined fetchNote()/fetchOpinion()/fetchRelationship()

### DIFF
--- a/app/Model/Relationship.php
+++ b/app/Model/Relationship.php
@@ -57,6 +57,9 @@ class Relationship extends AnalystData
     /** @var array|null */
     private $__currentUser;
 
+    /** @var bool set while expanding a related relationship, to stop afterFind() recursing */
+    private $__expandingRelatedRelationship = false;
+
     public function beforeValidate($options = array())
     {
         parent::beforeValidate($options);
@@ -132,31 +135,34 @@ class Relationship extends AnalystData
             $data = $this->rearrangeData($data, 'Object');
         } else if ($type == 'Note') {
             $this->Note = ClassRegistry::init('Note');
-            $params = [
-
-            ];
             $backup = $this->Note->includeAnalystData;
             $this->Note->includeAnalystData = false;
-            $data = $this->Note->fetchNote();
+            $data = $this->Note->fetchSimple($user, $uuid);
             $this->Note->includeAnalystData = $backup;
         } else if ($type == 'Opinion') {
             $this->Opinion = ClassRegistry::init('Opinion');
-            $params = [
-
-            ];
             $backup = $this->Opinion->includeAnalystData;
             $this->Opinion->includeAnalystData = false;
-            $data = $this->Opinion->fetchOpinion();
+            $data = $this->Opinion->fetchSimple($user, $uuid);
             $this->Opinion->includeAnalystData = $backup;
         } else if ($type == 'Relationship') {
+            // A relationship may point at another relationship. Fetching it
+            // runs Relationship::afterFind(), which would expand its own
+            // related_object and recurse indefinitely on cyclic graphs, so
+            // only expand one level deep.
+            if ($this->__expandingRelatedRelationship) {
+                return [];
+            }
             $this->Relationship = ClassRegistry::init('Relationship');
-            $params = [
-
-            ];
             $backup = $this->Relationship->includeAnalystData;
             $this->Relationship->includeAnalystData = false;
-            $data = $this->Relationship->fetchRelationship();
-            $this->Relationship->includeAnalystData = $backup;
+            $this->Relationship->__expandingRelatedRelationship = true;
+            try {
+                $data = $this->Relationship->fetchSimple($user, $uuid);
+            } finally {
+                $this->Relationship->__expandingRelatedRelationship = false;
+                $this->Relationship->includeAnalystData = $backup;
+            }
         }
         return $data;
     }


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `Relationship::getRelatedElement()` calls undefined methods, so reading analyst-data relationships crashes.

- **Problem** — Its `Note`, `Opinion` and `Relationship` branches call `fetchNote()`, `fetchOpinion()` and `fetchRelationship()`, which exist nowhere in the tree. `Relationship::afterFind()` invokes `getRelatedElement()` for any relationship carrying a `related_object_type`, and `AnalystData::valid_targets` permits all three, so merely reading such a relationship raises a fatal undefined-method error.
- **Fix** — Points the three branches at `AnalystData::fetchSimple()`, the counterpart of the working `Event`/`Attribute`/`Object` branches, which applies ACL conditions and contains `Org`/`Orgc`.
- **Effect** — Reading analyst-data relationships stops crashing.
<!-- /bluf -->

## Problem

`Relationship::getRelatedElement()` dispatches on `$type`. The `Event`, `Attribute` and `Object` branches are complete; the `Note`, `Opinion` and `Relationship` branches call methods that do not exist anywhere in the tree:

```php
// app/Model/Relationship.php:133-159 (before this change)
$data = $this->Note->fetchNote();                  // undefined
$data = $this->Opinion->fetchOpinion();            // undefined
$data = $this->Relationship->fetchRelationship();  // undefined
```

`grep -rn "function fetchNote\|function fetchOpinion\|function fetchRelationship" app/ --include=*.php` returns nothing. `Note` and `Opinion` extend `AnalystData`, which defines `fetchSimple()` and `fetchChildNotesAndOpinions()` — neither of the called names. Each branch also builds an empty `$params = [];` that is never used, unlike the working branches which populate and pass it.

**These branches are reachable.** `related_object_type` is validated against `AnalystData::valid_targets` (`app/Model/AnalystData.php:15-27`), which includes `Note`, `Opinion` and `Relationship`. `Relationship::afterFind()` (`app/Model/Relationship.php:74-89`) calls `getRelatedElement()` for every relationship that has a `related_object_type`/`related_object_uuid`, so simply reading back a relationship whose target is another analyst-data object raises `Error: Call to undefined method Note::fetchNote()` and takes down the request.

## Fix

Delegate to `AnalystData::fetchSimple($user, $id)` (`app/Model/AnalystData.php:440`), which is the analyst-data counterpart of `fetchSimpleEvent()` / `fetchAttributeSimple()` / `fetchObjectSimple()` used by the working branches: it accepts a UUID or an id, applies `buildConditions($user)` for ACL, and contains `Org`/`Orgc`. The `includeAnalystData` backup/restore scaffolding already present in each branch is kept unchanged, and the dead empty `$params` are removed.

`rearrangeData()` is deliberately **not** called for these three types (contrary to point 3 of the issue). It unconditionally dereferences `$data[$objectType]['Event']['Orgc']` (`app/Model/Relationship.php:~180`); analyst data has no `Event` contain, so calling it would raise a new error. The `Event` branch does not call it either.

### One judgement call: recursion guard on the `Relationship` branch

A relationship may target another relationship. Fetching that target runs `Relationship::afterFind()` again, which expands *its* `related_object` — and `afterFind()` does not consult `includeAnalystData`, so the flag the surrounding scaffolding sets does not stop it. `beforeValidate()` (`app/Model/Relationship.php:60-72`) only blocks direct self-reference, so a two-node cycle (A→B, B→A) is creatable and would recurse until the process dies.

This PR therefore expands a related relationship exactly one level and returns `[]` beyond that, via a private flag set on the instance the nested `afterFind()` will run on. This is the only piece of behaviour here that is not directly inferable from the existing code; a depth limit rather than a hard one-level stop would also be defensible (cf. the `$depth = 2` convention in `AnalystData::fetchChildNotesAndOpinions()`). Happy to change it, or to split the `Relationship` branch into a separate PR and land only `Note`/`Opinion` here, if maintainers prefer.

## Verified

- `php -l app/Model/Relationship.php` — no syntax errors (PHP 8.5).
- `AnalystData::fetchSimple()` is inherited by `Note`, `Opinion` and `Relationship` and is not overridden anywhere (`grep -rn "function fetchSimple" app/`).
- `includeAnalystData` is declared on `AppModel` (`app/Model/AppModel.php:51`), so the retained backup/restore lines are valid for all three models.
- Reachability of the branches traced from `afterFind()` and `AnalystData::valid_targets`.

## Not verified

- No runtime execution: I did not create a relationship targeting a Note/Opinion/Relationship and read it back, so the exact returned array shape is not empirically confirmed.
- No unit or functional tests were run.
- The recursion guard was reasoned about statically, not exercised against a real cyclic relationship pair.

Fixes #10934

🤖 Generated with [Claude Code](https://claude.com/claude-code)

