### PR TITLE
[medium] fix: [sync] validate push technique regardless of server push setting

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1284,21 +1284,28 @@ class Server extends AppModel
             return $push;
         }
 
+        // Validate the technique argument before branching on the server's push
+        // configuration. This dispatch used to live inside the `canPush && push`
+        // block below, so the very same invalid input threw an InvalidArgumentException
+        // on a push-enabled server but was silently accepted on a push-disabled one.
+        // The argument contract does not depend on the server's configuration, so it
+        // is enforced unconditionally here.
+        if ("full" == $technique) {
+            $eventid_conditions_key = 'Event.id >';
+            $eventid_conditions_value = 0;
+        } elseif ("incremental" == $technique) {
+            $eventid_conditions_key = 'Event.id >';
+            $eventid_conditions_value = $server['Server']['lastpushedid'];
+        } elseif (intval($technique) !== 0) {
+            $eventid_conditions_key = 'Event.id';
+            $eventid_conditions_value = intval($technique);
+        } else {
+            throw new InvalidArgumentException("Technique parameter must be 'full', 'incremental' or event ID.");
+        }
+
         // sync events if user is capable and server is configured for push
         if ($push['canPush'] && $server['Server']['push']) {
             $successes = array();
-            if ("full" == $technique) {
-                $eventid_conditions_key = 'Event.id >';
-                $eventid_conditions_value = 0;
-            } elseif ("incremental" == $technique) {
-                $eventid_conditions_key = 'Event.id >';
-                $eventid_conditions_value = $server['Server']['lastpushedid'];
-            } elseif (intval($technique) !== 0) {
-                $eventid_conditions_key = 'Event.id';
-                $eventid_conditions_value = intval($technique);
-            } else {
-                throw new InvalidArgumentException("Technique parameter must be 'full', 'incremental' or event ID.");
-            }
 
             // sync custom galaxy clusters if user is capable
             if ($push['canEditGalaxyCluster'] && $server['Server']['push_galaxy_clusters'] && "full" == $technique) {


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** An invalid push technique reports success whenever the server is not push-enabled.

- **Problem** — `Server::push()` validates `$technique` inside the block guarded by `canPush` && `Server.push`, so the `else` arm that throws `InvalidArgumentException` is skipped and an invalid technique falls through to the function's normal success return.
- **Fix** — Lifts the technique dispatch and its validation out of that conditional.
- **Effect** — `POST /servers/push/<id>/<technique>` with a bogus technique reports the error consistently instead of quietly claiming success whenever push is disabled.
<!-- /bluf -->

## Defect

`Server::push()` validates its `$technique` argument **inside** the block that is only entered when the server is both push-capable and push-enabled. The same invalid input therefore produces two completely different outcomes depending on a setting that has nothing to do with argument validity.

### Current code (`app/Model/Server.php`, `push()`)

```php
        // sync events if user is capable and server is configured for push
        if ($push['canPush'] && $server['Server']['push']) {
            $successes = array();
            if ("full" == $technique) {
                $eventid_conditions_key = 'Event.id >';
                $eventid_conditions_value = 0;
            } elseif ("incremental" == $technique) {
                $eventid_conditions_key = 'Event.id >';
                $eventid_conditions_value = $server['Server']['lastpushedid'];
            } elseif (intval($technique) !== 0) {
                $eventid_conditions_key = 'Event.id';
                $eventid_conditions_value = intval($technique);
            } else {
                throw new InvalidArgumentException("Technique parameter must be 'full', 'incremental' or event ID.");
            }
```

## Mechanism

The `full` / `incremental` / numeric / `throw` dispatch is nested one level too deep. When `$push['canPush'] && $server['Server']['push']` is false the whole block — including the `else { throw ... }` arm — is skipped. Execution continues straight to the sightings, analyst-data and collections blocks further down, which are gated on their *own* conditions (`canPush || canSight`, `canPush || canEditAnalystData`, …) and never look at `$technique`. The function then falls through to its normal success return.

## User-visible consequence

`POST /servers/push/<id>/<technique>` with a nonsense technique (`"lunch"`, `"ful"`, a typo in an automation script):

* against a **push-enabled** server → uncaught `InvalidArgumentException`, HTTP 500 / failed job with `Technique parameter must be 'full', 'incremental' or event ID.`
* against a **push-disabled** (e.g. sightings-only) server → **no error at all**. The call reports success, the job is marked done, and the operator has no way to learn that the technique they asked for was never honoured.

For an operator scripting against a mixed fleet of sync servers this is the worst shape of failure: the bad argument is loud on some peers and silent on others, so the typo survives.

## Fix

Hoist the dispatch above the `canPush && push` gate — **validate always, act conditionally**. The code is moved verbatim; no branch condition is altered. `$server['Server']['lastpushedid']` is already available at that point (`$server` is loaded at the top of the method), so the `incremental` arm is unaffected.

### Alternatives rejected

* **Duplicate the validation into the `else` branch.** Two copies of the same contract drift apart; and the `else` branch does not exist — the block simply has no counterpart.
* **Make the invalid technique a logged warning instead of an exception on push-disabled servers.** That preserves the split contract rather than removing it, and gives a third behaviour to reason about.
* **Return an error string instead of throwing.** `push()` already signals bad *arguments* with `InvalidArgumentException` and bad *remote state* with a string return; callers (`ServersController::push`, `ServerShell::push`) branch on `is_array($result)`. Turning a programming-error into a string return would make an argument bug indistinguishable from a remote being outdated.

## ⚠️ Behaviour change (release notes)

Input that is silently accepted today starts failing. Concretely: a synchronous `push()` with a technique that is not `full`, not `incremental` and not a non-zero-coercing event ID, against a server where `canPush && Server.push` is false, now throws `InvalidArgumentException` instead of quietly running the sightings/analyst-data push.

The one flow worth calling out: `ServersController::push($id = null, $technique = false)` defaults the technique to `false`. A synchronous `GET/POST /servers/push/<id>` **without** a technique segment against a sightings-only server currently performs a sightings-only push and will now throw. Note this is not a new inconsistency introduced here — that same call *already* throws today against a push-enabled server, so this change makes the no-technique call behave the same way everywhere. Callers should pass an explicit technique; the documented API path in `app/webroot/doc/openapi.yaml` is `/servers/push/{serverId}/{pushTechnique}`, and the UI (`app/View/Servers/index.ctp`, "Push all") always passes `full`. The background-job path is unaffected — `ServerShell::push()` normalises an empty argument to `'full'` before calling the model.

If maintainers would rather have `push()` treat an empty technique as `full` (matching `ServerShell`) instead of throwing, that is a one-line addition and I am happy to add it here.

## Reproduction

Without a live pair of servers, the control-flow claim is directly demonstrable:

```php
php -r '
function push_current($canPush, $serverPush, $technique) {
    if ($canPush && $serverPush) {
        if ("full" == $technique) { $c = "id > 0"; }
        elseif ("incremental" == $technique) { $c = "id > lastpushedid"; }
        elseif (intval($technique) !== 0) { $c = "id = " . intval($technique); }
        else { throw new InvalidArgumentException("Technique parameter must be ..."); }
    }
    return "reached the sightings/analyst-data blocks, returned success";
}
foreach ([[true, true], [false, true], [true, false]] as [$canPush, $serverPush]) {
    try { $r = push_current($canPush, $serverPush, "lunch"); }
    catch (InvalidArgumentException $e) { $r = "THREW: " . $e->getMessage(); }
    printf("canPush=%d serverPush=%d -> %s\n", $canPush, $serverPush, $r);
}'
```

```
canPush=1 serverPush=1 -> THREW: Technique parameter must be ...
canPush=0 serverPush=1 -> reached the sightings/analyst-data blocks, returned success
canPush=1 serverPush=0 -> reached the sightings/analyst-data blocks, returned success
```

Same input, three different outcomes. With this patch all three throw.

End to end: configure a sync server with `push = 0` and a sync user whose remote role has `perm_sighting`, then call `/servers/push/<id>/lunch` with `MISP.background_jobs` disabled. Today: success response. With this patch: the invalid technique is reported.

## Why this analysis might be wrong

I tried to falsify the claim four ways; each is ruled out below.

1. **"Some caller deliberately relies on the silence to run a sightings-only push."** Ruled out by enumerating every caller of `Server::push()`: `app/Controller/ServersController.php:1112` and `app/Console/Command/ServerShell.php:197` (both pass an operator-supplied technique) and `app/Console/Command/ServerShell.php:750` (passes the literal `'full'`). None passes a deliberately-invalid sentinel, and none loops over multiple servers with a shared technique, so no legitimate flow depends on the sentinel being swallowed. `ServerShell.php:855`/`:870` are `TaxiiServer->push()`, a different model. The one caller that *can* reach the model with a non-technique value is `ServersController::push`'s `$technique = false` default, addressed under "Behaviour change" above.
2. **"The nesting is intentional — the technique only means something for the event push, so it's fine to ignore it when there is no event push."** If that were the contract there would be no exception at all; the argument would be documented as advisory. The presence of a hard `throw` for exactly the same value on the other side of the gate shows the intent is rejection, not tolerance. The exception message ("Technique parameter must be …") is phrased as an argument contract, not as a statement about the server.
3. **"`canPush` is false only when the remote already rejected us, so we never get this far."** Ruled out by reading the code above the block: `push()` returns early with a string only when `!$push['canPush'] && !$push['canSight']`. A remote that grants `perm_sighting` but not `perm_sync` — or a local server row with `Server.push = 0` and any remote permission — reaches the block with the gate false. That is a supported, common configuration, not an error state.
4. **"`intval($technique) !== 0` already rejects everything invalid, so the `else` is unreachable anyway."** No: `intval("lunch") === 0`, so `"lunch"` lands in the `else`. Verified on PHP 8.3.

## Related

* The `intval($technique) !== 0` arm in this dispatch has its own coercion bug (`'1e3'` → event 1000), matching the one in `__getEventIdListBasedOnPullTechnique()`. It is deliberately **not** touched here to keep this PR to one defect; it is filed separately.
* Open PR #10994 (`chg/sync-serversync-injection`) changes the `push()` signature. This branch is cut from `2.5` and does not touch the signature line, so the diffs should not overlap textually, but a maintainer merging both should be aware they touch the same function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

