### PR TITLE
[medium] fix: [sync] actually detect a malformed remote version string

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -3278,9 +3278,15 @@ class Server extends AppModel
         $canSight = isset($remoteVersion['perm_sighting']) ? $remoteVersion['perm_sighting'] : false;
         $canEditGalaxyCluster = isset($remoteVersion['perm_galaxy_editor']) ? $remoteVersion['perm_galaxy_editor'] : false;
         $canEditAnalystData = isset($remoteVersion['perm_analyst_data']) ? $remoteVersion['perm_analyst_data'] : false;
-        $remoteVersionString = $remoteVersion['version'];
-        $remoteVersion = explode('.', $remoteVersion['version']);
-        if (!isset($remoteVersion[0])) {
+        $remoteVersionString = isset($remoteVersion['version']) ? $remoteVersion['version'] : null;
+        $remoteVersion = $remoteVersionString === null ? [] : explode('.', $remoteVersionString);
+        // The comparison ladder below reads $remoteVersion[0], [1] and [2], so all three
+        // components must be present and numeric. The previous guard tested
+        // `!isset($remoteVersion[0])`, which explode() can never make false - it always
+        // returns at least one element - so a truncated version such as "2" or "2.4" fell
+        // straight through to the ladder and produced undefined-array-key warnings and
+        // null comparisons on PHP 8 instead of the intended clean error.
+        if (count($remoteVersion) !== 3 || $remoteVersion !== array_filter($remoteVersion, 'ctype_digit')) {
             $message = __('Error: Server didn\'t send the expected response. This may be because the remote server version is outdated.');
             $this->loadLog()->createLogEntry($user, 'error', 'Server', $server['Server']['id'], $message);
             return $message;


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `Server::checkVersionCompatibility()`'s malformed-version guard is a tautology and never fires.

- **Problem** — `explode()` always returns at least one element, so `!isset($remoteVersion[0])` is always false. A malformed version string falls through into the comparison ladder, which reads `$remoteVersion[1]` and `[2]` even when those keys do not exist.
- **Fix** — Replaces the tautology with a check on the exploded parts.
- **Effect** — Admins connecting to a misbehaving remote get the intended error instead of undefined-key warnings and an unreliable verdict.
<!-- /bluf -->

## Defect

`Server::checkVersionCompatibility()` has a guard meant to catch a remote that answers with an unexpected/outdated version response. The guard can never fire — its condition is a tautology — so a malformed or truncated version string falls through into a comparison ladder that indexes array elements which do not exist.

### Current code (`app/Model/Server.php`, `checkVersionCompatibility()`)

```php
        $remoteVersionString = $remoteVersion['version'];
        $remoteVersion = explode('.', $remoteVersion['version']);
        if (!isset($remoteVersion[0])) {
            $message = __('Error: Server didn\'t send the expected response. This may be because the remote server version is outdated.');
            $this->loadLog()->createLogEntry($user, 'error', 'Server', $server['Server']['id'], $message);
            return $message;
        }
```

and the ladder it guards:

```php
        if ($localVersion['major'] > $remoteVersion[0]) { ... }
        ...
        if ($response === false && $localVersion['minor'] > $remoteVersion[1]) { ... }
        ...
        if ($response === false && $localVersion['hotfix'] > $remoteVersion[2]) { ... }
        ...
        if (empty($response) && $remoteVersion[1] <= 4 && $remoteVersion[2] < 111) { ... }
```

## Mechanism

`explode()` **always** returns an array with at least one element — for the empty string it returns `['']`. So `$remoteVersion[0]` is set unconditionally and `!isset($remoteVersion[0])` is always `false`. The branch is dead code.

The ladder below then reads `$remoteVersion[1]` and `$remoteVersion[2]`. A remote answering `version: "2"` produces `['2']`; a remote answering `version: "2.4"` produces `['2', '4']`. On PHP 8 those reads are `Warning: Undefined array key 1` / `key 2`, and the missing element evaluates as `null` in the comparison — so `$localVersion['minor'] > null` is true, `$localVersion['minor'] < null` is false, and the function silently produces whichever verdict the null comparisons happen to yield rather than the clean error the guard was written to return.

```bash
php -r '
$parts = explode(".", "2");
var_dump($parts, isset($parts[0]));   // ["2"], true - guard can never fire
error_reporting(E_ALL);
var_dump(5 > $parts[1]);              // Warning: Undefined array key 1 ... bool(true)'
```

## User-visible consequence

Against a remote whose `/servers/getVersion` returns a truncated or non-standard version string, an operator sees PHP undefined-array-key warnings in the error log (or in the HTTP response body, on instances that surface notices) instead of the actionable message *"Error: Server didn't send the expected response. This may be because the remote server version is outdated."* The sync then proceeds on a verdict derived from `null` comparisons, so the version-compatibility check — the thing standing between an operator and a sync against an incompatible peer — silently produces a meaningless answer. Nothing is written to the sync log, because the log entry lives in the branch that never runs.

## Fix

```php
        $remoteVersionString = isset($remoteVersion['version']) ? $remoteVersion['version'] : null;
        $remoteVersion = $remoteVersionString === null ? [] : explode('.', $remoteVersionString);
        if (count($remoteVersion) !== 3 || $remoteVersion !== array_filter($remoteVersion, 'ctype_digit')) {
            $message = __('Error: Server didn\'t send the expected response. ...');
            $this->loadLog()->createLogEntry($user, 'error', 'Server', $server['Server']['id'], $message);
            return $message;
        }
```

The guard now asserts exactly what the ladder below requires: three components, each a plain integer. The `array_filter` comparison is strict and key-preserving, so it is an identity test — if every element is digit-only the filtered array is identical, otherwise it is not.

The `isset()` on `['version']` is included because the line immediately above (`$remoteVersionString = $remoteVersion['version'];`) is itself an unguarded array read: a remote response with no `version` key at all warns *before* reaching the guard. Handling it here is the same defect one line earlier, and skipping it would leave the "malformed response" guard unable to catch the most malformed response of all. Flagging it explicitly in case maintainers would rather see it split out.

**The error return shape is preserved.** The method returns either an array (success shape, with `success` / `canPush` / `canSight` / `version` / `protectedMode`) or a `string` (error message), and callers branch on that:

* `app/Model/Server.php:1263` — `push()` does `if (!is_array($push)) { ...log...; return $push; }`.
* `app/Model/Event.php:989` — `uploadEventToServer()` does `if (empty($push['canPush'])) { return 'The remote user is not a sync user...'; }`.

The `Event.php` caller applies a string offset to a string. I verified on PHP 8.3.33 that `empty($str['canPush'])` on a string returns `true` without an error (illegal-offset warnings apply to reads, not to `empty()`/`isset()`), so a string return degrades to the "not a sync user" message rather than crashing. That is the existing behaviour for every other error path in this method; this patch adds no new shape.

### Alternatives rejected

* **`if (count($remoteVersion) < 3)` only** — catches truncation but not `"2.4.x"` or `"2.5.0-rc1"`, which still put a non-numeric value into the ladder's comparisons.
* **Pad the missing components with `0`** — silently invents a version for the peer and lets an incompatible sync proceed. The guard's message says the response was not the expected one; inventing data contradicts it.
* **`version_compare()` for the whole ladder** — genuinely better code, but it changes the verdict boundaries (major/minor/hotfix messages are distinct, and `$remoteVersion` is returned to callers as the exploded array), which is a refactor, not a bug fix.
* **`is_numeric` instead of `ctype_digit`** — would accept `"2.4.1e2"` and `"2.4.-1"`. Version components are plain digits.

## Behaviour change

No legitimate remote is affected. The version string a MISP peer sends is built in `ServersController::getVersion()` as `$versionArray['major'] . '.' . $versionArray['minor'] . '.' . $versionArray['hotfix']` from `VERSION.json`, whose three fields are integers (`{"major":2, "minor":5, "hotfix":45}`) — always exactly three numeric components.

The changed path is one that today produces undefined-array-key warnings and a nonsense verdict; it now returns the error string the code was written to return. Verified against the new predicate:

```
'2.5.24'    => ok        '2'         => ERROR      '2.4'   => ERROR
'2.4.111'   => ok        '2.5.0-rc1' => ERROR      '2.4.x' => ERROR
''          => ERROR     '2.4.111.1' => ERROR      null    => ERROR
```

## Reproduction

Statically, in one snippet:

```bash
php -r '
error_reporting(E_ALL);
$localVersion = ["major" => 2, "minor" => 5, "hotfix" => 45];
$remoteVersion = explode(".", "2");            // remote answered version: "2"
echo "guard fires? ", var_export(!isset($remoteVersion[0]), true), "\n";
$response = false;
if ($localVersion["major"] > $remoteVersion[0]) { $response = "behind by a major version"; }
if ($response === false && $localVersion["minor"] > $remoteVersion[1]) { $response = "behind by a minor version"; }
echo "verdict: ", var_export($response, true), "\n";'
```

```
guard fires? false
Warning: Undefined array key 1 in Command line code on line 8
verdict: 'behind by a minor version'
```

The guard does not fire, PHP warns, and the function reports a confident verdict derived from a comparison against `null`.

End to end: point a sync server row at any HTTP endpoint that answers `/servers/getVersion` with `{"version":"2","perm_sync":true}` and open the server's *Test connection* / run a push. Today: warnings in the error log and a "behind by a minor version" verdict. With this patch: the intended *"Server didn't send the expected response"* error, plus the sync log entry that currently never gets written.

## Why this analysis might be wrong

Conditions under which the current code would be correct, and how each was ruled out:

1. **"`explode()` can return an empty array, so the guard is reachable."** Ruled out empirically: `explode('.', '')` returns `['']`, and `explode()` has no documented input for which it returns `[]` — it either returns at least one element or (pre-PHP 8, for an empty delimiter) returned `false`, which is not the case here since the delimiter is the literal `'.'`. `isset($remoteVersion[0])` is therefore always `true`.
2. **"The guard is meant to catch `$remoteVersion['version']` being absent, not the explode result."** That would be a defensible intent, but it is not what the code does — the check runs *after* the reassignment, against the exploded array, and the unguarded read of `$remoteVersion['version']` one line above would already have warned. This patch covers that case too rather than leaving it, and says so above.
3. **"A remote could legitimately send a one- or two-component version."** Ruled out by reading the producer: `ServersController::getVersion()` (line 2208) always emits three integer components from `VERSION.json`. No MISP release emits `"2"` or `"2.4"`, so requiring three components rejects nothing legitimate.
4. **"Version components could legitimately be non-numeric (release candidates, `-dev` suffixes)."** Ruled out by the same producer: the components come from three integer JSON fields, and are never string-formatted with a suffix. Note `$remoteVersionString` — used for the `protectedMode` `version_compare()` against `'2.4.156'` — is captured *before* the guard and is unchanged, so the suffix-tolerant comparison keeps its original input.
5. **"Returning a string here breaks callers that expect an array."** Ruled out by enumerating both callers (cited above): `push()` explicitly tests `!is_array($push)` and returns the string as its own error; `Event::uploadEventToServer()` uses `empty($push['canPush'])`, which I verified returns `true` for a string on PHP 8.3.33 without error. This is the same shape every other error path in the method already returns — the connection-failure path directly above returns `$title`, a string.
6. **"The ladder tolerates `null` fine, so nothing is actually broken."** It does not error out, but the verdict is arbitrary: `$localVersion['minor'] > null` is `true` for any positive local minor, so a truncated version always reports "the remote is behind by a minor version" regardless of what the remote actually is. A compatibility check that returns the same answer for every malformed input is not performing a check.

## Note for maintainers

A test asserting the **current** dead-branch behaviour (`ServerVersionCompatibilityTest::testTheMalformedVersionGuardIsUnreachable`) exists on a separate test-coverage branch. It is not present in `2.5`, so it will not conflict with this PR, but the behaviour is pinned there and that test will be updated alongside this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

