### PR TITLE
[medium] fix: [event index filter] show sharing group names instead of IDs in the rule table

### DIFF
--- a/app/View/Events/filter_event_index.ctp
+++ b/app/View/Events/filter_event_index.ctp
@@ -228,6 +228,13 @@ var formInfoValues = {};
 
 var typeArray = {
         'tag' : <?php echo $tagJSON; ?>,
+        'sharinggroup' : <?php
+            $sharingGroupJSON = array();
+            foreach ($sharingGroups as $sharingGroupId => $sharingGroupName) {
+                $sharingGroupJSON[] = array('id' => $sharingGroupId, 'value' => $sharingGroupName);
+            }
+            echo json_encode($sharingGroupJSON, JSON_HEX_TAG);
+        ?>,
         'published' : [<?php echo __('"No"');?>, "<?php echo __('Yes');?>", "<?php echo __('Any');?>"],
         'is_extension' : [<?php echo __('"No"');?>, "<?php echo __('Yes');?>", "<?php echo __('Any');?>"],
         'is_extended' : [<?php echo __('"No"');?>, "<?php echo __('Yes');?>", "<?php echo __('Any');?>"],
@@ -272,7 +279,7 @@ var simpleFilters = ["tag", "eventinfo", "eventid", "threatlevel", "distribution
 
 var differentFilters = ["published", "date", "hasproposal", "timestamp", "publishtimestamp", "is_extension", "is_extended"];
 
-var typedFields = ["tag", "threatlevel", "distribution", "analysis"];
+var typedFields = ["tag", "sharinggroup", "threatlevel", "distribution", "analysis"];
 
 if (showorg == 1) {
     allFields.push("org");


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** The event index filter table shows bare sharing group IDs; this PR resolves them to names.

- **Problem** — The Filter Event Index rule table is rendered by `indexEvaluateSimpleFiltering()` in `misp.js`, which prints a stored value verbatim unless the field appears in `typedFields` with a matching `typeArray` entry. `sharinggroup` was in neither, so the rule table displayed the bare sharing group ID that `indexAddRule()` stores.
- **Fix** — `app/View/Events/filter_event_index.ctp` gains a `sharinggroup` entry in `typeArray`, built from the `$sharingGroups` the view already receives and encoded with `JSON_HEX_TAG`, and lists `sharinggroup` in `typedFields`.
- **Effect** — Analysts now see sharing group names in the filter rules.
<!-- /bluf -->

### Root cause

`app/View/Events/filter_event_index.ctp` renders the "Filter Event Index" rule table through `indexEvaluateSimpleFiltering()` (`app/webroot/js/misp.js:2597-2634`). That function prints a rule's stored value verbatim **unless** the field is listed in `typedFields`, in which case the stored ID is resolved to a human label via `typeArray[field]`.

`sharinggroup` was in neither list:

- `app/View/Events/filter_event_index.ctp:229-241` — `typeArray` had entries for `tag`, `published`, `is_extension`, `is_extended`, `hasproposal`, `distribution`, `threatlevel`, `analysis`, but none for `sharinggroup`.
- `app/View/Events/filter_event_index.ctp:275` — `typedFields = ["tag", "threatlevel", "distribution", "analysis"]`.

The value pushed into the filter is the sharing group ID (`indexAddRule()`, `app/webroot/js/misp.js:2657-2660`, reading `$('#EventSearchsharinggroup').val()`, whose options come from the `id => name` list set at `app/Controller/EventsController.php:1284`). With no type mapping, the rule table therefore showed the bare ID — exactly the screenshot in #5495.

### What changed

One file, `app/View/Events/filter_event_index.ctp`:

1. Added a `'sharinggroup'` entry to `typeArray`, built as `[{id, value}, …]` from the `$sharingGroups` variable the view already receives — the same shape `tagJSON` uses. `JSON_HEX_TAG` is passed to `json_encode()` so a sharing group name cannot break out of the inline `<script>` block.
2. Added `"sharinggroup"` to `typedFields`.

No JavaScript, controller, or model changes: the lookup machinery already existed and only lacked data for this field.

### Scope notes

- `org` is the same latent bug class (an `id => name` list, absent from `typedFields`), but it is not what #5495 reports and is deliberately left untouched.
- If a saved filter URL carries a sharing group ID the current user can no longer see, the cell renders empty rather than showing the ID. That is the pre-existing behaviour of every other `typedFields` entry (including `tag`) and is not changed here.
- `app/View/Servers/filter_event_index.ctp` has no sharing group filter, so it is unaffected.

### Verification

- `php -l app/View/Events/filter_event_index.ctp` — no syntax errors (PHP 8.5).
- The generated `typeArray` fragment was exercised standalone against sharing group names containing `<`, `"` and `</script>`; output is well-formed JSON with tags hex-escaped.
- **Not runtime-verified.** I have no live MISP instance available and did not run the test suite; the browser behaviour of the rule table was reasoned from the JS above, not observed.

Fixes #5495

🤖 Generated with [Claude Code](https://claude.com/claude-code)

