### PR TITLE
[cosmetic] fix: [ui] align to_ids / batch_import checkbox order with the proposal form (#467)

### DIFF
--- a/app/View/Attributes/add.ctp
+++ b/app/View/Attributes/add.ctp
@@ -53,16 +53,16 @@
                     'label' => __("Contextual Comment")
                 ),
                 array(
-                    'field' => 'batch_import',
-                    'type' => 'checkbox',
-                    'requirements' => $action === 'add',
-                    'label' => __('Batch import') . ' <span class="fas fa-info-circle" data-toggle="popover" data-trigger="hover" data-content="' . __('Insert multiple attributes to value field separated by new line') .'"></span>',
-                ),
-                array(
                     'field' => 'to_ids',
                     'type' => 'checkbox',
                     'label' => __("For Intrusion Detection System"),
                     //'stayInLine' => 1
+                ),
+                array(
+                    'field' => 'batch_import',
+                    'type' => 'checkbox',
+                    'requirements' => $action === 'add',
+                    'label' => __('Batch import') . ' <span class="fas fa-info-circle" data-toggle="popover" data-trigger="hover" data-content="' . __('Insert multiple attributes to value field separated by new line') .'"></span>',
                 ),
                 array(
                     'field' => 'disable_correlation',


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** The attribute add form and the proposal add form present the same two checkboxes in opposite orders.

- **Problem** — `app/View/Attributes/add.ctp` lists `batch_import` before `to_ids`, while `app/View/ShadowAttributes/add.ctp` lists `to_ids` first, so the two forms disagree.
- **Fix** — Moves the `batch_import` field definition in `Attributes/add.ctp` so both forms agree on `to_ids` first, carrying the requirements guard and popover label over verbatim.
- **Effect** — No field names, ids, labels or generated markup change — only the display order, so users moving between the two forms no longer face a swapped layout.
<!-- /bluf -->

## Root cause

`app/View/Attributes/add.ctp` and `app/View/ShadowAttributes/add.ctp` present the same two checkboxes in opposite orders:

- `app/View/Attributes/add.ctp:56` — `batch_import`, then `to_ids` at line 62
- `app/View/ShadowAttributes/add.ctp:43` — `to_ids`, then `batch_import` at line 49

This is exactly what #467 reported: the two forms disagree, which invites muscle-memory mis-clicks when moving between adding an attribute and adding a proposal.

## Why the original closure missed it

#467 was closed as completed on 2015-04-20 by PR #468. That PR only touched `app/View/ShadowAttributes/add.ctp`, flipping it to `to_ids` first, `batch_import` second, to match the attribute form as it stood then. The proposal form still carries that order today; the attribute form has since drifted back to `batch_import` first — most likely during the migration of the view to the `genericElements/Form/genericForm` element, where the field list was rebuilt. So the fix was real in 2015 but was applied to only one of the two files' worth of the invariant, and nothing pinned the order afterwards.

## Which order is correct

`to_ids` first, `batch_import` second — the order PR #468 chose when the issue was resolved, and the one the proposal form still uses. It also reads better: `to_ids` is a property of the attribute being created, whereas `batch_import` is a modifier of how the form is submitted, so grouping it last with the other form-level options is the more natural placement.

## The change

One block move in `app/View/Attributes/add.ctp`: the `batch_import` field definition now comes after `to_ids`. The `'requirements' => $action === 'add'` guard and the popover label are carried over verbatim.

No field names, ids, labels or generated markup change — only the order in which `genericForm` emits the two inputs.

## Verified / not verified

Verified:
- `php -l app/View/Attributes/add.ctp` passes.
- The diff is a pure reordering of two array entries — confirmed by inspecting the diff, which shows the identical 6 lines removed and re-added.
- Checked for JS that depends on the DOM order or position of these inputs before moving anything: `grep` over `app/webroot/js` and `app/View` finds only `app/webroot/js/mispOvermind.js`, which looks up `#AttributeBatchImport` **by id** and belongs to the separate `Themed/Overmind` layout (`app/View/Themed/Overmind/Attributes/add.ctp`). It is unaffected by this change, and that theme has its own card-based layout, so it is deliberately left alone here.

Not verified:
- No rendered-page check. There is no test suite covering these views and I did not have a live MISP instance available to click through the two forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

