### PR TITLE
[medium] fix: [sync] reject non-integer pull techniques instead of coercing them

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -286,7 +286,14 @@ class Server extends AppModel
                 'fields' => array('Event.uuid'),
             ));
             return array_intersect($eventIds, $localEventUuids);
-        } elseif (is_numeric($technique)) {
+        } elseif (is_int($technique) || ctype_digit((string)$technique)) {
+            // A remote event ID must be a clean integer. `is_numeric()` used to accept
+            // any numeric literal and `intval()` then coerced it, so '1e3' silently
+            // pulled event 1000, '3.9' and '3abc' pulled event 3, and only strings that
+            // happen to coerce to 0 were rejected. `ctype_digit()` on the string form
+            // accepts exactly the digit-only ids real callers pass (the `(string)` cast
+            // is required: ctype_digit() applied to an int argument is deprecated and
+            // interprets small ints as ASCII codepoints, so ctype_digit(3) is false).
             return array(intval($technique));
         } elseif (Validation::uuid($technique)) {
             return array($technique);


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `is_numeric()` plus `intval()` turn a mistyped pull technique into an unrelated event id.

- **Problem** — `Server::__getEventIdListBasedOnPullTechnique()` gates its numeric branch with `is_numeric()` then converts with `intval()`, and the two disagree: `'1e3'` becomes event 1000 and `'3.9'` becomes event 3, while `'3abc'` is loudly rejected.
- **Fix** — Accepts only genuine integer techniques and raises `InvalidArgumentException` for the rest.
- **Effect** — The further an argument was from the operator's intent, the more likely it was silently accepted; now a mistyped pull technique reports an error rather than pulling an unrelated event.
<!-- /bluf -->

## Defect

`Server::__getEventIdListBasedOnPullTechnique()` accepts a remote event ID as a "technique". It tests the argument with `is_numeric()` and then converts it with `intval()`. Those two functions do not agree on what a number is, and the gap between them silently pulls the **wrong event**.

### Current code (`app/Model/Server.php`)

```php
    private function __getEventIdListBasedOnPullTechnique($technique, ServerSyncTool $serverSync, $force = false)
    {
        if ("full" === $technique) {
            ...
        } elseif ("update" === $technique) {
            ...
        } elseif (is_numeric($technique)) {
            return array(intval($technique));
        } elseif (Validation::uuid($technique)) {
            return array($technique);
        }
        throw new InvalidArgumentException("Invalid pull technique `$technique`.");
    }
```

## Mechanism

`is_numeric()` accepts every numeric *literal* PHP recognises — scientific notation, floats, leading/trailing whitespace. `intval()` then does a lossy conversion. And because the `is_numeric()` gate is not exhaustive of what `intval()` will happily chew on, some non-numeric strings never reach it at all but *would* have been mangled if they had.

Verified on PHP 8.3.33:

| `$technique` | `is_numeric()` | `intval()` | outcome today |
|---|---|---|---|
| `'1e3'`  | true  | `1000` | **pulls event 1000** |
| `'3.9'`  | true  | `3`    | **pulls event 3** |
| `' 3'`   | true  | `3`    | pulls event 3 |
| `'3 '`   | true  | `3`    | pulls event 3 |
| `'3abc'` | false | –      | rejected (`InvalidArgumentException`) |
| `'0abc'` | false | –      | rejected |

Note the inconsistency in the last two rows versus the first two: `'3abc'` is loudly rejected while `'1e3'` — which is *further* from the operator's intent — is silently honoured as a different event.

## User-visible consequence

An operator (or an automation script, or a fat-fingered API call) asking to pull remote event `1e3` gets remote event **1000** pulled into the local instance, with a success message and no warning anywhere. In a threat-intelligence sync context that means unrequested data crossing an organisational boundary and being attributed to a deliberate operator action. The audit log records a successful pull; nothing records that the requested identifier was not the one used.

`'3.9'` is the more plausible real-world trigger — a technique field populated from a spreadsheet cell or a JSON float — and it silently pulls event 3.

## Fix

```php
} elseif (is_int($technique) || ctype_digit((string)$technique)) {
    return array(intval($technique));
}
```

An event ID is a positive integer; `ctype_digit()` on the string form accepts exactly the digit-only representation and nothing else. Anything that is not `full`, not `update`, not a clean integer ID and not a UUID now falls through to the existing `throw` — which is what the method was already written to do for `'3abc'`.

**The `(string)` cast is load-bearing.** `ctype_digit()` given an `int` argument is deprecated in PHP 8 and interprets values in 0–255 as ASCII codepoints, so `ctype_digit(3)` is `false` while `ctype_digit('3')` is `true`. Without the cast, callers passing a genuine integer ID would be rejected. `is_int($technique)` is kept as the explicit fast path for the integer case, so the intent survives even if the cast is later touched.

### Alternatives rejected

* **`filter_var($technique, FILTER_VALIDATE_INT)`** — accepts leading `+`/`-` and surrounding whitespace, so `'-5'` and `' 3'` would still slip through. An event ID is never negative.
* **`(string)(int)$technique === (string)$technique`** — works, but reads as a puzzle and quietly rejects `'007'`; `ctype_digit` states the intent directly.
* **Keep `is_numeric()` and reject afterwards if `intval($technique) != $technique`** — loose comparison reintroduces exactly the coercion being fixed (`'1e3' == 1000` is true).
* **Accept the coercion and just log a warning** — the operator still gets the wrong event; a warning in a sync log is not a substitute for not doing the wrong thing.

## ⚠️ Behaviour change (release notes)

Input that is silently accepted today starts failing: a pull technique of `'1e3'`, `'3.9'`, `' 3'`, `'3 '` or any other non-digit numeric literal now raises `InvalidArgumentException: Invalid pull technique ...` instead of pulling a coerced event ID. This is the intended outcome — the pull is refused rather than misdirected — but any automation currently relying on the coercion will start erroring, so it belongs in the release notes.

Legitimate callers are unaffected. Enumerated:

* `app/Controller/ServersController.php:393` — `$eventId` from the "pull event" action, an integer/digit string.
* `app/Controller/ServersController.php:1035` — operator-supplied technique (`full` / `update` / `pull_relevant_clusters` / an event ID).
* `app/Console/Command/ServerShell.php:160` — `$this->args[2]`, a CLI string that is a digit string when it is an ID.
* `app/Console/Command/ServerShell.php:579` — the literal `'full'`.

All of these produce either a keyword, a UUID, an `int`, or a digit-only string — every one of which the new predicate accepts. `'pull_relevant_clusters'` never reaches this method when galaxy-cluster pull is enabled (`Server::pull()` returns early), and already throws here when it is not; that is unchanged.

## Reproduction

```bash
php -r '
$technique = "1e3";                    // operator asked for event "1e3"
if (is_numeric($technique)) {          // current gate
    printf("current code pulls event %d\n", intval($technique));
}
if (is_int($technique) || ctype_digit((string)$technique)) {
    printf("patched code pulls event %d\n", intval($technique));
} else {
    echo "patched code throws: Invalid pull technique `$technique`.\n";
}'
```

```
current code pulls event 1000
patched code throws: Invalid pull technique `1e3`.
```

Full table:

```bash
php -r '
foreach (["full","update","3",3,"007","1e3","3.9"," 3","3 ","3abc","0abc","-5",
          "f3fd67f5-1b39-4d7e-a9b8-000000000000"] as $t) {
    $old = is_numeric($t) ? "id ".intval($t) : "reject/other";
    $new = (is_int($t) || ctype_digit((string)$t)) ? "id ".intval($t) : "reject/other";
    printf("%-40s old=%-14s new=%s\n", var_export($t, true), $old, $new);
}'
```

End to end: with a configured sync server, run
`sudo -u www-data app/Console/cake Server pull <user_id> <server_id> 1e3`.
Today the job completes and event **1000** appears locally; with this patch the job fails with `Invalid pull technique `1e3``.

## Why this analysis might be wrong

Conditions under which the current code would actually be correct, and how each was ruled out:

1. **"`is_numeric()` and `intval()` agree, so there is no gap."** Ruled out empirically on PHP 8.3.33: `intval('1e3') === 1000` and `intval('3.9') === 3`, both with `is_numeric()` true. The gap is real and produces a *different valid event ID*, not an error.
2. **"Some caller legitimately passes a float or exponent form."** Ruled out by enumerating all four callers (listed above). Event IDs originate from `Event.id`, an auto-increment integer column; no caller constructs a technique from a float, and none formats an ID with `%e` or a decimal point.
3. **"`ctype_digit` would reject integer IDs that callers do pass."** This is the real trap and it is why the fix is not a bare `ctype_digit($technique)`. `ctype_digit(3)` is `false` on PHP 8 (int arguments are read as codepoints, and the form is deprecated). Ruled out by the `(string)` cast plus the explicit `is_int()` arm; verified that `3`, `'3'` and `'007'` are all accepted by the patched predicate.
4. **"The coercion is a deliberate convenience — the caller meant event 1000."** No writer of `'1e3'` means 1000; if leniency were intended, `'3abc'` would be accepted too (`intval('3abc') === 3`), and it is not. The method's own inconsistency is the evidence that the coercion is accidental rather than a designed affordance.
5. **"It is unreachable because the technique is validated upstream."** Ruled out by reading the callers: `ServersController::pull` checks only whether the *server* has pull enabled for the `full`/`incremental`/`pull_relevant_clusters` keywords and passes anything else straight through; `ServerShell::pull` passes `$this->args[2]` verbatim. There is no upstream format check.

## Related

Open PR #10994 (`chg/sync-serversync-injection`) adds an optional `ServerSyncTool` parameter to `pull()`. This branch is cut from `2.5` and changes only the body of the private helper `__getEventIdListBasedOnPullTechnique()`, not any signature that PR touches, so the diffs should not overlap textually — but a maintainer merging both should be aware they are in the same call path.

The `intval($technique) !== 0` arm of `Server::push()` has the same coercion shape; it is filed separately to keep one defect per PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

