### PR TITLE
[cosmetic] fix: wrap long values in the OpenIOC import result view

### DIFF
--- a/app/View/Events/show_i_o_c_results.ctp
+++ b/app/View/Events/show_i_o_c_results.ctp
@@ -17,7 +17,7 @@ foreach ($attributes as $attribute): ?>
         <td class="short"><?php echo h($attribute['uuid']); ?>&nbsp;</td>
         <td class="short"><?php echo h($attribute['category']); ?>&nbsp;</td>
         <td class="short"><?php echo h($attribute['type']); ?>&nbsp;</td>
-        <td class="short"><?php echo h($attribute['value']); ?>&nbsp;</td>
+        <td><?php echo h($attribute['value']); ?>&nbsp;</td>
     </tr><?php
 endforeach; ?>
 </table>
@@ -37,7 +37,7 @@ foreach ($fails as $fail): ?>
     <tr>
         <td class="short"><?php echo h($fail['uuid']); ?>&nbsp;</td>
         <td class="short"><?php echo h($fail['search']); ?>&nbsp;</td>
-        <td class="short"><?php echo h($fail['value']); ?>&nbsp;</td>
+        <td><?php echo h($fail['value']); ?>&nbsp;</td>
     </tr><?php
 endforeach; ?>
 </table><br /><br />


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Long OpenIOC import values run off the page; this PR lets the two value cells wrap.

- **Problem** — `app/View/Events/show_i_o_c_results.ctp` gives every cell `class="short"`, including the two that hold the imported value at lines 20 and 40, and `td.short` carries `white-space: nowrap`, so long OpenIOC values such as a document description render on one line and run off the visible area.
- **Fix** — `class="short"` is dropped from just those two value cells, leaving the UUID, category, type and search-term columns unchanged.
- **Effect** — The OpenIOC import result view rendered by `EventsController::addIOC()` now wraps long values.
<!-- /bluf -->

### Root cause

`app/View/Events/show_i_o_c_results.ctp` renders every cell of the import result tables with `class="short"`, including the ones holding the imported value:

* `app/View/Events/show_i_o_c_results.ctp:20` — value of a successfully created attribute
* `app/View/Events/show_i_o_c_results.ctp:40` — content of a failed indicator

`td.short` is defined as

```css
td.short {
    width:5%;
    white-space: nowrap;
    text-align: left;
}
```

(`app/webroot/css/main.css:356`, and identically in `app/webroot/css/cake.generic.css:187`)

Because of `white-space: nowrap`, long values — typically the `description` of an OpenIOC document, the example in the issue is `fireeye/iocs APT3/db0b6ac6-874a-498e-892b-ac7c2020e061.ioc` — are rendered on a single line and run off the visible area instead of wrapping.

The view is live: `EventsController::addIOC()` renders it at `app/Controller/EventsController.php:5575` (`$this->render('showIOCResults')`), and there is no themed override of it under `app/View/Themed/`.

### What changed

The two value cells drop `class="short"` so they fall back to the default (wrapping) table cell behaviour. The UUID / category / type / search-term columns keep `class="short"`, as those are short by nature and benefit from staying on one line.

Two lines changed, no logic touched.

### Verified vs not verified

* Verified: `php -l` on the changed `.ctp` passes; the `td.short` rule and the render path were confirmed in the current 2.5 tree at the file:line above.
* Not verified: this was **not** exercised on a live MISP instance — I have no running instance here and did not run the test suite. The change is purely presentational (removal of a CSS class from two `<td>` elements).

Fixes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)


