### PR TITLE
[medium] new: [templates] support the 2.4+ hash types in the complex 'File' type (#901)

### DIFF
--- a/app/Lib/Tools/ComplexTypeTool.php
+++ b/app/Lib/Tools/ComplexTypeTool.php
@@ -91,7 +91,8 @@ class ComplexTypeTool
         }
     }
 
-    // checks if the passed input matches a valid file description attribute's pattern (filename, md5, sha1, sha256, filename|md5, filename|sha1, filename|sha256)
+    // checks if the passed input matches a valid file description attribute's pattern (filename, any of the hash types in
+    // self::HEX_HASH_TYPES and their filename| composite counterparts)
     public function checkComplexFile($input)
     {
         $original = $input;
@@ -107,14 +108,13 @@ class ComplexTypeTool
             }
             $input = $result[1];
         }
-        if (strlen($input) == 32 && preg_match("#[0-9a-f]{32}$#", $input)) {
-            $type .= 'md5';
-        }
-        if (strlen($input) == 40 && preg_match("#[0-9a-f]{40}$#", $input)) {
-            $type .= 'sha1';
-        }
-        if (strlen($input) == 64 && preg_match("#[0-9a-f]{64}$#", $input)) {
-            $type .= 'sha256';
+        $hash = $this->__resolveHash($input);
+        if ($hash) {
+            if ($type === 'filename|') {
+                $type = $hash['composite'][0];
+            } elseif ($type === '') {
+                $type = $hash['single'][0];
+            }
         }
         if ($type == '' && !$composite && preg_match("#^.+#", $input)) {
             $type = 'filename';

--- a/app/Model/MispAttribute.php
+++ b/app/Model/MispAttribute.php
@@ -471,7 +471,11 @@ class MispAttribute extends AppModel
     public $validTypeGroups = array(
             'File' => array(
                 'description' => '',
-                'types' => array('filename', 'filename|md5', 'filename|sha1', 'filename|sha256', 'md5', 'sha1', 'sha256'),
+                'types' => array(
+                    'filename',
+                    'filename|md5', 'filename|sha1', 'filename|sha224', 'filename|sha256', 'filename|sha384', 'filename|sha512',
+                    'md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512'
+                ),
             ),
             'CnC' => array(
                 'description' => '',


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** The complex `File` template type resolved only MD5, SHA1 and SHA256; this PR extends it to the full set.

- **Problem** — `ComplexTypeTool::checkComplexFile()` hand-rolled length checks for 32, 40 and 64 hex characters, so the complex `File` type used by event templates resolved only MD5, SHA1 and SHA256, and `$validTypeGroups['File']['types']` advertised the same three.
- **Fix** — `checkComplexFile()` delegates to the existing `__resolveHash()` and `HEX_HASH_TYPES` map, and the advertised list is extended with `sha224`, `sha384` and `sha512` plus their `filename|` composites.
- **Effect** — Template `File` fields now accept the full hash set, including uppercase input.
<!-- /bluf -->

## Root cause

The complex `File` type used by event templates only ever resolved MD5, SHA1 and SHA256, even though MISP gained SHA224/SHA384/SHA512 (and friends) as attribute types back in 2.4. Two places are stale:

* `app/Lib/Tools/ComplexTypeTool.php:110-118` (before this change) — `checkComplexFile()` hand-rolled three length checks (`32`/`40`/`64`) instead of using the `HEX_HASH_TYPES` map that the rest of the class already uses (`app/Lib/Tools/ComplexTypeTool.php:34-41`, consumed by `__resolveHash()` at `app/Lib/Tools/ComplexTypeTool.php:622-629`).
* `app/Model/MispAttribute.php:471-475` (before this change) — `$validTypeGroups['File']['types']` listed only those same three hashes plus `filename`. This list is what the template UI shows as the accepted types for a complex `File` field (`app/View/Elements/templateElements/populateTemplateAttribute.ctp:18`, `app/View/Elements/templateElements/templateRowAttribute.ctp:45`, `app/Controller/TemplateElementsController.php:39`).

## What changed

* `checkComplexFile()` now delegates hash resolution to the existing `__resolveHash()` / `HEX_HASH_TYPES`, so lengths 56 (sha224), 96 (sha384) and 128 (sha512) resolve too, and the composite form picks the `filename|…` variant from the same map.
* `$validTypeGroups['File']['types']` extended to exactly the set `checkComplexFile()` can now return: `filename`, `md5`, `sha1`, `sha224`, `sha256`, `sha384`, `sha512` and their `filename|` composites.

Two incidental consequences of reusing `__resolveHash()`, both intended:

* uppercase hashes are now recognised (`ctype_xdigit()` vs. the old `[0-9a-f]` regex);
* a malformed composite (`a|b|c`) now stays `other` instead of being concatenated into the nonexistent type `othermd5`.

## Blast radius

`checkComplexFile()` is reached only via `ComplexTypeTool::checkComplexRouter($input, 'File')` (`app/Lib/Tools/ComplexTypeTool.php:77-81`), whose only `'File'` caller is `MispAttribute::__createAttribute()` (`app/Model/MispAttribute.php:1883`) — i.e. event-template population. Freetext import, feeds and CSV parsing go through `checkFreeText()`/`checkCSV()` and are untouched.

## Verified vs not verified

* **Verified**: `php -l` clean on both files. `checkComplexFile()` exercised standalone under PHP 8.5 against filenames, all six hash lengths (lower- and upper-case), the `filename|<hash>` composites, a malformed composite and a non-hex 32-char string; every returned type is present in the new `validTypeGroups['File']['types']` list.
* **Not verified**: no live MISP instance is available here, so template population has **not** been exercised end-to-end through the UI, and the test suite has not been run.

Fixes #901

🤖 Generated with [Claude Code](https://claude.com/claude-code)

