### PR TITLE
[low] chg: [sync] allow a ServerSyncTool to be injected into push(), pull() and syncProposals()

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -588,13 +588,14 @@ class Server extends AppModel
      * @param array $server
      * @param int|false $jobId
      * @param bool $force
+     * @param ServerSyncTool|null $serverSync Injectable sync client; a fresh one is built when omitted.
      * @return array|string
      * @throws HttpSocketHttpException
      * @throws HttpSocketJsonException
      * @throws JsonException
      * @throws Exception
      */
-    public function pull(array $user, $technique, array $server, $jobId = false, $force = false)
+    public function pull(array $user, $technique, array $server, $jobId = false, $force = false, ServerSyncTool $serverSync = null)
     {
         if ($jobId) {
             Configure::write('CurrentUserId', $user['id']);
@@ -604,7 +605,7 @@ class Server extends AppModel
             $email = $user['email'];
         }
 
-        $serverSync = new ServerSyncTool($server, $this->setupSyncRequest($server));
+        $serverSync = $serverSync ? $serverSync : new ServerSyncTool($server, $this->setupSyncRequest($server));
         try {
             $server['Server']['version'] = $serverSync->info()['version'];
         } catch (Exception $e) {
@@ -1244,10 +1245,11 @@ class Server extends AppModel
      * @param int|false $jobId
      * @param HttpSocket $HttpSocket
      * @param array $user
+     * @param ServerSyncTool|null $serverSync Injectable sync client; a fresh one is built when omitted.
      * @return array|bool
      * @throws Exception
      */
-    public function push($id, $technique, $jobId = false, $HttpSocket, array $user)
+    public function push($id, $technique, $jobId = false, $HttpSocket, array $user, ServerSyncTool $serverSync = null)
     {
         if ($jobId) {
             $job = ClassRegistry::init('Job');
@@ -1256,7 +1258,7 @@ class Server extends AppModel
         if (!$server) {
             throw new NotFoundException('Server not found');
         }
-        $serverSync = new ServerSyncTool($server, $this->setupSyncRequest($server));
+        $serverSync = $serverSync ? $serverSync : new ServerSyncTool($server, $this->setupSyncRequest($server));
 
         $this->Event = ClassRegistry::init('Event');
         $url = $server['Server']['url'];
@@ -1411,7 +1413,7 @@ class Server extends AppModel
                 $server['Server']['lastpushedid'] = $lastpushedid;
                 $this->save($server);
             }
-            $this->syncProposals($HttpSocket, $server, null, null, $this->Event);
+            $this->syncProposals($HttpSocket, $server, null, null, $this->Event, $serverSync);
         }
 
         if ($push['canPush'] || $push['canSight']) {
@@ -1573,14 +1575,23 @@ class Server extends AppModel
         return $successes;
     }
 
-    public function syncProposals($HttpSocket, array $server, $sa_id = null, $event_id = null, $eventModel)
+    /**
+     * @param HttpSocket|null $HttpSocket
+     * @param array $server
+     * @param int|null $sa_id
+     * @param int|null $event_id
+     * @param Event $eventModel
+     * @param ServerSyncTool|null $serverSync Injectable sync client; a fresh one is built when omitted.
+     * @return bool
+     */
+    public function syncProposals($HttpSocket, array $server, $sa_id = null, $event_id = null, $eventModel, ServerSyncTool $serverSync = null)
     {
         $saModel = ClassRegistry::init('ShadowAttribute');
         $HttpSocket = $this->setupHttpSocket($server, $HttpSocket);
         if ($sa_id == null) {
             if ($event_id == null) {
                 // event_id is null when we are doing a push
-                $serverSync = new ServerSyncTool($server, $this->setupSyncRequest($server));
+                $serverSync = $serverSync ? $serverSync : new ServerSyncTool($server, $this->setupSyncRequest($server));
                 try {
                     $ids = $this->getEventIdsFromServer($serverSync, true, true);
                 } catch (Exception $e) {


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Optional `ServerSyncTool` injection makes `push()`, `pull()` and `syncProposals()` testable.

- **Problem** — Each of the three builds its own `ServerSyncTool`, whose HTTP socket is private with no setter, so the technique dispatch, error handling and pagination guards in `app/Model/Server.php` can only be exercised against a second reachable MISP instance.
- **Fix** — Gives each method an optional trailing `ServerSyncTool` argument defaulting to the object it built before, the shape `checkVersionCompatibility()` already uses here.
- **Effect** — Runtime behaviour is unchanged; these sync entry points become testable without a live peer.
<!-- /bluf -->

## What this is

A **testability seam**, not a behaviour change. `Server::push()` and `Server::pull()` are the two entry points of the whole sync path and neither can be exercised in a test today, because each builds its own HTTP client internally:

```php
$serverSync = new ServerSyncTool($server, $this->setupSyncRequest($server));
```

`ServerSyncTool::__construct()` ends with `$this->socket = $syncTool->setupHttpSocket($server);` (`app/Lib/Tools/ServerSyncTool.php:44-56`). `$socket` is `private`, there is no setter, and `SyncTool::setupHttpSocket()` → `createHttpSocket()` → `new HttpSocketExtended(...)` offers no injection hook. So the only way to run either method is against a second, reachable MISP instance — which is why the error handling, the technique dispatch and the pagination guards in this file are entirely uncovered.

This PR gives both methods an **optional trailing `ServerSyncTool` argument** that defaults to exactly the object they built before.

## The precedent already exists in this file

`Server::checkVersionCompatibility()` — `app/Model/Server.php:3254` and `:3261` on `2.5` @ `843b674450` — already does precisely this:

```php
public function checkVersionCompatibility(array $server, $user = [], ServerSyncTool $serverSync = null)
{
    ...
    $serverSync = $serverSync ? $serverSync : new ServerSyncTool($server, $this->setupSyncRequest($server));
```

This change applies the identical shape to `pull()`, `push()` and `syncProposals()`. Nothing new is invented.

## Why `syncProposals()` is in the diff too

`push()` calls `$this->syncProposals($HttpSocket, $server, null, null, $this->Event)` (old line 1414). Inside, on the `$event_id === null` branch that only a push takes, `syncProposals()` builds *its own* `ServerSyncTool` (old line 1583) and calls `getEventIdsFromServer()` on it. Without forwarding, an injected `push()` still opens a real socket, so the seam would not actually make `push()` testable. `push()` now passes its instance down and `syncProposals()` takes the same optional trailing argument.

Note this also clears up a nuance worth stating explicitly: `push()`'s **existing** `$HttpSocket` parameter is *not* a seam for the event push. It is used exactly once, in that `syncProposals()` call, and `AppModel::setupHttpSocket()` returns a passed socket unchanged — so it reaches the proposal `POST`s and the `checkuuid` `GET` and nothing else. The main event push, the sightings push, the analyst-data push and the collection push all go through `$serverSync`, which was unreachable.

## Behaviour is unchanged for every caller

Every call site, enumerated:

| Method | Call sites on `2.5` | Args passed | After this change |
|---|---|---|---|
| `pull()` | `ServersController.php:393`, `ServersController.php:1035`, `ServerShell.php:160`, `ServerShell.php:579` | 3–5 positional | 6th param absent → `null` → builds its own client, as before |
| `push()` | `ServersController.php:1112`, `ServerShell.php:197`, `ServerShell.php:750` | 5 positional | 6th param absent → `null` → builds its own client, as before |
| `syncProposals()` | `Server.php:1414` (push), `Event.php:6285` (publish) | 5 positional | `Event.php:6285` passes a non-null `$event_id`, so it takes the `else` branch and **never** constructed a `ServerSyncTool` in the first place |

Proof of preservation:

1. The new parameter is **trailing and optional** on all three methods. All callers pass positionally and none passes an argument in that position, so no argument shifts.
2. `grep` finds no dynamic dispatch (`$this->Server->$method(...)`, `call_user_func`) that could reach these three methods with a variadic argument list. The only `$this->$method()` sites in the tree are `AnalystDataParentBehavior.php:34` and `AttachmentObjectBuilder.php:252`, neither of which is on `Server`.
3. When the argument is `null` the expression `$serverSync ? $serverSync : new ServerSyncTool(...)` evaluates to exactly the previous right-hand side, unchanged and in the same place in the method.
4. `php -l` on the patched file reports the same four pre-existing `Optional parameter ... declared before required parameter` deprecations as the unpatched file — the new trailing parameters add none.

The one observable delta, stated honestly: when `push()` forwards its instance to `syncProposals()`, that instance's `info()` result is already cached from the `checkVersionCompatibility()` call earlier in `push()`. The two clients were configured identically (same `$server` array, same `setupSyncRequest($server)`), so the only difference is **at most one fewer `/servers/getVersion` round-trip per push**. No request that mattered is skipped or changed.

## What the seam unlocks

None of these tests can be written today. They add no production risk and need no remote instance. The integration harness lives on a separate branch, so **no test files are included in this PR** — the following is illustrative:

```php
/**
 * ServerSyncTool with the HTTP layer removed. The constructor is deliberately
 * NOT called, so no socket is ever built.
 */
class FakeServerSync extends ServerSyncTool
{
    private $info;
    public function __construct(array $info) { $this->info = $info; }
    public function info() { return $this->info; }
    public function serverId() { return 1; }
    public function serverName() { return 'fake'; }
    public function debug($message) {}
    public function isSupported($feature) { return false; }
}

/** pull(): a 403 from the remote must produce the sync-permission message. */
public function testPullReportsAnAuthorisationFailureDistinctly(): void
{
    $response = new HttpSocketResponse();
    $response->code = 403;
    $sync = new ThrowingServerSync(new HttpSocketHttpException($response));

    $message = $this->model('Server')->pull(
        $this->adminUser(), 'full', $this->serverRow(), false, false, $sync
    );

    $this->assertStringContainsString('Not authorised', $message);
}

/** push(): a remote that can neither push nor sight is collapsed to one message. */
public function testPushRefusesARemoteWithNoSyncPermission(): void
{
    $result = $this->model('Server')->push(
        $this->serverId, 'full', false, null, $this->adminUser(),
        new FakeServerSync(['version' => $this->localVersionString()])
    );

    $this->assertSame('Remote instance is outdated or no permission to push.', $result);
}

/** push(): the technique dispatch rejects anything that is not full/incremental/id. */
public function testPushRejectsAnUnknownTechnique(): void
{
    $this->expectException(InvalidArgumentException::class);
    $this->model('Server')->push(
        $this->serverId, 'sideways', false, null, $this->adminUser(),
        new FakeServerSync($this->remoteInfoWithPermSync())
    );
}
```

The same seam reaches the pagination guards in `getEventIdsFromServer()` (`$remoteIgnoredPagination`, the `$notAdvancing` loop guard, the unpublished-event drop) by scripting `eventIndex()` pages on the fake — logic that is currently impossible to test and easy to regress.

## Why this analysis might be wrong

- **`syncProposals()` may be scope creep.** It is a third method in a PR whose headline is "push and pull". If you would rather keep the diff to two methods I will drop it — but then `push()` still hits the network in any test where `$server['Server']['push']` is set, so the seam only half-works for push.
- **The `info()` caching delta might matter to someone.** I argue it cannot: `checkVersionCompatibility()` already fetched `getVersion` moments earlier in the same `push()` call, on an identically-configured client. If some deployment relies on `syncProposals()` re-fetching the remote version (a remote upgraded mid-push?), that behaviour changes. I could not find a reason it would, but I have not run a live sync against a real peer — my verification is static reading plus `php -l`, not an end-to-end push.
- **`push()`'s signature is already unusual** — `$jobId = false` sits before the required `$HttpSocket`, which PHP 8 deprecates. Adding to the end of that list is safe but arguably papers over a signature that wants a proper cleanup. A parameter object or a rework of `push()` would be better; it would also be a much larger, riskier change.
- **A `protected function makeServerSync(array $server)` factory was the main alternative and I rejected it.** It is a slightly smaller diff and touches no signature, and it would cover *every* `new ServerSyncTool` in `Server.php` at once rather than three. But it has no precedent in this file, whereas the optional parameter has one at line 3254; and overriding it from a test means subclassing a CakePHP 2 model, which needs `$name`/`$alias`/`$useTable` overrides and a `ClassRegistry` alias to stand in for `Server` — considerably more test machinery than passing an argument. If maintainers prefer the factory I will switch; the tests are cheap to adapt.
- **The premise that these methods are untestable could be wrong** if there is a fixture or mock layer in the project I did not find. I searched `app/Test` and found none that intercepts `SyncTool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

