### PR TITLE
[critical] fix: do not apply regexp replacements to pdb attribute values

### DIFF
--- a/app/Model/Behavior/RegexpBehavior.php
+++ b/app/Model/Behavior/RegexpBehavior.php
@@ -9,7 +9,7 @@ class RegexpBehavior extends ModelBehavior
 {
     private $__allRegexp = null;
 
-    const EXCLUDED_TYPES = ['sigma', 'size-in-bytes', 'counter', 'float'];
+    const EXCLUDED_TYPES = ['sigma', 'size-in-bytes', 'counter', 'float', 'pdb'];
 
     /**
      * replace the current value according to the regexp rules, or block blocklisted regular expressions


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Default regexps rewrite `pdb` debug-symbol paths to `%USERPROFILE%`, destroying the original value.

- **Problem** — `RegexpBehavior::runRegexp()` applies every type-ALL regexp to incoming attribute values, and the default dataset shipped in `INSTALL/MYSQL.sql` rewrites Windows user paths to `%USERPROFILE%`. `pdb` values are debug-symbol paths lifted verbatim from a binary, so the build machine's user directory — often the most identifying part of the artefact — is silently stripped before storage, with the original never recorded, breaking correlations and rules that depend on the exact string.
- **Fix** — Adds `pdb` to the existing `EXCLUDED_TYPES` constant alongside `sigma`, `size-in-bytes`, `counter` and `float`.
- **Effect** — `pdb` values are stored exactly as submitted on every instance, including ones with their own path-normalising regexps.
<!-- /bluf -->

## Root cause

`app/Model/Behavior/RegexpBehavior.php:12`

```php
const EXCLUDED_TYPES = ['sigma', 'size-in-bytes', 'counter', 'float'];
```

`runRegexp()` applies every regexp whose `type` is `ALL` (or matches the attribute type) to the incoming value. A fresh install ships default regexps of type `ALL` that rewrite Windows user paths — `INSTALL/MYSQL.sql:1845-1847` (and the same rows in `INSTALL/POSTGRESQL-data-initial.sql:291-293`):

```sql
(16, '/.:.Users\\\\(.*?)\\\\/i', '%USERPROFILE%\\\\', 'ALL'),
(17, '/.:.DOCUME~1.\\\\(.*?)\\\\/i', '%USERPROFILE%\\\\', 'ALL'),
(18, '/.:.Documents and Settings\\\\(.*?)\\\\/i', '%USERPROFILE%\\\\', 'ALL'),
```

`pdb` attributes are debug-symbol paths lifted verbatim out of a binary. They legitimately contain the build machine's user directory, and that directory name is often the most identifying part of the artefact. Under the default dataset:

```
c:\Users\USA\Documents\Visual Studio 2008\Projects\New folder (2)\kasper\Release\kasper.pdb
```

is silently stored as

```
%USERPROFILE%\Documents\Visual Studio 2008\Projects\New folder (2)\kasper\Release\kasper.pdb
```

destroying the forensic value and breaking any correlation or rule that depends on the exact string. This is #1420 and its duplicate #2823.

## The change

One line — add `pdb` to the existing exclusion list:

```php
const EXCLUDED_TYPES = ['sigma', 'size-in-bytes', 'counter', 'float', 'pdb'];
```

### Why a code-level exclusion rather than retuning the default regexp dataset

In #2823 @iglocska noted the default regexps are optional and the dataset could simply be revised. That is true but it does not solve the reported bug: the guarantee that a `pdb` value survives intact has to hold on every instance, including instances that have added their own path-normalising regexps of type `ALL` — which is exactly what an analyst deployment tends to do. Excluding the type is also the precedent already set in this file: `sigma`, `size-in-bytes`, `counter` and `float` are excluded because rewriting them corrupts a structurally exact value, and `pdb` is the same class of value. The shipped SQL datasets are left untouched, so path normalisation continues to work for every other type.

### Other types considered

`filename`, `filename|md5` and friends were considered and deliberately left alone — path generification is frequently *wanted* there, and there is no reported breakage. Hash and numeric types are already implicitly safe because the default regexps do not match them. Only `pdb` has a demonstrated, reported failure, so only `pdb` is changed.

### Known trade-off

`EXCLUDED_TYPES` short-circuits before the loop, so an excluded type also bypasses blocklist regexps (the `return false` branch, empty `replacement`). This is pre-existing behaviour shared by the four existing exclusions rather than something introduced here, and it is stated explicitly so it is not mistaken for an oversight. If blocklisting should apply to excluded types, that is a separate change to the behaviour's structure.

## Verification

Done:
- Confirmed the constant and the `runRegexp()` flow against `2.5` (`app/Model/Behavior/RegexpBehavior.php`, read in full).
- Confirmed the shipping default regexps of type `ALL` in both `INSTALL/MYSQL.sql` and `INSTALL/POSTGRESQL-data-initial.sql`.
- `php -l app/Model/Behavior/RegexpBehavior.php` — no syntax errors (PHP 8.5).

Not done (no environment available to me):
- No live MISP instance was used; the end-to-end path (attribute add → `runRegexp` → stored value) was not exercised at runtime.
- The test suite was not run.

Fixes #1420
Fixes #2823

🤖 Generated with [Claude Code](https://claude.com/claude-code)

