### PR TITLE
[high] fix: [analyst data] do not fatal when there is no acting user

### DIFF
--- a/app/Model/Behavior/AnalystDataBehavior.php
+++ b/app/Model/Behavior/AnalystDataBehavior.php
@@ -19,6 +19,14 @@ class AnalystDataBehavior extends ModelBehavior
     // Return the analystData of the current type for a given UUID (this only checks the ACL of the analystData, NOT of the parent.)
     public function fetchForUuid(Model $Model, $uuid, $user = null)
     {
+        // A null user means there is no ACL context to evaluate. Every branch
+        // below assumes one - SharingGroup::authorizedIds() is typed
+        // `array $user` and raises a fatal TypeError on null, and the
+        // Organisation lookups would fail too. Nothing is visible without a
+        // user, so return nothing rather than dying.
+        if (empty($user)) {
+            return [];
+        }
         $conditions = [
             'object_uuid' => $uuid
         ];
@@ -49,6 +57,14 @@ class AnalystDataBehavior extends ModelBehavior
     // Return the analystData of the current type for a given UUID (this only checks the ACL of the analystData, NOT of the parent.)
     public function fetchForUuids(Model $Model, $uuids, $user = null)
     {
+        // A null user means there is no ACL context to evaluate. Every branch
+        // below assumes one - SharingGroup::authorizedIds() is typed
+        // `array $user` and raises a fatal TypeError on null, and the
+        // Organisation lookups would fail too. Nothing is visible without a
+        // user, so return nothing rather than dying.
+        if (empty($user)) {
+            return [];
+        }
         $conditions = [
             'object_uuid' => $uuids
         ];

--- a/app/Model/Behavior/AnalystDataParentBehavior.php
+++ b/app/Model/Behavior/AnalystDataParentBehavior.php
@@ -25,6 +25,15 @@ class AnalystDataParentBehavior extends ModelBehavior
                 $this->__currentUser = $this->User->getAuthUser($user_id);
             }
         }
+        // Without an acting user there is nothing to evaluate ACL against, and
+        // every downstream call assumes one: SharingGroup::authorizedIds() is
+        // typed `array $user` and raises a fatal TypeError when handed null.
+        // Configure's CurrentUserId is set by an authenticated request, but not
+        // by console shells, background workers or tests - so attach nothing
+        // rather than dying with an error that names SharingGroup.
+        if (empty($this->__currentUser)) {
+            return $object;
+        }
         if (empty($this->__isRest)) {
             $this->__isRest = Configure::read('CurrentRequestIsRest');
         }


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Attaching analyst data outside a web request fatals on a null user; this PR returns an empty result.

- **Problem** — `AnalystDataBehavior::fetchForUuid()` and `fetchForUuids()` default `$user` to null, then pass it to `SharingGroup::authorizedIds()`, which is typed `array $user`, so the call is a fatal TypeError. The null arrives normally: `AnalystDataParentBehavior::attachAnalystData()` reads the user from `Configure::read('CurrentUserId')`, which console shells, workers and tests never set.
- **Fix** — Both methods return an empty result when there is no user, the ACL-correct answer, and `attachAnalystData()` returns early.
- **Effect** — Attaching analyst data outside a web request stops dying.
<!-- /bluf -->

## Problem

`AnalystDataBehavior::fetchForUuid()` and `fetchForUuids()` both declare `$user = null`, but every branch below assumes a user is present:

```php
public function fetchForUuids(Model $Model, $uuids, $user = null)
{
    ...
    if (empty($user['Role']['perm_site_admin'])) {
        $this->__valid_sharing_groups = $Model->SharingGroup->authorizedIds($user, true);
```

`SharingGroup::authorizedIds()` is typed `array $user`, so a null argument is a **fatal TypeError** — and the branch is entered precisely *because* the user is null (`empty(null['Role']...)` is true).

The null arrives by an ordinary route. `AnalystDataParentBehavior::attachAnalystData()` resolves the acting user from `Configure::read('CurrentUserId')`:

```php
if (empty($this->__currentUser)) {
    $user_id = Configure::read('CurrentUserId');
    if ($user_id) {
        $this->__currentUser = $this->User->getAuthUser($user_id);
    }
}
```

An authenticated web request sets that config. **A console shell, a background worker and a test do not.** When it is unset, `__currentUser` stays null and is passed straight through — so any code path that attaches analyst data outside a web request dies, and the error names `SharingGroup` rather than the missing configuration.

## Fix

Both methods return an empty result when there is no user. That is also the ACL-correct answer — without a user nothing is visible — and it holds regardless of which caller is at fault. `attachAnalystData()` additionally returns early, to skip work that can no longer produce anything.

## Verification

Runtime-verified against a live 2.5 instance, not just linted. A test driving `Event::fetchEvent(['includeAnalystData' => true])` with `CurrentUserId` unset:

- **before**: `TypeError: SharingGroup::authorizedIds(): Argument #1 ($user) must be of type array, null given`
- **after**: passes

With the change applied, the full integration suite (69 tests) and unit suite (1,731 tests) are green. `php -l` clean on both files.

Found while building characterization tests for `Event::fetchEvent()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

