### PR TITLE
[medium] fix: [log] surface PHP fatal errors in the MISP application log

### DIFF
--- a/app/Error/AppExceptionRenderer.php
+++ b/app/Error/AppExceptionRenderer.php
@@ -4,8 +4,28 @@ App::uses('ExceptionRenderer', 'Error');
 
 class AppExceptionRenderer extends ExceptionRenderer {
 
+    /**
+     * Error types that end the request. `error_get_last()` reporting one of these
+     * means we are running inside the fatal error shutdown chain
+     * (App::shutdown() -> App::_checkFatalError() -> ErrorHandler::handleFatalError()).
+     */
+    const FATAL_ERROR_TYPES = E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR;
+
+    /**
+     * Extra memory (in kilobytes) requested before touching the database, on top of
+     * the `Error.extraFatalErrorMemory` headroom App::shutdown() already granted.
+     */
+    const FATAL_ERROR_EXTRA_MEMORY_KB = 8192;
+
     public function __construct($exception) {
         $this->controller = $this->_getController($exception);
+
+        // Has to happen before the `appError` shortcut and before the exception is
+        // classified below: on a production instance (debug disabled) the fatal is
+        // wrapped into an InternalErrorException, which is not a CakeException and
+        // carries the generic 'Internal Server Error' message, so neither the
+        // classification below nor the exception message can be relied upon.
+        $this->_customErrorLogging($exception);
 
         if (method_exists($this->controller, 'appError')) {
             $this->controller->appError($exception);
@@ -16,7 +36,6 @@ class AppExceptionRenderer extends ExceptionRenderer {
 
         $methodExists = method_exists($this, $method);
         if ($exception instanceof CakeException && !$methodExists) {
-            $this->_customErrorLogging($exception);
             $method = '_cakeError';
             if (empty($template) || $template === 'internalError') {
                 $template = 'error500';
@@ -46,32 +65,134 @@ class AppExceptionRenderer extends ExceptionRenderer {
 
     protected function _customErrorLogging($exception): bool
     {
-        $message = $exception->getMessage();
         $errorDetection = [
             'Maximum execution time of' => 'timeout',
             'Allowed memory size of' => 'out of memory'
         ];
-        $user = $this->controller->Auth->user();
-        $ua = env('HTTP_USER_AGENT');
-        $source = $this->controller->IndexFilter->isRest() ? 'API' : 'web UI';
-        if (strpos($ua, 'MISP ') !== false) {
-            $source = 'MISP sync';
+
+        // Prefer the raw PHP error over the exception message: the exception is only
+        // a stand-in created by ErrorHandler::handleFatalError() and it only carries
+        // the original description while `debug` is enabled.
+        $message = $exception->getMessage();
+        $lastError = error_get_last();
+        if (is_array($lastError) && ($lastError['type'] & self::FATAL_ERROR_TYPES)) {
+            $message = $lastError['message'];
         }
+
         foreach ($errorDetection as $search => $errorName) {
-            if (strpos($message, $search) !== false) {
-                $logMessage = sprintf(
-                    '%s %s error triggered by User %s (%s) via the %s on %s.',
-                    date('Y-m-d H:i:s'),
-                    $errorName,
-                    $user['id'],
-                    $user['email'],
-                    $source,
-                    $this->controller->request->here()
-                );
-                file_put_contents(LOGS . 'fatal_error.log', $logMessage . PHP_EOL, FILE_APPEND);
-                return true;
+            if (strpos($message, $search) === false) {
+                continue;
             }
+
+            list($userId, $userEmail) = $this->_fatalErrorUser();
+            $logMessage = sprintf(
+                '%s %s error triggered by User %s (%s) via the %s on %s.',
+                date('Y-m-d H:i:s'),
+                $errorName,
+                $userId,
+                $userEmail,
+                $this->_fatalErrorSource(),
+                $this->_fatalErrorUrl()
+            );
+
+            // The flat file stays the guaranteed fallback and is written first, before
+            // anything that could itself fail during the shutdown.
+            file_put_contents(LOGS . 'fatal_error.log', $logMessage . PHP_EOL, FILE_APPEND);
+            $this->_logFatalErrorToDatabase($userId, $logMessage, $message);
+            return true;
         }
         return true;
+    }
+
+    /**
+     * Record the fatal error in the MISP application log, so that it shows up in
+     * Administration -> Logs rather than only in a file on disk.
+     *
+     * Everything here is best effort: we are running inside a shutdown function that
+     * was reached because the request ran out of memory or out of time, so the model
+     * layer or the database connection may well be unusable. A failure here must
+     * never replace the fatal error with an error of its own - the flat file written
+     * by the caller remains the fallback.
+     *
+     * @param int|string $userId
+     * @param string $logMessage
+     * @param string $errorMessage
+     * @return void
+     */
+    protected function _logFatalErrorToDatabase($userId, $logMessage, $errorMessage)
+    {
+        try {
+            // An out of memory fatal leaves no room to allocate anything. App::shutdown()
+            // already added `Error.extraFatalErrorMemory` (4 MB by default) before this
+            // chain was entered; give the database write some more so it cannot fatal a
+            // second time, this time inside the error handler itself.
+            App::increaseMemoryLimit(self::FATAL_ERROR_EXTRA_MEMORY_KB);
+
+            $log = ClassRegistry::init('Log');
+            $log->createLogEntry(
+                'SYSTEM',
+                'error',
+                'User',
+                (int)$userId,
+                $logMessage,
+                $errorMessage
+            );
+        } catch (Throwable $e) {
+            // Deliberately swallowed - see the docblock. The flat file already has the entry.
+            try {
+                file_put_contents(
+                    LOGS . 'fatal_error.log',
+                    sprintf('%s could not write the fatal error to the application log: %s', date('Y-m-d H:i:s'), $e->getMessage()) . PHP_EOL,
+                    FILE_APPEND
+                );
+            } catch (Throwable $ignored) {
+            }
+        }
+    }
+
+    /**
+     * @return array [user id, user e-mail]
+     */
+    protected function _fatalErrorUser(): array
+    {
+        try {
+            if (isset($this->controller->Auth)) {
+                $user = $this->controller->Auth->user();
+                if (!empty($user)) {
+                    return [$user['id'] ?? 0, $user['email'] ?? 'unknown'];
+                }
+            }
+        } catch (Throwable $e) {
+            // fall through
+        }
+        return [0, 'unknown'];
+    }
+
+    protected function _fatalErrorSource(): string
+    {
+        $ua = (string)env('HTTP_USER_AGENT');
+        if (strpos($ua, 'MISP ') !== false) {
+            return 'MISP sync';
+        }
+        try {
+            if (isset($this->controller->IndexFilter) && $this->controller->IndexFilter->isRest()) {
+                return 'API';
+            }
+        } catch (Throwable $e) {
+            // fall through
+        }
+        return 'web UI';
+    }
+
+    protected function _fatalErrorUrl(): string
+    {
+        try {
+            if (isset($this->controller->request)) {
+                return (string)$this->controller->request->here();
+            }
+        } catch (Throwable $e) {
+            // fall through
+        }
+        return (string)env('REQUEST_URI');
     }
 }


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** PHP fatal errors such as memory exhaustion or timeouts never reach the MISP application log.

- **Problem** — The detection code in `AppExceptionRenderer::_customErrorLogging()` only runs when a `CakeException` arrives without a dedicated handler method, so shutdown-time fatals bypass it.
- **Fix** — Reworks `app/Error/AppExceptionRenderer.php` (+141/-20) so those fatals are detected and surfaced.
- **Effect** — Administrators see timeout and out-of-memory failures in the log instead of silently losing them.
<!-- /bluf -->

Fixes #1336

## What the issue asks for

> add an error handler for PHP errors — fatals such as memory exhaustion or `max_execution_time` should be caught and surfaced so an administrator notices.

## Current code

`app/Error/AppExceptionRenderer.php` already contains detection logic:

```php
public function __construct($exception) {
    $this->controller = $this->_getController($exception);

    if (method_exists($this->controller, 'appError')) { ... }
    $method = $template = Inflector::variable(str_replace('Exception', '', get_class($exception)));
    $code = $exception->getCode();

    $methodExists = method_exists($this, $method);
    if ($exception instanceof CakeException && !$methodExists) {
        $this->_customErrorLogging($exception);          // <-- only here
        $method = '_cakeError';
        ...
```

```php
protected function _customErrorLogging($exception): bool
{
    $message = $exception->getMessage();
    $errorDetection = [
        'Maximum execution time of' => 'timeout',
        'Allowed memory size of' => 'out of memory'
    ];
    $user = $this->controller->Auth->user();
    $ua = env('HTTP_USER_AGENT');
    $source = $this->controller->IndexFilter->isRest() ? 'API' : 'web UI';
    if (strpos($ua, 'MISP ') !== false) {
        $source = 'MISP sync';
    }
    foreach ($errorDetection as $search => $errorName) {
        if (strpos($message, $search) !== false) {
            $logMessage = sprintf(...);
            file_put_contents(LOGS . 'fatal_error.log', $logMessage . PHP_EOL, FILE_APPEND);
            return true;
        }
    }
    return true;
}
```

The plumbing that reaches it is real: `App::init()` registers a shutdown function (`app/Lib/cakephp/lib/Cake/Core/App.php:777`) → `App::shutdown()` (`:928`) → `App::_checkFatalError()` (`:951`, reads `error_get_last()`) → `ErrorHandler::handleFatalError()` (`app/Lib/cakephp/lib/Cake/Error/ErrorHandler.php:276`) → the configured exception renderer, i.e. `AppExceptionRenderer`.

## Mechanism of the problem

There are two defects, and the second one is the more serious.

**1. The destination is a flat file, not the application log.**

`file_put_contents(LOGS . 'fatal_error.log', ...)` writes to `app/tmp/logs/fatal_error.log`. Nothing in the UI reads that file. An admin looking at *Administration → Logs* sees nothing at all, which is exactly the "so an admin notices" part of the request.

**2. On a production instance the detection never runs.**

`ErrorHandler::handleFatalError()` does not pass the real error down; it substitutes an exception:

```php
if (Configure::read('debug')) {
    $exception = new FatalErrorException($description, 500, $file, $line);
} else {
    $exception = new InternalErrorException();
}
```

With `debug` disabled — the normal production setting — the renderer receives an `InternalErrorException`. In CakePHP 2 the class hierarchy is:

```
CakeBaseException
 ├── CakeException          (FatalErrorException extends this)
 └── HttpException          (InternalErrorException extends this)
```

`InternalErrorException` is therefore **not** an instance of `CakeException`, so `__construct()` falls through to the `elseif (!$methodExists)` branch and `_customErrorLogging()` is never called. And even if it were called, `InternalErrorException::__construct()` defaults its message to the literal string `'Internal Server Error'`, so `strpos($message, 'Allowed memory size of')` could not match either.

Net effect: **the existing fatal-error detection only works while `debug` is on.** On the production instances the issue is about, an OOM or timeout fatal produces neither a `Log` row nor a line in `fatal_error.log`.

## User-visible effect

An event export or a sync run dies at the PHP memory limit. The user gets a blank/500 page. The admin sees nothing in *Administration → Logs*, nothing in `fatal_error.log`, and only a terse `Fatal Error (1): Allowed memory size of ... exhausted` line in `error.log` written by `CakeLog::write()` — which carries no user, no source and no URL, so there is no way to tell whose request or which endpoint blew up.

## The change

`app/Error/AppExceptionRenderer.php` only.

1. **Read the fatal from `error_get_last()`** rather than from the stand-in exception message, guarded by a fatal type mask (`E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR`). Detection is now independent of `debug`. If there is no fatal on record, it falls back to the exception message, which preserves the old debug-mode behaviour.
2. **Call `_customErrorLogging()` unconditionally**, at the top of the constructor, and let it guard itself. It is no longer coupled to the `instanceof CakeException` classification, and it also runs before the `appError` shortcut. For a normal 404 the guard short-circuits after one `error_get_last()` call.
3. **Write a `Log` entry as well as the file.** `ClassRegistry::init('Log')->createLogEntry('SYSTEM', 'error', 'User', $userId, $logMessage, $rawErrorMessage)` — `createLogEntry` with the `'SYSTEM'` string is the established idiom for system-level rows, and `error` is already in `Log::$validate['action']`'s `inList`. The message keeps the existing format (user id, e-mail, source `web UI` / `API` / `MISP sync`, URL) so the file and the `Log` row read identically.
4. **The flat file write stays**, is written *first*, and is unconditional. It remains the fallback for exactly the case where the database write cannot work.
5. **The database write is defensive**, because this runs inside a shutdown function reached because the request ran out of memory or out of time:
   - `App::increaseMemoryLimit(8192)` before touching the model layer. `App::shutdown()` already grants `Error.extraFatalErrorMemory` (4 MB by default) before `_checkFatalError()`, but 4 MB is a thin budget for a model init plus an INSERT after an OOM. Note this is *necessary*: memory exhaustion in PHP 7/8 is a hard fatal, not a `Throwable`, so a `try`/`catch` alone would not protect this path.
   - the whole write is wrapped in `catch (Throwable)`. `Log::createLogEntry()` throws on validation failure and the DB connection may be gone, so a failure has to be swallowed — with a one-line note appended to `fatal_error.log`.
   - a `max_execution_time` fatal is safe to follow with a DB write: PHP does not re-arm the execution timer during shutdown.
6. **Tolerate a degraded controller.** `_getController()` can return a bare `Controller` when `AppController` fails to construct. The existing code called `$this->controller->Auth->user()`, `$this->controller->IndexFilter->isRest()` and `$this->controller->request->here()` unconditionally; those are now `isset`-guarded with `Throwable` fallbacks, and `env('HTTP_USER_AGENT')` is cast before `strpos()` (passing `null` is deprecated on PHP 8.1+).

## Alternatives rejected

- **Only change the destination (file → `Log`), leave the trigger alone.** Rejected: it would have fixed nothing on a production instance, because the trigger never fires there. The `debug`-dependency is the actual bug.
- **Replace the file log with a `Log` row.** Rejected: the DB is the least reliable thing available during an OOM shutdown. The file is the only write that is guaranteed to be attempted, so it stays as the fallback, and it is written first.
- **Register a dedicated `register_shutdown_function` in `bootstrap.php`.** Rejected: it would duplicate the chain CakePHP already provides, would run in addition to `App::shutdown()` and would have to re-implement the memory headroom logic. The renderer is already the single funnel.
- **Match on `FatalErrorException` / `InternalErrorException` by type instead of by message.** Rejected: `InternalErrorException` is also thrown deliberately by application code that has nothing to do with a fatal, so it is not a reliable signal. `error_get_last()` is.
- **Log every fatal, not only OOM/timeout.** Rejected as scope creep for this issue; the detection map is unchanged and stays easy to extend.

## Why this analysis might be wrong

Conditions under which the current behaviour would actually be correct, and how they were ruled out:

- **"`InternalErrorException` is a `CakeException`, so the branch is taken in production too."** Ruled out by reading `app/Lib/cakephp/lib/Cake/Error/exceptions.php`: `class CakeException extends CakeBaseException` (`:207`) and `class HttpException extends CakeBaseException` (`:65`), `class InternalErrorException extends HttpException` (`:184`). They are siblings, not ancestor/descendant.
- **"MISP overrides `Exception.renderer`/`Exception.handler` so a different path handles fatals."** Checked `app/Config/core.php` / bootstrap: `AppExceptionRenderer` is the configured renderer and the standard `ErrorHandler::handleException` chain is in use.
- **"`AppController::appError()` exists, so the constructor returns before the logging."** Ruled out by grep: no `appError()` is defined anywhere under `app/Controller/`. The call was nevertheless moved above that shortcut so it holds even if one is added later.
- **"Something else already writes fatals to the `Log` table."** `ErrorHandler::handleFatalError()` calls `CakeLog::write(LOG_ERR, ...)`, which goes to `app/tmp/logs/error.log`, not to the `logs` DB table, and carries no user/source/URL context. No other writer of a `Log` row for PHP fatals exists.
- **"`Log::createLogEntry()` will reject `action => 'error'`."** Ruled out: `error` is present in the `inList` whitelist in `Log::$validate`.
- **"The 4 MB `Error.extraFatalErrorMemory` headroom is already enough, so the extra bump is noise."** Possible, but unverifiable in general — it depends on how much of the model layer is already warm. The bump is cheap and the failure mode without it (a second fatal *inside* the error handler, losing the log entry entirely) is bad enough to justify it. If a maintainer prefers to rely on `Error.extraFatalErrorMemory` alone, dropping that one line is a safe reduction.
- **Behaviour change worth flagging:** `_customErrorLogging()` now runs for every rendered exception rather than only for `CakeException`s. It is a no-op unless `error_get_last()` reports a matching fatal, so the added cost on a 404 is a single `error_get_last()` call.

## Reproduction / test scenario

On an instance with `debug` set to 0 (i.e. a normal production configuration):

1. Temporarily lower the limit so a fatal is easy to trigger, e.g. in `app/Config/bootstrap.php` add `ini_set('memory_limit', '32M');`, or set `max_execution_time = 1` in `php.ini` for the web SAPI.
2. Trigger a heavy request as a logged-in user — a large event export (`/events/restSearch` over a big event), or `/events/view/<big event id>`.
3. **Before this patch:** the request 500s; `app/tmp/logs/fatal_error.log` does not exist / is not appended to; *Administration → Logs* shows nothing. Only `app/tmp/logs/error.log` gets `Fatal Error (1): Allowed memory size of ... exhausted`.
4. **After this patch:** `app/tmp/logs/fatal_error.log` gets
   `2026-08-27 11:00:00 out of memory error triggered by User 1 (admin@admin.test) via the web UI on /events/view/123.`
   and *Administration → Logs* shows a matching row with `Org: SYSTEM`, `Action: error`, `Model: User`, the same title, and the raw PHP error message in `change`.
5. Repeat with `debug` set to 1 to confirm the debug path (which used to be the only working one) still logs, now to both destinations.
6. Repeat with the API (`Authorization` header + `Accept: application/json`) and with a `User-Agent: MISP 2.5.x` to confirm the `API` / `MISP sync` source labels.
7. Negative check: request a non-existent URL (`/events/view/999999999`). No `fatal_error.log` line and no `error` row should be produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

