### PR TITLE
[high] fix: [logs] record the accepting org on proposal acceptance instead of SYSTEM (#824)

### DIFF
--- a/app/Model/ShadowAttribute.php
+++ b/app/Model/ShadowAttribute.php
@@ -996,7 +996,7 @@ class ShadowAttribute extends AppModel
             $this->Event->unpublishEvent($activeAttribute['Attribute']['event_id'], true);
             $this->Log->create();
             $this->Log->saveOrFailSilently(array(
-                'org_id' => $user['org_id'],
+                'org' => $user['Organisation']['name'],
                 'model' => 'ShadowAttribute',
                 'model_id' => $id,
                 'email' => $user['email'],
@@ -1031,7 +1031,7 @@ class ShadowAttribute extends AppModel
             }
             $this->Log->create();
             $this->Log->saveOrFailSilently(array(
-                'org_id' => $user['org_id'],
+                'org' => $user['Organisation']['name'],
                 'model' => 'ShadowAttribute',
                 'model_id' => $id,
                 'email' => $user['email'],


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Proposal acceptances log an unknown `org_id` key, so every one is attributed to `SYSTEM` in the audit trail.

- **Problem** — `ShadowAttribute::acceptProposal()` writes its audit entry with an `org_id` key, but the `logs` table has no `org_id` column — only a name string `org` — so CakePHP drops the key and `Log::beforeSave()` substitutes the placeholder `SYSTEM`. Every proposal acceptance therefore shows as `SYSTEM` in the event history and logs index, hiding which organisation accepted it.
- **Fix** — Both branches now pass the organisation name in the `org` field, matching the convention used elsewhere in the `Log` model.
- **Effect** — Proposal acceptances are correctly attributed in the audit trail.
<!-- /bluf -->

## Root cause

`ShadowAttribute::acceptProposal()` logs the acceptance with an `org_id` key:

- `app/Model/ShadowAttribute.php:999` — the "proposed edit to an existing attribute" branch
- `app/Model/ShadowAttribute.php:1034` — the "brand new proposed attribute" branch

Both do `'org_id' => $user['org_id']`.

The `logs` table has no `org_id` column. It has `org`, a name string:

```
INSTALL/MYSQL.sql:758  CREATE TABLE `logs` (
  ... `email` varchar(255) ..., `org` varchar(255) NOT NULL DEFAULT '', ...
```

`db_schema.json` agrees — `logs` is `id, title, created, model, model_id, action, user_id, change, email, org, description, ip`.

CakePHP builds its insert from the table schema, so the unknown `org_id` key is silently dropped. `Log::beforeSave()` then finds `org` empty and substitutes the placeholder:

```php
app/Model/Log.php:210    if (empty($this->data['Log']['org'])) {
app/Model/Log.php:211        $this->data['Log']['org'] = 'SYSTEM';
```

Result: every proposal acceptance is attributed to `SYSTEM` in the event history and in the logs index, so you cannot see which organisation accepted a proposal. That is what #824 describes ("the org that accepted the proposal is empty"). The `email` field on the same entry is correct, which is why the entry looks half-populated rather than obviously broken.

This issue has been open since 2016-01-07; it was never closed, and the two call sites still carry the original mistake.

## The change

Pass the organisation **name** in the field the Log model actually persists, at both call sites:

```php
-                'org_id' => $user['org_id'],
+                'org' => $user['Organisation']['name'],
```

This is the established convention across the codebase for user-attributed log entries — `app/Model/Log.php:329` and `:402`, `app/Model/Organisation.php:343`, `app/Model/Server.php:1272`, `app/Model/Event.php:3312` all use `'org' => $user['Organisation']['name']`.

**No schema change and no migration are required**, which is deliberate: the column the log index and the event history already read from is `org`, so filling it correctly is sufficient.

## Is `$user['Organisation']['name']` always available here?

Both callers of `acceptProposal()` supply a user array that contains `Organisation`:

- `app/Controller/ShadowAttributesController.php:96` passes `$this->Auth->user()`. The auth user is built by `User::getAuthUserByConditions()` (`app/Model/User.php:755`), which contains `'Organisation'`.
- `app/Model/WorkflowModules/action/Module_proposal_action.php:92` passes `$roamingData->getUser()`, which returns the array from `Workflow::getUserForWorkflow()` (`app/Model/Workflow.php:792-815`). Both of its branches include `Organisation` — the host-org branch sets `'Organisation' => $hostOrg['Organisation']`, and the site-admin branch contains `'Organisation' => ['fields' => ['name']]`.

## Verified / not verified

Verified:
- `php -l app/Model/ShadowAttribute.php` passes.
- The absence of an `org_id` column in `logs`, in both `INSTALL/MYSQL.sql` and `db_schema.json`.
- The `SYSTEM` substitution path in `Log::beforeSave()`.
- Both `acceptProposal()` call paths supply `Organisation` in the user array, as traced above.
- Both acceptance branches are fixed; the surrounding `discardProposal()` logging was not touched, as it is outside the scope of this report.

Not verified:
- No end-to-end run. There is no test suite covering proposal acceptance logging, and I did not have a live MISP instance available to accept a proposal and read back the resulting `logs` row. The fix rests on schema inspection and on the identical pattern already used by the other log call sites listed above.
- Existing historical `logs` rows are not rewritten; this only affects acceptances logged from here on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

