### PR TITLE
[high] fix: [enrichment] restore background_jobs branch in Event::enrichmentRouter

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -7994,8 +7994,6 @@ class Event extends AppModel
 
     public function enrichmentRouter($options)
     {
-        $result = $this->enrichment($options);
-        return __('#' . $result . ' attributes have been created during the enrichment process.');
         if (Configure::read('MISP.background_jobs')) {
 
             /** @var Job $job */


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** An unconditional early return makes `enrichmentRouter()`'s background-jobs branch unreachable.

- **Problem** — `Event::enrichmentRouter()` in `app/Model/Event.php` begins with an unconditional `return` placed above its `if (Configure::read('MISP.background_jobs'))` block, dead since a stray 2022 commit, so enrichment always runs synchronously in the request and `EventsController::enrichEvent()`'s "Enrichment task queued for background processing" path can never be taken.
- **Fix** — Deletes the two dead lines so the branch is reachable again.
- **Effect** — Instances with background jobs enabled queue enrichment instead of blocking the request.
<!-- /bluf -->

## The dead code

`Event::enrichmentRouter()` (`app/Model/Event.php`) begins with an unconditional `return`, placed *above* the `if (Configure::read('MISP.background_jobs'))` block:

```php
public function enrichmentRouter($options)
{
    $result = $this->enrichment($options);
    return __('#' . $result . ' attributes have been created during the enrichment process.');
    if (Configure::read('MISP.background_jobs')) {
        ...
```

Everything from the `if` onwards is unreachable. The method is a router in name only — it has behaved as a plain synchronous call for years.

## How it got there

The two lines were added in `508424aa37f201780a7be0c24fa5c0e3678e64ab` — *"chg: [workflow] Convert to MISP Core format before passing data to the workflow"* (2022-07-18, on `feature-workflows-2`). The rest of that commit is about object distribution fields and the workflow format converter; the `enrichmentRouter` hunk is unrelated to its subject, carries no comment and no config flag. It reads as a local debug shortcut that was committed by accident rather than a deliberate disable, and nothing in the surrounding history re-visits it.

## Fix chosen: restore the branch (delete the early return)

Alternatives considered and rejected:

- **Delete the dead block and keep synchronous behaviour.** Rejected: the queued path is not stale, it is fully wired and its callers still expect it.
  - The enqueue targets `BackgroundJobsTool::CMD_EVENT` → `EventShell`, and `EventShell::enrichment()` takes exactly the arguments passed (`user id`, `event id`, JSON modules, `jobId`), creating/updating the `Job` row and writing the log entry.
  - `EventsController::enrichEvent()` still special-cases a `true` return with the flash message *"Enrichment task queued for background processing. Check back later to see the results."* — a message that is currently unreachable.
  - `MispAttribute::enrichmentRouter()` is the same router for attributes with an identical, working structure (no early return), using the same `Job::WORKER_PRIO` / `BackgroundJobsTool::PRIO_QUEUE` constants. It is the reference pattern for what this method should look like.
- **Treat it as a deliberate temporary disable and leave it.** Rejected: no marker of intent anywhere (no comment, no setting, no issue reference), and the commit that added it is about something else entirely.

The change is the deletion of those two lines and nothing more. The background branch still returns `true`, so the existing controller handling is unchanged; with `MISP.background_jobs` disabled the synchronous `else` branch produces exactly the message users see today.

## User-visible consequence

With `MISP.background_jobs` enabled, event enrichment was still executed inline in the web request. Enriching a large event, or enriching in bulk, ran every module synchronously and could hit the PHP `max_execution_time` or the web server timeout instead of being handed to the prio worker with a progress-tracked job. After this change the setting is honoured again and enrichment is queued as intended.

## Testing

`./app/Vendor/bin/parallel-lint app/Model/Event.php` — no syntax errors (PHP 8.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
