### PR TITLE
[high] fix: seed NIDS SIDs at or above 5,000,000 to avoid public ruleset collisions

### DIFF
--- a/app/Controller/Component/Auth/ApacheAuthenticate.php
+++ b/app/Controller/Component/Auth/ApacheAuthenticate.php
@@ -163,7 +163,7 @@ class ApacheAuthenticate extends BaseAuthenticate
                 'password' => '',
                 'confirm_password' => '',
                 'authkey' => $userModel->generateAuthKey(),
-                'nids_sid' => 4000000,
+                'nids_sid' => 5000000,
                 'newsread' => 0,
                 'role_id' => $roleId,
                 'change_pw' => 0

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -280,7 +280,7 @@ class User extends AppModel
             $user['authkey'] = $this->generateAuthKey();
         }
         if (empty($user['nids_sid'])) {
-            $user['nids_sid'] = mt_rand(1000000, 9999999);
+            $user['nids_sid'] = mt_rand(5000000, 9999999);
         }
         if (!empty(Configure::read('Security.limit_site_admins_to_host_org'))){
             if (!empty($user['role_id']) and !empty($user['org_id'] and $user['org_id'] != Configure::read('MISP.host_org_id'))){
@@ -1187,7 +1187,7 @@ class User extends AppModel
             'password' => 'admin',
             'confirm_password' => 'admin',
             'authkey' => $authKeyOld,
-            'nids_sid' => 4000000,
+            'nids_sid' => 5000000,
             'newsread' => 0,
             'role_id' => 1,
             'change_pw' => 1

--- a/app/Plugin/LdapAuth/Controller/Component/Auth/LdapAuthenticate.php
+++ b/app/Plugin/LdapAuth/Controller/Component/Auth/LdapAuthenticate.php
@@ -854,7 +854,7 @@ class LdapAuthenticate extends BaseAuthenticate
                 'password' => '',
                 'confirm_password' => '',
                 'authkey' => $userModel->generateAuthKey(),
-                'nids_sid' => 4000000,
+                'nids_sid' => 5000000,
                 'newsread' => 0,
                 'role_id' => $roleId,
                 'change_pw' => 0,


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** New users get a NIDS SID base that collides with public Snort/Suricata rulesets about a fifth of the time.

- **Problem** — `User::__generateNidsSid()` seeds each user's NIDS SID base with `mt_rand(1000000, 9999999)`, and that base is what `NidsExport` and `NidsSuricataExport` use to allocate exported rule ids. Roughly a fifth of the range falls inside the space reserved by Talos, GPL and Emerging Threats rulesets, so a colliding SID means a sensor silently drops or overwrites one of the two rules.
- **Fix** — Raises the floor to 5000000 and moves the three hardcoded 4000000 seeds (bootstrap admin, Apache auth and LDAP auto-provisioning) to the same floor.
- **Effect** — Exported Snort/Suricata rules stop clashing with widely deployed public rulesets.
<!-- /bluf -->

## Root cause

`app/Model/User.php:283`

```php
if (empty($user['nids_sid'])) {
    $user['nids_sid'] = mt_rand(1000000, 9999999);
}
```

The generated value is the *base* from which NIDS exports allocate rule ids — `app/Lib/Export/NidsSuricataExport.php:45` does `$sid = $startSid + ($item['Attribute']['id'] * 10);`, and the same base is read in `app/Lib/Export/NidsExport.php:24,57,91`.

Snort/Suricata SIDs are allocated by convention: Cisco Talos (ex Sourcefire VRT), the GPL ruleset and Emerging Threats occupy ranges up to 2,999,999 (see the ET SID allocation table referenced in #538). A base drawn from `[1000000, 9999999]` lands inside that reserved space about 22% of the time, so roughly one in five new users generates rules that collide with widely deployed public rulesets — a duplicate SID means one of the two rules is dropped or overwritten by the sensor, silently.

## The change

```php
$user['nids_sid'] = mt_rand(5000000, 9999999);
```

5,000,000 is the floor asked for in #538. The upper bound is left at 9,999,999 to keep the diff minimal.

For consistency, the three hardcoded seeds that also default a user's SID were moved from `4000000` (still inside the range this PR is trying to clear on the low side of the 5M convention line) to `5000000`:

- `app/Model/User.php:1190` — the bootstrap `admin@admin.test` account
- `app/Controller/Component/Auth/ApacheAuthenticate.php:166` — Apache-auth auto-provisioned users
- `app/Plugin/LdapAuth/Controller/Component/Auth/LdapAuthenticate.php:857` — LDAP auto-provisioned users

Leaving those at 4,000,000 while claiming "generated SIDs cannot collide with public allocations" would have been inconsistent.

### Deliberately out of scope

- The two auto-provisioning paths give **every** such user the same fixed base, so Apache/LDAP-provisioned users on one instance collide with *each other*. That is pre-existing behaviour and a different problem from #538 (collision with public rulesets); it is noted here rather than changed, since routing them through `beforeValidate()`'s random assignment is a behavioural change that deserves its own discussion.
- Existing users are not migrated. This only affects newly created accounts; admins can still set the field by hand (`app/View/Users/admin_edit.ctp:84`).
- The column default itself (`INSTALL/MYSQL.sql:1705`, `nids_sid int(15) NOT NULL DEFAULT 0`) is left alone — `0` is the "unset" sentinel that `empty()` at `User.php:282` keys on, so changing it would break the assignment.

## Verification

Done:
- Confirmed `mt_rand(1000000, 9999999)` at `app/Model/User.php:283` on `2.5`.
- Grepped the full tree for every `nids_sid` write and for `4000000`: the four sites changed here are the only defaults. **No server setting seeds `nids_sid`** — `app/Model/Server.php` and `app/Model/Server/` contain zero references; the `nids_sid` occurrences in `INSTALL/ansible/.../config.php` and `app/Config/config.default.php` are LDAP/`userModelKey` mappings, unrelated.
- `app/Test/Unit/Export/ExportContractTest.php:139` supplies `nids_sid => 4000000` as an explicit fixture input, not an assertion about the default, so it is unaffected. No other fixture pins these values.
- `php -l` on all three changed files — no syntax errors (PHP 8.5).

Not done (no environment available to me):
- The test suite was not run and no live instance was used; user creation and a NIDS export were not exercised at runtime.

Fixes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)

