### PR TITLE
[medium] feat(users): make the user account expiration date settable and enforced

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -683,6 +683,24 @@ class AppController extends Controller
             return false;
         }
 
+        // Check if the user account itself has expired
+        if (!empty($user['expiration']) && strtotime($user['expiration']) < ($_SERVER['REQUEST_TIME'] ?? time())) {
+            if ($this->_shouldLog('expired_user:' . $user['id'])) {
+                $this->Log = ClassRegistry::init('Log');
+                $change = $this->User->UserLoginProfile->_getUserProfile();
+                $this->Log->createLogEntry($user, 'auth_fail', 'User', $user['id'], 'Login attempt by expired user.', json_encode($change));
+            }
+
+            $this->Auth->logout();
+            if ($this->_isRest()) {
+                throw new ForbiddenException('Authentication failed. Your user account has expired.');
+            } else {
+                $this->Flash->error(__('Your user account has expired.'));
+                $this->_redirectToLogin();
+            }
+            return false;
+        }
+
         // Check if auth key is not expired. Make sense when Security.authkey_keep_session is enabled.
         if (isset($user['authkey_expiration']) && $user['authkey_expiration']) {
             $time = $_SERVER['REQUEST_TIME'] ?? time();

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -807,7 +807,7 @@ class UsersController extends AppController
                         $this->Flash->error(__('The user could not be saved. Invalid organisation.'));
                     }
                 } else {
-                    $fieldList = array('password', 'email', 'external_auth_required', 'external_auth_key', 'enable_password', 'confirm_password', 'org_id', 'role_id', 'authkey', 'nids_sid', 'server_id', 'gpgkey', 'certif_public', 'autoalert', 'contactalert', 'disabled', 'invited_by', 'change_pw', 'termsaccepted', 'newsread', 'date_created', 'date_modified', 'last_pw_change');
+                    $fieldList = array('password', 'email', 'external_auth_required', 'external_auth_key', 'enable_password', 'confirm_password', 'org_id', 'role_id', 'authkey', 'nids_sid', 'server_id', 'gpgkey', 'certif_public', 'autoalert', 'contactalert', 'disabled', 'expiration', 'invited_by', 'change_pw', 'termsaccepted', 'newsread', 'date_created', 'date_modified', 'last_pw_change');
                     if ($this->User->save($this->request->data, true, $fieldList)) {
                         $notification_message = '';
                         if (!empty($this->request->data['User']['notify'])) {

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -282,6 +282,15 @@ class User extends AppModel
         if (empty($user['nids_sid'])) {
             $user['nids_sid'] = mt_rand(1000000, 9999999);
         }
+        if (array_key_exists('expiration', $user)) {
+            if (empty($user['expiration'])) {
+                $user['expiration'] = null; // no expiration set, keep the column NULL
+            } elseif (!is_string($user['expiration']) || strtotime($user['expiration']) === false) {
+                $this->invalidate('expiration', __('Invalid expiration date, use the YYYY-MM-DD format.'));
+            } else {
+                $user['expiration'] = date('Y-m-d H:i:s', strtotime($user['expiration']));
+            }
+        }
         if (!empty(Configure::read('Security.limit_site_admins_to_host_org'))){
             if (!empty($user['role_id']) and !empty($user['org_id'] and $user['org_id'] != Configure::read('MISP.host_org_id'))){
                 $role = $this->Role->find('first', array(

--- a/app/View/Themed/Overmind/Users/admin_add.ctp
+++ b/app/View/Themed/Overmind/Users/admin_add.ctp
@@ -252,6 +252,10 @@ echo $this->Form->create('User', [
                 <?= $switch('disabled', __('Immediately disable this account')) ?>
                 <?= $switch('notify', __('Send credentials automatically'), $checkedOr('notify', true)) ?>
             </div>
+            <div class="mt-2">
+                <?= $this->Form->label('expiration', __('Account expiration (keep empty for no expiration)'), ['class' => 'form-label fw-semibold']) ?>
+                <?= $this->Form->text('expiration', ['class' => 'form-control bg-light', 'placeholder' => 'YYYY-MM-DD']) ?>
+            </div>
         </div>
 
     </div>

--- a/app/View/Themed/Overmind/Users/admin_edit.ctp
+++ b/app/View/Themed/Overmind/Users/admin_edit.ctp
@@ -237,6 +237,14 @@ echo $this->Form->create('User', [
                 <?= $switch('contactalert', __('Receive "Contact reporter" request emails')) ?>
                 <?= $switch('disabled', __('Immediately disable this account')) ?>
             </div>
+            <div class="mt-2">
+                <?= $this->Form->label('expiration', __('Account expiration (keep empty for no expiration)'), ['class' => 'form-label fw-semibold']) ?>
+                <?= $this->Form->text('expiration', [
+                    'class' => 'form-control bg-light',
+                    'placeholder' => 'YYYY-MM-DD',
+                    'value' => empty($this->request->data['User']['expiration']) ? '' : substr($this->request->data['User']['expiration'], 0, 10),
+                ]) ?>
+            </div>
         </div>
 
         <!-- NOTIFICATIONS -->

--- a/app/View/Users/admin_add.ctp
+++ b/app/View/Users/admin_add.ctp
@@ -98,6 +98,13 @@
             'checked' => isset($this->request->data['User']['contactalert']) ? $this->request->data['User']['contactalert'] : true
         ));
         echo $this->Form->input('disabled', array('type' => 'checkbox', 'label' => __('Immediately disable this user account')));
+        echo $this->Form->input('expiration', array(
+            'type' => 'text',
+            'div' => 'input clear',
+            'class' => 'datepicker',
+            'placeholder' => 'YYYY-MM-DD',
+            'label' => __('Account expiration (keep empty for no expiration)')
+        ));
         echo $this->Form->input('notify', array(
             'label' => __('Send credentials automatically'),
             'type' => 'checkbox',

--- a/app/View/Users/admin_edit.ctp
+++ b/app/View/Users/admin_edit.ctp
@@ -111,6 +111,14 @@
         echo $this->Form->input('contactalert', array('label' => __('Receive email alerts from "Contact reporter" requests'), 'type' => 'checkbox'));
         echo $this->Form->input('disabled', array('type' => 'checkbox', 'label' => __('Immediately disable this user account')));
         echo '</div>';
+        echo $this->Form->input('expiration', array(
+            'type' => 'text',
+            'div' => 'input clear',
+            'class' => 'datepicker',
+            'placeholder' => 'YYYY-MM-DD',
+            'value' => empty($this->request->data['User']['expiration']) ? '' : substr($this->request->data['User']['expiration'], 0, 10),
+            'label' => __('Account expiration (keep empty for no expiration)')
+        ));
     ?>
     <h5><?= __('Subscribe to the following notification:') ?></h5>
     <div class="user-edit-checkboxes">

--- a/app/View/Users/view.ctp
+++ b/app/View/Users/view.ctp
@@ -184,6 +184,11 @@ if ($admin_view) {
         'class' => empty($user['User']['disabled']) ? '' : 'background-red',
         'boolean' => $user['User']['disabled']
     );
+    $tableData[] = array(
+        'key' => __('Account expiration'),
+        'class' => empty($user['User']['expiration']) || strtotime($user['User']['expiration']) > time() ? '' : 'background-red',
+        'value' => empty($user['User']['expiration']) ? __('N/A') : $user['User']['expiration']
+    );
 }
 echo $this->element('genericElements/assetLoader', array(
     'css' => array('vis', 'distribution-graph'),


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** The `users.expiration` column is dead storage; this makes it settable and enforced.

- **Problem** — `users.expiration` has existed for years but nothing uses it: no admin form offers it, `admin_add()`'s `$fieldList` omits it so REST posts are dropped, and nothing in `app/` ever reads it back beyond echoing it in the admin user index.
- **Fix** — Adds the field to the add and edit forms in both the default and Overmind themes, includes it in the saved field list, and enforces it so expired accounts are blocked.
- **Effect** — Admins can set an account expiration date and expired accounts are actually locked out.
- **Cost** — Any value a REST client previously wrote into the column, which had no effect until now, starts being honoured after merge.
<!-- /bluf -->

Fixes #533

## The problem: `users.expiration` is dead storage

`users` has carried an `expiration datetime DEFAULT NULL` column for years — `INSTALL/MYSQL.sql:1712` and the `users` block of `db_schema.json` — but nothing in `app/` ever set it or acted on it:

- No form offered the field. `app/View/Users/admin_add.ctp` and `app/View/Users/admin_edit.ctp` had no `expiration` input, nor did the Overmind theme's copies.
- `UsersController::admin_add()` saved with an explicit `$fieldList` (`app/Controller/UsersController.php:810`) that did not contain `expiration`, so even a REST client posting it there was silently ignored.
- Nothing read it. The only occurrence of the column anywhere in `app/` was the read-only field list of the admin user index (`app/Controller/UsersController.php:497`), which just carried the value into the listing/API output.

(For the avoidance of doubt: `auth_keys.expiration` — `INSTALL/MYSQL.sql:162`, an `int` — is a different, working feature, and the "expiration" mentions in `app/Model/User.php:571-572` are GPG subkey expiry. Neither is this column.)

`admin_edit()` builds its `$fields` list from whatever keys are posted, so a REST client *could* already write a value into the column — it simply had no effect. See the deployment note at the bottom.

## What this adds

**Setting it (admin-facing).**
- `expiration` added to `admin_add()`'s `$fieldList` (`UsersController.php:810`).
- A text input on `admin_add.ctp` / `admin_edit.ctp` and on the Overmind theme's equivalents. The default theme reuses the `datepicker` class that `app/View/AuthKeys/add.ctp:29` already uses for the auth key expiration field (globally initialised in `app/webroot/js/misp.js:5651` with `yyyy-mm-dd`). Empty means "no expiration", which is the existing default.
- `admin_edit()` already derives its save field list from the posted keys, so it needed no controller change.
- The user view page shows the value to admins, highlighted red once it is in the past.

**Normalising it.** `User::beforeValidate()` turns an empty submission back into `NULL` (rather than letting `''` reach a `datetime` column), rejects an unparseable value with a validation error, and otherwise stores `date('Y-m-d H:i:s', strtotime($value))`. Both `admin_add()` and `admin_edit()` call `save()` with validation enabled, so this runs on both paths.

**Enforcing it.** `AppController::__verifyUser()` refuses an expired account, immediately after the existing `disabled` check and immediately before the existing auth key expiration check.

**Not touched:** the self-service `UsersController::edit()` field list (`UsersController.php:208`). A user must not be able to clear their own expiration.

No database schema change is required — the column already exists in `INSTALL/MYSQL.sql` and `db_schema.json`.

## The design choice: block at authentication, not a scheduled disable

The issue says "auto-disable them at that date", which reads as a scheduled task flipping `disabled`. I implemented the other option — a check on the auth path — and did not implement both. Reasons:

1. **Fail-closed.** A scheduled job that is not running (no worker, no cron, a wedged queue) means expired accounts keep full access, and nothing surfaces that. An auth-time check cannot silently not happen.
2. **It is the pattern already in place.** `disabled` is enforced at exactly this point (`AppController.php:669`), and auth key expiration is enforced ten lines below it (`AppController.php:685-697`) — an `int` timestamp compared against `$_SERVER['REQUEST_TIME']`, logged as `auth_fail`, then `ForbiddenException` for REST / flash + redirect for the UI. The new block mirrors that shape, with its own distinct log line and message so admins can tell "expired" from "disabled" in the audit log.
3. **One chokepoint covers both session and API auth.** `__verifyUser()` runs on every authenticated request from `AppController::beforeFilter()` (`AppController.php:353`), so no separate handling is needed for authkey-authenticated REST calls.
4. **It keeps `disabled` meaning what it means.** Flipping `disabled` from a scheduler conflates "an admin disabled this account" with "this account timed out", and clearing or extending the expiration afterwards would not re-enable the user without a second mechanism to remember why they were disabled.

`expiration` is already part of the session user array — `User::describeAuthFields()` (`app/Model/User.php:967`) includes every schema column except `gpgkey`, `certif_public`, `password` and `authkey` — so the check needs no extra query, and `__verifyUser()` already reloads the user from the database when `date_modified` has advanced.

**What the alternative would have looked like:** a new console task under `app/Console/Command/Task/` registered in the `tasks` table, running e.g. daily, selecting `User.expiration IS NOT NULL AND User.expiration < NOW() AND User.disabled = 0` and calling `saveField('disabled', true)` on each, with a log entry per user. That is more code, a schema row, and a new operational dependency, for weaker guarantees.

## Behaviour notes

- Granularity is effectively a day: the datepicker submits `YYYY-MM-DD`, which `strtotime()` resolves to midnight. Setting today's date expires the account immediately.
- Over REST, any string `strtotime()` accepts is fine (`2027-01-01`, `2027-01-01 18:00:00`). A bare integer timestamp is *not* accepted and produces a validation error.
- The expired user is logged out on their next request with "Your user account has expired." (UI) or a `ForbiddenException` (REST), and an `auth_fail` log entry "Login attempt by expired user." is written under the same rate limiting (`_shouldLog`) as the disabled-user entry.

**Deployment note:** because `admin_edit()` accepted arbitrary posted fields, an instance where somebody happened to write a past `expiration` over the API will start refusing those accounts as soon as this is deployed. That is the intended semantics of the column, but it is a behaviour change on an auth path, so it is worth flagging. `SELECT id, email, expiration FROM users WHERE expiration IS NOT NULL;` shows whether any instance is affected.

## Verification

`php -l` passes on all eight changed files (PHP 8.5). Beyond that, this was **not** verified at runtime: I have no live MISP instance here and did not run the test suite. The claims above come from reading the code, not from executing it. The auth-path change in particular deserves a look on a real instance before merge.

