### PR TITLE
[high] fix: normalise whitespace-separated x509 fingerprints (certutil output)

### DIFF
--- a/app/Lib/Tools/AttributeValidationTool.php
+++ b/app/Lib/Tools/AttributeValidationTool.php
@@ -183,7 +183,9 @@ class AttributeValidationTool
             case 'x509-fingerprint-md5':
             case 'x509-fingerprint-sha256':
             case 'x509-fingerprint-sha1':
-                $value = str_replace(':', '', $value);
+                // Fingerprints are commonly copied from tools that group the bytes: openssl
+                // separates them with colons, Windows certutil with spaces or newlines.
+                $value = preg_replace('/[\s:]+/', '', $value);
                 return strtolower($value);
             case 'ip-dst|port':
             case 'ip-src|port':

--- a/app/Test/AttributeValidationToolTest.php
+++ b/app/Test/AttributeValidationToolTest.php
@@ -145,6 +145,25 @@ class AttributeValidationToolTest extends TestCase
         $this->assertEquals('127.0.0.1', AttributeValidationTool::modifyBeforeValidation('ip-src', '127.0.0.1'));
     }
 
+    public function testX509FingerprintSeparators()
+    {
+        $expected = 'aa6fc83f37787abea6be2c5126163fd3';
+        // openssl x509 -fingerprint
+        $this->assertEquals($expected, AttributeValidationTool::modifyBeforeValidation('x509-fingerprint-md5', 'AA:6F:C8:3F:37:78:7A:BE:A6:BE:2C:51:26:16:3F:D3'));
+        // Windows certutil -hashfile
+        $this->assertEquals($expected, AttributeValidationTool::modifyBeforeValidation('x509-fingerprint-md5', 'aa 6f c8 3f 37 78 7a be a6 be 2c 51 26 16 3f d3'));
+        $this->assertEquals($expected, AttributeValidationTool::modifyBeforeValidation('x509-fingerprint-md5', "AA 6F C8 3F 37 78 7A BE\nA6 BE 2C 51 26 16 3F D3"));
+        // Already normalised values are left alone
+        $this->assertEquals($expected, AttributeValidationTool::modifyBeforeValidation('x509-fingerprint-md5', $expected));
+
+        $sha1 = 'da39a3ee5e6b4b0d3255bfef95601890afd80709';
+        $this->assertEquals($sha1, AttributeValidationTool::modifyBeforeValidation('x509-fingerprint-sha1', 'DA:39:A3:EE:5E:6B:4B:0D:32:55:BF:EF:95:60:18:90:AF:D8:07:09'));
+        $this->assertEquals($sha1, AttributeValidationTool::modifyBeforeValidation('x509-fingerprint-sha1', 'da 39 a3 ee 5e 6b 4b 0d 32 55 bf ef 95 60 18 90 af d8 07 09'));
+
+        $sha256 = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+        $this->assertEquals($sha256, AttributeValidationTool::modifyBeforeValidation('x509-fingerprint-sha256', 'e3 b0 c4 42 98 fc 1c 14 9a fb f4 c8 99 6f b9 24 27 ae 41 e4 64 9b 93 4c a4 95 99 1b 78 52 b8 55'));
+    }
+
     public function testFilenameHashLowercase()
     {
         $this->assertEquals('CMD.EXE|0cc175b9c0f1b6a831c399e269772661', AttributeValidationTool::modifyBeforeValidation('filename|md5', 'CMD.EXE|0CC175B9C0F1B6A831C399E269772661'));


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** x509 fingerprints pasted from Windows `certutil` are rejected; this PR strips whitespace too.

- **Problem** — `AttributeValidationTool::modifyBeforeValidation()` normalises `x509-fingerprint-md5`, `-sha1` and `-sha256` by stripping colons only, so the space-separated, line-wrapped form produced by Windows `certutil -hashfile` and the certificate MMC passes through unchanged and is then rejected by `validate()` with "Checksum has an invalid length or format".
- **Fix** — Whitespace is stripped as well as colons, and `testX509FingerprintSeparators()` adds coverage.
- **Effect** — Fingerprints pasted from Windows tools now validate, import and correlate.
<!-- /bluf -->

## Root cause

`AttributeValidationTool::modifyBeforeValidation()` normalises `x509-fingerprint-md5` / `-sha1` / `-sha256` by stripping colons only:

https://github.com/MISP/MISP/blob/2.5/app/Lib/Tools/AttributeValidationTool.php#L183-L187

```php
case 'x509-fingerprint-md5':
case 'x509-fingerprint-sha256':
case 'x509-fingerprint-sha1':
    $value = str_replace(':', '', $value);
    return strtolower($value);
```

That covers `openssl x509 -fingerprint` output (`AA:6F:C8:...`), but not the other common source: Windows `certutil -hashfile` / the Windows certificate MMC, which group the bytes with spaces and wrap across lines (`aa 6f c8 3f ...`). Those values fall through unchanged and are then rejected by `AttributeValidationTool::validate()` (`app/Lib/Tools/AttributeValidationTool.php:281-289`, hash-length check against `HASH_HEX_LENGTH`) with *"Checksum has an invalid length or format"*.

This is issue #1644. Per @iglocska's comment on that issue, the right shape is to convert the alternate input into the common format rather than to accept several stored representations — so correlations keep working — which is what the existing colon-stripping already does and what this change extends.

## What changed

`app/Lib/Tools/AttributeValidationTool.php` — one line, in the same three `case` labels:

```php
$value = preg_replace('/[\s:]+/', '', $value);
```

Colons and any whitespace (spaces, tabs, newlines) are stripped before lowercasing. Whitespace is never valid inside a hex fingerprint, so nothing that used to validate changes value, and nothing newly invalid is accepted — the length/hex check in `validate()` is unchanged and still gates the result.

`app/Test/AttributeValidationToolTest.php` — new `testX509FingerprintSeparators()` covering the colon form, the space form, a multi-line certutil-style value, an already-normalised value, and all three fingerprint types.

## Verified vs not verified

**Verified:** the new and existing unit tests in `app/Test/AttributeValidationToolTest.php` run green under PHPUnit 9.6 (`13 tests, 84 assertions`). The only failure in that file is the pre-existing `testDomainModify` IDN assertion, which fails identically on unpatched `2.5` in my environment because the `intl` extension is absent — unrelated to this change. `php -l` is clean on both files. I also checked, directly against `AttributeValidationTool`, that each normalised value then passes `validate()`.

**Not verified:** I have no live MISP instance, so this was not exercised through the attribute add/edit UI, the REST API, the freetext importer, or a full test-suite run. The change is confined to one pure static string-normalisation branch, so the blast radius is limited to those three attribute types.

Fixes #1644

🤖 Generated with [Claude Code](https://claude.com/claude-code)

