### PR TITLE
[high] fix: [sync] guard the pull loop's anti-stall check against an empty id list

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1153,9 +1153,20 @@ class Server extends AppModel
             // Safety net against a remote that honours `limit` but ignores `page`
             // (would otherwise loop forever): the minimal index is sorted by
             // Event.id asc, so the max id must strictly advance between pages.
-            $maxId = (int)max(array_column($eventArray, 'id'));
-            $notAdvancing = ($previousMaxId !== null && $maxId <= $previousMaxId);
-            $previousMaxId = $maxId;
+            // `id` is guaranteed by the `minimal=1` index of any MISP remote, but a
+            // remote that answers with well-formed rows carrying no `id` would leave
+            // array_column() empty and max([]) throws a ValueError on PHP 8 - i.e. the
+            // guard written to survive a misbehaving remote would crash on one. When no
+            // id is available we cannot prove the page advanced, so we treat it exactly
+            // like a non-advancing page: process it and stop paginating.
+            $ids = array_column($eventArray, 'id');
+            if ($ids === []) {
+                $notAdvancing = true;
+            } else {
+                $maxId = (int)max($ids);
+                $notAdvancing = ($previousMaxId !== null && $maxId <= $previousMaxId);
+                $previousMaxId = $maxId;
+            }
 
             if (!$all) {
                 if (!empty($this->EventBlocklist)) {


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** An empty id column makes `max()` throw and kills the whole sync pull on PHP 8.

- **Problem** — `Server::getEventIdsFromServer()`'s anti-stall guard calls `max(array_column($eventArray, 'id'))`; when a page of remote events carries no `id` key, `array_column` returns an empty array and `max()` throws `ValueError` on PHP 8, though the rest of the loop tolerates that shape.
- **Fix** — Guards the guard so the empty case is handled.
- **Effect** — The response is remote-controlled, so a field-stripping proxy or truncated reply no longer kills a pull with an uncaught fatal; pulls against such remotes finish or fail cleanly instead of dying mid-run.
<!-- /bluf -->

## Defect

The anti-stall guard in `Server::getEventIdsFromServer()` exists to survive a misbehaving remote. It is itself unguarded: on PHP 8 it throws `ValueError` on exactly the class of malformed response it was written to defend against.

### Current code (`app/Model/Server.php`, `getEventIdsFromServer()`)

```php
            // Safety net against a remote that honours `limit` but ignores `page`
            // (would otherwise loop forever): the minimal index is sorted by
            // Event.id asc, so the max id must strictly advance between pages.
            $maxId = (int)max(array_column($eventArray, 'id'));
            $notAdvancing = ($previousMaxId !== null && $maxId <= $previousMaxId);
            $previousMaxId = $maxId;
```

## Mechanism

`array_column($eventArray, 'id')` returns `[]` when no row in the page carries an `id` key. `max([])` throws `ValueError: max(): Argument #1 ($value) must contain at least one element` on PHP 8 (on PHP 5/7 it emitted a warning and returned `false`, which the `(int)` cast then turned into `0` — so this code was warning-noisy but non-fatal before the PHP 8 migration).

`$eventArray` is not local data: it is whatever the remote returned from its `/events/index` with `minimal=1`. A remote can return a syntactically valid, non-empty JSON array of objects that simply lack `id` — a proxy that strips fields, an alternate MISP-compatible implementation, a partially-migrated instance, a truncated or rewritten response. The rest of the loop tolerates that shape (`removeBlockedEvents()`, the `published` filter and `removeOlderEvents()` all use `isset`/array access on other keys or handle absence); only the guard is fatal.

## User-visible consequence

A sync pull against such a remote dies with an uncaught `ValueError` instead of the intended graceful stop. In the background-worker path the job is marked failed with a PHP internal error message rather than a sync diagnostic, giving the operator no indication that the *remote* is the problem. The irony is the point: the line was added to make the loop robust against a remote that does not behave, and it is the line that crashes on one.

**Currently latent, not currently exploitable.** I confirmed the `minimal=1` index always carries `id`: `EventsController::index()` builds the minimal response with an explicit field list — `app/Controller/EventsController.php:857`, `'fields' => array('id', 'timestamp', 'sighting_timestamp', 'published', 'uuid', 'protected')` — and `Server::getEventIndexFromServer()` always sets `$filterRules['minimal'] = 1`. So any genuine MISP peer is safe. This is a robustness fix for a guard whose entire purpose is to handle peers that are *not* genuine.

## Fix

```php
            $ids = array_column($eventArray, 'id');
            if ($ids === []) {
                $notAdvancing = true;
            } else {
                $maxId = (int)max($ids);
                $notAdvancing = ($previousMaxId !== null && $maxId <= $previousMaxId);
                $previousMaxId = $maxId;
            }
```

When ids are present the semantics are byte-for-byte what they were: same `max()`, same `<=` comparison against the same `$previousMaxId`, same update. Only the no-id case is new.

**Why `$notAdvancing = true` is the right no-id behaviour.** The guard's contract is "do not continue paginating unless the page provably advanced". With no ids, advancement cannot be proven, so continuing would be exactly the infinite loop the guard exists to prevent. Setting `notAdvancing` makes the loop process this page normally (its UUIDs are still collected, so no data is dropped) and then stop — the same treatment a duplicate page gets today. `$previousMaxId` is deliberately left untouched in this branch so a later page carrying real ids is still compared against the last id we actually saw, rather than against a fabricated `0`.

### Alternatives rejected

* **`max(array_column(...) ?: [0])` / `(int)max([...[0]])`** — one character shorter, but it fabricates `maxId = 0`, which is `<= $previousMaxId` for every page after the first and *also* clobbers `$previousMaxId` to `0`, so a subsequent real page would compare against a wrong baseline. It reaches the right answer on the first page for the wrong reason.
* **`break` immediately on empty ids** — discards the page's UUIDs. The page may be perfectly usable data; the id is only needed for the loop-termination check, not for the result.
* **Throw a descriptive sync exception** — turns a currently-survivable remote quirk into a hard pull failure, which is a bigger behaviour change than the bug being fixed. If maintainers prefer a logged warning alongside the stop, that is a comfortable addition.
* **Require `id` in `getEventIndexFromServer()` and filter rows without it** — pushes validation into a hot path shared by other callers, for a defect that only affects one loop-control line.

## Behaviour change

None when ids are present — that is every real MISP peer, and the case the existing tests cover. The only changed path is one that currently raises an uncaught `ValueError`, which becomes a clean stop.

## Reproduction

The PHP 8 behaviour, and the guard's two inputs:

```bash
php -r '
$page = [["uuid" => "aaa", "published" => 1], ["uuid" => "bbb", "published" => 1]];
var_dump(array_column($page, "id"));          // array(0) {} - well-formed page, no ids
try {
    $maxId = (int)max(array_column($page, "id"));   // the current line
    echo "maxId = $maxId\n";
} catch (\Throwable $e) {
    echo get_class($e), ": ", $e->getMessage(), "\n";
}'
```

```
array(0) {
}
ValueError: max(): Argument #1 ($value) must contain at least one element
```

(Confirmed on PHP 8.3.33.)

End to end, without touching a live instance: point a sync server row at any HTTP endpoint that answers `/events/index` with `[{"uuid":"...","published":1}]` — a two-line stub is enough — and run a pull. The worker fails with the `ValueError` above; with this patch the page is processed and pagination stops.

## Why this analysis might be wrong

Conditions under which the current code would be correct, and how each was ruled out:

1. **"`max([])` does not throw."** Ruled out empirically on PHP 8.3.33 — output above. It was a warning returning `false` on PHP 5/7, which is why the line was safe when similar patterns were written; MISP 2.5 runs PHP 8.
2. **"`array_column` cannot return `[]` here, because the loop already `break`s on an empty page."** Ruled out by reading the two conditions: the `break` at the top tests `count($eventArray) === 0`, i.e. *no rows*. `array_column` returns `[]` for a different condition — rows present, none carrying the key. A page of 500 rows with no `id` passes the `break` and reaches `max()`.
3. **"The remote always sends `id`, so the line is unreachable."** Confirmed true for genuine MISP peers (`EventsController::index()` minimal field list, cited above) — which is why this is filed as latent rather than as a live crash. It does not make the code correct: the enclosing comment states the guard's purpose is defending against a remote that ignores `page`, i.e. one that already does not behave as documented. A defence that assumes the attacker follows the spec is not a defence. The response is also unvalidated network input on the pull path.
4. **"A page without ids should abort the whole pull, so crashing is nearly right."** The crash is an uncaught `ValueError` surfacing as a PHP internal error in a job status, not a sync diagnostic, and it discards the page's already-fetched UUIDs. If aborting is genuinely the desired policy it should be an explicit, logged sync error — see the rejected alternative above; I did not choose it because it is a larger behaviour change than the defect warrants.
5. **"Treating no-ids as `notAdvancing` changes the guard's meaning when ids *are* present."** Ruled out by construction: the `else` arm is the original three lines verbatim, and `$previousMaxId` is only ever written from a real id.

## Related

The surrounding pagination loop is recent (`MISP.event_index_pull_chunk_size`, #10881); this patch touches only the loop-control line and no filtering, dedup or caching logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

