### PR TITLE
[high] fix: [sync] galaxy clusters never pushed on background-job path ($this->data vs $server)

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1302,7 +1302,7 @@ class Server extends AppModel
 
             // sync custom galaxy clusters if user is capable
             if ($push['canEditGalaxyCluster'] && $server['Server']['push_galaxy_clusters'] && "full" == $technique) {
-                $clustersSuccesses = $this->syncGalaxyClusters($serverSync, $this->data, $user, $technique='full');
+                $clustersSuccesses = $this->syncGalaxyClusters($serverSync, $server, $user, $technique='full');
             } else {
                 $clustersSuccesses = array();
             }
@@ -1386,7 +1386,7 @@ class Server extends AppModel
                         $this->Event->shouldBePushedToServer($event, $server);
 
                     if ($pushGalaxyClustersForEvent) {
-                        $this->syncGalaxyClusters($serverSync, $this->data, $user, $technique=$event['Event']['id'], $event=$event);
+                        $this->syncGalaxyClusters($serverSync, $server, $user, $technique=$event['Event']['id'], $event=$event);
                     }
 
                     $result = $this->Event->uploadEventToServer($event, $server, $serverSync);


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Background-job syncs never push custom galaxy clusters because `push()` passes the wrong array.

- **Problem** — `Server::push()` in `app/Model/Server.php` passes `$this->data` to both `syncGalaxyClusters()` call sites instead of the `$server` array it just fetched; CakePHP 2 never populates `Model::$data` from `find()`, so on the background-job and scheduled-push paths that array is empty and `push_galaxy_clusters` is read as unset.
- **Fix** — A two-line change passes `$server` instead at both call sites.
- **Effect** — Scheduled and job-driven syncs push custom galaxy clusters as configured, rather than silently never pushing them.
<!-- /bluf -->

## Summary

`Server::push()` passes `$this->data` — not the `$server` array it just fetched — to both `syncGalaxyClusters()` call sites. `Model::find()` does not populate `Model::$data`, so on the background-job and scheduled-push paths `$this->data` is an empty array and custom galaxy clusters are never pushed.

## The current code

`app/Model/Server.php` (2.5 @ 843b674):

```php
public function push($id, $technique, $jobId = false, $HttpSocket, array $user)
{
    ...
    $server = $this->find('first', ['conditions' => ['Server.id' => $id]]);   // line ~1255
    ...
        // sync custom galaxy clusters if user is capable
        if ($push['canEditGalaxyCluster'] && $server['Server']['push_galaxy_clusters'] && "full" == $technique) {
            $clustersSuccesses = $this->syncGalaxyClusters($serverSync, $this->data, $user, $technique='full');   // line 1305
        } else {
            $clustersSuccesses = array();
        }
    ...
                if ($pushGalaxyClustersForEvent) {
                    $this->syncGalaxyClusters($serverSync, $this->data, $user, $technique=$event['Event']['id'], $event=$event);   // line 1389
                }
```

and the callee, line ~1526:

```php
public function syncGalaxyClusters(ServerSyncTool $serverSync, array $server, array $user, $technique='full', $event=false)
{
    if (!$server['Server']['push_galaxy_clusters']) {
        return []; // pushing clusters is not enabled
    }
```

## Mechanism

In CakePHP 2, `Model::$data` is assigned in exactly three places (`lib/Cake/Model/Model.php`): `create()`, `read()` and `_doSave()`. **`find()` is not one of them.** `Server.php` contains no other write to `$this->data` outside `beforeSave()`, and neither `checkVersionCompatibility()` nor `setupSyncRequest()` — the only model calls between the `find('first')` and line 1305 — touches it.

So whether this works depends entirely on the caller:

| caller | how the server is loaded | `$this->data` at line 1305 | galaxy clusters pushed? |
|---|---|---|---|
| `ServersController::push()` | `$this->Server->read(null, $id)` before calling `push()` | populated | ✅ yes |
| `ServerShell::push()` (line 197) | `getServer()` → `$this->Server->find('first', ...)` | `array()` | ❌ no |
| `ServerShell::enqueuePush()` (line 750) | `$this->Server->find('all', ...)` | `array()` | ❌ no |

`ServersController::push()` only calls `Server->push()` inline when `MISP.background_jobs` is **disabled**; with background jobs on (the default and the recommended production setup) every push goes through `ServerShell`, as does every scheduled push. On those paths `syncGalaxyClusters()` receives `[]`:

```console
$ php -r 'error_reporting(E_ALL);
$f = function(array $server) { if (!$server["Server"]["push_galaxy_clusters"]) { return "NO-OP: returned [] early"; } return "proceeded"; };
echo $f([]), PHP_EOL;'
Warning: Undefined array key "Server" in Command line code on line 2
Warning: Trying to access array offset on null in Command line code on line 2
NO-OP: returned [] early
```

Non-fatal on PHP 8, so it fails silently: two warnings in the error log (or none at all with `display_errors`/`error_reporting` tuned down), an empty success list, and no indication in the job output that cluster sync was skipped.

## How it got here

* 176e29c94f (2020-05-26, `galaxy-cluster2.0`) added the call. At that time `push()` opened with `$this->read(null, $id); $url = $this->data['Server']['url'];` — `$this->data` **was** the right thing to pass.
* 94f2b5bbbb (2020-09-04) replaced `read()` with `$server = $this->find('first', ...)` and rewrote every `$this->data` in `push()` to `$server` — url, lastpushedid, push_rules, `checkIfServerInSG()`, `uploadEventToServer()`, `syncProposals()`, `syncSightings()`.
* The two `syncGalaxyClusters()` calls were on a branch in flight and merged afterwards, still carrying the pre-refactor form. They are now the **only** remaining `$this->data` references in `push()`.

`Event.php:6275` calls the same method with a real `$server` array, which is the shape the signature documents (`@param array $server`).

## Reproduction

1. On the sending instance enable background jobs (`MISP.background_jobs = true`) and create a sync server with **Push** and **Push galaxy clusters** both enabled, against a remote that grants `perm_galaxy_editor`.
2. Create a custom galaxy cluster that is eligible for push (published, distribution > 0, `default = 0`).
3. Trigger a full push from the UI (which enqueues a job) or directly:
   `sudo -u www-data app/Console/cake Server push <user_id> <server_id> full`
4. **Current behaviour:** the job completes, no clusters appear on the remote, and the sync debug log has no `Starting full clusters sync` line. `Undefined array key "Server"` appears in the PHP error log.
   **With this patch:** `Starting full clusters sync` is logged and eligible clusters are pushed.
5. Contrast: set `MISP.background_jobs = false` and repeat step 3 from the UI — clusters *are* pushed, because `ServersController::push()` calls `read()` first. That asymmetry is the tell.

## PHPUnit-style test

`app/Test/Integration/` is not on this branch, so the test is inline. It pins the invariant without needing a remote instance — a `ServerSyncTool`-free spy on the argument that reaches `syncGalaxyClusters()`:

```php
<?php
// app/Test/Case/Model/ServerPushGalaxyClusterArgTest.php
App::uses('Server', 'Model');

class ServerPushGalaxyClusterArgTest extends CakeTestCase
{
    /**
     * Model::find() does not populate Model::$data — only create(), read() and _doSave() do.
     * push() loads its server with find('first'), so $this->data is empty on the
     * ServerShell (background job / scheduled push) paths.
     */
    public function testFindDoesNotPopulateModelData()
    {
        $Server = ClassRegistry::init('Server');
        $Server->data = array();                       // fresh instance, as in ServerShell
        $found = $Server->find('first', array('recursive' => -1));
        $this->assertNotEmpty($found, 'need at least one server row');
        $this->assertEmpty($Server->data, 'find() must not populate $this->data');

        // ... which is what push() would have handed to syncGalaxyClusters():
        $this->assertArrayNotHasKey('Server', $Server->data);
    }

    /**
     * With an empty array the guard in syncGalaxyClusters() short-circuits,
     * regardless of the server's actual push_galaxy_clusters setting.
     */
    public function testEmptyServerArrayShortCircuitsTheGuard()
    {
        $guard = function (array $server) {
            return empty($server['Server']['push_galaxy_clusters']) ? 'no-op' : 'sync';
        };
        $this->assertEquals('no-op', @$guard(array()));                                   // $this->data today
        $this->assertEquals('sync',  $guard(array('Server' => array('push_galaxy_clusters' => 1))));  // $server after this patch
    }
}
```

An end-to-end variant is to subclass `Server`, override `syncGalaxyClusters()` to record `$server` and return `[]`, and assert the recorded array has a `Server` key after `push()` runs against a stubbed `ServerSyncTool`.

## Why this analysis might be wrong

* **"Some caller populates `$this->data` before `push()`."** One does: `ServersController::push()` calls `$this->Server->read(null, $id)` on the same instance, which is why this has gone unnoticed for five years in UI-driven, foreground pushes. That is precisely why this PR is scoped as *"broken on the background-job and scheduler paths"* rather than *"always broken"*. All three call sites of `Server::push()` in the tree were checked (`ServersController.php:1112`, `ServerShell.php:197`, `ServerShell.php:750`); the two shell ones use `find()`.
* **"Something inside `push()` populates it before line 1305."** `Server.php`'s only other `$this->data` reference is `beforeSave()`, which runs on `save()` — and the single `save()` in `push()` happens *after* both call sites. Neither `checkVersionCompatibility()` nor `setupSyncRequest()` calls `read()`/`create()`/`set()` on `$this`.
* **"A stale `$this->data` would still be the same server."** Only if the same instance had previously `read()`/`save()`d *this* server. `ServerShell::enqueuePush()` loops over many servers on one `Server` instance, so the plausible stale value is a *different* server's row from an earlier `save()` — worse than empty, since it would gate cluster push on the wrong server's `push_galaxy_clusters` flag.
* **"The empty array throws, so it would have been noticed."** It does not throw. `array $server` accepts `[]`; the two undefined-key accesses are PHP 8 *warnings*, and the method returns `[]` normally. The caller merges `[]` into `$successes` and reports success.
* **"The guard in `syncGalaxyClusters()` is the real check, so the callee needs its own copy."** The call sites already test `$server['Server']['push_galaxy_clusters']` on the correct array before calling. Passing `$server` makes the callee's guard consistent with that test rather than contradicting it. The guard is left in place — it is now redundant but harmless, and `Event.php:6275` reaches it by a different route.
* **"`$this->data` is deliberate — the intent is the *local* instance's settings, not the peer's."** No: `syncGalaxyClusters()` reads `$server['Server']['push_galaxy_clusters']`, a per-sync-server column, and `Event.php:6275` passes the remote server array. Git history (94f2b5bbbb) shows the surrounding `$this->data` uses were all mechanically converted to `$server`; these two were simply missed.

## The fix

Two-line change: `$this->data` → `$server` at both call sites. Nothing else.

`./app/Vendor/bin/parallel-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

