### PR TITLE
[medium] fix: [log] aggregate and optionally suppress "email cannot be encrypted" log entries

### DIFF
--- a/app/Lib/Tools/SendEmail.php
+++ b/app/Lib/Tools/SendEmail.php
@@ -3,6 +3,18 @@ App::uses('CakeEmail', 'Network/Email');
 
 class SendEmailException extends Exception {}
 
+/**
+ * Raised when `GnuPG.onlyencrypted` is set but the recipient has neither a usable
+ * GnuPG key nor a usable S/MIME certificate, so the message cannot be sent at all.
+ *
+ * This is a distinct class rather than a message string because it is the one
+ * SendEmailException that is expected to happen in bulk - once per recipient of a
+ * publish alert - and callers therefore need to be able to recognise and aggregate
+ * it. It extends SendEmailException, so existing `catch (SendEmailException $e)`
+ * handlers keep working unchanged.
+ */
+class SendEmailEncryptionKeyMissingException extends SendEmailException {}
+
 class CakeEmailBody
 {
     /** @var string|null */
@@ -450,7 +462,7 @@ class SendEmail
         $canEncryptSmime = !empty($user['User']['certif_public']) && Configure::read('SMIME.enabled');
 
         if (Configure::read('GnuPG.onlyencrypted') && !$canEncryptGpg && !$canEncryptSmime) {
-            throw new SendEmailException('Encrypted messages are enforced and the message could not be encrypted for this user as no valid encryption key was found.');
+            throw new SendEmailEncryptionKeyMissingException('Encrypted messages are enforced and the message could not be encrypted for this user as no valid encryption key was found.');
         }
 
         // If 'GnuPG.bodyonlyencrypted' is enabled and the user has no encryption key, use the alternate body

--- a/app/Lib/Tools/ServerSettingGroups.php
+++ b/app/Lib/Tools/ServerSettingGroups.php
@@ -358,6 +358,7 @@ class ServerSettingGroups
                     'MISP.disable_seen_ips_authkeys',
                     'MISP.log_new_audit',
                     'MISP.log_new_audit_compress',
+                    'MISP.log_skip_email_encryption_failures',
                 ),
             ),
             array(

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -35,6 +35,9 @@ class Event extends AppModel
     const NO_PUSH_DISTRIBUTION = 'distribution',
         NO_PUSH_SERVER_RULES = 'push_rules';
 
+    /** Maximum number of e-mail addresses spelled out in the aggregated encryption failure log entry. */
+    const ENCRYPTION_FAILURE_LOG_LIMIT = 200;
+
     public $actsAs = array(
         'AuditLog',
         'SysLogLogable.SysLogLogable' => array(
@@ -4677,6 +4680,8 @@ class Event extends AppModel
 
         $userCount = count($usersWithAccess);
         $metadataOnly = Configure::read('MISP.event_alert_metadata_only') || Configure::read('MISP.publish_alerts_summary_only');
+        // Collected instead of logged one by one - see logEncryptionFailures() below.
+        $encryptionFailures = [];
         foreach ($usersWithAccess as $k => $user) {
             // Fetch event for user that will receive alert e-mail to respect all ACLs
             $eventForUser = $this->fetchEvent($user, [
@@ -4695,17 +4700,63 @@ class Event extends AppModel
             $eventForUser = $eventForUser[0];
             if ($this->User->UserSetting->checkPublishFilter($user, $eventForUser)) {
                 $body = $this->prepareAlertEmail($eventForUser, $user, $oldpublish);
-                $this->User->sendEmail(['User' => $user], $body, false, null);
+                $this->User->sendEmail(['User' => $user], $body, false, null, false, $encryptionFailures);
             }
             if ($jobId) {
                 $this->Job->saveProgress($jobId, null, $k / $userCount * 100);
             }
         }
 
+        $this->logEncryptionFailures($senderUser, $id, $userCount, $encryptionFailures);
+
         if ($jobId) {
             $this->Job->saveStatus($jobId, true, __('Mails sent.'));
         }
         return true;
+    }
+
+    /**
+     * Write a single Log entry summarising the recipients that could not be alerted because
+     * `GnuPG.onlyencrypted` is set and they have no usable encryption key.
+     *
+     * Before this existed, User::sendEmail() wrote one entry per affected recipient, which on a
+     * large instance means hundreds of near-identical rows for a single publish.
+     *
+     * @param array $senderUser
+     * @param int $eventId
+     * @param int $userCount Total number of users with alerting enabled that were attempted.
+     * @param array $encryptionFailures E-mail addresses that could not be encrypted for.
+     * @return void
+     */
+    private function logEncryptionFailures(array $senderUser, $eventId, $userCount, array $encryptionFailures)
+    {
+        if (empty($encryptionFailures)) {
+            return;
+        }
+        if (Configure::read('MISP.log_skip_email_encryption_failures')) {
+            return;
+        }
+        $failureCount = count($encryptionFailures);
+        // `logs`.`change` is a TEXT column, so do not let a very large instance overflow it.
+        $listed = array_slice($encryptionFailures, 0, self::ENCRYPTION_FAILURE_LOG_LIMIT);
+        $affected = implode(', ', $listed);
+        if ($failureCount > count($listed)) {
+            $affected .= __(' and %s more', $failureCount - count($listed));
+        }
+        $title = __(
+            'Encrypted e-mails are enforced, but no valid encryption key was found for %s of the %s users with alerting enabled for event #%s, so no alert e-mail could be sent to them.',
+            $failureCount,
+            $userCount,
+            $eventId
+        );
+        $this->loadLog()->createLogEntry(
+            $senderUser,
+            'email',
+            'Event',
+            $eventId,
+            $title,
+            __('Affected users: %s', $affected)
+        );
     }
 
     /**

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -6659,6 +6659,14 @@ class Server extends AppModel
                     'type' => 'boolean',
                     'null' => true
                 ],
+                'log_skip_email_encryption_failures' => [
+                    'level' => self::SETTING_OPTIONAL,
+                    'description' => __('When `GnuPG.onlyencrypted` is enabled, MISP logs an entry every time an e-mail cannot be sent because the recipient has no valid encryption key. Publish alerts already collapse these into a single entry per event, but on an instance where a large share of the users have no key even that summary may be unwanted noise. Enable this to skip these log entries entirely. The failures are still reported in the error log.'),
+                    'value' => false,
+                    'test' => 'testBool',
+                    'type' => 'boolean',
+                    'null' => true
+                ],
                 'delegation' => array(
                     'level' => 1,
                     'description' => __('This feature allows users to create org only events and ask another organisation to take ownership of the event. This allows organisations to remain anonymous by asking a partner to publish an event for them.'),

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -876,11 +876,15 @@ class User extends AppModel
      * @param string|false $bodyNoEnc
      * @param string|null $subject
      * @param array|false $replyToUser
+     * @param array|null $encryptionFailures Opt-in collector for callers that send to many users at once.
+     *      When an array is passed by reference, a "no valid encryption key" failure appends the recipient's
+     *      e-mail address to it instead of writing an individual Log entry, leaving it to the caller to write
+     *      a single aggregated entry after its loop. Every other failure is logged as before.
      * @return bool
      * @throws Crypt_GPG_BadPassphraseException
      * @throws Crypt_GPG_Exception
      */
-    public function sendEmail(array $user, $body, $bodyNoEnc = false, $subject, $replyToUser = false)
+    public function sendEmail(array $user, $body, $bodyNoEnc = false, $subject, $replyToUser = false, &$encryptionFailures = null)
     {
         if (Configure::read('MISP.disable_emailing')) {
             return true;
@@ -903,7 +907,19 @@ class User extends AppModel
             $result = $sendEmail->sendToUser($user, $subject, $body, $bodyNoEnc,$replyToUser ?: []);
 
         } catch (SendEmailException $e) {
+            $isEncryptionKeyMissing = $e instanceof SendEmailEncryptionKeyMissingException;
+            // Opt-in aggregation: the caller owns the loop and writes one summary entry for all
+            // of the recipients it could not encrypt for, so nothing is recorded per recipient.
+            if ($isEncryptionKeyMissing && is_array($encryptionFailures)) {
+                $encryptionFailures[] = $user['User']['email'];
+                return false;
+            }
             $this->logException("Exception during sending e-mail with subject '$subject' to {$user['User']['email']}", $e);
+            // Opt-in suppression of this specific, expected and potentially very noisy entry.
+            // The exception above is still written to the error log.
+            if ($isEncryptionKeyMissing && Configure::read('MISP.log_skip_email_encryption_failures')) {
+                return false;
+            }
             $log->create();
             $log->saveOrFailSilently(array(
                 'org' => 'SYSTEM',


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Publishing to a large org floods the log with one "cannot be encrypted" row per recipient.

- **Problem** — With `GnuPG.onlyencrypted` set, `SendEmail` throws once per recipient lacking a usable key and `User::sendEmail()` writes one `Log` row per throw.
- **Fix** — Aggregates them into one summary entry per publish in `app/Model/Event.php` and adds a server setting, registered in `ServerSettingGroups.php`, that suppresses both the per-recipient rows and the summary.
- **Effect** — The log stays readable after a publish; addresses issues #1100 and #702.
<!-- /bluf -->

Fixes #1100
Fixes #702

## Why one PR for both issues

#1100 asks for the "e-mail cannot be encrypted" log entries to be collapsed into one entry per publish; #702 asks for an option to disable them entirely. They are the same log line, written on the same code path, at the same call site. Splitting them would mean two PRs touching the same three lines of `User::sendEmail()`, and the suppression setting only makes sense described next to the aggregation it modifies (it has to switch off *both* the per-recipient rows and the new summary row, otherwise "entirely" is not true). Hence: one PR, aggregation by default, plus a setting for administrators who want none of it.

## Current code

`app/Lib/Tools/SendEmail.php:453` — one throw per recipient:

```php
if (Configure::read('GnuPG.onlyencrypted') && !$canEncryptGpg && !$canEncryptSmime) {
    throw new SendEmailException('Encrypted messages are enforced and the message could not be encrypted for this user as no valid encryption key was found.');
}
```

`app/Model/User.php:904-919` — one `Log` row per throw:

```php
try {
    $result = $sendEmail->sendToUser($user, $subject, $body, $bodyNoEnc, $replyToUser ?: []);
} catch (SendEmailException $e) {
    $this->logException("Exception during sending e-mail with subject '$subject' to {$user['User']['email']}", $e);
    $log->create();
    $log->saveOrFailSilently(array(
        'org' => 'SYSTEM',
        'model' => 'User',
        'model_id' => $user['User']['id'],
        'email' => $user['User']['email'],
        'action' => 'email',
        'title' => 'Email' . $replyToLog . ' to ' . $user['User']['email'] . ', titled "' . $subject . '" failed. Reason: ' . $e->getMessage(),
        'change' => null,
    ));
    return false;
}
```

`app/Model/Event.php:4680-4700` — the loop that calls it once per recipient:

```php
foreach ($usersWithAccess as $k => $user) {
    ...
    if ($this->User->UserSetting->checkPublishFilter($user, $eventForUser)) {
        $body = $this->prepareAlertEmail($eventForUser, $user, $oldpublish);
        $this->User->sendEmail(['User' => $user], $body, false, null);
    }
    ...
}
```

No aggregation exists anywhere in `app/Model/Log.php`.

## Mechanism

`GnuPG.onlyencrypted` is a per-instance policy, but the *absence of a key* is a per-user property. On an instance that enforces encryption and where a large fraction of users have never uploaded a GnuPG key or an S/MIME certificate, every publish walks every alerting user, fails identically for each key-less one, and writes one row each. Nothing anywhere collapses them, because **`User::sendEmail()` does the logging, not the caller** — the function that has the loop, and therefore the only place that knows this is one logical event rather than N, never sees the failures.

## User-visible effect

From #1100: an instance with ~800 users. One publish produces up to ~800 `Log` rows reading

> Email to user@example.com, titled "..." failed. Reason: Encrypted messages are enforced and the message could not be encrypted for this user as no valid encryption key was found.

*Administration → Logs* becomes unusable — a single publish pushes everything else off the first several pages, the `logs` table grows for no diagnostic value (the information content of row 800 is identical to that of row 1), and the actual reason is a known, static, instance-wide configuration state rather than an incident.

## The change

**1. A distinct exception class** (`app/Lib/Tools/SendEmail.php`)

```php
class SendEmailEncryptionKeyMissingException extends SendEmailException {}
```

thrown at the former line 453. It extends `SendEmailException`, so every existing `catch (SendEmailException $e)` — including the one in `SendEmail::sendExternal()` — keeps working byte-for-byte.

**2. An opt-in aggregation seam** (`app/Model/User.php`)

```php
public function sendEmail(array $user, $body, $bodyNoEnc = false, $subject, $replyToUser = false, &$encryptionFailures = null)
```

```php
} catch (SendEmailException $e) {
    $isEncryptionKeyMissing = $e instanceof SendEmailEncryptionKeyMissingException;
    if ($isEncryptionKeyMissing && is_array($encryptionFailures)) {
        $encryptionFailures[] = $user['User']['email'];
        return false;
    }
    $this->logException(...);
    if ($isEncryptionKeyMissing && Configure::read('MISP.log_skip_email_encryption_failures')) {
        return false;
    }
    $log->create();
    ...
```

The collector is a by-reference parameter defaulting to `null` and gated on `is_array()`. All 16 other call sites (`ShadowAttribute`, `Post`, `Event::sendEventReportEmail`, `User::initiatePasswordReset`, `UserLoginProfile` ×4, `Module_send_mail`, `UsersController` ×4, `ServerShell`) pass nothing and are behaviourally unchanged: same `Log` row, same `return false`, so `sendAlertEmail`'s and `ShadowAttribute`'s result accumulation still work.

**3. One summary entry per publish** (`app/Model/Event.php`)

`sendAlertEmail()` passes a collector into the loop and, after it, writes one row:

```php
$this->loadLog()->createLogEntry(
    $senderUser, 'email', 'Event', $eventId,
    __('Encrypted e-mails are enforced, but no valid encryption key was found for %s of the %s users with alerting enabled for event #%s, so no alert e-mail could be sent to them.', ...),
    __('Affected users: %s', $affected)
);
```

`createLogEntry()` is the established idiom in this very function (it is already used a few lines above for the ACL-blocked case), `email` is in `Log::$validate['action']`'s whitelist, and the addresses go in `change` (a `TEXT` column) capped at `Event::ENCRYPTION_FAILURE_LOG_LIMIT` (200) plus "and N more", so an instance with thousands of key-less users cannot overflow the column.

**4. The setting** (`app/Model/Server.php`, `app/Lib/Tools/ServerSettingGroups.php`)

`MISP.log_skip_email_encryption_failures`, `level => SETTING_OPTIONAL`, `value => false`, `test => 'testBool'`, `type => 'boolean'`, `null => true` — declared next to the other `MISP.log_*` booleans and claimed by the `logging` ("Logging & audit") section of `ServerSettingGroups` so it renders in the right accordion card rather than falling into the catch-all. The closest precedent for the whole feature is `Security.log_each_individual_auth_fail`, which exists for exactly this reason: collapse an expected, repeating, low-information failure into one entry, with a switch for admins who want the opposite.

When enabled it suppresses the missing-key rows **everywhere** — the per-recipient rows from single sends as well as the aggregated summary — which is what #702's "entirely" asks for. `logException()` still runs, so `app/tmp/logs/error.log` keeps a trace.

## Decisions a reviewer should know about

- **Only the `GnuPG.onlyencrypted` / no-key-at-all throw was reclassified.** The invalid-key (`:393`) and expired-key (`:396`, `:527`) throws still produce a row per user. Those are per-user, individually actionable misconfigurations, not the bulk "this user never uploaded a key" case, so they are deliberately left alone. Easy to extend later if maintainers disagree.
- **Filterability tradeoff.** Today an admin can filter *Logs* by a user's e-mail and see that alerting failed for them. After this change those addresses live in the `change` column of a single `Event`-model row, so per-user filtering by `email` no longer finds them (search on `change` still does). This is the accepted cost of the aggregation #1100 asks for.
- **No type hint on `$encryptionFailures`.** `array &$x = null` would be an implicitly-nullable typed parameter, deprecated as of PHP 8.4. The untyped by-reference parameter plus the `is_array()` gate is intentional; please do not "fix" it.
- **The aggregated path skips `logException()` too.** 800 stack traces in `error.log` is the same noise problem in a different file; the summary row names the affected users. The non-aggregated path is unchanged.

## Alternatives rejected

- **Suppress only (implement #702, close #1100 as a duplicate).** Rejected: it forces admins to choose between "no visibility at all" and "800 rows". The default should be usable without configuration, which is what aggregation gives.
- **Aggregate only (implement #1100, close #702 as covered).** Rejected: on an instance where most users have no key, even one summary row per publish is unwanted, and #702 asks for a switch, not for less noise.
- **Aggregate inside `User::sendEmail()`** (e.g. a static counter / time-window dedupe, the way `log_each_individual_auth_fail` dedupes by hour). Rejected: it would change behaviour for all 17 callers, would need a flush point that a model method has no natural place for, and would silently swallow errors for callers that legitimately want the per-send row. The loop belongs to `sendAlertEmail()`, so the aggregation seam belongs there too — opt-in from the caller.
- **String-match `$e->getMessage()` against 'no valid encryption key was found'.** Rejected: brittle against rewording and against translation. A subclass is free and precise.
- **Dedupe in `Log::save()` / `Log::createLogEntry()` generically.** Rejected: a generic "collapse identical log rows" mechanism is a much larger and riskier change than this issue justifies, and it would silently alter the audit trail semantics of every other log producer.
- **Throttle by adding a `GnuPG.onlyencrypted` pre-check in the alert loop and skipping key-less users before calling `sendEmail()`.** Rejected: it duplicates `SendEmail`'s policy logic in a second place, and it would also hide the S/MIME branch.

## Why this analysis might be wrong

Conditions under which the current behaviour would actually be correct, and how they were ruled out:

- **"The per-user rows are load-bearing for an existing test."** `User::sendEmail()` carries a `// Intentional two spaces to pass test :)` comment — but that guards the *success*-path title, which is untouched. `grep -rn "Encrypted messages are enforced\|sendEmail" app/Test/ tests/` returns nothing, so no test asserts on the failure-path row.
- **"Some caller relies on the failure row being written to detect a problem."** All 17 call sites were enumerated; the only behavioural contract any of them relies on is the `false` return value, which is preserved on every path. None reads the `Log` table back.
- **"`$senderUser` is not a full user array, so `createLogEntry()` will fail on `$user['Organisation']['name']`."** Ruled out by precedent: `sendAlertEmail()` already calls `createLogEntry($senderUser, 'alert', 'User', ...)` a few lines above, on the same variable.
- **"Aggregating loses information."** The summary carries the count, the total attempted, the event id and the affected addresses (up to 200). The only thing genuinely lost is the per-user `subject`, which for publish alerts is the same generated subject for everyone.
- **"An admin *wants* one row per user for compliance."** That is why the aggregation is scoped to the alert loop and why the setting is off by default; every other sender still writes per-recipient rows. If a maintainer wants the aggregation itself to be switchable too, that is a one-line addition to the same setting family.
- **Known imprecision, stated deliberately:** the `%s of the %s users` denominator is `count($usersWithAccess)`, i.e. everyone with alerting enabled and access to the event, including those the publish filter or an ACL-blocked `fetchEvent` skipped before an e-mail was ever attempted. The wording says "users with alerting enabled" rather than "recipients" for that reason.

## Reproduction / test scenario

1. On a test instance, set `GnuPG.onlyencrypted` to true (*Administration → Server settings → GnuPG*).
2. Create, say, 5 users in an org, all with `autoalert` enabled and **no** `gpgkey` and no `certif_public`.
3. Create an event visible to them and publish it (either synchronously or via the background job).
4. **Before this patch:** *Administration → Logs* shows 5 rows, `Action: email`, `Model: User`, one per user, each ending `Reason: Encrypted messages are enforced ... no valid encryption key was found.`
5. **After this patch:** exactly one row, `Action: email`, `Model: Event`, `Model ID:` the event id, titled
   `Encrypted e-mails are enforced, but no valid encryption key was found for 5 of the 5 users with alerting enabled for event #123, so no alert e-mail could be sent to them.`
   with `change` = `Affected users: a@x, b@x, c@x, d@x, e@x`.
6. Now set `MISP.log_skip_email_encryption_failures` to true and publish again: **no** row at all, and `app/tmp/logs/error.log` still records the `SendEmailEncryptionKeyMissingException`s.
7. Regression check on the non-aggregated path: with the setting **off**, use *Administration → Contact users* (or a password reset) to mail one of the key-less users directly. A single per-user failure row must still appear, exactly as before. With the setting **on**, that row must be gone too (this is the #702 half).
8. Regression check on unrelated failures: break the SMTP configuration and send to a user *with* a valid key. The normal per-user failure row must still be written regardless of the setting, since that is not a `SendEmailEncryptionKeyMissingException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

