### PR TITLE
[medium] fix: use a valid jQuery selector for the settings accordion data-parent

### DIFF
--- a/app/View/Elements/healthElements/settings_table_composition.ctp
+++ b/app/View/Elements/healthElements/settings_table_composition.ctp
@@ -5,7 +5,7 @@
         echo sprintf(
             '<div class="accordion-group"><div class="accordion-heading">%s</div><div id=collapse_%s class="accordion-body collapse">%s</div></div>',
             sprintf(
-                '<a class="accordion-toggle" data-toggle="collapse" data-parent="accordion" href="#collapse_%s">%s</a>',
+                '<a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#collapse_%s">%s</a>',
                 h($subGroup),
                 h($subGroup)
             ),


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `data-parent="accordion"` is not a valid selector, so settings groups never collapse.

- **Problem** — The settings accordion in `app/View/Elements/healthElements/settings_table_composition.ctp` emits each group toggle with `data-parent="accordion"`, but Bootstrap 2.3.2 treats `data-parent` as a jQuery selector, so `$("accordion")` matches nothing and the sibling-collapse branch never fires.
- **Fix** — Changes the attribute to the container's real id, `#accordion`.
- **Effect** — Opening one settings group closes the one that was already open, instead of leaving every group stacked open.
<!-- /bluf -->

### What

`app/View/Elements/healthElements/settings_table_composition.ctp` renders the settings accordion container as:

```php
<div class="accordion" id="accordion">
```

but every group toggle inside it is emitted with:

```php
'<a class="accordion-toggle" data-toggle="collapse" data-parent="accordion" href="#collapse_%s">%s</a>',
```

(`settings_table_composition.ctp:2` and `:8` on `2.5` @ `843b674450`)

Bootstrap 2.3.2 — the version bundled at `app/webroot/js/bootstrap.js` — treats `data-parent` as a **jQuery selector**:

```js
if (this.options.parent) {
  this.$parent = $(this.options.parent)     // bootstrap.js:500-501
}
...
actives = this.$parent && this.$parent.find('> .accordion-group > .in')   // bootstrap.js:526
```

`$("accordion")` is a *type* selector: it matches no element in the document, so `actives` is always empty and the "close the sibling group that is currently open" branch never fires. Opening a second settings group leaves the first one open.

This one-character change points `data-parent` at the container's real id, `#accordion`, which does exist and whose children match the `> .accordion-group > .in` shape the plugin looks for.

### Scope / honesty about #1098

This is **not** the symptom #1098 reports. That issue describes a group that will not fold back *after an inline setting edit* — and @adulau's comment there ("you must reload the page") points at state getting out of sync after the AJAX setting update, which is a separate problem I have not been able to reproduce or diagnose. I have deliberately used `Refs #1098` rather than `Fixes #1098`: this patch repairs a real, independently verifiable accordion defect found while reading that markup, but the originally reported behaviour should stay open.

### Also noticed (not changed)

`app/View/Api/rest.ctp:24` and `:36` carry the same `data-parent="accordion"` string, but there is no element with `id="accordion"` on that page at all — the accordion groups sit in a plain `<div style="width:542px">`. Fixing that would mean *adding* a container id, i.e. a different change on a different page, so I left it alone rather than widen this PR.

### Verification

- `php -l app/View/Elements/healthElements/settings_table_composition.ctp` — clean (PHP 8.5.4).
- Confirmed only one `id="accordion"` can be in the DOM at a time on this page: `settings_table_composition` is rendered once, from `healthElements/settings_tab.ctp:3`, itself included once from `app/View/Servers/server_settings.ctp:9`. So `#accordion` is unambiguous.
- **Not** runtime-verified: I have no live MISP instance available and could not run the test suite. The change is markup-only and the reasoning above is read from the bundled `bootstrap.js` source.

