### PR TITLE
[medium] feat: add a to_ids filter to the correlation graph

### DIFF
--- a/app/View/Events/view_graph.ctp
+++ b/app/View/Events/view_graph.ctp
@@ -25,6 +25,7 @@
             <li id="context-delete"><?php echo __('Delete');?></li>
         </ul>
         <button class="correlation-stop-btn btn btn-inverse" onclick="togglePhysics();" title="<?php echo __('Toggle the physics engine on/off.');?>">Toggle physics</button>
+        <button id="correlation-toids-btn" class="correlation-toids-btn btn btn-inverse" title="<?php echo __('Only show attributes that are flagged as to_ids.');?>"><?php echo __('Only to_ids');?></button>
 <?php
     if (!$ajax):
 ?>

--- a/app/View/Themed/Overmind/Events/view_graph.ctp
+++ b/app/View/Themed/Overmind/Events/view_graph.ctp
@@ -32,6 +32,16 @@
                         <i class="fas fa-atom"></i>
                         <?= __('Physics') ?>
                     </button>
+
+                    <!-- to_ids filter -->
+                    <button id="correlation-toids-btn"
+                            class="btn btn-outline-secondary btn-sm d-flex align-items-center gap-2"
+                            type="button"
+                            aria-pressed="false"
+                            title="<?= __('Only show attributes that are flagged as to_ids.') ?>">
+                        <i class="fas fa-filter"></i>
+                        <?= __('Only to_ids') ?>
+                    </button>
                 </div>
 
             </div>

--- a/app/webroot/css/correlation-graph.css
+++ b/app/webroot/css/correlation-graph.css
@@ -100,3 +100,9 @@ line.link {
     top: 60px;
     right:10px;
 }
+
+.correlation-toids-btn {
+    position: absolute;
+    top: 95px;
+    right:10px;
+}

--- a/app/webroot/js/correlation-graph.js
+++ b/app/webroot/js/correlation-graph.js
@@ -48,6 +48,7 @@ $(document).ready( function() {
   });
 
   var root;
+  var toIdsOnly = false;
 
   var highlighted;
   var hovered;
@@ -109,6 +110,13 @@ $(document).ready( function() {
 
   d3.json(baseurl + "/events/updateGraph/" + scope_id + "/" + scope + ".json", function(error, json) {
   	root = json;
+  	resolveLinkEnds(root);
+  	update();
+  });
+
+  $('#correlation-toids-btn').click(function() {
+  	toIdsOnly = !toIdsOnly;
+  	$(this).toggleClass('active', toIdsOnly);
   	update();
   });
 
@@ -123,8 +131,44 @@ $(document).ready( function() {
   	graphElementTranslate = d3.event.translate;
   }
 
+  // The graph JSON ships the to_ids flag of every attribute node as att_ids.
+  // CakePHP casts the tinyint(1) to_ids column to a boolean, so the value on the
+  // wire is true/false - 1 and "1" are accepted defensively.
+  function isToIdsNode(d) {
+  	return d.att_ids === true || d.att_ids === 1 || d.att_ids === '1';
+  }
+
+  // The server sends link endpoints as node indexes; d3 replaces them with node
+  // references on force.start(). Resolve them up front so that the filter can
+  // always look at the node objects, including before the very first render.
+  function resolveLinkEnds(graph) {
+  	graph['links'].forEach(function(l) {
+  		if (typeof l.source === 'number') l.source = graph['nodes'][l.source];
+  		if (typeof l.target === 'number') l.target = graph['nodes'][l.target];
+  	});
+  }
+
+  // Never mutate root: it is posted back to the server on expand() so that the
+  // already known part of the graph can be deduplicated there.
+  function visibleGraph() {
+  	if (!toIdsOnly) {
+  		return root;
+  	}
+  	var kept = {};
+  	var nodes = root['nodes'].filter(function(d) {
+  		var keep = d.type !== 'attribute' || isToIdsNode(d);
+  		if (keep) kept[d.unique_id] = true;
+  		return keep;
+  	});
+  	var links = root['links'].filter(function(l) {
+  		return kept[l.source.unique_id] && kept[l.target.unique_id];
+  	});
+  	return {'nodes': nodes, 'links': links};
+  }
+
   function update() {
-  	var nodes = root['nodes'], links = root['links'];
+  	var graph = visibleGraph();
+  	var nodes = graph['nodes'], links = graph['links'];
 
 
   	// Restart the force layout.
@@ -135,7 +179,7 @@ $(document).ready( function() {
   	link.exit().remove();
   	link.enter().insert("line", ".node").attr("class", "link");
   	// Update nodes.
-  	node = node.data(nodes);
+  	node = node.data(nodes, function(d) { return d.unique_id; });
   	node.exit().remove();
 
   	var nodeEnter = node.enter().append("g").attr("class", "node").call(drag1);
@@ -423,6 +467,7 @@ $(document).ready( function() {
   	        JSON.stringify(root),
   	        function(err, rawData){
   		        root = JSON.parse(rawData.response);
+  		        resolveLinkEnds(root);
   		        update();
   	        }
   	    );

--- a/app/webroot/js/correlation-graphOvermind.js
+++ b/app/webroot/js/correlation-graphOvermind.js
@@ -69,6 +69,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     var root;
+    var toIdsOnly = false;
     var highlighted;
     var hovered;
 
@@ -129,8 +130,20 @@ document.addEventListener('DOMContentLoaded', function() {
 
     d3.json(baseurl + "/events/updateGraph/" + scope_id + "/" + scope + ".json", function(error, json) {
         root = json;
+        resolveLinkEnds(root);
         update();
     });
+
+    const toIdsBtn = document.getElementById('correlation-toids-btn');
+
+    if (toIdsBtn) {
+        toIdsBtn.addEventListener('click', function() {
+            toIdsOnly = !toIdsOnly;
+            toIdsBtn.classList.toggle('active', toIdsOnly);
+            toIdsBtn.setAttribute('aria-pressed', toIdsOnly ? 'true' : 'false');
+            update();
+        });
+    }
 
     var graphElementScale = 1;
     var graphElementTranslate = [0, 0];
@@ -143,8 +156,44 @@ document.addEventListener('DOMContentLoaded', function() {
         graphElementTranslate = d3.event.translate;
     }
 
+    // The graph JSON ships the to_ids flag of every attribute node as att_ids.
+    // CakePHP casts the tinyint(1) to_ids column to a boolean, so the value on
+    // the wire is true/false - 1 and "1" are accepted defensively.
+    function isToIdsNode(d) {
+        return d.att_ids === true || d.att_ids === 1 || d.att_ids === '1';
+    }
+
+    // The server sends link endpoints as node indexes; d3 replaces them with
+    // node references on force.start(). Resolve them up front so that the filter
+    // can always look at the node objects, including before the first render.
+    function resolveLinkEnds(graph) {
+        graph['links'].forEach(function(l) {
+            if (typeof l.source === 'number') l.source = graph['nodes'][l.source];
+            if (typeof l.target === 'number') l.target = graph['nodes'][l.target];
+        });
+    }
+
+    // Never mutate root: it is posted back to the server on expand() so that the
+    // already known part of the graph can be deduplicated there.
+    function visibleGraph() {
+        if (!toIdsOnly) {
+            return root;
+        }
+        var kept = {};
+        var nodes = root['nodes'].filter(function(d) {
+            var keep = d.type !== 'attribute' || isToIdsNode(d);
+            if (keep) kept[d.unique_id] = true;
+            return keep;
+        });
+        var links = root['links'].filter(function(l) {
+            return kept[l.source.unique_id] && kept[l.target.unique_id];
+        });
+        return {'nodes': nodes, 'links': links};
+    }
+
     function update() {
-        var nodes = root['nodes'], links = root['links'];
+        var graph = visibleGraph();
+        var nodes = graph['nodes'], links = graph['links'];
 
         force.nodes(nodes).links(links).start();
 
@@ -152,7 +201,7 @@ document.addEventListener('DOMContentLoaded', function() {
         link.exit().remove();
         link.enter().insert("line", ".node").attr("class", "link");
 
-        node = node.data(nodes);
+        node = node.data(nodes, function(d) { return d.unique_id; });
         node.exit().remove();
 
         var nodeEnter = node.enter().append("g").attr("class", "node").call(drag1);
@@ -380,6 +429,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     JSON.stringify(root),
                     function(err, rawData) {
                         root = JSON.parse(rawData.response);
+                        resolveLinkEnds(root);
                         update();
                     }
                 );


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Adds an "Only to_ids" toggle to the correlation graph, using a flag already on the wire.

- **Problem** — The correlation graph already receives each attribute's `to_ids` flag, since `CorrelationGraphTool::__createNode()` emits it as `att_ids`, but a repo-wide search shows nothing ever reads it back, so the renderer ignores it.
- **Fix** — Adds the "Only to_ids" toggle requested in #812 next to the existing physics control, filtering attribute nodes and their links at render time in `visibleGraph()` while leaving `root` unmutated so `expand()` still posts the full graph for server-side dedup.
- **Effect** — Analysts can hide non-actionable attributes from the graph.
<!-- /bluf -->

### What

Adds the "Only to_ids" filter asked for in #812 to the correlation graph.

### Why this is front-end only

The backend already does the work. `CorrelationGraphTool::__createNode()` puts the attribute's `to_ids` flag straight into the graph JSON:

```php
// app/Lib/Tools/CorrelationGraphTool.php:335
'att_ids' => $data['to_ids'],
```

A repository-wide search on `2.5` @ `843b674450` returns exactly one hit for `att_ids` — that line. No `.ctp`, no `.js`, no PHP reads it back. So the flag was already on the wire and simply ignored by the renderer.

The value on the wire is JSON `true`/`false`: `to_ids` is `tinyint(1)` (`INSTALL/MYSQL.sql:106`) and CakePHP's MySQL datasource casts `tinyint(1)` columns to PHP booleans on read (`lib/Cake/Model/Datasource/Database/Mysql.php:286-287`). The predicate accepts `1` and `"1"` as well, defensively.

### What the toggle does

A button next to the existing physics toggle. When enabled, attribute nodes with `att_ids` false are removed, along with every link that had one as an endpoint. Nodes of the other types (event, object, tag, galaxy) are kept, so the graph stays navigable rather than collapsing to a set of orphans.

### Implementation notes

Three things worth calling out, because they are the parts that are more than "filter an array":

1. **`root` is never mutated.** The filter is computed in `visibleGraph()` at render time. This matters: `expand()` posts `JSON.stringify(root)` back to `/events/updateGraph` so the server can deduplicate the already-known part of the graph. Posting a filtered `root` would make the server happily re-add every node the user just filtered out.
2. **Link endpoints are resolved from indexes to node references up front.** The server emits `links[].source`/`target` as node indexes; d3 replaces them with node objects on `force.start()`. `resolveLinkEnds()` does it eagerly (and is idempotent — it only touches `typeof === 'number'`) so the filter can read `l.source.unique_id` even before the first render.
3. **The node data join is now keyed on `unique_id`.** Previously `node.data(nodes)` used the default index join, which was safe only because `expand()` is append-only. Removing nodes from the *middle* of the array under an index join would rebind surviving `<g>` elements to different data — and since the icon, label and element id are only set in `enter()`, that renders the wrong icon/label on the wrong node. The key function fixes that and makes the join correct in general.

### Both renderers

The change is applied to both the default renderer (`app/webroot/js/correlation-graph.js` + `app/View/Events/view_graph.ctp` + a CSS rule for the button position) and the Overmind theme variant (`app/webroot/js/correlation-graphOvermind.js` + `app/View/Themed/Overmind/Events/view_graph.ctp`). The Overmind file is a jQuery-free rewrite with Bootstrap 5 markup, but its `root` / `update()` / `expand()` structure is identical, so the filter logic is the same in both — only the button markup and its event binding differ per theme.

### Verification — and what was *not* verified

- `php -l` clean on both changed `.ctp` files (PHP 8.5.4).
- `node --check` clean on both changed `.js` files.
- The three new pure helpers (`isToIdsNode`, `resolveLinkEnds`, `visibleGraph`) were extracted from the two shipped files and exercised in node against a synthetic graph payload covering `att_ids` as `true` / `false` / `1` / `"0"`, plus an event and an object node. Both files produce identical results: the correct four nodes and three links survive, `root` is left untouched, and re-running `resolveLinkEnds` is a no-op.
- **Not verified at runtime.** I have no live MISP instance available here and did not run the test suite, so nothing in the d3 rendering path, the button styling, or the interaction with `expand()` has been exercised in a browser. The claims above about d3's index-join behaviour and about `force.start()` resolving numeric endpoints are read from the bundled d3 v3 source and from the existing code, not observed.

Fixes #812

