### PR TITLE
[medium] new: [export] nfdump filter export format for IP attributes (#640)

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -5360,6 +5360,7 @@ class EventsController extends AppController
                 'hosts' => __('Hosts file'),
                 'json' => __('MISP JSON'),
                 'netfilter' => __('Netfilter'),
+                'nfdump' => __('nfdump filter'),
                 'opendata' => __('Open data'),
                 'openioc' => __('OpenIOC'),
                 'rpz' => __('RPZ'),

--- a/app/Lib/Export/NfdumpExport.php
+++ b/app/Lib/Export/NfdumpExport.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * Exports IP attributes as an nfdump filter expression, so that the result can be
+ * fed to nfdump directly in order to look up the matching netflow records:
+ *
+ *   nfdump -R /var/cache/nfdump -f misp_filter.txt
+ *
+ * By default the direction of every term is derived from the attribute type
+ * (ip-src => "src host", ip-dst => "dst host"), types that carry no direction
+ * (domain|ip) fall back to the undirected "host". The derived direction can be
+ * overridden for the whole export with the nfdump_direction filter, which
+ * accepts "src", "dst" or "any".
+ */
+class NfdumpExport
+{
+    public $additional_params = array(
+        'flatten' => 1,
+        'conditions' => array(
+            'AND' => array(
+                'Attribute.type' => array(
+                    'ip-dst', 'ip-src', 'domain|ip', 'ip-dst|port', 'ip-src|port'
+                )
+            )
+        )
+    );
+
+    public $non_restrictive_export = true;
+
+    /**
+     * position: index of the IP inside a composite value, or 'full' if the whole value is the IP
+     * direction: nfdump direction implied by the attribute type
+     */
+    private $__attributeTypeMappings = array(
+        'ip-dst' => array('position' => 'full', 'direction' => 'dst'),
+        'ip-src' => array('position' => 'full', 'direction' => 'src'),
+        'domain|ip' => array('position' => 1, 'direction' => 'any'),
+        'ip-dst|port' => array('position' => 0, 'direction' => 'dst'),
+        'ip-src|port' => array('position' => 0, 'direction' => 'src')
+    );
+
+    public function handler($data, $options = array())
+    {
+        $direction = $this->__requestedDirection($options);
+        if ($options['scope'] === 'Attribute') {
+            return $this->__convertToFilter($data['Attribute'], $direction);
+        }
+        if ($options['scope'] === 'Event') {
+            $result = array();
+            foreach ($data['Attribute'] as $attribute) {
+                $filter = $this->__convertToFilter($attribute, $direction);
+                if ($filter !== '') {
+                    $result[] = $filter;
+                }
+            }
+            return implode($this->separator(), $result);
+        }
+        return '';
+    }
+
+    private function __requestedDirection($options)
+    {
+        if (empty($options['filters']['nfdump_direction'])) {
+            return false;
+        }
+        $direction = $options['filters']['nfdump_direction'];
+        return in_array($direction, array('src', 'dst', 'any'), true) ? $direction : false;
+    }
+
+    private function __convertToFilter($attribute, $direction)
+    {
+        if (!isset($this->__attributeTypeMappings[$attribute['type']])) {
+            return '';
+        }
+        $mapping = $this->__attributeTypeMappings[$attribute['type']];
+        if ($mapping['position'] === 'full') {
+            $value = $attribute['value'];
+        } else {
+            $parts = explode('|', $attribute['value']);
+            if (!isset($parts[$mapping['position']])) {
+                return '';
+            }
+            $value = $parts[$mapping['position']];
+        }
+        if ($direction === false) {
+            $direction = $mapping['direction'];
+        }
+        $prefix = $direction === 'any' ? '' : $direction . ' ';
+        if (strpos($value, '/') !== false) {
+            list($network, $mask) = explode('/', $value, 2);
+            if (filter_var($network, FILTER_VALIDATE_IP) === false || !ctype_digit($mask)) {
+                return '';
+            }
+            return sprintf('%snet %s/%s', $prefix, $network, $mask);
+        }
+        if (filter_var($value, FILTER_VALIDATE_IP) === false) {
+            return '';
+        }
+        return sprintf('%shost %s', $prefix, $value);
+    }
+
+    public function header($options = array())
+    {
+        return '';
+    }
+
+    public function footer()
+    {
+        return "\n";
+    }
+
+    public function separator()
+    {
+        return " or ";
+    }
+}

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -117,6 +117,7 @@ class Event extends AppModel
         'json' => array('json', 'JsonExport', 'json'),
         'kunai' => ['json', 'KunaiExport', 'json'],
         'netfilter' => array('txt', 'NetfilterExport', 'sh'),
+        'nfdump' => array('txt', 'NfdumpExport', 'txt'),
         'opendata' => array('txt', 'OpendataExport', 'txt'),
         'openioc' => array('xml', 'OpeniocExport', 'ioc'),
         'rpz' => array('txt', 'RPZExport', 'rpz'),

--- a/app/Model/MispAttribute.php
+++ b/app/Model/MispAttribute.php
@@ -357,6 +357,7 @@ class MispAttribute extends AppModel
         'json' => array('json', 'JsonExport', 'json'),
         'kunai' => ['json', 'KunaiExport', 'json'],
         'netfilter' => array('txt', 'NetfilterExport', 'sh'),
+        'nfdump' => array('txt', 'NfdumpExport', 'txt'),
         'opendata' => array('txt', 'OpendataExport', 'txt'),
         'openioc' => array('xml', 'OpeniocExport', 'ioc'),
         'rpz' => array('txt', 'RPZExport', 'rpz'),


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Adds an nfdump filter export so event and `restSearch` IP indicators can be run against stored netflow.

- **Problem** — MISP has no export format emitting nfdump filter expressions, so event or `restSearch` IP indicators cannot be used against locally stored netflow; the only network-oriented IP export, `NetfilterExport.php`, produces iptables rules.
- **Fix** — New `app/Lib/Export/NfdumpExport.php` derives src/dst from the attribute type, emits CIDR as nfdump `net` terms, skips invalid values and supports an `nfdump_direction` override, registered alongside `netfilter` in `Event.php`, `MispAttribute.php` and `EventsController`.
- **Effect** — Users get a filter file usable with `nfdump -f`.
<!-- /bluf -->

## Root cause

MISP has no export format that produces [nfdump](https://github.com/phaag/nfdump) filter expressions, so there is no way to take the IP indicators of an event (or of a restSearch result) and query locally stored netflow records with them. The only network-oriented IP export today is `netfilter` (`app/Lib/Export/NetfilterExport.php`), which emits `iptables` rules.

Requested in #640; @adulau suggested in https://github.com/MISP/MISP/issues/640#issuecomment-1861201216 adapting `NetfilterExport.php` for this.

## What changed

* **New** `app/Lib/Export/NfdumpExport.php` — modelled on `NetfilterExport.php`, restricted to the same attribute types (`ip-src`, `ip-dst`, `domain|ip`, `ip-src|port`, `ip-dst|port`).
  * The direction of each term is derived from the attribute type: `ip-src` → `src host <ip>`, `ip-dst` → `dst host <ip>`, `domain|ip` (no direction implied) → `host <ip>`. Composite values have the IP extracted.
  * CIDR values are emitted as nfdump `net` terms (`dst net 192.168.0.0/16`).
  * Values that are not a valid IP / CIDR are skipped rather than emitted verbatim.
  * The derived direction can be overridden for a whole export with the `nfdump_direction` filter (`src`, `dst` or `any`), which covers the three use cases listed in the issue.
  * Terms are joined with ` or `, so the whole file is a single valid nfdump filter: `nfdump -R /var/cache/nfdump -f misp_filter.txt`.
* **Registered** the format in the three places `netfilter` is registered:
  * `app/Model/Event.php:120`
  * `app/Model/MispAttribute.php:360`
  * `app/Controller/EventsController.php:5363` (export picker label)

`NetfilterExport.php` itself is untouched.

## Verified vs not verified

* **Verified**: `php -l` clean on all four changed/added files. The export class was exercised standalone under PHP 8.5 with representative attributes (`ip-src`, `ip-dst`, `domain|ip`, `ip-src|port`, a CIDR, an invalid IP, and an unrelated type) in both `Event` and `Attribute` scope, and with `nfdump_direction` set — output was as intended and non-matching attributes produced an empty string (which the export driver at `app/Model/Event.php:9333` and `app/Model/MispAttribute.php:3852` skips).
* **Not verified**: there is no live MISP instance available here, so this has **not** been exercised end-to-end through the UI/restSearch, and the test suite has not been run.

Fixes #640

🤖 Generated with [Claude Code](https://claude.com/claude-code)

