### PR TITLE
[medium] feat: filter the user index on whether a PGP key is set

### DIFF
--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -462,6 +462,15 @@ class UsersController extends AppController
                         $this->paginate['conditions']['AND'][] = array('User.current_login <' =>  time() - 60*60*24*30);  // older than a month
                         $this->paginate['conditions']['AND'][] = array('User.last_api_access <' =>  time() - 60*60*24*30);  // older than a month
                     }
+                } elseif ("gpgkey" == $searchTerm) {
+                    if ($v == "1") {
+                        $this->paginate['conditions']['AND'][] = array('User.gpgkey !=' => '');
+                    } elseif ($v == "0") {
+                        $this->paginate['conditions']['AND'][] = array('OR' => array(
+                            array('User.gpgkey' => null),
+                            array('User.gpgkey' => '')
+                        ));
+                    }
                 }
                 $passedArgsArray[$searchTerm] = $v;
             }
@@ -554,7 +563,7 @@ class UsersController extends AppController
     public function admin_filterUserIndex()
     {
         $passedArgsArray = array();
-        $booleanFields = array('autoalert', 'contactalert', 'termsaccepted', 'disabled', 'inactive');
+        $booleanFields = array('autoalert', 'contactalert', 'termsaccepted', 'disabled', 'inactive', 'gpgkey');
         $textFields = array('role', 'email');
         if (empty(Configure::read('Security.advanced_authkeys'))) {
             $textFields[] = 'authkey';


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Admins cannot filter the user index on whether a PGP key is set; this PR adds that filter.

- **Problem** — The user index filter builder in `UsersController::admin_filterUserIndex()` offers a fixed field list, and `gpgkey` appears in neither `$booleanFields` nor `$textFields`, so admins cannot ask which users do or do not have a PGP key.
- **Fix** — `gpgkey` is added to `$booleanFields`, and a branch in `admin_index()` translates `searchgpgkey:1` and `:0` into conditions on `User.gpgkey`, handling the nullable column in both directions.
- **Effect** — Admins get the usual Any/No/Yes selector for PGP keys in the UI and, because conditions are built in the shared loop, in the REST view of `admin_index` too.
<!-- /bluf -->

### Root cause

The user index filter builder offers a fixed set of fields:

* `app/Controller/UsersController.php:557` — `$booleanFields = array('autoalert', 'contactalert', 'termsaccepted', 'disabled', 'inactive');`
* `app/Controller/UsersController.php:558` — `$textFields = array('role', 'email');`

`gpgkey` is in neither list, so the filter builder rendered by `app/View/Users/admin_filter_user_index.ctp` cannot express "does this user have a PGP key or not". Per the issue discussion, the useful filter is exactly that yes/no question rather than a search over key material.

### What changed

Two spots, following the existing `inactive` precedent (a boolean-style filter offered by the builder and translated into conditions by `admin_index`):

1. `admin_filterUserIndex()` — `gpgkey` added to `$booleanFields`, so the builder renders the usual Any / No / Yes select for it. The surrounding machinery (`app/View/Users/admin_filter_user_index.ctp`, `app/webroot/js/misp.js` `differentFilters` handling) is generic and needs no change.
2. `admin_index()` — a branch next to the existing `inactive` one turns `searchgpgkey:1` into `User.gpgkey != ''` and `searchgpgkey:0` into `User.gpgkey IS NULL OR User.gpgkey = ''`. `users.gpgkey` is nullable (`INSTALL/MYSQL.sql`, `db_schema.json`), hence both cases.

Because the conditions are built in the shared loop, the filter also works for the REST view of `admin_index`.

### Verified vs not verified

* Verified: `php -l` passes on the changed controller; the filter-builder JS path was read and is field-agnostic; the `inactive` precedent it mirrors is at `app/Controller/UsersController.php:459-465` in current 2.5.
* Not verified: **not** exercised against a live instance — no running MISP here, and the test suite was not run. In particular the rendered label for the new row is the generic `ucfirst()` of the field name ("Gpgkey"), consistent with the existing rows ("Termsaccepted"), but I could not eyeball it.

Fixes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)


