### PR TITLE
[high] fix: restore temporarily removed attribute validation rules (Refs #1221)

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -5313,10 +5313,6 @@ class Event extends AppModel
         if ($fromXml) {
             // Workaround for different structure in XML/array than what CakePHP expects
             $data = $this->cleanupEventArrayFromXML($data);
-            // the event_id field is not set (normal) so make sure no validation errors are thrown
-            // LATER do this with   $this->validator()->remove('event_id');
-            unset($this->Attribute->validate['event_id']); // otherwise gives bugs because event_id is not set
-            unset($this->Attribute->validate['value']['uniqueValue']); // unset this - we are saving a new event, there are no values to compare against and event_id is not set in the attributes
         }
         unset($data['Event']['id']);
         if (
@@ -5407,48 +5403,65 @@ class Event extends AppModel
 
             $this->dedupAttributesForCorrelation($data);
 
-            if (!empty($data['Event']['Attribute'])) {
-                $attributeHashes = [];
-                foreach ($data['Event']['Attribute'] as $attribute) {
-                    if (!empty($attribute['deleted'])) {
-                        $this->Attribute->captureAttribute($attribute, $this->id, $user, 0, null, $parentEvent);
-                    } else {
-                        $attributeHash = sha1($attribute['value'] . '|' . $attribute['type'] . '|' . $attribute['category'], true);
-                        if (!isset($attributeHashes[$attributeHash])) { // do not save duplicate values
-                            $attributeHashes[$attributeHash] = true;
+            // The event_id field is not set in the pushed attributes (normal), so make sure no
+            // validation errors are thrown. This is scoped to the capturing of this event only:
+            // the Attribute model is shared for the whole request / worker run, so leaving these
+            // rules unset would silently disable the duplicate attribute check for every event
+            // handled afterwards by the same process (for example the rest of a pull).
+            // LATER do this with   $this->Attribute->validator()->remove('event_id');
+            $removedAttributeRules = [];
+            if ($fromXml) {
+                $removedAttributeRules = $this->Attribute->removeValidationRules([
+                    ['event_id'],
+                    ['value', 'uniqueValue'], // we are saving a new event, there are no values to compare against
+                ]);
+            }
+            try {
+                if (!empty($data['Event']['Attribute'])) {
+                    $attributeHashes = [];
+                    foreach ($data['Event']['Attribute'] as $attribute) {
+                        if (!empty($attribute['deleted'])) {
                             $this->Attribute->captureAttribute($attribute, $this->id, $user, 0, null, $parentEvent);
+                        } else {
+                            $attributeHash = sha1($attribute['value'] . '|' . $attribute['type'] . '|' . $attribute['category'], true);
+                            if (!isset($attributeHashes[$attributeHash])) { // do not save duplicate values
+                                $attributeHashes[$attributeHash] = true;
+                                $this->Attribute->captureAttribute($attribute, $this->id, $user, 0, null, $parentEvent);
+                            }
                         }
                     }
+                    unset($attributeHashes);
                 }
-                unset($attributeHashes);
-            }
 
-            if (!empty($data['Event']['Object'])) {
-                $referencesToCapture = [];
-                foreach ($data['Event']['Object'] as $object) {
-                    $result = $this->Object->captureObject($object, $this->id, $user, false, $breakOnDuplicate, $parentEvent);
-                    if (isset($object['ObjectReference'])) {
-                        foreach ($object['ObjectReference'] as $objectRef) {
-                            $objectRef['source_uuid'] = $object['uuid'];
-                            $referencesToCapture[] = $objectRef;
+                if (!empty($data['Event']['Object'])) {
+                    $referencesToCapture = [];
+                    foreach ($data['Event']['Object'] as $object) {
+                        $result = $this->Object->captureObject($object, $this->id, $user, false, $breakOnDuplicate, $parentEvent);
+                        if (isset($object['ObjectReference'])) {
+                            foreach ($object['ObjectReference'] as $objectRef) {
+                                $objectRef['source_uuid'] = $object['uuid'];
+                                $referencesToCapture[] = $objectRef;
+                            }
+                        }
+                    }
+                    foreach ($referencesToCapture as $referenceToCapture) {
+                        $result = $this->Object->ObjectReference->captureReference(
+                            $referenceToCapture,
+                            $this->id
+                        );
+                        if ($result !== true) {
+                            $title = "Could not save object reference when capturing event with ID {$this->id}";
+                            $this->loadLog()->validationError($user, 'add', 'ObjectReference', $title, $result, $referenceToCapture);
                         }
                     }
                 }
-                foreach ($referencesToCapture as $referenceToCapture) {
-                    $result = $this->Object->ObjectReference->captureReference(
-                        $referenceToCapture,
-                        $this->id
-                    );
-                    if ($result !== true) {
-                        $title = "Could not save object reference when capturing event with ID {$this->id}";
-                        $this->loadLog()->validationError($user, 'add', 'ObjectReference', $title, $result, $referenceToCapture);
+                if (!empty($data['Event']['EventReport'])) {
+                    foreach ($data['Event']['EventReport'] as $report) {
+                        $result = $this->EventReport->captureReport($user, $report, $this->id, $server);
                     }
                 }
-            }
-            if (!empty($data['Event']['EventReport'])) {
-                foreach ($data['Event']['EventReport'] as $report) {
-                    $result = $this->EventReport->captureReport($user, $report, $this->id, $server);
-                }
+            } finally {
+                $this->Attribute->restoreValidationRules($removedAttributeRules);
             }
 
             // capture new keys, update existing, remove those no longer in the pushed data

--- a/app/Model/MispAttribute.php
+++ b/app/Model/MispAttribute.php
@@ -2827,15 +2827,68 @@ class MispAttribute extends AppModel
     public function validateAttribute(array $attribute, $context = true)
     {
         $this->set($attribute);
+        // The model instance is shared for the whole request, so any validation rule that is
+        // removed here has to be put back afterwards - otherwise every subsequent attribute
+        // saved in the same request / worker run skips these checks as well.
+        $removedRules = [];
         if (!$context) {
-            unset($this->validate['event_id']);
-            unset($this->validate['value']['uniqueValue']);
-            unset($this->validate['uuid']['unique']);
+            $removedRules = $this->removeValidationRules([
+                ['event_id'],
+                ['value', 'uniqueValue'],
+                ['uuid', 'unique'],
+            ]);
         }
-        if ($this->validates()) {
-            return true;
-        } else {
-            return $this->validationErrors;
+        try {
+            if ($this->validates()) {
+                return true;
+            } else {
+                return $this->validationErrors;
+            }
+        } finally {
+            $this->restoreValidationRules($removedRules);
+        }
+    }
+
+    /**
+     * Temporarily remove validation rules from the shared model instance.
+     *
+     * @param array $paths List of rule paths, either ['field'] or ['field', 'rule']
+     * @return array Removed rules, to be handed to MispAttribute::restoreValidationRules()
+     */
+    public function removeValidationRules(array $paths)
+    {
+        $removed = [];
+        foreach ($paths as $path) {
+            if (count($path) === 1) {
+                if (isset($this->validate[$path[0]])) {
+                    $removed[] = [$path, $this->validate[$path[0]]];
+                    unset($this->validate[$path[0]]);
+                }
+            } else {
+                if (isset($this->validate[$path[0]][$path[1]])) {
+                    $removed[] = [$path, $this->validate[$path[0]][$path[1]]];
+                    unset($this->validate[$path[0]][$path[1]]);
+                }
+            }
+        }
+        return $removed;
+    }
+
+    /**
+     * Restore validation rules removed by MispAttribute::removeValidationRules().
+     *
+     * @param array $removedRules
+     * @return void
+     */
+    public function restoreValidationRules(array $removedRules)
+    {
+        foreach ($removedRules as $removedRule) {
+            list($path, $rule) = $removedRule;
+            if (count($path) === 1) {
+                $this->validate[$path[0]] = $rule;
+            } else {
+                $this->validate[$path[0]][$path[1]] = $rule;
+            }
         }
     }
 
@@ -3157,8 +3210,9 @@ class MispAttribute extends AppModel
             }
         }
         // if breakOnDuplicate=false, try to find the existing attribute by value and set the id and uuid
+        $removedRules = [];
         if ($breakOnDuplicate === false) {
-            unset($this->validate['value']['uniqueValue']);
+            $removedRules = $this->removeValidationRules([['value', 'uniqueValue']]);
             $existingAttribute = $this->findAttributeByValue($attribute);
             if (!empty($existingAttribute)) {
                 $attribute['id'] = $existingAttribute['Attribute']['id'];
@@ -3166,7 +3220,12 @@ class MispAttribute extends AppModel
                 $this->id = $attribute['id'];
             }
         }
-        $savedAttribute = $this->save(['Attribute' => $attribute], $params);
+        try {
+            $savedAttribute = $this->save(['Attribute' => $attribute], $params);
+        } finally {
+            // the model instance is shared, only skip the uniqueness check for this attribute
+            $this->restoreValidationRules($removedRules);
+        }
         if (!$savedAttribute) {
             $this->logDropped($user, $attribute);
         } else {


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A leaked validation-rule removal disables the duplicate-attribute check for the rest of a sync run.

- **Problem** — Three call sites unset the `value.uniqueValue` attribute validation rule and never put it back, and because CakePHP 2 models are request-wide singletons the removal leaks into every later attribute save in the same process. `Event::_add()` with `$fromXml=true` runs in a loop from `Server::__pullEvent()` and `Feed`, so after the first new event is captured the check is off for the rest of the pull.
- **Fix** — Adds `MispAttribute::removeValidationRules()` and `restoreValidationRules()`, and restores the rules in a `finally` block at all three sites.
- **Effect** — Sync and feed runs stop silently accepting duplicate type/category/value attributes.
<!-- /bluf -->

## What

Attribute validation rules that are removed *temporarily* are never put back. Since CakePHP 2 models are registry singletons, `$this->validate` is shared for the whole request / worker run, so the removal silently leaks into every subsequent attribute save handled by the same process.

The rule that leaks is `value.uniqueValue` (`valueIsUnique()`), i.e. the only thing that stops the same `type` / `category` / `value` triplet being stored twice in one event. That is the check behind #1221.

Three sites, all `unset()` without restore:

* `Event::_add()` (`app/Model/Event.php:5318-5319`, `$fromXml` branch)
* `MispAttribute::captureAttribute()` (`app/Model/MispAttribute.php:3161`, `breakOnDuplicate=false`)
* `MispAttribute::validateAttribute()` (`app/Model/MispAttribute.php:2831-2833`, `$context=false`)

The `Event::_add()` one is the one that bites in practice. `_add(..., $fromXml=true)` is called in a loop from `Server::__pullEvent()` (`app/Model/Server.php:489`/`491`) and `Feed` (`app/Model/Feed.php:1024`/`1194`). As soon as one *new* event is captured during a pull, `value.uniqueValue` is gone for the rest of that job — so every `_edit()` that follows in the same run saves attributes with the uniqueness rule disabled. `Event::_edit()` has no intra-batch dedup of its own (unlike `_add()`, which dedups by `value|type|category` hash at `Event.php:5410`), and `editAttributeBulk()` culls bad records purely on the validation pass (`MispAttribute.php:3327-3345`) — with the rule gone, nothing culls duplicates.

## Change

Adds `MispAttribute::removeValidationRules()` / `restoreValidationRules()` and uses them at the three sites, restoring in a `finally` so early returns and exceptions cannot leak the state. Behaviour inside each scope is unchanged; in `Event::_add()` the removal is also moved down next to the capture loop it exists for, so the two early returns above it (`$fromPull` / existing-uuid) no longer leak either.

## Behavioural note (please read)

For a pull run, this restores `value.uniqueValue` for the `_edit()` calls that follow an `_add()`. That is the behaviour a pull already has today when the run happens to start with an edit, so this makes the two orderings consistent rather than introducing a new rule — but it does mean incoming duplicates that previously slipped through a mixed add+edit pull will now be dropped and logged as validation errors, as they already are elsewhere. Flagging it explicitly in case you want it scoped differently.

## Not addressed (deliberately)

* **No DB-level constraint.** `attributes` has unique keys on `id` and `uuid` only (`INSTALL/MYSQL.sql:116-128`, `db_schema.json`). `valueIsUnique()` is a check-then-act `find()`-then-`save()` with no transaction, row lock or upsert, so two concurrent API calls adding the same attribute can still both pass the check and both insert — exactly what @wilson-santos-pf described in #1221. Only a unique index on `(event_id, type, category, value1, value2, deleted, object_id)` (or an equivalent hash column) really closes that, and that is a schema migration + a data-cleanup decision for maintainers, so it is not in this PR.
* **`fast_update`.** `valueIsUnique()` returns `true` unconditionally when `fast_update` is set (`MispAttribute.php:977`); the comment there says this is a deliberate tradeoff, so it is left alone.
* `Event::_edit()` (`Event.php:5628-5629`) also unsets `Attribute.validate['event_id']` without restoring, and the line next to it unsets `validate['value']['unique']` — a rule name that does not exist (the rule is `uniqueValue`), so it is a no-op. Left as-is to keep this PR to one concern; happy to follow up.

## Testing

`php -l` clean on both files. I have no instance to run the suite against, and the concurrency analysis above is reasoning from the code, not an observed race.

Refs #1221

