### PR TITLE
[medium] fix: [restSearch] honour the $paramsOnly flag in Event::restSearch

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -9253,7 +9253,7 @@ class Event extends AppModel
      * @param int|false $jobId
      * @param int $elementCounter
      * @param bool $renderView
-     * @return TmpFileTool
+     * @return array|TmpFileTool Array of massaged filters when $paramsOnly is true
      * @throws Exception
      */
     public function restSearch(array $user, $returnFormat, $filters, $paramsOnly = false, $jobId = false, &$elementCounter = 0, &$renderView = false)
@@ -9280,7 +9280,7 @@ class Event extends AppModel
         $filters = $this->restSearchFilterMassage($filters, $non_restrictive_export, $user);
 
         $filters = $this->addFiltersFromUserSettings($user, $filters);
-        if (empty($exportTool->mock_query_only)) {
+        if (empty($exportTool->mock_query_only) && !$paramsOnly) {
             $filters['include_attribute_count'] = 1;
             $eventid = $this->filterEventIds($user, $filters, $elementCounter);
             $eventCount = count($eventid);
@@ -9306,6 +9306,9 @@ class Event extends AppModel
             if (!isset($filters['published'])) {
                 $filters['published'] = 1;
             }
+        }
+        if ($paramsOnly) {
+            return $filters;
         }
         $tmpfile = new TmpFileTool();
         $tmpfile->write($exportTool->header($exportToolParams));


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `Event::restSearch()` declares a `$paramsOnly` flag but never reads it.

- **Problem** — `Event::restSearch()` in `app/Model/Event.php` declares and documents `$paramsOnly` but never reads it, unlike the sibling implementations in `MispAttribute`, `MispObject` and `GalaxyCluster`, which all return the massaged parameters early. Passing `true` against `Event` therefore runs the full export and returns a `TmpFileTool` where a query description was requested.
- **Fix** — Implements the flag to match the shared positional contract that `AppController::restSearch()` dispatches through.
- **Effect** — The four models behave alike; the defect is latent today, since no current caller passes `true` to the `Event` version.
<!-- /bluf -->

### Current code

`app/Model/Event.php`:

```php
/**
 * ...
 * @param bool $paramsOnly
 * ...
 * @return TmpFileTool
 */
public function restSearch(array $user, $returnFormat, $filters, $paramsOnly = false, $jobId = false, &$elementCounter = 0, &$renderView = false)
{
    ...
}
```

`$paramsOnly` is declared in the signature and documented in the docblock, but the body never reads it. `grep -n 'paramsOnly' app/Model/Event.php` returns only the docblock line and the signature line.

### What goes wrong

The three sibling `restSearch()` implementations all honour the flag and return the massaged query parameters instead of running the export:

* `app/Model/MispAttribute.php:3744` — `if ($paramsOnly) { return $params; }`
* `app/Model/MispObject.php:1768` — same
* `app/Model/GalaxyCluster.php:1286` — same

`Event::restSearch()` silently ignores it: passing `true` still runs `filterEventIds()`, `clusterEventIds()` and the full per-chunk `fetchEvent()` export, and returns a `TmpFileTool`.

### User-visible consequence

Latent today — no caller passes `true` to the Event version (`DecayingModelController.php:747`, `Sighting.php:847` and `Module_attach_decay_score.php:65` all use the Attribute one). But `AppController::restSearch()` (line 1621) dispatches to whichever model is in scope through this shared positional signature, so any code that starts using the flag against `Event` gets a full export — an expensive DB walk and a serialized result set — where it asked for a query description, and then a type error when it treats the `TmpFileTool` as an array.

### The fix, and why this one

Implement it, rather than removing the parameter. The signature is a shared positional contract: `AppController::restSearch()` calls `$model->restSearch($user, $returnFormat, $filters, false, false, $elementCounter, $renderView, $skippedElementsCounter)` polymorphically, and `UsersController.php:2594`, `EventsController.php:5406`, `User.php:2020` and `EventShell.php:237` all pass the later arguments positionally. Dropping the fourth parameter from `Event` alone would shift `$jobId` into its slot and break that dispatch.

Two changes:

1. Guard the expensive block — `if (empty($exportTool->mock_query_only) && !$paramsOnly)` — so `filterEventIds()`/`clusterEventIds()` are skipped, which is the point of the flag. The `mock_query_only` export tools already take this path, so the `$eventids_chunked = array()` fallback is established.
2. Return `$filters` after the `to_ids`/`published` defaults block, just before the `TmpFileTool` is created.

The return point matters, and it was chosen to match the sibling contract rather than the earliest convenient line. `MispAttribute::restSearch()` applies its `to_ids`/`published` defaults at the top of the method, *before* its `paramsOnly` return, so the params it hands back already carry those restrictive defaults. `Event` applies the same defaults late, so returning right after `addFiltersFromUserSettings()` — the other obvious candidate — would hand back a filter set that omits them and therefore describes a *different* query than the one the export would actually run. Returning after the defaults block keeps the two consistent.

For `Event` the analogue of the siblings' `$params` is `$filters`, since that is the array handed to `fetchEvent()`. Nothing is reordered, so behaviour for every existing caller (all of which pass `false`) is bit-for-bit unchanged. The docblock `@return` is updated to `array|TmpFileTool`, matching `MispAttribute`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

