### PR TITLE
[cosmetic] fix: let the discussion box use the full page width

### DIFF
--- a/app/webroot/css/main.css
+++ b/app/webroot/css/main.css
@@ -707,7 +707,6 @@ dd {
     border-collapse: separate;
     box-shadow: 5px 5px 5px #888888;
     width:100%;
-    max-width:900px;
 }
 
 .discussionBoxTD {


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** The discussion box is capped at 900px; this PR drops the cap so it spans the page.

- **Problem** — The `.discussionBox` rule at `app/webroot/css/main.css:706-711` sets `width:100%` but also `max-width:900px`, which stops the discussion from spanning the page the way the data tables do; the class is applied to every post in `eventdiscussion.ctp` and `Threads/view.ctp`.
- **Fix** — The `max-width` line is deleted so the box follows its container.
- **Effect** — Event discussions and threads use the full page width.
<!-- /bluf -->

### Root cause

`app/webroot/css/main.css:706-711` caps the discussion box:

```css
.discussionBox {
    border-collapse: separate;
    box-shadow: 5px 5px 5px #888888;
    width:100%;
    max-width:900px;
}
```

The `max-width:900px` is what keeps the discussion from spanning the page the way the data tables do. The class is applied to every post in `app/View/Elements/eventdiscussion.ctp:26`, which is the element used both by the event discussion and by `app/View/Threads/view.ctp:10`.

### What changed

One line removed: the `max-width:900px` cap. `width:100%` already makes the box follow its container.

### Verified vs not verified

* Verified: the rule above is present in the current 2.5 tree; no other stylesheet in `app/webroot/css/` redefines `.discussionBox`.
* Not verified: not rendered on a live instance — I have no running MISP here and did not run the test suite.

If the 900px cap was a deliberate readable-line-length choice rather than an oversight, feel free to close this — the issue asks for the full-width behaviour, but that call is yours.

Fixes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)


