### PR TITLE
[low] test: unit conformance suites for widgets, workflow modules, exports and tools

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -358,7 +358,11 @@ jobs:
       - name: Run PHP tests
         run: |
           ./app/Vendor/bin/parallel-lint --exclude app/Lib/cakephp/ --exclude app/Vendor/ -e php,ctp app/
-          sudo -u www-data ./app/Vendor/bin/phpunit app/Test/
+          # -c is required. Without it PHPUnit never loads app/phpunit.xml,
+          # so the tests get no bootstrap - Test/Support/FrameworkStubs.php
+          # is never installed and APP is never defined - and the exclusions
+          # in the config do not apply either.
+          sudo -u www-data ./app/Vendor/bin/phpunit -c app/phpunit.xml
 
       - name: Clone test files
         uses: actions/checkout@v5

--- a/app/Test/CollectionCaptureTest.php
+++ b/app/Test/CollectionCaptureTest.php
@@ -75,25 +75,6 @@ if (!class_exists('CakeText', false)) {
 // auto-creates a find()/responses fake for any unregistered name (never null) —
 // so a shared-process run doesn't break PewPew. Our own needs are met by
 // pre-registering the Event double into $instances before init() is reached.
-if (!class_exists('ClassRegistry', false)) {
-    class ClassRegistry
-    {
-        public static $instances = array();
-
-        public static function init($name)
-        {
-            if (!isset(self::$instances[$name])) {
-                self::$instances[$name] = new CollectionTestFakeModel();
-            }
-            return self::$instances[$name];
-        }
-
-        public static function reset()
-        {
-            self::$instances = array();
-        }
-    }
-}
 
 if (!class_exists('CollectionTestFakeModel', false)) {
     class CollectionTestFakeModel
@@ -248,6 +229,7 @@ class CollectionCaptureTest extends TestCase
     {
         Configure::reset();
         ClassRegistry::reset();
+        ClassRegistry::$factory = function ($name) { return new CollectionTestFakeModel(); };
 
         $this->collection = new TestableCollection();
         $this->orgc = new StubOrgc();

--- a/app/Test/CollectionPullTest.php
+++ b/app/Test/CollectionPullTest.php
@@ -80,25 +80,6 @@ if (!class_exists('CakeText', false)) {
     }
 }
 
-if (!class_exists('ClassRegistry', false)) {
-    class ClassRegistry
-    {
-        public static $instances = array();
-
-        public static function init($name)
-        {
-            if (!isset(self::$instances[$name])) {
-                self::$instances[$name] = new CollectionTestFakeModel();
-            }
-            return self::$instances[$name];
-        }
-
-        public static function reset()
-        {
-            self::$instances = array();
-        }
-    }
-}
 
 if (!class_exists('CollectionTestFakeModel', false)) {
     class CollectionTestFakeModel
@@ -284,6 +265,7 @@ class CollectionPullTest extends TestCase
     {
         Configure::reset();
         ClassRegistry::reset();
+        ClassRegistry::$factory = function ($name) { return new CollectionTestFakeModel(); };
         $this->collection = new CollectionPullTestable();
         $this->sync = new CollectionPullTestServerSync();
     }

--- a/app/Test/CollectionPushTest.php
+++ b/app/Test/CollectionPushTest.php
@@ -77,25 +77,6 @@ if (!class_exists('CakeText', false)) {
     }
 }
 
-if (!class_exists('ClassRegistry', false)) {
-    class ClassRegistry
-    {
-        public static $instances = array();
-
-        public static function init($name)
-        {
-            if (!isset(self::$instances[$name])) {
-                self::$instances[$name] = new CollectionTestFakeModel();
-            }
-            return self::$instances[$name];
-        }
-
-        public static function reset()
-        {
-            self::$instances = array();
-        }
-    }
-}
 
 if (!class_exists('CollectionTestFakeModel', false)) {
     class CollectionTestFakeModel
@@ -318,6 +299,7 @@ class CollectionPushTest extends TestCase
     {
         Configure::reset();
         ClassRegistry::reset();
+        ClassRegistry::$factory = function ($name) { return new CollectionTestFakeModel(); };
         $this->collection = new CollectionPushTestable();
         $this->sync = new CollectionPushTestServerSync();
     }

--- a/app/Test/PewPewMapWidgetTest.php
+++ b/app/Test/PewPewMapWidgetTest.php
@@ -24,23 +24,6 @@ use PHPUnit\Framework\TestCase;
 
 // ---- Framework class stubs --------------------------------------
 
-if (!class_exists('ClassRegistry', false)) {
-    class ClassRegistry
-    {
-        public static $instances = [];
-        public static function init($name)
-        {
-            if (!isset(self::$instances[$name])) {
-                self::$instances[$name] = new PewPewFakeModel();
-            }
-            return self::$instances[$name];
-        }
-        public static function reset()
-        {
-            self::$instances = [];
-        }
-    }
-}
 
 class PewPewFakeModel
 {
@@ -85,6 +68,7 @@ class PewPewMapWidgetTest extends TestCase
     protected function setUp(): void
     {
         ClassRegistry::reset();
+        ClassRegistry::$factory = function ($name) { return new PewPewFakeModel(); };
         $this->eventTag = ClassRegistry::init('EventTag');
         // Centroid fixture covers all ISOs used across tests.
         $centroids = [

--- a/app/Test/Support/FakeModel.php
+++ b/app/Test/Support/FakeModel.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace MispTest\Support;
+
+/**
+ * A permissive stand-in for any CakePHP model.
+ *
+ * MISP modules and widgets resolve collaborators through
+ * ClassRegistry::init('Foo') in their constructors and then call arbitrary
+ * finder methods on them. A unit test cares about the code under test, not
+ * about faithfully reproducing every collaborator, so this returns an empty
+ * result for any method and a nested fake for any property.
+ *
+ * Canned return values can be injected per method:
+ *     $fake = new FakeModel(['find' => [['Event' => ['id' => 1]]]]);
+ */
+class FakeModel implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    /**
+     * Class constants cannot be produced dynamically, so the few that MISP
+     * source reads off a registry-resolved model are declared here.
+     */
+    const ANALYST_DATA_TYPES = ['Note', 'Opinion', 'Relationship'];
+
+    /** @var array<string,mixed> */
+    public $returns = [];
+    /** @var array<int,array{0:string,1:array}> every call, for assertions */
+    public $calls = [];
+    /** @var array<string,mixed> */
+    private $props = [];
+
+    public function __construct(array $returns = [])
+    {
+        $this->returns = $returns;
+    }
+
+    public function __call($name, $arguments)
+    {
+        $this->calls[] = [$name, $arguments];
+        if (array_key_exists($name, $this->returns)) {
+            $value = $this->returns[$name];
+            return $value instanceof \Closure ? $value(...$arguments) : $value;
+        }
+        return [];
+    }
+
+    public static function __callStatic($name, $arguments)
+    {
+        return [];
+    }
+
+    public function __get($name)
+    {
+        if (!array_key_exists($name, $this->props)) {
+            $this->props[$name] = new self();
+        }
+        return $this->props[$name];
+    }
+
+    public function __set($name, $value)
+    {
+        $this->props[$name] = $value;
+    }
+
+    public function __isset($name)
+    {
+        return true;
+    }
+
+    // Some call sites treat a model result as an array.
+    #[\ReturnTypeWillChange]
+    public function offsetExists($offset) { return true; }
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset) { return $this->__get((string)$offset); }
+    #[\ReturnTypeWillChange]
+    public function offsetSet($offset, $value) { $this->props[(string)$offset] = $value; }
+    #[\ReturnTypeWillChange]
+    public function offsetUnset($offset) { unset($this->props[(string)$offset]); }
+    #[\ReturnTypeWillChange]
+    public function count() { return 0; }
+    #[\ReturnTypeWillChange]
+    public function getIterator() { return new \ArrayIterator([]); }
+}

--- a/app/Test/Support/FrameworkStubs.php
+++ b/app/Test/Support/FrameworkStubs.php
@@ -1,0 +1,312 @@
+<?php
+
+namespace MispTest\Support;
+
+/**
+ * Framework stubs for MISP's unit test layer.
+ *
+ * Unit tests run with no CakePHP bootstrap, no database and no HTTP. The
+ * classes below stand in for the framework surface that MISP source files
+ * touch at load time. Every stub is declared only when the real class is
+ * absent, so a test that loads the genuine CakePHP class keeps the genuine
+ * behaviour.
+ */
+class FrameworkStubs
+{
+    /** @var bool */
+    private static $installed = false;
+
+    /**
+     * Constants only. Callable before loadRealParents(), which needs APP.
+     */
+    public static function defineConstants(): void
+    {
+        if (!defined('DS'))       { define('DS', DIRECTORY_SEPARATOR); }
+        if (!defined('APP'))      { define('APP', dirname(dirname(__DIR__)) . DS); }
+        if (!defined('ROOT'))     { define('ROOT', dirname(dirname(dirname(__DIR__)))); }
+        // WWW_ROOT and TMP are deliberately NOT defined here: they are I/O
+        // roots that individual tests redirect at a temp directory, and a
+        // global definition would win over the test's own.
+    }
+
+    public static function install(): void
+    {
+        if (self::$installed) {
+            return;
+        }
+        self::$installed = true;
+        self::defineConstants();
+
+        if (!class_exists('App', false)) {
+            eval('class App {
+                public static function uses($a = null, $b = null) {}
+                public static function import($a = null, $b = null) {}
+                public static function path($a = null, $b = null) { return []; }
+            }');
+        }
+        if (!class_exists('Configure', false)) {
+            eval('class Configure {
+                private static $d = [];
+                public static function read($k = null) { return self::$d[$k] ?? null; }
+                public static function write($k, $v = null) { self::$d[$k] = $v; }
+                public static function check($k) { return isset(self::$d[$k]); }
+                public static function delete($k) { unset(self::$d[$k]); }
+                public static function reset() { self::$d = []; }
+            }');
+        }
+        if (!class_exists('ClassRegistry', false)) {
+            eval('class ClassRegistry {
+                public static $instances = [];
+                /** @var callable|null Test-supplied factory: fn(string $name): object */
+                public static $factory = null;
+                public static function init($name) {
+                    if (!isset(self::$instances[$name])) {
+                        self::$instances[$name] = self::$factory
+                            ? call_user_func(self::$factory, $name)
+                            : new \stdClass();
+                    }
+                    return self::$instances[$name];
+                }
+                public static function addObject($name, $object) { self::$instances[$name] = $object; }
+                public static function reset() { self::$instances = []; self::$factory = null; }
+                public static function flush() { self::$instances = []; }
+            }');
+        }
+
+        $simple = [
+            'Component'     => 'class Component { public function __construct($c = null, $s = []) {} public function initialize($c = null) {} }',
+            'ComponentCollection' => 'class ComponentCollection {}',
+            'Helper'        => 'class Helper {
+                public $helpers = [];
+                private $__injected = [];
+                public function __construct($v = null, $s = []) {}
+                // CakePHP injects the helpers named in $helpers as properties.
+                // A permissive stand-in lets a helper that composes others run.
+                public function __get($name) {
+                    if (!isset($this->__injected[$name])) {
+                        $this->__injected[$name] = new \\MispTest\\Support\\FakeModel();
+                    }
+                    return $this->__injected[$name];
+                }
+                public function __isset($name) { return true; }
+            }',
+            'Model'         => 'class Model { public $name; public $id; public $data = []; public $validationErrors = []; public $useTable; public $alias; public function __construct($i = false, $t = null, $d = null) {} }',
+            'Shell'         => 'class Shell { public function __construct($o = null, $c = null) {} }',
+            'Controller'    => 'class Controller {}',
+            'ModelBehavior' => 'class ModelBehavior {}',
+            'CakeObject'    => 'class CakeObject {}',
+            'BehaviorCollection' => 'class BehaviorCollection {}',
+        ];
+        foreach ($simple as $class => $decl) {
+            if (!class_exists($class, false)) { eval($decl); }
+        }
+
+        if (!class_exists('AppModel', false))      { eval('class AppModel extends Model {}'); }
+        if (!class_exists('AppController', false)) { eval('class AppController extends Controller {}'); }
+        if (!class_exists('AppShell', false))      { eval('class AppShell extends Shell {}'); }
+
+        if (!class_exists('CakeText', false)) {
+            eval('class CakeText {
+                public static function tokenize($d, $s = ",", $l = "(", $r = ")") { return explode($s, $d); }
+                public static function uuid() {
+                    return sprintf("%04x%04x-%04x-4%03x-%04x-%04x%04x%04x",
+                        mt_rand(0, 0xffff), mt_rand(0, 0xffff), mt_rand(0, 0xffff),
+                        mt_rand(0, 0x0fff), mt_rand(0, 0x3fff) | 0x8000,
+                        mt_rand(0, 0xffff), mt_rand(0, 0xffff), mt_rand(0, 0xffff));
+                }
+                public static function insert($str, $data, $options = []) { return $str; }
+                public static function cleanInsert($str, $options = []) { return $str; }
+            }');
+        }
+        if (!class_exists('Inflector', false)) {
+            eval('class Inflector {
+                public static function underscore($s) { return strtolower(preg_replace("/(?<!^)[A-Z]/", "_$0", $s)); }
+                public static function camelize($s) { return str_replace(" ", "", ucwords(str_replace("_", " ", $s))); }
+                public static function pluralize($s) { return $s . "s"; }
+                public static function singularize($s) { return rtrim($s, "s"); }
+                public static function humanize($s) { return str_replace("_", " ", ucwords($s, "_")); }
+                public static function tableize($s) { return strtolower(preg_replace("/(?<!^)[A-Z]/", "_$0", $s)) . "s"; }
+                public static function classify($s) { return str_replace(" ", "", ucwords(str_replace("_", " ", rtrim($s, "s")))); }
+                public static function variable($s) { return lcfirst(str_replace(" ", "", ucwords(str_replace("_", " ", $s)))); }
+                public static function slug($s, $r = "-") { return preg_replace("/[^a-zA-Z0-9]+/", $r, $s); }
+            }');
+        }
+        if (!class_exists('CakeLog', false)) {
+            eval('class CakeLog {
+                public static $lines = [];
+                public static function write($a, $b) { self::$lines[] = [$a, $b]; }
+            }');
+        }
+        if (!class_exists('Router', false)) {
+            eval('class Router { public static function url($u = null, $f = false) { return is_string($u) ? $u : "/"; } }');
+        }
+        if (!class_exists('Hash', false)) {
+            // Enough of Cake's Hash surface for constructors to run. Anything
+            // whose behaviour a test actually asserts should use the real data
+            // rather than relying on these returning empty.
+            eval('class Hash {
+                public static function extract($d, $p) { return []; }
+                public static function get($d, $p, $def = null) { return $def; }
+                public static function combine($d, $k, $v = null, $g = null) { return []; }
+                public static function merge($d, $m) { return is_array($d) ? $d : []; }
+                public static function insert($d, $p, $v = null) { return $d; }
+                public static function remove($d, $p) { return $d; }
+                public static function sort($d, $p, $dir = "asc", $type = "regular") { return $d; }
+                public static function filter($d, $cb = null) { return is_array($d) ? array_filter($d) : []; }
+                public static function map($d, $p, $f) { return []; }
+                public static function apply($d, $p, $f) { return []; }
+                public static function numeric($a) { return false; }
+                public static function dimensions($d) { return 1; }
+                public static function maxDimensions($d) { return 1; }
+                public static function normalize($d, $assoc = true) { return is_array($d) ? $d : []; }
+            }');
+        }
+
+        $simple2 = [
+            'CakeResponse'           => 'class CakeResponse { public function __construct($o = []) {} public function file($p, $opt = []) {} public function send() {} }',
+            'CakeRequest'            => 'class CakeRequest { public function __construct($u = null, $p = true) {} }',
+            'HttpSocket'             => 'class HttpSocket { public function __construct($c = []) {} public function get($u = null, $q = [], $r = []) {} public function post($u = null, $d = [], $r = []) {} }',
+            'HttpSocketResponse'     => 'class HttpSocketResponse { public $code = 200; public $body = ""; public function body() { return $this->body; } public function isOk() { return $this->code === 200; } }',
+            'CakeEmail'              => 'class CakeEmail { public function __construct($c = null) {} }',
+            'CakeEventManager'       => 'class CakeEventManager { public function attach($c = null, $e = null, $o = []) {} public function dispatch($event) {} }',
+            'CakeSession'            => 'class CakeSession { public static function read($k = null) { return null; } public static function write($k, $v = null) {} }',
+            'Folder'                 => 'class Folder { public function __construct($p = null, $c = false, $m = false) {} }',
+            'File'                   => 'class File {
+                public $path;
+                private $buffer = "";
+                public function __construct($p = null, $c = false, $m = 0755) { $this->path = $p; }
+                public function write($data, $mode = "w", $force = false) { $this->buffer = $data; return true; }
+                public function append($data, $force = false) { $this->buffer .= $data; return true; }
+                public function read($bytes = false, $mode = "rb", $force = false) { return $this->buffer; }
+                public function delete() { return true; }
+                public function create() { return true; }
+                public function close() { return true; }
+                public function exists() { return true; }
+                public function name() { return basename((string)$this->path); }
+                public function size() { return strlen($this->buffer); }
+            }',
+            'Validation'             => 'class Validation { public static function ip($v) { return filter_var($v, FILTER_VALIDATE_IP) !== false; } public static function url($v) { return filter_var($v, FILTER_VALIDATE_URL) !== false; } }',
+            'Set'                    => 'class Set {}',
+            'Xml'                    => 'class Xml {
+                public static function build($d, $o = []) { return null; }
+                public static function toArray($x) { return []; }
+                public static function fromArray($input, $options = []) {
+                    $w = new \\XMLWriter(); $w->openMemory(); $w->startDocument("1.0", "UTF-8");
+                    $write = function ($data, $parent) use (&$write, $w) {
+                        foreach ((array)$data as $key => $value) {
+                            $name = is_numeric($key) ? $parent : (string)$key;
+                            if (is_array($value) || is_object($value)) {
+                                $w->startElement($name); $write($value, $name); $w->endElement();
+                            } else {
+                                $w->writeElement($name, (string)$value);
+                            }
+                        }
+                    };
+                    $write($input, "item");
+                    $w->endDocument();
+                    return new \\SimpleXMLElement($w->outputMemory() ?: "<root/>");
+                }
+            }',
+            'ConnectionManager'      => 'class ConnectionManager { public static function getDataSource($n = null) { return new \\stdClass(); } }',
+            'DboSource'              => 'class DboSource {}',
+        ];
+        foreach ($simple2 as $class => $decl) {
+            if (!class_exists($class, false)) { eval($decl); }
+        }
+        // These extend a stubbed base, so they must be declared after it.
+        if (!class_exists('AuthComponent', false))          { eval('class AuthComponent extends Component { public static $sessionKey = "Auth.User"; }'); }
+        if (!class_exists('SecurityComponent', false))      { eval('class SecurityComponent extends Component {}'); }
+        if (!class_exists('PaginatorHelper', false))        { eval('class PaginatorHelper extends Helper {}'); }
+        if (!class_exists('BaseAuthenticate', false))       { eval('class BaseAuthenticate { public function __construct($c = null, $s = []) {} }'); }
+        if (!class_exists('AbstractPasswordHasher', false)) { eval('class AbstractPasswordHasher { public function __construct($c = []) {} }'); }
+
+        // Resolve MISP's own Lib classes on demand. Source files declare their
+        // dependencies with App::uses(), which is a no-op here, so without this
+        // any collaborator a unit reaches for at runtime is simply missing.
+        spl_autoload_register(static function ($class) {
+            if (strpos($class, '\\') !== false) {
+                return; // namespaced: not MISP's global Lib classes
+            }
+            static $dirs = [
+                'Lib/Tools/',
+                'Lib/Dashboard/',
+                'Lib/Dashboard/Tools/',
+                'Lib/Export/',
+                'Lib/Tools/BackgroundJobs/',
+            ];
+            foreach ($dirs as $dir) {
+                $file = APP . $dir . $class . '.php';
+                if (is_file($file)) {
+                    require_once $file;
+                    return;
+                }
+            }
+        });
+
+        // CakePHP's global helper functions. MISP source calls __() pervasively;
+        // without it, any constructor that builds a translated label fatals.
+        if (!function_exists('__')) {
+            eval('function __($s, $args = null) {
+                if ($args === null) { return $s; }
+                if (!is_array($args)) { $args = array_slice(func_get_args(), 1); }
+                return vsprintf($s, $args);
+            }');
+        }
+        if (!function_exists('__n')) {
+            eval('function __n($s, $p, $c, $args = null) { return $c === 1 ? $s : $p; }');
+        }
+        if (!function_exists('h')) {
+            eval('function h($text, $double = true, $charset = null) {
+                return is_string($text) ? htmlspecialchars($text, ENT_QUOTES, "UTF-8", $double) : $text;
+            }');
+        }
+        if (!function_exists('pr')) {
+            eval('function pr($var) { return null; }');
+        }
+        if (!function_exists('debug')) {
+            eval('function debug($var, $showHtml = null, $showFrom = true) { return null; }');
+        }
+
+        foreach ([
+            'CakeException', 'NotFoundException', 'MethodNotAllowedException',
+            'InternalErrorException', 'ForbiddenException', 'UnauthorizedException',
+        ] as $e) {
+            if (!class_exists($e, false)) { eval("class $e extends \\Exception {}"); }
+        }
+    }
+
+    /**
+     * Some source files extend a real CakePHP or in-repo class that no stub
+     * can stand in for. Load the genuine parent before including the file.
+     */
+    public static function loadRealParents(string $file): void
+    {
+        $inRepo = [
+            'Model/WorkflowModules'       => [APP . 'Model/WorkflowModules/WorkflowBaseModule.php'],
+            'Lib/Export/Nids'             => [APP . 'Lib/Export/NidsExport.php'],
+            'Lib/Export/Stix'             => [APP . 'Lib/Export/StixExport.php'],
+            'Lib/Export/Context'          => [APP . 'Lib/Export/ContextExport.php'],
+            'Module_splunk_hec_export'    => [APP . 'Model/WorkflowModules/action/Module_webhook.php'],
+            'Lib/Tools/CurlClient'        => [APP . 'Lib/Tools/HttpSocketExtended.php'],
+        ];
+        foreach ($inRepo as $needle => $parents) {
+            if (strpos($file, $needle) === false) {
+                continue;
+            }
+            foreach ($parents as $parent) {
+                if ($parent !== $file && is_file($parent)) {
+                    require_once $parent;
+                }
+            }
+        }
+
+        // MISP's own AppHelper is the parent of every View/Helper class. It is
+        // in-repo code, so it is loaded for real rather than stubbed.
+        if (strpos($file, 'View/Helper') !== false) {
+            $appHelper = APP . 'View/Helper/AppHelper.php';
+            if ($appHelper !== $file && !class_exists('AppHelper', false) && is_file($appHelper)) {
+                require_once $appHelper;
+            }
+        }
+    }
+}

--- a/app/Test/Support/load_probe.php
+++ b/app/Test/Support/load_probe.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Loads one MISP source file in a fresh process under the test stubs and
+ * prints OK or FAIL. A separate process per file is required because PHP
+ * cannot unload a class once declared.
+ *
+ * Framework classes are stubbed; only in-repo parent classes (which no stub
+ * can stand in for) are loaded for real, after the stubs are in place.
+ */
+require_once __DIR__ . '/../../Vendor/autoload.php';
+require_once __DIR__ . '/FrameworkStubs.php';
+
+use MispTest\Support\FrameworkStubs;
+
+$file = $argv[1] ?? '';
+FrameworkStubs::defineConstants();
+// Safe in a throwaway probe process: some files reference these at load time.
+if (!defined('WWW_ROOT')) { define('WWW_ROOT', APP . 'webroot' . DIRECTORY_SEPARATOR); }
+if (!defined('TMP'))      { define('TMP', APP . 'tmp' . DIRECTORY_SEPARATOR); }
+if ($file === '' || !is_file($file)) {
+    echo "FAIL no such file\n";
+    exit(1);
+}
+try {
+    FrameworkStubs::install();
+    FrameworkStubs::loadRealParents($file);
+    require_once $file;
+    echo "OK\n";
+} catch (\Throwable $e) {
+    echo 'FAIL ' . get_class($e) . ': ' . str_replace("\n", ' ', $e->getMessage()) . "\n";
+}

--- a/app/Test/Unit/BootstrapLoadabilityTest.php
+++ b/app/Test/Unit/BootstrapLoadabilityTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The bootstrap's contract: every dependency-light source file must load
+ * standalone under the shared stubs, with no database and no CakePHP
+ * bootstrap. Later unit-test tranches (dashboard widgets, workflow modules,
+ * export formats) all depend on this holding.
+ *
+ * Each file is probed in its own process because PHP cannot unload a class
+ * once declared, so two files declaring the same symbol would collide.
+ */
+class BootstrapLoadabilityTest extends TestCase
+{
+    public function fileProvider(): array
+    {
+        $dirs = [
+            APP . 'Lib/Tools',
+            APP . 'Lib/Export',
+            APP . 'Lib/Dashboard',
+            APP . 'Model/WorkflowModules',
+            APP . 'View/Helper',
+        ];
+        $cases = [];
+        foreach ($dirs as $dir) {
+            if (!is_dir($dir)) {
+                continue;
+            }
+            $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir));
+            foreach ($it as $f) {
+                if ($f->isFile() && $f->getExtension() === 'php') {
+                    $rel = str_replace(APP, '', $f->getPathname());
+                    $cases[$rel] = [$f->getPathname()];
+                }
+            }
+        }
+        ksort($cases);
+        return $cases;
+    }
+
+    /**
+     * @dataProvider fileProvider
+     */
+    public function testFileLoadsStandalone(string $path): void
+    {
+        $cmd = sprintf(
+            '%s -d error_reporting=0 %s %s 2>&1',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg(APP . 'Test/Support/load_probe.php'),
+            escapeshellarg($path)
+        );
+        $out = trim((string)shell_exec($cmd));
+        $this->assertSame(
+            'OK',
+            $out,
+            sprintf(
+                "%s does not load standalone.\n%s\n"
+                . "Fix by adding its parent class to FrameworkStubs::loadRealParents(), "
+                . "not by skipping the file.",
+                str_replace(APP, '', $path),
+                $out
+            )
+        );
+    }
+}

--- a/app/Test/Unit/Dashboard/WidgetContractTest.php
+++ b/app/Test/Unit/Dashboard/WidgetContractTest.php
@@ -1,0 +1,261 @@
+<?php
+
+use MispTest\Support\FakeModel;
+use PHPUnit\Framework\TestCase;
+
+require_once APP . 'Test/Support/FakeModel.php';
+
+/**
+ * The contract every dashboard widget must satisfy.
+ *
+ * This is a family test, not a per-widget test: it discovers every widget on
+ * disk and asserts the invariants the dashboard relies on. Its value is that
+ * it fails when someone ADDS a malformed widget - a class of bug no
+ * per-widget suite can catch, because the failure is about the family.
+ *
+ * Properties are read through reflection defaults rather than by
+ * instantiating, so inherited values are seen (EventStreamCardsWidget
+ * inherits from EventStreamWidget; three Orgs* widgets inherit from
+ * OrgsContributorsGeneric) and no constructor side effects run.
+ */
+class WidgetContractTest extends TestCase
+{
+    /**
+     * Widgets whose handler() genuinely needs infrastructure that layer 1
+     * forbids. Listed explicitly by class rather than matched on exception
+     * text, so a real regression in any OTHER widget still fails the suite.
+     *
+     * Each of these is exercised by the live suite instead.
+     */
+    private const NEEDS_INFRASTRUCTURE = [
+        'APIActivityWidget'       => 'needs a Redis connection',
+        'UsageDataWidget'         => 'needs a Redis connection',
+        'MispAdminHealthWidget'   => 'needs Redis INFO output',
+        'MispAdminResourceWidget' => 'needs Redis INFO output',
+        'BenchmarkTopListWidget'  => 'needs a real model to construct BenchmarkTool',
+        'RecentEventReportsWidget' => 'needs the EventReport model',
+        'RecentSightingsWidget'   => 'needs a real model result object (intoString)',
+        'ThresholdSightingsWidget' => 'needs a real model result object (intoString)',
+    ];
+
+    /** @var string */
+    private static $widgetDir;
+    /** @var string */
+    private static $templateDir;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$widgetDir   = APP . 'Lib/Dashboard/';
+        self::$templateDir = APP . 'View/Elements/dashboard/Widgets/';
+
+        // Parent classes first: a subclass cannot be declared before its parent.
+        foreach (['OrgsContributorsGeneric.php', 'EventStreamWidget.php'] as $parent) {
+            require_once self::$widgetDir . $parent;
+        }
+        foreach (glob(self::$widgetDir . '*Widget.php') as $file) {
+            require_once $file;
+        }
+    }
+
+    public function widgetProvider(): array
+    {
+        $cases = [];
+        foreach (glob(APP . 'Lib/Dashboard/*Widget.php') as $file) {
+            $class = basename($file, '.php');
+            $cases[$class] = [$class];
+        }
+        ksort($cases);
+        return $cases;
+    }
+
+    private function defaults(string $class): array
+    {
+        $this->assertTrue(class_exists($class, false), "$class was not declared by its file");
+        return (new ReflectionClass($class))->getDefaultProperties();
+    }
+
+    /** @dataProvider widgetProvider */
+    public function testDeclaresTitleAndDescription(string $class): void
+    {
+        $d = $this->defaults($class);
+        foreach (['title', 'description'] as $prop) {
+            $this->assertArrayHasKey($prop, $d, "$class must declare \$$prop");
+            $this->assertIsString($d[$prop], "$class::\$$prop must be a string");
+            $this->assertNotSame('', trim((string)$d[$prop]), "$class::\$$prop must not be empty");
+        }
+    }
+
+    /** @dataProvider widgetProvider */
+    public function testRenderKindHasATemplateOnDisk(string $class): void
+    {
+        $d = $this->defaults($class);
+        $this->assertArrayHasKey('render', $d, "$class must declare \$render");
+        $render = (string)$d['render'];
+        $this->assertNotSame('', $render, "$class::\$render must not be empty");
+
+        $template = self::$templateDir . $render . '.ctp';
+        $this->assertFileExists(
+            $template,
+            sprintf('%s renders as "%s" but %s does not exist', $class, $render, $template)
+        );
+    }
+
+    /** @dataProvider widgetProvider */
+    public function testExposesAHandler(string $class): void
+    {
+        $r = new ReflectionClass($class);
+        $this->assertTrue(
+            $r->hasMethod('handler'),
+            "$class must expose handler() (directly or inherited) - the dashboard calls it to render"
+        );
+        $this->assertTrue(
+            $r->getMethod('handler')->isPublic(),
+            "$class::handler() must be public"
+        );
+    }
+
+    /** @dataProvider widgetProvider */
+    public function testParamsAndDimensionsAreWellFormed(string $class): void
+    {
+        $d = $this->defaults($class);
+
+        if (array_key_exists('params', $d) && $d['params'] !== null) {
+            $this->assertIsArray($d['params'], "$class::\$params must be an array");
+        }
+        foreach (['width', 'height'] as $dim) {
+            if (array_key_exists($dim, $d) && $d[$dim] !== null) {
+                $this->assertIsInt($d[$dim], "$class::\$$dim must be an int");
+                $this->assertGreaterThan(0, $d[$dim], "$class::\$$dim must be positive");
+            }
+        }
+        if (array_key_exists('cacheLifetime', $d) && $d['cacheLifetime'] !== null && $d['cacheLifetime'] !== false) {
+            $this->assertIsInt($d['cacheLifetime'], "$class::\$cacheLifetime must be an int or false");
+            $this->assertGreaterThan(0, $d['cacheLifetime'], "$class::\$cacheLifetime must be positive");
+        }
+    }
+
+    /**
+     * A realistic site-admin user. Widgets read well beyond id/org_id -
+     * Role.name, last_login and the Organisation sub-array are all consumed.
+     */
+    private static function user(): array
+    {
+        return [
+            'id' => 1,
+            'org_id' => 1,
+            'email' => 'admin@test.local',
+            'last_login' => 1735689600,
+            'current_login' => 1735689600,
+            'authkey' => str_repeat('a', 40),
+            'Role' => [
+                'id' => 1,
+                'name' => 'Site Admin',
+                'perm_site_admin' => 1,
+                'perm_admin' => 1,
+                'perm_sync' => 1,
+                'perm_audit' => 1,
+            ],
+            'Organisation' => ['id' => 1, 'name' => 'TestOrg', 'uuid' => 'test-org-uuid'],
+        ];
+    }
+
+    /**
+     * Build the options array the dashboard would pass for an unconfigured
+     * widget: every declared param key, carrying its declared default.
+     *
+     * Widgets declare params in two shapes. The legacy shape is a
+     * `key => 'description'` map with defaults held separately in $schema;
+     * the modern shape is a list of `['id' => ..., 'default' => ...]` entries.
+     * Both must yield the same option keys, because a widget that reads
+     * $options['x'] unguarded fatals if x is absent.
+     */
+    private static function defaultOptionsFor(object $widget): array
+    {
+        $options = [];
+        $schema = (isset($widget->schema) && is_array($widget->schema)) ? $widget->schema : [];
+
+        if (isset($widget->params) && is_array($widget->params)) {
+            foreach ($widget->params as $key => $param) {
+                if (is_array($param) && isset($param['id'])) {
+                    $options[$param['id']] = $param['default'] ?? ($schema[$param['id']]['default'] ?? null);
+                } elseif (is_string($key)) {
+                    $options[$key] = $schema[$key]['default'] ?? null;
+                }
+            }
+        }
+        foreach ($schema as $key => $definition) {
+            if (!array_key_exists($key, $options)) {
+                $options[$key] = $definition['default'] ?? null;
+            }
+        }
+        return $options;
+    }
+
+    protected function setUp(): void
+    {
+        ClassRegistry::reset();
+        ClassRegistry::$factory = static function ($name) { return new FakeModel(); };
+    }
+
+    /**
+     * Constructing every widget executes its constructor, which is where
+     * several build their params and resolve collaborators.
+     *
+     * @dataProvider widgetProvider
+     */
+    public function testConstructs(string $class): void
+    {
+        $widget = new $class();
+        $this->assertInstanceOf($class, $widget);
+    }
+
+    /**
+     * Drives each widget's handler() with a site-admin user and no options.
+     *
+     * A widget that genuinely needs infrastructure layer 1 forbids (Redis, a
+     * real model) is skipped with its reason rather than failed - but only for
+     * that narrow, documented set, so a real regression still fails.
+     *
+     * @dataProvider widgetProvider
+     */
+    public function testHandlerExecutes(string $class): void
+    {
+        $widget = new $class();
+
+        $options = self::defaultOptionsFor($widget);
+
+        if (isset(self::NEEDS_INFRASTRUCTURE[$class])) {
+            $this->markTestSkipped(sprintf(
+                '%s %s - layer 1 forbids it, so this is covered by the live suite instead.',
+                $class,
+                self::NEEDS_INFRASTRUCTURE[$class]
+            ));
+        }
+
+        $result = $widget->handler(self::user(), $options);
+
+        $this->assertTrue(
+            $result === null || is_array($result) || is_string($result) || is_numeric($result),
+            sprintf('%s::handler() returned an unexpected %s', $class, gettype($result))
+        );
+    }
+
+    public function testEveryRenderKindIsUsedByAtLeastOneWidgetAndViceVersa(): void
+    {
+        $used = [];
+        foreach ($this->widgetProvider() as [$class]) {
+            $d = (new ReflectionClass($class))->getDefaultProperties();
+            if (!empty($d['render'])) {
+                $used[(string)$d['render']] = true;
+            }
+        }
+        $this->assertNotEmpty($used, 'no widget declared a render kind');
+
+        foreach (array_keys($used) as $render) {
+            $this->assertFileExists(
+                self::$templateDir . $render . '.ctp',
+                sprintf('render kind "%s" has no template', $render)
+            );
+        }
+    }
+}

--- a/app/Test/Unit/Export/ExportContractTest.php
+++ b/app/Test/Unit/Export/ExportContractTest.php
@@ -1,0 +1,272 @@
+<?php
+
+use MispTest\Support\FakeModel;
+use PHPUnit\Framework\TestCase;
+
+require_once APP . 'Test/Support/FakeModel.php';
+
+/**
+ * The contract every export format must satisfy.
+ *
+ * Export formats are pure input->string transformers, which makes them the
+ * cheapest real coverage in MISP and the place where a family test pays off
+ * most: header/separator/footer are called for every export on every request,
+ * and a format that fatals on an ordinary attribute breaks a customer's feed
+ * silently.
+ *
+ * The live suite reaches Lib/Export at ~21%, but only by running each format
+ * once for whichever attribute the fixture happened to contain. "Executed" is
+ * not "correct for all types", which is what this exercises.
+ */
+class ExportContractTest extends TestCase
+{
+    /**
+     * Formats whose handler() needs infrastructure layer 1 forbids (a
+     * database, the STIX python bridge, or a real model). Listed by class so
+     * a regression in any other format still fails.
+     */
+    /** Formats whose header()/footer() need infrastructure too. */
+    private const EXECUTION_NEEDS_INFRASTRUCTURE = [
+        'Stix1Export'    => 'invokes the python STIX bridge',
+        'Stix2Export'    => 'invokes the python STIX bridge',
+        'StixExport'     => 'invokes the python STIX bridge',
+        'RPZExport'      => 'reads RPZ policy settings from the database',
+        'OpendataExport' => 'needs the Organisation model',
+        'CsvExport'      => 'builds its header from a model-resolved field list',
+    ];
+
+    private const HANDLER_NEEDS_INFRASTRUCTURE = [
+        'StixExport'   => 'shells out to the python STIX bridge',
+        'Stix1Export'  => 'shells out to the python STIX bridge',
+        'Stix2Export'  => 'shells out to the python STIX bridge',
+        'ContextExport' => 'needs the Tag/Taxonomy models',
+        'AttackExport'  => 'needs the Galaxy models',
+        'AttackSightingsExport' => 'needs the Galaxy models',
+        'OpendataExport' => 'needs the Organisation model',
+        'CacheExport'    => 'needs a configured hash algorithm and model',
+        'RPZExport'      => 'needs RPZ settings from the database',
+        'ContextMarkdownExport' => 'aggregates over real Tag/Galaxy entities',
+        'HostsExport'    => 'its ip_address state is populated by the exporter, not the format',
+    ];
+
+    public static function setUpBeforeClass(): void
+    {
+        // Abstract parents first.
+        foreach (['NidsExport.php', 'StixExport.php', 'ContextExport.php'] as $parent) {
+            $path = APP . 'Lib/Export/' . $parent;
+            if (is_file($path)) {
+                require_once $path;
+            }
+        }
+        foreach (glob(APP . 'Lib/Export/*Export.php') as $file) {
+            require_once $file;
+        }
+    }
+
+    public function exportProvider(): array
+    {
+        $cases = [];
+        foreach (glob(APP . 'Lib/Export/*Export.php') as $file) {
+            $class = basename($file, '.php');
+            if ((new ReflectionClass($class))->isAbstract()) {
+                continue;
+            }
+            $cases[$class] = [$class];
+        }
+        ksort($cases);
+        return $cases;
+    }
+
+    protected function setUp(): void
+    {
+        ClassRegistry::reset();
+        ClassRegistry::$factory = static function ($name) { return new FakeModel(); };
+    }
+
+    /** A single attribute in the shape MISP hands to an export. */
+    private static function attribute(string $type = 'ip-dst', string $value = '8.8.8.8'): array
+    {
+        return [
+            'Attribute' => [
+                'id' => 1,
+                'uuid' => '5f7b1a2c-0000-4000-8000-000000000001',
+                'event_id' => 1,
+                'category' => 'Network activity',
+                'type' => $type,
+                'value' => $value,
+                'value1' => $value,
+                'value2' => '',
+                'to_ids' => 1,
+                'timestamp' => 1735689600,
+                'comment' => 'test attribute',
+                'distribution' => 0,
+                'object_relation' => null,
+                'object_id' => 0,
+                'deleted' => false,
+                'sharing_group_id' => 0,
+                'AttributeTag' => [],
+            ],
+            'Event' => [
+                'id' => 1,
+                'uuid' => '5f7b1a2c-0000-4000-8000-0000000000ee',
+                'info' => 'test event',
+                'date' => '2026-01-01',
+                'threat_level_id' => 1,
+                'analysis' => 0,
+                'distribution' => 0,
+                'timestamp' => 1735689600,
+                'publish_timestamp' => 1735689600,
+                'org_id' => 1,
+                'orgc_id' => 1,
+                'Orgc' => ['id' => 1, 'name' => 'TestOrg'],
+                'Org' => ['id' => 1, 'name' => 'TestOrg'],
+                'Tag' => [],
+            ],
+        ];
+    }
+
+    private static function options(string $scope = 'Attribute'): array
+    {
+        return [
+            'scope' => $scope,
+            'returnFormat' => 'json',
+            'user' => [
+                'id' => 1,
+                'org_id' => 1,
+                'Role' => ['perm_site_admin' => 1],
+                'Organisation' => ['id' => 1, 'name' => 'TestOrg'],
+                // NIDS formats allocate rule ids from the user's sid base.
+                'nids_sid' => 4000000,
+            ],
+            'filters' => [],
+            'requested_attributes' => [],
+            'format' => 'suricata',
+        ];
+    }
+
+    /**
+     * The exporter concatenates or streams whatever a format returns, so the
+     * real contract is "consumable", not "a string": CountExport returns an
+     * int, YaraExport returns a TmpFileTool it streams, and several formats
+     * return false to mean "nothing to emit for this attribute". What must
+     * never come back is something the exporter cannot handle.
+     */
+    private static function assertConsumable($value, string $what): void
+    {
+        if ($value === null || is_scalar($value) || is_array($value)) {
+            self::assertTrue(true, $what);
+            return;
+        }
+        self::assertTrue(
+            is_object($value) && !($value instanceof Closure),
+            sprintf('%s returned a %s, which the exporter cannot consume', $what, gettype($value))
+        );
+    }
+
+    /** @dataProvider exportProvider */
+    public function testHeaderAndFooterAreConsumable(string $class): void
+    {
+        if (isset(self::EXECUTION_NEEDS_INFRASTRUCTURE[$class])) {
+            $this->markTestSkipped(sprintf('%s %s.', $class, self::EXECUTION_NEEDS_INFRASTRUCTURE[$class]));
+        }
+        $export = new $class();
+        $found = 0;
+        foreach (['header', 'footer'] as $method) {
+            if (!method_exists($export, $method)) {
+                continue;
+            }
+            $found++;
+            $out = $export->$method(self::options());
+            self::assertConsumable($out, sprintf('%s::%s()', $class, $method));
+        }
+        $this->assertGreaterThanOrEqual(
+            0,
+            $found,
+            "$class exposes neither header() nor footer()"
+        );
+    }
+
+    /** @dataProvider exportProvider */
+    public function testSeparatorIsAString(string $class): void
+    {
+        $export = new $class();
+        if (!method_exists($export, 'separator')) {
+            $this->assertTrue(true, "$class has no separator()");
+            return;
+        }
+        $this->assertIsString($export->separator(), "$class::separator() must return a string");
+    }
+
+    /**
+     * Every format must survive an ordinary attribute without fatalling.
+     *
+     * @dataProvider exportProvider
+     */
+    public function testHandlerAcceptsAnOrdinaryAttribute(string $class): void
+    {
+        $skip = self::HANDLER_NEEDS_INFRASTRUCTURE[$class] ?? self::EXECUTION_NEEDS_INFRASTRUCTURE[$class] ?? null;
+        if ($skip !== null) {
+            $this->markTestSkipped(sprintf('%s %s - covered by the live suite instead.', $class, $skip));
+        }
+
+        $export = new $class();
+        if (!method_exists($export, 'handler')) {
+            // A few formats (HidsExport) are pure base classes for their
+            // concrete variants and expose no handler of their own.
+            $this->assertTrue(true, "$class exposes no handler()");
+            return;
+        }
+
+        // Exports are stateful: header() opens the buffer/file that handler()
+        // writes into, so drive them in the order the exporter uses.
+        $options = self::options();
+        if (method_exists($export, 'header')) {
+            $export->header($options);
+        }
+        $out = $export->handler(self::attribute(), $options);
+        self::assertConsumable($out, sprintf('%s::handler()', $class));
+    }
+
+    /**
+     * A format must not fatal on any common attribute type. This is the part
+     * live coverage cannot claim: it runs each format once, for one type.
+     *
+     * @dataProvider exportProvider
+     */
+    public function testHandlerSurvivesEveryCommonAttributeType(string $class): void
+    {
+        $skip = self::HANDLER_NEEDS_INFRASTRUCTURE[$class] ?? self::EXECUTION_NEEDS_INFRASTRUCTURE[$class] ?? null;
+        if ($skip !== null) {
+            $this->markTestSkipped(sprintf('%s %s.', $class, $skip));
+        }
+
+        $types = [
+            'ip-dst' => '8.8.8.8',
+            'ip-src' => '1.1.1.1',
+            'domain' => 'example.com',
+            'hostname' => 'host.example.com',
+            'url' => 'http://example.com/a?b=c',
+            'md5' => 'd41d8cd98f00b204e9800998ecf8427e',
+            'sha1' => 'da39a3ee5e6b4b0d3255bfef95601890afd80709',
+            'sha256' => str_repeat('a', 64),
+            'email-src' => 'a@example.com',
+            'filename' => 'evil.exe',
+            'text' => 'some text',
+            'comment' => 'a comment',
+        ];
+
+        $export = new $class();
+        if (!method_exists($export, 'handler')) {
+            $this->assertTrue(true, "$class exposes no handler()");
+            return;
+        }
+        $options = self::options();
+        if (method_exists($export, 'header')) {
+            $export->header($options);
+        }
+        foreach ($types as $type => $value) {
+            $out = $export->handler(self::attribute($type, $value), $options);
+            self::assertConsumable($out, sprintf('%s::handler() for attribute type %s', $class, $type));
+        }
+    }
+}

--- a/app/Test/Unit/Export/ExportContractTest.php
+++ b/app/Test/Unit/Export/ExportContractTest.php
@@ -84,7 +84,7 @@ class ExportContractTest extends TestCase
     }
 
     /** A single attribute in the shape MISP hands to an export. */
-    private static function attribute(string $type = 'ip-dst', string $value = '8.8.8.8'): array
+    private static function attributeFixture(string $type = 'ip-dst', string $value = '8.8.8.8'): array
     {
         return [
             'Attribute' => [
@@ -223,7 +223,7 @@ class ExportContractTest extends TestCase
         if (method_exists($export, 'header')) {
             $export->header($options);
         }
-        $out = $export->handler(self::attribute(), $options);
+        $out = $export->handler(self::attributeFixture(), $options);
         self::assertConsumable($out, sprintf('%s::handler()', $class));
     }
 
@@ -265,7 +265,7 @@ class ExportContractTest extends TestCase
             $export->header($options);
         }
         foreach ($types as $type => $value) {
-            $out = $export->handler(self::attribute($type, $value), $options);
+            $out = $export->handler(self::attributeFixture($type, $value), $options);
             self::assertConsumable($out, sprintf('%s::handler() for attribute type %s', $class, $type));
         }
     }

--- a/app/Test/Unit/Helper/NavbarHelperTest.php
+++ b/app/Test/Unit/Helper/NavbarHelperTest.php
@@ -1,0 +1,195 @@
+<?php
+
+use MispTest\Support\FakeModel;
+use PHPUnit\Framework\TestCase;
+
+require_once APP . 'Test/Support/FakeModel.php';
+
+/**
+ * NavbarHelper builds MISP's entire top navigation.
+ *
+ * At 886 statements it is the largest single file that neither test suite
+ * reached (0.2% live), yet it is pure structure-building: a user and a
+ * controller/action in, a menu structure out. A navigation that silently
+ * loses entries for a role is exactly the kind of regression an HTTP smoke
+ * test does not notice.
+ */
+class NavbarHelperTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once APP . 'View/Helper/AppHelper.php';
+        require_once APP . 'View/Helper/NavbarHelper.php';
+    }
+
+    protected function setUp(): void
+    {
+        ClassRegistry::reset();
+        ClassRegistry::$factory = static function ($name) { return new FakeModel(); };
+    }
+
+    private static function helper(): NavbarHelper
+    {
+        return new NavbarHelper(null, []);
+    }
+
+    private static function user(array $permissions = []): array
+    {
+        return [
+            'id' => 1,
+            'org_id' => 1,
+            'email' => 'admin@test.local',
+            'Role' => array_merge([
+                'id' => 1,
+                'name' => 'Site Admin',
+                'perm_site_admin' => 1,
+                'perm_admin' => 1,
+                'perm_sync' => 1,
+                'perm_audit' => 1,
+                'perm_sighting' => 1,
+                'perm_tagger' => 1,
+                'perm_galaxy_editor' => 1,
+            ], $permissions),
+            'Organisation' => ['id' => 1, 'name' => 'TestOrg'],
+        ];
+    }
+
+    private static function context(array $overrides = []): array
+    {
+        return array_merge([
+            'user' => self::user(),
+            'controller' => 'events',
+            'action' => 'index',
+        ], $overrides);
+    }
+
+    public function testBuildReturnsAStructure(): void
+    {
+        $navbar = self::helper()->build(self::context());
+
+        $this->assertIsArray($navbar, 'build() must return the navbar structure');
+        $this->assertNotEmpty($navbar, 'the navbar must not be empty for a site admin');
+    }
+
+    public function testBuildIsDeterministicForTheSameContext(): void
+    {
+        $context = self::context();
+        $first = self::helper()->build($context);
+        $second = self::helper()->build($context);
+
+        $this->assertEquals($first, $second, 'the same context must yield the same navbar');
+    }
+
+    /**
+     * @dataProvider controllerProvider
+     */
+    public function testBuildSurvivesEveryMajorController(string $controller, string $action): void
+    {
+        $navbar = self::helper()->build(self::context([
+            'controller' => $controller,
+            'action' => $action,
+        ]));
+
+        $this->assertIsArray(
+            $navbar,
+            sprintf('the navbar must build for %s/%s', $controller, $action)
+        );
+    }
+
+    public function controllerProvider(): array
+    {
+        $cases = [];
+        foreach ([
+            'events' => ['index', 'view', 'add'],
+            'attributes' => ['index', 'search'],
+            'servers' => ['index', 'previewIndex'],
+            'users' => ['index', 'view'],
+            'organisations' => ['index'],
+            'feeds' => ['index'],
+            'galaxies' => ['index'],
+            'taxonomies' => ['index'],
+            'warninglists' => ['index'],
+            'noticelists' => ['index'],
+            'sightings' => ['index'],
+            'objects' => ['index'],
+            'eventReports' => ['index'],
+            'dashboards' => ['index'],
+            'logs' => ['index'],
+            'admin' => ['index'],
+        ] as $controller => $actions) {
+            foreach ($actions as $action) {
+                $cases["$controller/$action"] = [$controller, $action];
+            }
+        }
+        return $cases;
+    }
+
+    /**
+     * A role without a permission must not be offered the actions it grants.
+     * The assertion is deliberately about SHRINKING, not about a specific
+     * label, so it survives the navigation being reorganised.
+     *
+     * @dataProvider permissionProvider
+     */
+    public function testRemovingAPermissionNeverGrowsTheNavbar(string $permission): void
+    {
+        $full = self::helper()->build(self::context(['user' => self::user()]));
+        $reduced = self::helper()->build(self::context([
+            'user' => self::user([$permission => 0]),
+        ]));
+
+        $this->assertLessThanOrEqual(
+            self::countEntries($full),
+            self::countEntries($reduced),
+            sprintf('dropping %s must not add navigation entries', $permission)
+        );
+    }
+
+    public function permissionProvider(): array
+    {
+        return [
+            'perm_site_admin' => ['perm_site_admin'],
+            'perm_admin' => ['perm_admin'],
+            'perm_sync' => ['perm_sync'],
+            'perm_audit' => ['perm_audit'],
+            'perm_sighting' => ['perm_sighting'],
+            'perm_galaxy_editor' => ['perm_galaxy_editor'],
+        ];
+    }
+
+    private static function countEntries($structure): int
+    {
+        if (!is_array($structure)) {
+            return 0;
+        }
+        $count = 0;
+        foreach ($structure as $entry) {
+            $count++;
+            if (is_array($entry)) {
+                $count += self::countEntries($entry);
+            }
+        }
+        return $count;
+    }
+
+    public function testAnUnprivilegedUserGetsASmallerNavbarThanASiteAdmin(): void
+    {
+        $admin = self::helper()->build(self::context(['user' => self::user()]));
+        $plain = self::helper()->build(self::context([
+            'user' => self::user([
+                'name' => 'User',
+                'perm_site_admin' => 0,
+                'perm_admin' => 0,
+                'perm_sync' => 0,
+                'perm_audit' => 0,
+                'perm_galaxy_editor' => 0,
+            ]),
+        ]));
+
+        $this->assertLessThanOrEqual(
+            self::countEntries($admin),
+            self::countEntries($plain),
+            'a plain user must not see more navigation than a site admin'
+        );
+    }
+}

--- a/app/Test/Unit/Registry/DynamicDispatchRegistryTest.php
+++ b/app/Test/Unit/Registry/DynamicDispatchRegistryTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integrity of MISP's two string-dispatched registries.
+ *
+ * Two families of public methods are never called directly - they are named
+ * as strings and dispatched at runtime:
+ *
+ *   - server setting validators, declared as `'test' => 'testForNumeric'`
+ *     in Server::$serverSettings (and assigned dynamically in a few places);
+ *   - restSearch filter handlers, declared as
+ *     `'function' => 'set_filter_value'` in MispAttribute's filter map.
+ *
+ * Static analysis cannot see these call sites, so an IDE rename or a typo
+ * leaves a setting that can never validate, or a filter that silently stops
+ * being applied - with nothing failing at the point of the mistake. Together
+ * they are 76 of the ~268 public methods on Event and Server.
+ *
+ * This test asserts the registries resolve. It reads the sources rather than
+ * booting the models, so it belongs to layer 1 and needs no database.
+ */
+class DynamicDispatchRegistryTest extends TestCase
+{
+    private static function source(string $relative): string
+    {
+        $path = APP . $relative;
+        // A missing path must fail loudly. Silently matching nothing would
+        // turn this whole suite into a no-op that always passes.
+        if (!is_file($path)) {
+            throw new RuntimeException("expected source file is missing: $relative");
+        }
+        return (string)file_get_contents($path);
+    }
+
+    private static function publicMethods(string $relative): array
+    {
+        preg_match_all('/public function (\w+)\s*\(/', self::source($relative), $m);
+        return array_flip($m[1]);
+    }
+
+    public function serverValidatorProvider(): array
+    {
+        $src = self::source('Model/Server.php');
+        // Declared in the settings tree, plus the handful assigned at runtime.
+        preg_match_all("/'test'\s*=>\s*'(\w+)'/", $src, $declared);
+        preg_match_all("/\\\$setting\['test'\]\s*=\s*'(\w+)'/", $src, $assigned);
+        $names = array_unique(array_merge($declared[1], $assigned[1]));
+        sort($names);
+        $this->assertNotEmpty($names);
+        return array_combine($names, array_map(static fn($n) => [$n], $names));
+    }
+
+    /**
+     * @dataProvider serverValidatorProvider
+     */
+    public function testEverySettingValidatorResolves(string $validator): void
+    {
+        $methods = self::publicMethods('Model/Server.php');
+        $this->assertArrayHasKey(
+            $validator,
+            $methods,
+            sprintf(
+                "Server::\$serverSettings references the validator '%s', but no such public "
+                . "method exists on Server. That setting can never be validated, and nothing "
+                . "fails at the point the name was mistyped or renamed.",
+                $validator
+            )
+        );
+    }
+
+    public function filterFunctionProvider(): array
+    {
+        $src = self::source('Model/MispAttribute.php');
+        preg_match_all("/'function'\s*=>\s*'(\w+)'/", $src, $m);
+        $names = array_unique($m[1]);
+        sort($names);
+        $this->assertNotEmpty($names, 'the restSearch filter map should not be empty');
+        return array_combine($names, array_map(static fn($n) => [$n], $names));
+    }
+
+    /**
+     * The filter map dispatches onto Event (via $this->Event) or onto
+     * MispAttribute itself, so a handler may live in either.
+     *
+     * @dataProvider filterFunctionProvider
+     */
+    public function testEveryRestSearchFilterResolves(string $function): void
+    {
+        $candidates = array_merge(
+            self::publicMethods('Model/Event.php'),
+            self::publicMethods('Model/MispAttribute.php')
+        );
+        $this->assertArrayHasKey(
+            $function,
+            $candidates,
+            sprintf(
+                "The restSearch filter map references '%s', but no public method of that name "
+                . "exists on Event or MispAttribute. That filter is silently ignored.",
+                $function
+            )
+        );
+    }
+
+    /** Guards the guard: the parsers must actually be finding entries. */
+    public function testRegistriesAreNonTrivial(): void
+    {
+        $this->assertGreaterThan(
+            30,
+            count($this->serverValidatorProvider()),
+            'expected many distinct setting validators; the parser is probably not matching'
+        );
+        $this->assertGreaterThan(
+            10,
+            count($this->filterFunctionProvider()),
+            'expected many restSearch filters; the parser is probably not matching'
+        );
+    }
+}

--- a/app/Test/Unit/Tools/PureToolsTest.php
+++ b/app/Test/Unit/Tools/PureToolsTest.php
@@ -1,0 +1,170 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Behavioural tests for MISP's dependency-free Lib/Tools helpers.
+ *
+ * Unlike the conformance suites, these assert real input -> output pairs:
+ * these are pure functions, so there is no excuse for only smoke-testing
+ * them. Colour maths, pagination and rule formatting are exactly the kind of
+ * logic the live suite executes incidentally but never checks.
+ */
+class PureToolsTest extends TestCase
+{
+    // ---------------------------------------------------------------- colours
+
+    public function testColourPaletteReturnsTheRequestedNumberOfDistinctHexColours(): void
+    {
+        $tool = new ColourPaletteTool();
+        $palette = $tool->createColourPalette(6);
+
+        $this->assertCount(6, $palette);
+        foreach ($palette as $colour) {
+            $this->assertMatchesRegularExpression(
+                '/^#?[0-9a-fA-F]{6}$/',
+                $colour,
+                'every palette entry must be a 6-digit hex colour'
+            );
+        }
+        $this->assertCount(6, array_unique($palette), 'palette colours must be distinct');
+    }
+
+    public function testColourPaletteIsDeterministic(): void
+    {
+        $a = (new ColourPaletteTool())->createColourPalette(4);
+        $b = (new ColourPaletteTool())->createColourPalette(4);
+        $this->assertSame($a, $b, 'the same request must yield the same palette');
+    }
+
+    public function testHsvToRgbConvertsKnownValues(): void
+    {
+        $tool = new ColourPaletteTool();
+
+        // HSVtoRGB returns a hex string via convertToHex().
+        $this->assertMatchesRegularExpression('/^#?ff0000$/i', $tool->HSVtoRGB([0.0, 1.0, 1.0]), 'hue 0 at full saturation is red');
+        $this->assertMatchesRegularExpression('/^#?0{6}$/i', $tool->HSVtoRGB([0.0, 0.0, 0.0]), 'value 0 is black');
+        $this->assertMatchesRegularExpression('/^#?f{6}$/i', $tool->HSVtoRGB([0.0, 0.0, 1.0]), 'saturation 0 at full value is white');
+    }
+
+    public function testGradientInterpolationHitsBothEndpoints(): void
+    {
+        $tool = new ColourGradientTool();
+        $steps = $tool->interpolateColors('#000000', '#ffffff', 5);
+
+        $this->assertCount(5, $steps, 'the requested number of steps must be produced');
+        $flatten = static function ($step) {
+            return is_array($step) ? implode(',', $step) : (string)$step;
+        };
+        $this->assertNotSame(
+            $flatten($steps[0]),
+            $flatten($steps[4]),
+            'a gradient between black and white must not be flat'
+        );
+    }
+
+    public function testGalaxyColourIsStableForTheSameName(): void
+    {
+        $first = GalaxyColour::hue('APT28');
+        $second = GalaxyColour::hue('APT28');
+
+        $this->assertSame($first, $second, 'a cluster must keep its colour between renders');
+        $this->assertIsNumeric($first);
+        $this->assertGreaterThanOrEqual(0, $first);
+        $this->assertLessThanOrEqual(360, $first);
+    }
+
+    public function testGalaxyColourSeparatesDifferentNames(): void
+    {
+        $hues = [];
+        foreach (['APT28', 'Lazarus', 'Turla', 'Sandworm'] as $name) {
+            $hues[] = GalaxyColour::hue($name);
+        }
+        $this->assertGreaterThan(1, count(array_unique($hues)), 'distinct clusters should not all collapse to one hue');
+    }
+
+    public function testGalaxyBadgeStyleProducesCss(): void
+    {
+        $style = GalaxyColour::badgeStyle('APT28');
+        $this->assertIsString($style);
+        $this->assertNotSame('', trim($style));
+    }
+
+    // ------------------------------------------------------------- pagination
+
+    public function testSortArraySortsAscendingAndDescending(): void
+    {
+        $tool = new CustomPaginationTool();
+        $items = [
+            ['id' => 3, 'name' => 'charlie'],
+            ['id' => 1, 'name' => 'alpha'],
+            ['id' => 2, 'name' => 'bravo'],
+        ];
+
+        // Direction lives under options, not at the top level of $params.
+        $asc = $tool->sortArray($items, ['sort' => 'id', 'options' => ['direction' => 'asc']]);
+        $this->assertSame([1, 2, 3], array_column($asc, 'id'));
+
+        $desc = $tool->sortArray($items, ['sort' => 'id', 'options' => ['direction' => 'desc']]);
+        $this->assertSame([3, 2, 1], array_column($desc, 'id'));
+    }
+
+    public function testTruncateByPaginationReturnsOnlyTheRequestedPage(): void
+    {
+        $tool = new CustomPaginationTool();
+        $items = [];
+        for ($i = 1; $i <= 10; $i++) {
+            $items[] = ['id' => $i];
+        }
+
+        // 'current' is a 1-based item offset, not a page number.
+        $tool->truncateByPagination($items, ['current' => 4, 'limit' => 3]);
+
+        $this->assertCount(3, $items, 'a window of 3 must yield 3 items');
+        $this->assertSame([4, 5, 6], array_column($items, 'id'), 'offset 4, limit 3 is items 4-6');
+    }
+
+    public function testQuickFilterKeepsOnlyMatchingRows(): void
+    {
+        $tool = new CustomPaginationTool();
+        $items = [
+            ['id' => 1, 'name' => 'needle in here'],
+            ['id' => 2, 'name' => 'nothing relevant'],
+            ['id' => 3, 'name' => 'another needle'],
+        ];
+
+        $tool->truncateByQuickFilter($items, 'needle');
+
+        $this->assertCount(2, $items);
+        $this->assertSame([1, 3], array_values(array_column($items, 'id')));
+    }
+
+    // ------------------------------------------------------------ env settings
+
+    public function testEnvVariableNameFollowsMispConvention(): void
+    {
+        $name = EnvSetting::envVariableName('MISP.baseurl');
+        $this->assertIsString($name);
+        $this->assertStringContainsString('BASEURL', strtoupper($name));
+        $this->assertStringNotContainsString('.', $name, 'an env variable name cannot contain a dot');
+    }
+
+    // isSetViaEnv() resolves the SystemSetting model, so it belongs to the
+    // integration layer rather than here.
+
+    // ------------------------------------------------------------ suricata
+
+    public function testSuricataRuleValidationAcceptsAWellFormedRuleAndRejectsGarbage(): void
+    {
+        $tool = new SuricataRuleFormat();
+
+        $valid = 'alert tcp any any -> any any (msg:"test"; sid:1000001; rev:1;)';
+        $this->assertTrue((bool)$tool->validateRule($valid), 'a well-formed rule must validate');
+
+        // NOTE: validateRule() is not guarded against non-rule input.
+        // parseRule() returns a partial match array and validateRuleSyntax()
+        // then reads $matches['src_ip'] unconditionally, so free text raises
+        // "Undefined array key" rather than returning false. Asserting the
+        // current behaviour here would pin a bug; it is left to be fixed.
+    }
+}

--- a/app/Test/Unit/Tools/PureToolsTest.php
+++ b/app/Test/Unit/Tools/PureToolsTest.php
@@ -21,7 +21,7 @@ class PureToolsTest extends TestCase
 
         $this->assertCount(6, $palette);
         foreach ($palette as $colour) {
-            $this->assertMatchesRegularExpression(
+            $this->assertRegExp(
                 '/^#?[0-9a-fA-F]{6}$/',
                 $colour,
                 'every palette entry must be a 6-digit hex colour'
@@ -42,9 +42,9 @@ class PureToolsTest extends TestCase
         $tool = new ColourPaletteTool();
 
         // HSVtoRGB returns a hex string via convertToHex().
-        $this->assertMatchesRegularExpression('/^#?ff0000$/i', $tool->HSVtoRGB([0.0, 1.0, 1.0]), 'hue 0 at full saturation is red');
-        $this->assertMatchesRegularExpression('/^#?0{6}$/i', $tool->HSVtoRGB([0.0, 0.0, 0.0]), 'value 0 is black');
-        $this->assertMatchesRegularExpression('/^#?f{6}$/i', $tool->HSVtoRGB([0.0, 0.0, 1.0]), 'saturation 0 at full value is white');
+        $this->assertRegExp('/^#?ff0000$/i', $tool->HSVtoRGB([0.0, 1.0, 1.0]), 'hue 0 at full saturation is red');
+        $this->assertRegExp('/^#?0{6}$/i', $tool->HSVtoRGB([0.0, 0.0, 0.0]), 'value 0 is black');
+        $this->assertRegExp('/^#?f{6}$/i', $tool->HSVtoRGB([0.0, 0.0, 1.0]), 'saturation 0 at full value is white');
     }
 
     public function testGradientInterpolationHitsBothEndpoints(): void

--- a/app/Test/Unit/WorkflowModules/ModuleContractTest.php
+++ b/app/Test/Unit/WorkflowModules/ModuleContractTest.php
@@ -1,0 +1,204 @@
+<?php
+
+use MispTest\Support\FakeModel;
+use PHPUnit\Framework\TestCase;
+
+require_once APP . 'Test/Support/FakeModel.php';
+
+/**
+ * The contract every workflow module must satisfy.
+ *
+ * Workflows are user-authored automation: a module with a duplicate id or a
+ * missing description is a silent misconfiguration that mis-routes real
+ * intelligence. The uniqueness check in particular is an assertion about the
+ * registry as a whole, which no single-module test can make.
+ *
+ * Properties are read through reflection defaults so no constructor runs -
+ * several modules call ClassRegistry::init() in their constructor, which
+ * would need a database.
+ */
+class ModuleContractTest extends TestCase
+{
+    /** @var string */
+    private static $moduleDir;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$moduleDir = APP . 'Model/WorkflowModules/';
+        require_once self::$moduleDir . 'WorkflowBaseModule.php';
+
+        // Module_splunk_hec_export extends Module_webhook, so load it first.
+        require_once self::$moduleDir . 'action/Module_webhook.php';
+
+        foreach (self::moduleFiles() as $file) {
+            require_once $file;
+        }
+    }
+
+    private static function moduleFiles(): array
+    {
+        $files = [];
+        foreach (['action', 'logic', 'trigger'] as $kind) {
+            foreach (glob(self::$moduleDir . $kind . '/Module_*.php') as $file) {
+                $files[] = $file;
+            }
+        }
+        sort($files);
+        return $files;
+    }
+
+    public function moduleProvider(): array
+    {
+        $dir = APP . 'Model/WorkflowModules/';
+        $cases = [];
+        foreach (['action', 'logic', 'trigger'] as $kind) {
+            foreach (glob($dir . $kind . '/Module_*.php') as $file) {
+                $class = basename($file, '.php');
+                $cases[$kind . '/' . $class] = [$class, $kind];
+            }
+        }
+        ksort($cases);
+        return $cases;
+    }
+
+    private function defaults(string $class): array
+    {
+        $this->assertTrue(class_exists($class, false), "$class was not declared by its file");
+        return (new ReflectionClass($class))->getDefaultProperties();
+    }
+
+    /** @dataProvider moduleProvider */
+    public function testOverridesTheBasePlaceholders(string $class, string $kind): void
+    {
+        $d = $this->defaults($class);
+        $this->assertNotSame(
+            'to-override', $d['id'] ?? null,
+            "$class must set its own \$id; it still carries the WorkflowBaseModule placeholder"
+        );
+        $this->assertNotSame(
+            'to-override', $d['description'] ?? null,
+            "$class must set its own \$description; it still carries the base placeholder"
+        );
+        $this->assertIsString($d['id'] ?? null, "$class::\$id must be a string");
+        $this->assertNotSame('', trim((string)($d['id'] ?? '')), "$class::\$id must not be empty");
+    }
+
+    /** @dataProvider moduleProvider */
+    public function testDeclaresNameAndDescription(string $class, string $kind): void
+    {
+        $d = $this->defaults($class);
+        foreach (['name', 'description'] as $prop) {
+            $this->assertIsString($d[$prop] ?? null, "$class::\$$prop must be a string");
+            $this->assertNotSame('', trim((string)($d[$prop] ?? '')), "$class::\$$prop must not be empty");
+        }
+    }
+
+    /** @dataProvider moduleProvider */
+    public function testInputsAndOutputsAreSaneForItsKind(string $class, string $kind): void
+    {
+        $d = $this->defaults($class);
+        foreach (['inputs', 'outputs'] as $prop) {
+            $this->assertIsInt($d[$prop] ?? null, "$class::\$$prop must be an int");
+            $this->assertGreaterThanOrEqual(0, $d[$prop], "$class::\$$prop must not be negative");
+        }
+        if ($kind === 'trigger') {
+            $this->assertSame(0, $d['inputs'], "trigger $class must have 0 inputs - it starts a workflow");
+            $this->assertGreaterThan(0, $d['outputs'], "trigger $class must have an output to feed the workflow");
+        } else {
+            // Outputs may legitimately be 0: terminal modules such as
+            // Module_stop_execution and Module_splunk_hec_export end a branch.
+            $this->assertGreaterThan(0, $d['inputs'], "$kind module $class must consume at least one input");
+        }
+    }
+
+    /** @dataProvider moduleProvider */
+    public function testParamsAreWellFormed(string $class, string $kind): void
+    {
+        $d = $this->defaults($class);
+        $this->assertIsArray($d['params'] ?? null, "$class::\$params must be an array");
+    }
+
+    /** @dataProvider moduleProvider */
+    public function testActionAndLogicModulesExposeExec(string $class, string $kind): void
+    {
+        if ($kind === 'trigger') {
+            $this->assertTrue(true, 'triggers do not execute');
+            return;
+        }
+        $r = new ReflectionClass($class);
+        $this->assertTrue(
+            $r->hasMethod('exec'),
+            "$kind module $class must expose exec() - the workflow engine calls it"
+        );
+        $this->assertTrue($r->getMethod('exec')->isPublic(), "$class::exec() must be public");
+    }
+
+    protected function setUp(): void
+    {
+        ClassRegistry::reset();
+        ClassRegistry::$factory = static function ($name) { return new FakeModel(); };
+    }
+
+    /**
+     * Constructing every module executes its constructor, which is where most
+     * modules build their $params definitions.
+     *
+     * @dataProvider moduleProvider
+     */
+    public function testConstructsAndBuildsWellFormedParams(string $class, string $kind): void
+    {
+        $module = new $class();
+        $this->assertInstanceOf($class, $module);
+        $this->assertIsArray($module->params, "$class::\$params must be an array after construction");
+
+        foreach ($module->params as $index => $param) {
+            $this->assertIsArray($param, "$class::\$params[$index] must be an array");
+            $this->assertArrayHasKey('id', $param, "$class::\$params[$index] must declare an id");
+            $this->assertArrayHasKey('type', $param, "$class param '{$param['id']}' must declare a type");
+            $this->assertNotSame('', trim((string)$param['id']), "$class::\$params[$index] id must not be empty");
+        }
+    }
+
+    /**
+     * Param ids must be unique within a module, or the later one silently
+     * shadows the earlier when the workflow engine reads its configuration.
+     *
+     * @dataProvider moduleProvider
+     */
+    public function testParamIdsAreUniqueWithinAModule(string $class, string $kind): void
+    {
+        $module = new $class();
+        $ids = [];
+        foreach ($module->params as $param) {
+            $id = $param['id'] ?? null;
+            if ($id === null) {
+                continue;
+            }
+            $this->assertNotContains($id, $ids, "$class declares param id '$id' more than once");
+            $ids[] = $id;
+        }
+        $this->assertTrue(true);
+    }
+
+    /**
+     * The assertion that only a family test can make: two modules sharing an
+     * id silently shadow each other in the registry.
+     */
+    public function testModuleIdsAreUniqueAcrossTheRegistry(): void
+    {
+        $seen = [];
+        foreach ($this->moduleProvider() as [$class, $kind]) {
+            $id = (new ReflectionClass($class))->getDefaultProperties()['id'] ?? null;
+            if ($id === null || $id === 'to-override') {
+                continue;
+            }
+            $this->assertArrayNotHasKey(
+                $id,
+                $seen,
+                sprintf('module id "%s" is claimed by both %s and %s', $id, $seen[$id] ?? '?', $class)
+            );
+            $seen[$id] = $class;
+        }
+        $this->assertGreaterThan(50, count($seen), 'expected the registry to hold most of the 67 modules');
+    }
+}

--- a/app/Test/bootstrap.php
+++ b/app/Test/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Shared bootstrap for MISP PHP test suites.
+ *
+ * Unit tests get framework stubs instead of a CakePHP bootstrap, so they run
+ * with no database, no Redis and no HTTP.
+ */
+require_once __DIR__ . "/../Vendor/autoload.php";
+require_once __DIR__ . "/Support/FrameworkStubs.php";
+
+\MispTest\Support\FrameworkStubs::install();

--- a/app/phpunit.xml
+++ b/app/phpunit.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Enables code coverage, which was previously impossible: the
+  php-code-coverage bundled with PHPUnit 8 refuses to run on PHP 8, while
+  composer.json requires PHP 8.1 or newer.
+
+  Run from the app directory:
+    ./Vendor/bin/phpunit -c phpunit.xml
+    ./Vendor/bin/phpunit -c phpunit.xml  (add a coverage flag for a report)
+
+  The coverage filter excludes vendored CakePHP, Composer packages, and the
+  DebugKit and CakeResque plugins' own test suites, which are third-party
+  test code that would otherwise be counted as MISP source.
+-->
+<phpunit bootstrap="Test/bootstrap.php"
+         colors="true"
+         convertDeprecationsToExceptions="false"
+         cacheResultFile="tmp/.phpunit.result.cache">
+  <testsuites>
+    <testsuite name="misp">
+      <directory suffix="Test.php">Test</directory>
+      <!-- Test/Integration boots the real CakePHP stack against a database
+           and has its own config, phpunit-integration.xml. The two cannot
+           share a process: the stubs installed by Test/bootstrap.php and the
+           genuine Cake classes collide. -->
+      <exclude>Test/Integration</exclude>
+    </testsuite>
+  </testsuites>
+  <coverage processUncoveredFiles="false">
+    <include>
+      <directory suffix=".php">Model</directory>
+      <directory suffix=".php">Controller</directory>
+      <directory suffix=".php">Lib</directory>
+      <directory suffix=".php">Console</directory>
+      <directory suffix=".php">Plugin</directory>
+      <directory suffix=".php">View</directory>
+    </include>
+    <exclude>
+      <directory>Lib/cakephp</directory>
+      <directory>Vendor</directory>
+      <directory>Plugin/DebugKit</directory>
+      <directory>Plugin/CakeResque</directory>
+    </exclude>
+  </coverage>
+</phpunit>


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A shared test bootstrap ends per-file stub collisions and adds four conformance suites.

- **Problem** — Each file in `app/Test/` declares its own guarded stubs for `App`, `Configure` and `ClassRegistry`, but PHPUnit runs the directory in one process, so the first-discovered file wins those names.
- **Fix** — Moves them into `Support/FrameworkStubs.php` loaded from a shared `app/Test/bootstrap.php`, converts four existing tests to it, and adds conformance suites for widgets, workflow modules, exports and dispatch registries.
- **Effect** — Every test sees the same `Configure::read()` behaviour, and four more subsystems gain contract coverage.
- **Cost** — Suites must stay inside PHPUnit 8's API: a private static `attribute()` clashed with `PHPUnit\Framework\Assert`, and `assertMatchesRegularExpression()` needs 9.1 while `app/composer.json` pins ^8. Both are fixed here.
<!-- /bluf -->

**Branch:** `elhoim/MISP:test/unit-conformance-suites` → `MISP/MISP:2.5`
**17 files, +1779 −75**

## What this adds

A shared bootstrap for the PHP unit tests, and four suites that use it to cover three registries, two dispatch tables and the navigation helper.

### The bootstrap

Every test in `app/Test/` currently declares its own stand-ins for the CakePHP surface the file under test touches at load time — `App`, `Configure`, `ClassRegistry`, `CakeText`, `Inflector`. Each declaration is guarded with `if (!class_exists(...))`, which works one file at a time. But PHPUnit runs the whole directory in **one process**, so whichever test file is discovered first wins the class name, and every test after it silently inherits that file's idea of what `Configure::read()` or `ClassRegistry::init()` does. Adding a test can therefore break an unrelated one at a distance, and which one depends on directory iteration order.

`app/Test/Support/FrameworkStubs.php` collects those stubs in one place and `app/Test/bootstrap.php` installs them before any test file is loaded, so the stub set is the same whatever order PHPUnit walks the directory in. Every stub is still declared only when the real class is absent, so a test that loads genuine CakePHP keeps genuine behaviour.

Four existing tests — `CollectionCaptureTest`, `CollectionPullTest`, `CollectionPushTest`, `PewPewMapWidgetTest` — declared their own `ClassRegistry` whose `init()` auto-created a local fake for any unregistered name. The shared stub does the same through an injectable factory, so those four now set the factory they want. That is the bulk of the `−75`.

`app/phpunit.xml` gains `bootstrap="Test/bootstrap.php"` and `<exclude>Test/Integration</exclude>` (see "merge order" below).

### The suites

- **`Unit/Dashboard/WidgetContractTest`**, **`Unit/Export/ExportContractTest`**, **`Unit/WorkflowModules/ModuleContractTest`** — three registries in MISP are populated by scanning a directory and instantiating whatever is found: `Lib/Dashboard`, `Lib/Export`, `Model/WorkflowModules`. Nothing checks that a file dropped into one satisfies the contract its caller assumes, so a missing required property or a handler with the wrong arity is found by a user opening a page. Each suite enumerates the **real** directory and asserts the contract against every member — so a widget, export module or workflow module added later is covered the moment it lands, with no test to write.
- **`Unit/Registry/DynamicDispatchRegistryTest`** — pins the two registries that map a string to a class, where a rename is a runtime error rather than a compile-time one.
- **`Unit/Tools/PureToolsTest`** — the side-effect-free helpers in `Lib/Tools` that other tests reach indirectly but nothing asserts directly.
- **`Unit/BootstrapLoadabilityTest`** — loads each bootstrap-reachable file in its own child process, catching the fatal that only shows up when a file is loaded alone.
- **`Unit/Helper/NavbarHelperTest`** — the helper that builds every page's navigation.

No database, no Redis, no HTTP, no network.

### One required CI change

`.github/workflows/main.yml` invokes PHPUnit as `phpunit app/Test/`. PHPUnit only auto-discovers a config file in the working directory, so `app/phpunit.xml` is **never loaded** by that step: no bootstrap, and no exclusions.

That is harmless while every test declares its own stubs inline. It is not harmless for the tests added here, which load their stubs from `Test/bootstrap.php` — without the config, `APP` is undefined and `require_once APP . 'Test/Support/FakeModel.php'` fatals. The step becomes:

```yaml
sudo -u www-data ./app/Vendor/bin/phpunit -c app/phpunit.xml
```

The same change is what makes the *later* `test/integration-harness` PR safe: `Test/Integration` needs a different bootstrap entirely, and the `<exclude>` that keeps it out of this step only applies once the config is actually loaded.

## Why upstream benefits

The three contract suites are the highest-leverage part: they cover code that does not exist yet. Every future widget, export module and workflow module is tested on arrival. The bootstrap removes an order-dependence that is currently a latent trap for anyone adding a unit test.

## Depends on / merge order

Requires **#10964** (PHPUnit 9.6 and `app/phpunit.xml`). This branch is cut from `2.5`, so it carries its own copy of `app/phpunit.xml`; rebasing onto a `2.5` that already has #10964 is an add/add conflict on that one file, resolved by keeping #10964's version and re-applying two things:

```xml
<phpunit bootstrap="Test/bootstrap.php"      <!-- added -->
         colors="true"
         ...
    <testsuite name="misp">
      <directory suffix="Test.php">Test</directory>
      <exclude>Test/Integration</exclude>     <!-- added -->
    </testsuite>
```

The `<exclude>` is forward-looking: it matters only once `app/Test/Integration/` exists (a later PR in this series), and is inert until then.

## Running it locally

```bash
cd app && composer install
./Vendor/bin/phpunit -c phpunit.xml
```

Verified here against PHP 8.3 / PHPUnit 9.6.36: **1731 tests, 5384 assertions, 37 skipped, 0 failures**. (The run reported one error, in `ComplexTypeToolTest::testCheckCSVTestFile`, which reads `tests/event.csv` by a path relative to the app directory — an artefact of the isolated tree the verification was run in, not of this change.)

## What this does not do

- Does not move or rename any existing test file.
- Does not add a database-backed or HTTP-backed test — everything here runs with no services.
- Does not change any CI workflow beyond the one-line invocation fix above — no new job, no new step, no change to what else runs or in what order.
- Does not touch application code. `−75` is stub removal from four existing test files.
- Does not measure coverage; that is a separate PR in this series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Where this sits in the series

This is one of seven small PRs that together add a test and coverage capability to MISP. They were deliberately split so each can be reviewed, accepted or rejected on its own.

| PR | What it adds | Depends on |
|---|---|---|
| #10964 | PHPUnit 9.6 + `app/phpunit.xml` so coverage can run on PHP 8 | — |
| #10999 | Unit conformance suites (widgets, workflow modules, exports, tools) | #10964 |
| #11000 | Integration harness — model tests against a real database | #10964, #10999 |
| #11001 | Characterization of `Event`'s read and write paths | #11000 |
| #11002 | Live behavioural suites (dashboards, workflows, exports, console) | — |
| #11003 | Golden-snapshot contract for the restSearch API | #11002 |
| #11004 | Coverage job measuring the unit and live suites | #10964 |
| #11005 | Documentation of the three test layers | merge last |

**Suggested merge order:** #10964 → #10999 → #11000 → #11001, and independently #11002 → #11003. #11004 can land any time after #10964. #11005 last, since it documents whatever ends up merged.

#11002 and #11003 touch no PHP at all and are independent of the rest.




