### PR TITLE
[high] fix: [restSearch] read the right config key for the event memory divisor

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -9353,7 +9353,10 @@ class Event extends AppModel
     {
         $memory_in_mb = $this->convert_to_memory_limit_to_mb(ini_get('memory_limit'));
         $default_attribute_memory_coefficient = Configure::check('MISP.default_attribute_memory_coefficient') ? Configure::read('MISP.default_attribute_memory_coefficient') : 80;
-        $default_event_memory_divisor = Configure::check('MISP.default_event_memory_multiplier') ? Configure::read('MISP.default_event_memory_divisor') : 3;
+        $default_event_memory_divisor = Configure::check('MISP.default_event_memory_divisor') ? Configure::read('MISP.default_event_memory_divisor') : 3;
+        if (!is_numeric($default_event_memory_divisor) || $default_event_memory_divisor <= 0) {
+            $default_event_memory_divisor = 3;
+        }
         $memory_scaling_factor = isset($exportTool->memory_scaling_factor) ? $exportTool->memory_scaling_factor : $default_attribute_memory_coefficient;
         // increase the cost per attribute to account for the overhead of object metadata
         $memory_scaling_factor = $memory_scaling_factor / $default_event_memory_divisor;
@@ -9372,7 +9375,6 @@ class Event extends AppModel
             if ($current_chunk_size == 0 && $count > $limit) {
                 $eventIdList[$i][] = $id;
                 $current_chunk_size = $count;
-                $i++;
             } else {
                 if (($current_chunk_size + $count) > $limit) {
                     $i++;


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `clusterEventIds()` checks a phantom config key, so the real event memory divisor is ignored.

- **Problem** — `Event::clusterEventIds()` checks `Configure` for `MISP.default_event_memory_multiplier`, a key that exists nowhere in the tree, but then reads `MISP.default_event_memory_divisor`. Admins who set the real, documented divisor from the server settings UI see it discarded in favour of the hardcoded `3`, and anyone who sets the phantom multiplier key gets a null divisor and a broken export.
- **Fix** — Reads the same key it checks, in `app/Model/Event.php`.
- **Effect** — `MISP.default_event_memory_divisor` actually controls restSearch's per-chunk memory envelope.
<!-- /bluf -->

Two independent defects in `Event::clusterEventIds()` (`app/Model/Event.php`). They are in the same method and the second is a one-line deletion, so they are proposed as a single coherent diff; happy to split if preferred.

## 1. The wrong config key is checked

### Current code

```php
$default_event_memory_divisor = Configure::check('MISP.default_event_memory_multiplier') ? Configure::read('MISP.default_event_memory_divisor') : 3;
$memory_scaling_factor = isset($exportTool->memory_scaling_factor) ? $exportTool->memory_scaling_factor : $default_attribute_memory_coefficient;
$memory_scaling_factor = $memory_scaling_factor / $default_event_memory_divisor;
```

It **checks** `MISP.default_event_memory_multiplier` but **reads** `MISP.default_event_memory_divisor`.

### What goes wrong

`MISP.default_event_memory_divisor` is the real, documented setting — defined in `app/Model/Server.php:5779` (default `3`, `testForNumeric`, with a description explaining exactly this divisor) and exposed in the UI via `app/Lib/Tools/ServerSettingGroups.php:371`. `MISP.default_event_memory_multiplier` appears nowhere else in the tree: not in `Server.php`, not in `ServerSettingGroups.php`, not in the docs. It is a typo, not a second setting.

Two consequences follow, both reproducible:

* **Setting the documented divisor has no effect.** `Configure::check('...multiplier')` is false, so the ternary takes the `: 3` branch and the configured value is discarded. An admin who raises the divisor to control the fetcher's memory envelope for correlation-heavy events — precisely what the setting's description tells them to do — changes nothing.
* **Setting the undefined multiplier key crashes the export.** `Configure::check('...multiplier')` is true, `Configure::read('...divisor')` returns `null`, and `$memory_scaling_factor / null` raises `DivisionByZeroError`, taking down every `/events/restSearch` call.

### The fix, and why this one

Check and read the same key — the divisor — since that is the one that is defined, documented, surfaced in the UI and used arithmetically as a divisor. The alternative reading, that the code intends a genuine multiplier, has nothing to support it: there is no such setting anywhere, and the arithmetic (`$memory_scaling_factor / $default_event_memory_divisor`, with the comment "increase the cost per attribute") is a division. Introducing a multiplier setting would mean adding a new server setting and changing documented behaviour; correcting the key restores the behaviour that is already documented.

A guard is added for the configured value:

```php
$default_event_memory_divisor = Configure::check('MISP.default_event_memory_divisor') ? Configure::read('MISP.default_event_memory_divisor') : 3;
if (!is_numeric($default_event_memory_divisor) || $default_event_memory_divisor <= 0) {
    $default_event_memory_divisor = 3;
}
```

Without it, fixing the key alone would newly expose a stored `0` or empty string to the same `DivisionByZeroError` — `Configure::check()` passing says nothing about the value being usable. A negative value would invert the memory budget, so it falls back too. `default_attribute_memory_coefficient` is deliberately left alone to keep the diff minimal.

## 2. The returned array is sparsely keyed

### Current code

```php
if ($current_chunk_size == 0 && $count > $limit) {
    $eventIdList[$i][] = $id;
    $current_chunk_size = $count;
    $i++;
} else {
    if (($current_chunk_size + $count) > $limit) {
        $i++;
        $eventIdList[$i][] = $id;
        $current_chunk_size = $count;
    } else {
        ...
    }
}
```

The oversized-event branch increments `$i` *after* writing; the overflow branch increments *before* writing. So an oversized event isolated at key `0` leaves `$i == 1`, and the next event — which necessarily overflows, since `$current_chunk_size` is already above `$limit` — increments to `2` before writing. Key `1` never exists.

### Consequence

Cosmetic today: `restSearch()` only ever `foreach`-es the result, which is indifferent to the keys. It would bite any positional access (`$eventIdList[1]`, `$eventIdList[count(...) - 1]`, or a chunk-index progress counter).

### Fix

Drop the trailing `$i++` from the oversized branch. The remaining `$i++` in the overflow branch always immediately precedes a write, so keys stay contiguous. Chunk *contents* are unchanged in every path — after an oversized event `$current_chunk_size > $limit`, so the following event always takes the overflow branch and starts a new chunk exactly as before, only now at key `1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

