### PR TITLE
[low] test: integration harness for model-level tests against a real database

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -391,6 +391,17 @@ jobs:
           python tools/misp-feed/validate.py
           deactivate
 
+      # Deliberately after the Python suites, not beside "Run PHP tests".
+      # This suite writes to the events table, and although it deletes its own
+      # rows, InnoDB does not roll AUTO_INCREMENT back. tests/curl_tests_GH.sh
+      # hardcodes event id 1 - it POSTs tests/event.json and then diffs
+      # GET /events/csv/download/1 - so running the integration suite before it
+      # makes that diff fail, and because the script runs under `set -e` it
+      # aborts BEFORE its own cleanup `POST /events/delete/1`, leaving 38
+      # attributes behind that break the suites after it.
+      - name: Run PHP integration tests
+        run: sudo -u www-data ./app/Vendor/bin/phpunit -c app/phpunit-integration.xml
+
       # Deliberately after the other suites: this switches the instance to
       # LDAP authentication, which changes how every subsequent form login
       # behaves. Nothing after this point logs in through the web form.

--- a/app/Test/Integration/CorrelationEngineTest.php
+++ b/app/Test/Integration/CorrelationEngineTest.php
@@ -1,0 +1,277 @@
+<?php
+
+require_once __DIR__ . '/IntegrationTestCase.php';
+
+/**
+ * MISP ships three interchangeable correlation strategies:
+ * DefaultCorrelationBehavior, NoAclCorrelationBehavior and
+ * OnDemandCorrelationBehavior, selected by MISP.correlation_engine.
+ *
+ * They are interchangeable only if they AGREE. That is an assertion about
+ * three implementations relative to each other, which no single HTTP request
+ * can make - it is the reason layer 2 exists. Combined they are 1,195
+ * statements, of which OnDemandCorrelationBehavior was 0% in both suites.
+ */
+class CorrelationEngineTest extends IntegrationTestCase
+{
+    private const ENGINES = ['Default', 'NoAcl', 'OnDemand'];
+
+    /** @var string|null */
+    private $originalEngine;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalEngine = Configure::read('MISP.correlation_engine');
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore the engine before the base class removes fixture events, so
+        // cleanup runs against the configuration the instance started with.
+        Configure::write('MISP.correlation_engine', $this->originalEngine);
+        parent::tearDown();
+    }
+
+    private function behaviorClass(string $engine): string
+    {
+        return $engine . 'CorrelationBehavior';
+    }
+
+    private function loadBehavior(string $engine): void
+    {
+        App::uses($this->behaviorClass($engine), 'Model/Behavior');
+    }
+
+    // ------------------------------------------------------------ interface
+
+    /**
+     * Every engine must expose the same public surface. If one gains a method
+     * the others lack, switching engines silently changes behaviour.
+     */
+    public function testAllEnginesShareThePublicInterface(): void
+    {
+        $surfaces = [];
+        foreach (self::ENGINES as $engine) {
+            $this->loadBehavior($engine);
+            $class = $this->behaviorClass($engine);
+            $this->assertTrue(class_exists($class), "$class must exist");
+
+            $methods = [];
+            foreach ((new ReflectionClass($class))->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+                if ($method->getDeclaringClass()->getName() === 'ModelBehavior') {
+                    continue; // inherited framework surface, not the strategy's
+                }
+                if (strpos($method->getName(), '_') === 0) {
+                    continue; // engine-private helper
+                }
+                $methods[] = $method->getName();
+            }
+            sort($methods);
+            $surfaces[$engine] = $methods;
+        }
+
+        $reference = $surfaces['Default'];
+        foreach (['NoAcl', 'OnDemand'] as $engine) {
+            $missing = array_diff($reference, $surfaces[$engine]);
+            $this->assertSame(
+                [],
+                array_values($missing),
+                sprintf(
+                    '%s is missing methods the Default engine provides: %s',
+                    $this->behaviorClass($engine),
+                    implode(', ', $missing)
+                )
+            );
+        }
+    }
+
+    /**
+     * An engine may accept FEWER arguments than the caller passes - PHP
+     * discards the extras - but it must never REQUIRE more, or swapping to it
+     * breaks the call site.
+     *
+     * NoAclCorrelationBehavior::runGetAttributesRelatedToEvent legitimately
+     * takes one parameter fewer than Default: Correlation.php:1115 passes
+     * $sgids, and an engine that skips ACL has no use for sharing-group ids,
+     * so it drops them. That is a deliberate narrowing, which this invariant
+     * permits. A widening would be a real break, which it does not.
+     */
+    public function testNoEngineRequiresMoreArgumentsThanTheDefault(): void
+    {
+        $required = [];
+        foreach (self::ENGINES as $engine) {
+            $this->loadBehavior($engine);
+            foreach ((new ReflectionClass($this->behaviorClass($engine)))->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+                if ($method->getDeclaringClass()->getName() === 'ModelBehavior') {
+                    continue;
+                }
+                $required[$engine][$method->getName()] = $method->getNumberOfRequiredParameters();
+            }
+        }
+
+        $breaks = [];
+        foreach ($required['Default'] as $name => $defaultRequired) {
+            foreach (['NoAcl', 'OnDemand'] as $engine) {
+                if (!isset($required[$engine][$name])) {
+                    continue;
+                }
+                if ($required[$engine][$name] > $defaultRequired) {
+                    $breaks[] = sprintf(
+                        '%s::%s requires %d args but the Default engine requires only %d, '
+                        . 'so call sites written against Default would break',
+                        $this->behaviorClass($engine), $name,
+                        $required[$engine][$name], $defaultRequired
+                    );
+                }
+            }
+        }
+        $this->assertSame([], $breaks, implode("\n", $breaks));
+    }
+
+    /**
+     * Records the one place the engines' signatures diverge today, so a NEW
+     * divergence stands out instead of hiding among accepted ones.
+     */
+    public function testTheOnlyKnownSignatureDivergenceIsTheAclArgument(): void
+    {
+        $known = ['NoAclCorrelationBehavior::runGetAttributesRelatedToEvent'];
+
+        $required = [];
+        foreach (self::ENGINES as $engine) {
+            $this->loadBehavior($engine);
+            foreach ((new ReflectionClass($this->behaviorClass($engine)))->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+                if ($method->getDeclaringClass()->getName() === 'ModelBehavior') {
+                    continue;
+                }
+                $required[$engine][$method->getName()] = $method->getNumberOfRequiredParameters();
+            }
+        }
+
+        $divergences = [];
+        foreach ($required['Default'] as $name => $defaultRequired) {
+            foreach (['NoAcl', 'OnDemand'] as $engine) {
+                if (!isset($required[$engine][$name])) {
+                    continue;
+                }
+                if ($required[$engine][$name] !== $defaultRequired) {
+                    $divergences[] = $this->behaviorClass($engine) . '::' . $name;
+                }
+            }
+        }
+        sort($divergences);
+        sort($known);
+
+        $this->assertSame(
+            $known,
+            $divergences,
+            "the set of engines whose signatures differ from Default has changed"
+        );
+    }
+
+    /** Each engine must name a correlation table, and they must differ. */
+    public function testEachEngineDeclaresItsOwnTable(): void
+    {
+        $correlation = $this->model('Correlation');
+        $tables = [];
+        foreach (self::ENGINES as $engine) {
+            Configure::write('MISP.correlation_engine', $engine);
+            $fresh = ClassRegistry::init('Correlation', true);
+            $table = method_exists($fresh, 'getTableName') ? $fresh->getTableName() : null;
+            if ($table === null) {
+                $this->markTestSkipped('Correlation::getTableName() is not exposed on this version');
+            }
+            $this->assertIsString($table, "$engine must name a correlation table");
+            $this->assertNotSame('', $table);
+            $tables[$engine] = $table;
+        }
+        $this->assertCount(
+            count(self::ENGINES),
+            array_unique($tables),
+            'engines must not share a correlation table: ' . json_encode($tables)
+        );
+        unset($correlation);
+    }
+
+    // ------------------------------------------------------------ behaviour
+
+    /**
+     * Two events sharing an attribute value must correlate.
+     *
+     * This is the base fact every engine has to satisfy before their
+     * agreement is meaningful.
+     */
+    public function testTwoEventsSharingAValueCorrelate(): void
+    {
+        $value = '198.51.100.' . random_int(2, 250);
+
+        $firstId = $this->createEvent('correlation fixture A', [
+            ['type' => 'ip-dst', 'value' => $value],
+        ]);
+        $secondId = $this->createEvent('correlation fixture B', [
+            ['type' => 'ip-dst', 'value' => $value],
+        ]);
+
+        $correlation = $this->model('Correlation');
+        $correlation->generateCorrelation(false, $firstId);
+        $correlation->generateCorrelation(false, $secondId);
+
+        $related = $correlation->fetchRelatedEventIds($this->adminUser(), $firstId, []);
+        if ($related === null) {
+            $this->markTestSkipped('this engine does not expose fetchRelatedEventIds directly');
+        }
+
+        $this->assertContains(
+            $secondId,
+            array_map('intval', (array)$related),
+            'an event sharing an attribute value must be reported as related'
+        );
+    }
+
+    /**
+     * The Default and NoAcl engines must agree for a site admin.
+     *
+     * NoAcl exists to skip the ACL filtering that Default applies. For a user
+     * who can see everything, that filtering is a no-op, so the two engines
+     * must produce the same related-event set. If they diverge here, one of
+     * them is wrong.
+     */
+    public function testDefaultAndNoAclAgreeForASiteAdmin(): void
+    {
+        $value = '198.51.100.' . random_int(2, 250);
+
+        $firstId = $this->createEvent('engine agreement A', [
+            ['type' => 'ip-dst', 'value' => $value],
+        ]);
+        $secondId = $this->createEvent('engine agreement B', [
+            ['type' => 'ip-dst', 'value' => $value],
+        ]);
+
+        $user = $this->adminUser();
+        if (empty($user['Role']['perm_site_admin'])) {
+            $this->markTestSkipped('user 1 is not a site admin on this instance');
+        }
+
+        $results = [];
+        foreach (['Default', 'NoAcl'] as $engine) {
+            Configure::write('MISP.correlation_engine', $engine);
+            $correlation = ClassRegistry::init('Correlation', true);
+            $correlation->generateCorrelation(false, $firstId);
+            $correlation->generateCorrelation(false, $secondId);
+
+            $related = $correlation->fetchRelatedEventIds($user, $firstId, []);
+            if ($related === null) {
+                $this->markTestSkipped("engine $engine does not expose fetchRelatedEventIds");
+            }
+            $ids = array_map('intval', (array)$related);
+            sort($ids);
+            $results[$engine] = $ids;
+        }
+
+        $this->assertSame(
+            $results['Default'],
+            $results['NoAcl'],
+            'for a site admin the ACL filter is a no-op, so both engines must agree'
+        );
+    }
+}

--- a/app/Test/Integration/IntegrationTestCase.php
+++ b/app/Test/Integration/IntegrationTestCase.php
@@ -1,0 +1,141 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Base for layer-2 tests: real CakePHP models against the real database.
+ *
+ * Layer 2 exists for behaviour that needs model internals AND cannot be
+ * asserted over HTTP - the correlation strategies agreeing with each other
+ * being the motivating case. Anything assertable over HTTP belongs in the
+ * live Python suite instead.
+ *
+ * Each test records the events it creates and removes them in tearDown, so a
+ * failing test cannot leave state that breaks the next one. (The live suite
+ * learned that lesson the hard way.)
+ */
+abstract class IntegrationTestCase extends TestCase
+{
+    /** @var array<int,int> event ids created by the running test */
+    protected $createdEventIds = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        if (!class_exists('ClassRegistry')) {
+            self::markTestSkipped('CakePHP was not bootstrapped; run with phpunit-integration.xml');
+        }
+    }
+
+    protected function setUp(): void
+    {
+        // AnalystDataParentBehavior resolves the acting user from
+        // Configure::read('CurrentUserId') and fatals if it is unset (see
+        // EventFetchCharacterizationTest::testAnalystDataWithoutCurrentUserId).
+        // A web request sets it; a test, a shell and a worker do not. Set it
+        // so tests exercise the normal authenticated path.
+        Configure::write('CurrentUserId', 1);
+        try {
+            $this->model('Event')->find('count');
+        } catch (\Throwable $e) {
+            $this->markTestSkipped('no usable database connection: ' . $e->getMessage());
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (array_reverse($this->createdEventIds) as $eventId) {
+            try {
+                $this->model('Event')->delete($eventId);
+            } catch (\Throwable $e) {
+                // Best effort: a test must not fail during cleanup.
+            }
+        }
+        $this->createdEventIds = [];
+    }
+
+    /**
+     * Register an event created outside createEvent() - e.g. by _add() under
+     * test - so tearDown still removes it.
+     */
+    protected function trackEvent(int $eventId): int
+    {
+        $this->createdEventIds[] = $eventId;
+        return $eventId;
+    }
+
+    protected function model(string $name)
+    {
+        return ClassRegistry::init($name);
+    }
+
+    /** The site-admin user array MISP's model layer expects. */
+    protected function adminUser(): array
+    {
+        $user = $this->model('User')->find('first', [
+            'recursive' => -1,
+            'conditions' => ['User.id' => 1],
+            'contain' => false,
+        ]);
+        if (empty($user)) {
+            $this->markTestSkipped('no user with id 1 on this instance');
+        }
+        $user = $user['User'];
+        $user['Role'] = $this->model('Role')->find('first', [
+            'recursive' => -1,
+            'conditions' => ['Role.id' => $user['role_id']],
+        ])['Role'] ?? ['perm_site_admin' => 1];
+        $user['Organisation'] = $this->model('Organisation')->find('first', [
+            'recursive' => -1,
+            'conditions' => ['Organisation.id' => $user['org_id']],
+        ])['Organisation'] ?? ['id' => $user['org_id'], 'name' => 'ORGNAME'];
+        return $user;
+    }
+
+    /**
+     * Create an event carrying the given attribute values, and register it
+     * for cleanup.
+     *
+     * @param array<int,array{type:string,value:string}> $attributes
+     */
+    protected function createEvent(string $info, array $attributes): int
+    {
+        $eventModel = $this->model('Event');
+        $eventModel->create();
+        $saved = $eventModel->save([
+            'Event' => [
+                'info' => $info,
+                'date' => date('Y-m-d'),
+                'analysis' => 0,
+                'threat_level_id' => 1,
+                'distribution' => 3,
+                'org_id' => 1,
+                'orgc_id' => 1,
+                'user_id' => 1,
+                'uuid' => CakeText::uuid(),
+                'published' => false,
+            ],
+        ]);
+        $this->assertNotEmpty($saved, "could not create the fixture event '$info'");
+        $eventId = (int)$eventModel->id;
+        $this->createdEventIds[] = $eventId;
+
+        $attributeModel = $this->model('MispAttribute');
+        foreach ($attributes as $attribute) {
+            $attributeModel->create();
+            $ok = $attributeModel->save([
+                'Attribute' => [
+                    'event_id' => $eventId,
+                    'category' => $attribute['category'] ?? 'Network activity',
+                    'type' => $attribute['type'],
+                    'value' => $attribute['value'],
+                    'to_ids' => 1,
+                    'distribution' => 5,
+                    'uuid' => CakeText::uuid(),
+                ],
+            ]);
+            $this->assertNotEmpty($ok, "could not create attribute {$attribute['value']}");
+        }
+
+        return $eventId;
+    }
+}

--- a/app/Test/Integration/ServerPullTransformTest.php
+++ b/app/Test/Integration/ServerPullTransformTest.php
@@ -1,0 +1,376 @@
+<?php
+
+require_once __DIR__ . '/IntegrationTestCase.php';
+
+/**
+ * Specification tests for the three pure transforms in Server's pull path:
+ *
+ *   - filterRuleToParameter()          - sync filter rules to search parameters
+ *   - __checkIfEventSaveAble()         - "is there anything left worth saving"
+ *   - __updatePulledEventBeforeInsert() - the distribution downgrade cascade
+ *
+ * None of them touches the network or the database: they are array in, array
+ * out. They were nevertheless completely uncovered, because they sit inside
+ * pull(), which does need a remote instance. Driving them directly is the
+ * cheapest coverage in the whole sync path, and the downgrade cascade in
+ * particular is security-relevant - it is what stops a pulled event being
+ * redistributed more widely than its origin intended.
+ *
+ * Unlike the Event characterization tests these are SPECIFICATIONS (ADR 0002):
+ * the distribution downgrade is a documented rule, not an accident, so a change
+ * that breaks one of these assertions is a bug rather than a re-baseline.
+ *
+ * The last two are private, so they are reached by reflection. That is
+ * deliberate: making them public purely to test them would widen Server's API
+ * for no caller's benefit.
+ */
+class ServerPullTransformTest extends IntegrationTestCase
+{
+    /** @var array<string,mixed> config keys this test writes, with their prior values */
+    private $savedConfig = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->savedConfig as $key => $value) {
+            if ($value === null) {
+                Configure::delete($key);
+            } else {
+                Configure::write($key, $value);
+            }
+        }
+        $this->savedConfig = [];
+        parent::tearDown();
+    }
+
+    private function setConfig(string $key, $value): void
+    {
+        if (!array_key_exists($key, $this->savedConfig)) {
+            $this->savedConfig[$key] = Configure::check($key) ? Configure::read($key) : null;
+        }
+        Configure::write($key, $value);
+    }
+
+    private function server()
+    {
+        return $this->model('Server');
+    }
+
+    private function callPrivate(string $method, array &$args)
+    {
+        $reflection = new ReflectionMethod('Server', $method);
+        $reflection->setAccessible(true);
+        return $reflection->invokeArgs($this->server(), $args);
+    }
+
+    // ------------------------------------------------ filterRuleToParameter
+
+    public function testEmptyFilterRulesProduceNoParameters(): void
+    {
+        $this->assertSame([], $this->server()->filterRuleToParameter(''));
+        $this->assertSame([], $this->server()->filterRuleToParameter('[]'));
+    }
+
+    public function testPluralRuleFieldsAreSingularisedForTheSearchApi(): void
+    {
+        // 'tags' => 'tag', 'orgs' => 'org' - the search API takes the singular.
+        $rules = json_encode(['tags' => ['OR' => ['tlp:white']], 'orgs' => ['OR' => ['CIRCL']]]);
+        $out = $this->server()->filterRuleToParameter($rules);
+        $this->assertSame(['tag' => ['tlp:white'], 'org' => ['CIRCL']], $out);
+    }
+
+    public function testNotRulesBecomeBangPrefixedValues(): void
+    {
+        $rules = json_encode(['tags' => ['NOT' => ['tlp:red', 'tlp:amber']]]);
+        $this->assertSame(['tag' => ['!tlp:red', '!tlp:amber']], $this->server()->filterRuleToParameter($rules));
+    }
+
+    public function testOrAndNotRulesForOneFieldAreFlattenedTogether(): void
+    {
+        $rules = json_encode(['tags' => ['OR' => ['tlp:white'], 'NOT' => ['tlp:red']]]);
+        $this->assertSame(['tag' => ['tlp:white', '!tlp:red']], $this->server()->filterRuleToParameter($rules));
+    }
+
+    public function testEmptyRuleValuesAreDropped(): void
+    {
+        $rules = json_encode(['tags' => ['OR' => ['', 'tlp:white', '']]]);
+        $this->assertSame(['tag' => ['tlp:white']], $this->server()->filterRuleToParameter($rules));
+    }
+
+    public function testAFieldWhoseValuesAreAllEmptyProducesNoParameter(): void
+    {
+        $rules = json_encode(['tags' => ['OR' => ['', '']]]);
+        $this->assertSame([], $this->server()->filterRuleToParameter($rules));
+    }
+
+    public function testUrlParamsAreMergedRatherThanSingularised(): void
+    {
+        $rules = json_encode([
+            'tags' => ['OR' => ['tlp:white']],
+            'url_params' => json_encode(['published' => 1]),
+        ]);
+        $out = $this->server()->filterRuleToParameter($rules);
+        $this->assertSame(['tlp:white'], $out['tag']);
+        $this->assertSame(1, $out['published'], 'url_params are merged in verbatim, keeping their own key');
+        $this->assertArrayNotHasKey('url_param', $out, 'url_params is not a plural field to singularise');
+    }
+
+    public function testEmptyUrlParamsAreIgnored(): void
+    {
+        $rules = json_encode(['tags' => ['OR' => ['tlp:white']], 'url_params' => '']);
+        $this->assertSame(['tag' => ['tlp:white']], $this->server()->filterRuleToParameter($rules));
+    }
+
+    // ------------------------------------------------- __checkIfEventSaveAble
+
+    private function saveable(array $event): bool
+    {
+        $args = [$event];
+        return $this->callPrivate('__checkIfEventSaveAble', $args);
+    }
+
+    public function testAnEmptyEventIsNotWorthSaving(): void
+    {
+        $this->assertFalse($this->saveable(['Event' => []]));
+    }
+
+    public function testOneLiveAttributeMakesAnEventSaveable(): void
+    {
+        $this->assertTrue($this->saveable(['Event' => ['Attribute' => [['deleted' => false]]]]));
+    }
+
+    public function testAnEventOfOnlyDeletedAttributesIsNotSaveable(): void
+    {
+        $this->assertFalse($this->saveable(['Event' => ['Attribute' => [['deleted' => true]]]]));
+    }
+
+    public function testALiveAttributeInsideALiveObjectMakesAnEventSaveable(): void
+    {
+        $this->assertTrue($this->saveable(['Event' => ['Object' => [
+            ['deleted' => false, 'Attribute' => [['deleted' => false]]],
+        ]]]));
+    }
+
+    public function testALiveAttributeInsideADeletedObjectDoesNotCount(): void
+    {
+        $this->assertFalse($this->saveable(['Event' => ['Object' => [
+            ['deleted' => true, 'Attribute' => [['deleted' => false]]],
+        ]]]));
+    }
+
+    public function testAnObjectWithNoAttributesDoesNotMakeAnEventSaveable(): void
+    {
+        $this->assertFalse($this->saveable(['Event' => ['Object' => [['deleted' => false]]]]));
+    }
+
+    public function testALiveEventReportAloneMakesAnEventSaveable(): void
+    {
+        $this->assertTrue($this->saveable(['Event' => ['EventReport' => [['deleted' => false]]]]));
+    }
+
+    public function testADeletedEventReportAloneDoesNot(): void
+    {
+        $this->assertFalse($this->saveable(['Event' => ['EventReport' => [['deleted' => true]]]]));
+    }
+
+    // --------------------------------------- __updatePulledEventBeforeInsert
+
+    private function pullUser(): array
+    {
+        return ['id' => 42, 'email' => 'puller@example.com'];
+    }
+
+    private function externalServer(): array
+    {
+        return ['Server' => ['id' => 1, 'internal' => 0, 'org_id' => 1]];
+    }
+
+    /**
+     * @return array{0:array,1:bool} the transformed event and the
+     *         "pull rules emptied this event" flag
+     */
+    private function transform(array $event, array $server = null, array $pullRules = [], $remoteUser = false): array
+    {
+        $server = $server ?: $this->externalServer();
+        $args = [&$event, $server, $this->pullUser(), $pullRules, $remoteUser];
+        $emptied = $this->callPrivate('__updatePulledEventBeforeInsert', $args);
+        return [$event, $emptied];
+    }
+
+    public function testAPulledEventIsAlwaysLockedAndReattributed(): void
+    {
+        [$event] = $this->transform(['Event' => ['distribution' => '0']]);
+        $this->assertTrue($event['Event']['locked'], 'a pulled event must be locked against local edits');
+        $this->assertSame(42, $event['Event']['user_id'], 'the pulling admin becomes the reporter');
+    }
+
+    public function testAVersionOneEventWithoutDistributionDefaultsToCommunity(): void
+    {
+        // No distribution key at all - MISP 1.x events. It is defaulted to '1'
+        // and then immediately downgraded to '0' by the external-server rule.
+        [$event] = $this->transform(['Event' => []]);
+        $this->assertSame('0', $event['Event']['distribution']);
+    }
+
+    public function testCommunityOnlyIsDowngradedToOrganisationOnly(): void
+    {
+        [$event] = $this->transform(['Event' => ['distribution' => 1]]);
+        $this->assertSame('0', $event['Event']['distribution']);
+    }
+
+    public function testConnectedCommunitiesIsDowngradedToCommunityOnly(): void
+    {
+        [$event] = $this->transform(['Event' => ['distribution' => 2]]);
+        $this->assertSame('1', $event['Event']['distribution']);
+    }
+
+    public function testAllCommunitiesAndSharingGroupAreLeftAlone(): void
+    {
+        [$allCommunities] = $this->transform(['Event' => ['distribution' => 3]]);
+        $this->assertSame(3, $allCommunities['Event']['distribution']);
+        [$sharingGroup] = $this->transform(['Event' => ['distribution' => 4]]);
+        $this->assertSame(4, $sharingGroup['Event']['distribution']);
+    }
+
+    public function testTheDowngradeCascadesToAttributesObjectsAndReports(): void
+    {
+        [$event] = $this->transform(['Event' => [
+            'distribution' => '2',
+            'Attribute' => [['type' => 'ip-dst', 'distribution' => '1'], ['type' => 'domain', 'distribution' => '2']],
+            'Object' => [[
+                'template_uuid' => 'tpl-1',
+                'distribution' => '2',
+                'Attribute' => [['type' => 'md5', 'distribution' => '1']],
+            ]],
+            'EventReport' => [['distribution' => '1'], ['distribution' => '2']],
+        ]]);
+
+        $this->assertSame('0', $event['Event']['Attribute'][0]['distribution']);
+        $this->assertSame('1', $event['Event']['Attribute'][1]['distribution']);
+        $this->assertSame('1', $event['Event']['Object'][0]['distribution']);
+        $this->assertSame('0', $event['Event']['Object'][0]['Attribute'][0]['distribution']);
+        $this->assertSame('0', $event['Event']['EventReport'][0]['distribution']);
+        $this->assertSame('1', $event['Event']['EventReport'][1]['distribution']);
+    }
+
+    public function testAnInternalServerInTheHostOrgSkipsEveryDowngrade(): void
+    {
+        // All four conditions must hold: host_org_id set, the server flagged
+        // internal, the server owned by the host org, and the remote user
+        // holding perm_sync_internal. This is the internal-sync exemption.
+        $this->setConfig('MISP.host_org_id', 7);
+        [$event] = $this->transform(
+            ['Event' => ['distribution' => '1', 'Attribute' => [['type' => 'ip-dst', 'distribution' => '1']]]],
+            ['Server' => ['id' => 1, 'internal' => 1, 'org_id' => 7]],
+            [],
+            ['Role' => ['perm_sync_internal' => 1]]
+        );
+        $this->assertSame('1', $event['Event']['distribution'], 'internal sync preserves distribution');
+        $this->assertSame('1', $event['Event']['Attribute'][0]['distribution']);
+    }
+
+    public function testAnInternalServerWithoutThePermissionStillDowngrades(): void
+    {
+        $this->setConfig('MISP.host_org_id', 7);
+        [$event] = $this->transform(
+            ['Event' => ['distribution' => '1']],
+            ['Server' => ['id' => 1, 'internal' => 1, 'org_id' => 7]],
+            [],
+            ['Role' => ['perm_sync_internal' => 0]]
+        );
+        $this->assertSame('0', $event['Event']['distribution']);
+    }
+
+    public function testAnInternalServerOfAnotherOrgStillDowngrades(): void
+    {
+        $this->setConfig('MISP.host_org_id', 7);
+        [$event] = $this->transform(
+            ['Event' => ['distribution' => '1']],
+            ['Server' => ['id' => 1, 'internal' => 1, 'org_id' => 8]],
+            [],
+            ['Role' => ['perm_sync_internal' => 1]]
+        );
+        $this->assertSame('0', $event['Event']['distribution']);
+    }
+
+    // ---- pull rules: type filtering ------------------------------------
+
+    public function testTypeFilteringIsInertUntilTheFeatureIsEnabled(): void
+    {
+        $this->setConfig('MISP.enable_synchronisation_filtering_on_type', false);
+        [$event, $emptied] = $this->transform(
+            ['Event' => ['distribution' => '0', 'Attribute' => [['type' => 'ip-dst', 'distribution' => '0']]]],
+            null,
+            ['type_attributes' => ['NOT' => ['ip-dst']]]
+        );
+        $this->assertCount(1, $event['Event']['Attribute'], 'the setting gates the whole filter');
+        $this->assertFalse($emptied);
+    }
+
+    public function testBlockedAttributeTypesAreStrippedWhenEnabled(): void
+    {
+        $this->setConfig('MISP.enable_synchronisation_filtering_on_type', true);
+        [$event, $emptied] = $this->transform(
+            ['Event' => ['distribution' => '0', 'Attribute' => [
+                ['type' => 'ip-dst', 'distribution' => '0'],
+                ['type' => 'domain', 'distribution' => '0'],
+            ]]],
+            null,
+            ['type_attributes' => ['NOT' => ['ip-dst']]]
+        );
+        $this->assertCount(1, $event['Event']['Attribute']);
+        $this->assertFalse($emptied, 'something survived, so the event was not emptied');
+    }
+
+    public function testAnEventStrippedOfEveryAttributeIsReportedAsEmptied(): void
+    {
+        $this->setConfig('MISP.enable_synchronisation_filtering_on_type', true);
+        [$event, $emptied] = $this->transform(
+            ['Event' => ['distribution' => '0', 'Attribute' => [['type' => 'ip-dst', 'distribution' => '0']]]],
+            null,
+            ['type_attributes' => ['NOT' => ['ip-dst']]]
+        );
+        $this->assertEmpty($event['Event']['Attribute']);
+        $this->assertTrue($emptied, 'the caller needs to know the pull rules, not the remote, emptied this');
+    }
+
+    public function testAnEventThatArrivedWithNoAttributesIsNotReportedAsEmptied(): void
+    {
+        // originalCount is 0, so the pull rules cannot be blamed.
+        $this->setConfig('MISP.enable_synchronisation_filtering_on_type', true);
+        [, $emptied] = $this->transform(
+            ['Event' => ['distribution' => '0', 'Attribute' => []]],
+            null,
+            ['type_attributes' => ['NOT' => ['ip-dst']]]
+        );
+        $this->assertFalse($emptied);
+    }
+
+    public function testBlockedObjectTemplatesAreStripped(): void
+    {
+        $this->setConfig('MISP.enable_synchronisation_filtering_on_type', true);
+        [$event, $emptied] = $this->transform(
+            ['Event' => ['distribution' => '0', 'Object' => [
+                ['template_uuid' => 'blocked-tpl', 'distribution' => '0', 'Attribute' => []],
+            ]]],
+            null,
+            ['type_objects' => ['NOT' => ['blocked-tpl']]]
+        );
+        $this->assertEmpty($event['Event']['Object']);
+        $this->assertTrue($emptied);
+    }
+
+    public function testAnObjectLeftWithNoAttributesIsDiscardedEntirely(): void
+    {
+        $this->setConfig('MISP.enable_synchronisation_filtering_on_type', true);
+        [$event] = $this->transform(
+            ['Event' => ['distribution' => '0', 'Object' => [
+                ['template_uuid' => 'tpl-1', 'distribution' => '0', 'Attribute' => [
+                    ['type' => 'ip-dst', 'distribution' => '0'],
+                ]],
+            ]]],
+            null,
+            ['type_attributes' => ['NOT' => ['ip-dst']]]
+        );
+        $this->assertEmpty($event['Event']['Object'], 'an object with every attribute filtered out is dropped');
+    }
+}

--- a/app/Test/Integration/ServerPushRuleFilterTest.php
+++ b/app/Test/Integration/ServerPushRuleFilterTest.php
@@ -1,0 +1,211 @@
+<?php
+
+require_once __DIR__ . '/IntegrationTestCase.php';
+
+/**
+ * Specification tests for Server::eventFilterPushableServers() and its private
+ * helper convertUUIDsToIDs().
+ *
+ * These decide which remote instances an event is offered to. Getting them
+ * wrong leaks data to a server that was explicitly excluded, so they are
+ * specifications rather than characterizations (ADR 0002): a change that
+ * breaks one of these assertions is a bug, not a re-baseline.
+ *
+ * The filter itself is pure - tags and orgs in, servers out - and needs no
+ * network. Only the UUID-to-id conversion touches the database, which is why
+ * this sits at the integration layer rather than the unit layer.
+ */
+class ServerPushRuleFilterTest extends IntegrationTestCase
+{
+    private function server()
+    {
+        return $this->model('Server');
+    }
+
+    /** A server row carrying the given push rules. */
+    private function serverWithRules(int $id, array $rules = null): array
+    {
+        return ['Server' => [
+            'id' => $id,
+            'name' => "server $id",
+            'push_rules' => $rules === null ? '' : json_encode($rules),
+        ]];
+    }
+
+    /** An event owned by $orgcId carrying $tagIds. */
+    private function event(int $orgcId, array $tagIds = []): array
+    {
+        return [
+            'Event' => ['id' => 1, 'orgc_id' => $orgcId],
+            'EventTag' => array_map(function ($tagId) {
+                return ['tag_id' => $tagId];
+            }, $tagIds),
+        ];
+    }
+
+    /** @return array<int,int> the ids of the servers that survived the filter */
+    private function pushable(array $event, array $servers): array
+    {
+        $result = $this->server()->eventFilterPushableServers($event, $servers);
+        return array_map(function ($server) {
+            return (int)$server['Server']['id'];
+        }, $result);
+    }
+
+    // -------------------------------------------------------- no rules at all
+
+    public function testAServerWithoutPushRulesAcceptsEverything(): void
+    {
+        $this->assertSame(
+            [1],
+            $this->pushable($this->event(1, [10]), [$this->serverWithRules(1)])
+        );
+    }
+
+    public function testAllServersAreReturnedWhenNoRuleMatches(): void
+    {
+        $servers = [$this->serverWithRules(1), $this->serverWithRules(2)];
+        $this->assertSame([1, 2], $this->pushable($this->event(1), $servers));
+    }
+
+    // ------------------------------------------------------------- tag rules
+
+    public function testAnOrTagRuleRequiresAtLeastOneMatchingTag(): void
+    {
+        $servers = [$this->serverWithRules(1, ['tags' => ['OR' => [10, 11]]])];
+        $this->assertSame([1], $this->pushable($this->event(1, [11]), $servers), 'one shared tag is enough');
+        $this->assertSame([], $this->pushable($this->event(1, [99]), $servers), 'no shared tag blocks the push');
+    }
+
+    public function testAnOrTagRuleBlocksAnEventWithNoTagsAtAll(): void
+    {
+        $servers = [$this->serverWithRules(1, ['tags' => ['OR' => [10]]])];
+        $this->assertSame([], $this->pushable($this->event(1, []), $servers));
+    }
+
+    public function testANotTagRuleBlocksOnAnyMatch(): void
+    {
+        $servers = [$this->serverWithRules(1, ['tags' => ['NOT' => [10]]])];
+        $this->assertSame([], $this->pushable($this->event(1, [10, 11]), $servers), 'one blocked tag is enough');
+        $this->assertSame([1], $this->pushable($this->event(1, [11]), $servers));
+    }
+
+    public function testNotWinsOverOrWhenBothWouldApply(): void
+    {
+        // OR is evaluated first and passes, then NOT rejects. The event is
+        // blocked: an explicit exclusion beats an inclusion.
+        $servers = [$this->serverWithRules(1, ['tags' => ['OR' => [10], 'NOT' => [11]]])];
+        $this->assertSame([], $this->pushable($this->event(1, [10, 11]), $servers));
+        $this->assertSame([1], $this->pushable($this->event(1, [10]), $servers));
+    }
+
+    // ------------------------------------------------------------- org rules
+
+    public function testAnOrOrgRuleRequiresTheEventCreatorToBeListed(): void
+    {
+        $servers = [$this->serverWithRules(1, ['orgs' => ['OR' => [1]]])];
+        $this->assertSame([1], $this->pushable($this->event(1), $servers));
+        $this->assertSame([], $this->pushable($this->event(2), $servers));
+    }
+
+    public function testANotOrgRuleExcludesTheListedCreator(): void
+    {
+        $servers = [$this->serverWithRules(1, ['orgs' => ['NOT' => [1]]])];
+        $this->assertSame([], $this->pushable($this->event(1), $servers));
+        $this->assertSame([1], $this->pushable($this->event(2), $servers));
+    }
+
+    public function testOrgRulesAcceptUuidsAsWellAsIds(): void
+    {
+        // Sync rules are authored against org UUIDs, because ids differ
+        // between instances; convertUUIDsToIDs resolves them locally.
+        $org = $this->model('Organisation')->find('first', [
+            'recursive' => -1,
+            'conditions' => ['Organisation.id' => 1],
+        ]);
+        $this->assertNotEmpty($org, 'this instance needs an organisation with id 1');
+        $uuid = $org['Organisation']['uuid'];
+
+        $servers = [$this->serverWithRules(1, ['orgs' => ['OR' => [$uuid]]])];
+        $this->assertSame([1], $this->pushable($this->event(1), $servers), 'the uuid must resolve to org 1');
+        $this->assertSame([], $this->pushable($this->event(99999), $servers));
+    }
+
+    public function testAnUnknownUuidMatchesNothing(): void
+    {
+        $servers = [$this->serverWithRules(1, [
+            'orgs' => ['OR' => ['00000000-0000-4000-8000-000000000000']],
+        ])];
+        $this->assertSame([], $this->pushable($this->event(1), $servers));
+    }
+
+    // ------------------------------------------------------- several servers
+
+    public function testEachServerIsJudgedIndependently(): void
+    {
+        $servers = [
+            $this->serverWithRules(1, ['tags' => ['OR' => [10]]]),
+            $this->serverWithRules(2, ['tags' => ['NOT' => [10]]]),
+            $this->serverWithRules(3),
+        ];
+        $this->assertSame(
+            [1, 3],
+            $this->pushable($this->event(1, [10]), $servers),
+            'server 1 requires the tag, server 2 forbids it, server 3 has no opinion'
+        );
+    }
+
+    public function testTheReturnedListIsNotReindexed(): void
+    {
+        // $validServers[] = $server, so the survivors are densely keyed even
+        // when a server in the middle is dropped.
+        $servers = [
+            $this->serverWithRules(1, ['tags' => ['NOT' => [10]]]),
+            $this->serverWithRules(2),
+        ];
+        $result = $this->server()->eventFilterPushableServers($this->event(1, [10]), $servers);
+        $this->assertSame([0], array_keys($result));
+    }
+
+    // -------------------------------------------------------- convertUUIDsToIDs
+
+    private function convert(array $orgs): array
+    {
+        $reflection = new ReflectionMethod('Server', 'convertUUIDsToIDs');
+        $reflection->setAccessible(true);
+        return $reflection->invoke($this->server(), $orgs);
+    }
+
+    public function testPlainIdsArePassedThroughUnchanged(): void
+    {
+        $this->assertSame([1, 2], $this->convert([1, 2]));
+    }
+
+    public function testAnEmptyRuleConvertsToAnEmptyList(): void
+    {
+        $this->assertSame([], $this->convert([]));
+    }
+
+    public function testAKnownUuidIsResolvedToItsLocalId(): void
+    {
+        $org = $this->model('Organisation')->find('first', [
+            'recursive' => -1,
+            'conditions' => ['Organisation.id' => 1],
+        ]);
+        $this->assertNotEmpty($org, 'this instance needs an organisation with id 1');
+        $converted = $this->convert([$org['Organisation']['uuid']]);
+        $this->assertSame([1], array_map('intval', $converted));
+    }
+
+    public function testIdsAndUuidsCanBeMixedInOneRule(): void
+    {
+        $org = $this->model('Organisation')->find('first', [
+            'recursive' => -1,
+            'conditions' => ['Organisation.id' => 1],
+        ]);
+        $this->assertNotEmpty($org);
+        // Ids keep their position at the front; resolved uuids are appended.
+        $converted = array_map('intval', $this->convert([42, $org['Organisation']['uuid']]));
+        $this->assertSame([42, 1], $converted);
+    }
+}

--- a/app/Test/Integration/ServerVersionCompatibilityTest.php
+++ b/app/Test/Integration/ServerVersionCompatibilityTest.php
@@ -1,0 +1,310 @@
+<?php
+
+require_once __DIR__ . '/IntegrationTestCase.php';
+
+App::uses('ServerSyncTool', 'Tools');
+App::uses('HttpSocketExtended', 'Tools');
+// HttpSocketHttpException is declared inside HttpSocketExtended.php, so the
+// autoloader never fires for its own name. Touch the class that IS mapped to
+// that file to pull both declarations in.
+class_exists('HttpSocketExtended');
+
+/**
+ * Characterization of Server::checkVersionCompatibility().
+ *
+ * This is the gate every sync passes through: it decides whether a push or a
+ * pull may run at all, and what the remote instance is permitted to do. It is
+ * also the one method in the whole sync path that is already injectable -
+ * Server.php:3254 accepts an optional ServerSyncTool - so its version
+ * comparison ladder can be driven without a remote instance and without any
+ * change to production code.
+ *
+ * Expectations are derived from checkMISPVersion() at runtime rather than
+ * hardcoded, so this file does not need editing every release.
+ */
+class ServerVersionCompatibilityTest extends IntegrationTestCase
+{
+    /** @var int|null */
+    private $serverId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $serverModel = $this->model('Server');
+        $serverModel->create();
+        $saved = $serverModel->save([
+            'Server' => [
+                'name' => 'checkVersionCompatibility fixture',
+                'url' => 'https://sync.invalid',
+                'authkey' => str_repeat('a', 40),
+                'org_id' => 1,
+                'remote_org_id' => 1,
+                'push' => 0,
+                'pull' => 0,
+                // servers has several NOT NULL columns with no DB default;
+                // omitting any of them makes save() fail with a 1364.
+                'self_signed' => 0,
+                'pull_rules' => '',
+                'push_rules' => '',
+            ],
+        ]);
+        $this->assertNotEmpty($saved, 'could not create the fixture server');
+        $this->serverId = (int)$serverModel->id;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->serverId) {
+            try {
+                $this->model('Server')->delete($this->serverId);
+            } catch (\Throwable $e) {
+                // Best effort: a test must not fail during cleanup.
+            }
+            $this->serverId = null;
+        }
+        parent::tearDown();
+    }
+
+    private function server(): array
+    {
+        return $this->model('Server')->find('first', [
+            'recursive' => -1,
+            'conditions' => ['Server.id' => $this->serverId],
+        ]);
+    }
+
+    private function localVersion(): array
+    {
+        return $this->model('Server')->checkMISPVersion();
+    }
+
+    /** Run the check against a remote advertising $info. */
+    private function check(array $info): array
+    {
+        return $this->model('Server')->checkVersionCompatibility(
+            $this->server(),
+            $this->adminUser(),
+            new FakeServerSync($info)
+        );
+    }
+
+    /** Build a remote getVersion payload offset from the local version. */
+    private function remoteInfo(int $majorDelta, int $minorDelta, int $hotfixDelta, array $extra = []): array
+    {
+        $local = $this->localVersion();
+        return array_merge([
+            'version' => sprintf(
+                '%d.%d.%d',
+                $local['major'] + $majorDelta,
+                $local['minor'] + $minorDelta,
+                $local['hotfix'] + $hotfixDelta
+            ),
+        ], $extra);
+    }
+
+    // ------------------------------------------------------- the happy path
+
+    public function testIdenticalVersionsSyncCleanly(): void
+    {
+        $result = $this->check($this->remoteInfo(0, 0, 0));
+        $this->assertTrue($result['success']);
+        $this->assertFalse($result['response'], 'an exact version match produces no message');
+    }
+
+    public function testCapabilityFlagsAreTakenFromTheRemotePayload(): void
+    {
+        $result = $this->check($this->remoteInfo(0, 0, 0, [
+            'perm_sync' => true,
+            'perm_sighting' => true,
+            'perm_galaxy_editor' => true,
+            'perm_analyst_data' => true,
+        ]));
+        $this->assertTrue($result['canPush']);
+        $this->assertTrue($result['canSight']);
+        $this->assertTrue($result['canEditGalaxyCluster']);
+        $this->assertTrue($result['canEditAnalystData']);
+    }
+
+    public function testMissingCapabilityFlagsDefaultToFalse(): void
+    {
+        $result = $this->check($this->remoteInfo(0, 0, 0));
+        $this->assertFalse($result['canPush'], 'absent perm_sync must not be read as permission');
+        $this->assertFalse($result['canSight']);
+        $this->assertFalse($result['canEditGalaxyCluster']);
+        $this->assertFalse($result['canEditAnalystData']);
+    }
+
+    // ------------------------------------------------- the comparison ladder
+
+    public function testRemoteBehindByAMajorVersionAbortsSync(): void
+    {
+        $result = $this->check($this->remoteInfo(-1, 0, 0));
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('behind by a major version', $result['response']);
+    }
+
+    public function testRemoteAheadByAMajorVersionAbortsSync(): void
+    {
+        $result = $this->check($this->remoteInfo(1, 0, 0));
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('full major version ahead', $result['response']);
+    }
+
+    public function testRemoteBehindByAMinorVersionAbortsSync(): void
+    {
+        $result = $this->check($this->remoteInfo(0, -1, 0));
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('behind by a minor version', $result['response']);
+    }
+
+    public function testRemoteAheadByAMinorVersionAbortsSync(): void
+    {
+        $result = $this->check($this->remoteInfo(0, 1, 0));
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('full minor version ahead', $result['response']);
+    }
+
+    public function testAHotfixGapStillSucceedsButWarns(): void
+    {
+        // The hotfix comparisons run only after $success has already been set
+        // to true, so a hotfix gap reports a message AND success.
+        $result = $this->check($this->remoteInfo(0, 0, -1));
+        $this->assertTrue($result['success'], 'a hotfix gap must not block sync');
+        $this->assertStringContainsString('a few hotfixes behind', $result['response']);
+    }
+
+    public function testRemoteAheadByAHotfixSucceedsButWarns(): void
+    {
+        $result = $this->check($this->remoteInfo(0, 0, 1));
+        $this->assertTrue($result['success']);
+        $this->assertStringContainsString('a few hotfixes ahead', $result['response']);
+    }
+
+    public function testMajorMismatchWinsOverMinorMismatch(): void
+    {
+        // Each comparison is guarded by `$response === false`, so the first
+        // one to match is the one reported.
+        $result = $this->check($this->remoteInfo(-1, -1, 0));
+        $this->assertStringContainsString('behind by a major version', $result['response']);
+        $this->assertStringNotContainsString('minor', $result['response']);
+    }
+
+    // -------------------------------------------------------- protectedMode
+
+    public function testProtectedModeIsOnFromTwoFourOneFiftySix(): void
+    {
+        $this->assertTrue($this->check(['version' => '2.4.156'])['protectedMode']);
+        $this->assertTrue($this->check($this->remoteInfo(0, 0, 0))['protectedMode']);
+    }
+
+    public function testProtectedModeIsOffBelowTwoFourOneFiftySix(): void
+    {
+        $this->assertFalse($this->check(['version' => '2.4.155'])['protectedMode']);
+    }
+
+    public function testAncientRemoteIsToldProposalsNeedTwoFourOneEleven(): void
+    {
+        // Reached only when nothing above matched, which needs the local major
+        // and minor to be 2.4 - skip rather than lie about coverage otherwise.
+        $local = $this->localVersion();
+        if ((int)$local['major'] !== 2 || (int)$local['minor'] !== 4) {
+            $this->markTestSkipped('the 2.4.111 proposals branch is only reachable from a 2.4.x local version');
+        }
+        $result = $this->check(['version' => '2.4.110']);
+        $this->assertStringContainsString('2.4.111 is required', $result['response']);
+    }
+
+    // ------------------------------------------------------------- failures
+
+    /**
+     * HttpSocketHttpException takes a response object, not a message - it
+     * derives both its message and its code from the response. Build the
+     * smallest thing that satisfies it.
+     */
+    private static function httpError(int $code): HttpSocketHttpException
+    {
+        $response = new HttpSocketResponseExtended();
+        $response->code = $code;
+        $response->body = '';
+        return new HttpSocketHttpException($response, 'https://sync.invalid/servers/getVersion');
+    }
+
+    public function testAnHttpErrorReportsTheResponseCode(): void
+    {
+        $result = $this->model('Server')->checkVersionCompatibility(
+            $this->server(),
+            $this->adminUser(),
+            new FakeServerSync(self::httpError(403))
+        );
+        $this->assertIsString($result, 'a failed connection returns the message, not the result array');
+        $this->assertStringContainsString('Returned response code: 403', $result);
+    }
+
+    public function testANonHttpErrorReportsTheExceptionMessage(): void
+    {
+        $result = $this->model('Server')->checkVersionCompatibility(
+            $this->server(),
+            $this->adminUser(),
+            new FakeServerSync(new Exception('name resolution failed'))
+        );
+        $this->assertIsString($result);
+        $this->assertStringContainsString('name resolution failed', $result);
+    }
+
+    /**
+     * KNOWN-DEFECT: the guard for a malformed remote response is
+     *
+     *   $remoteVersion = explode('.', $remoteVersion['version']);
+     *   if (!isset($remoteVersion[0])) { ... }
+     *
+     * explode() always returns at least one element, so index 0 is always set
+     * and this branch is unreachable. A remote answering with a version of
+     * '2' therefore falls through to the comparison ladder, where indexes 1
+     * and 2 do not exist. Under PHP 8 that is an undefined-array-key warning
+     * and a null comparison, not the intended clean error message.
+     *
+     * The test asserts the branch is dead rather than that the outcome is
+     * good: it records that a truncated version is NOT reported as a bad
+     * response, which is exactly what a fix would change.
+     */
+    public function testTheMalformedVersionGuardIsUnreachable(): void
+    {
+        $result = @$this->check(['version' => '2']);
+        $this->assertIsArray(
+            $result,
+            'if this is now a string the malformed-response guard has been made reachable - good, ' .
+            'but the callers that expect an array on a bad version need checking'
+        );
+        $this->assertSame(['2'], $result['version'], 'the version is passed through unsplit');
+    }
+
+    public function testTheEmptyVersionStringIsAlsoNotCaught(): void
+    {
+        $result = @$this->check(['version' => '']);
+        $this->assertIsArray($result, 'explode on an empty string still yields index 0');
+    }
+}
+
+/**
+ * ServerSyncTool with the HTTP layer removed. The constructor is deliberately
+ * NOT called, so no socket is ever built; info() replays the injected payload,
+ * or throws the injected Throwable.
+ */
+class FakeServerSync extends ServerSyncTool
+{
+    /** @var array|Throwable */
+    private $injected;
+
+    public function __construct($injected)
+    {
+        $this->injected = $injected;
+    }
+
+    public function info()
+    {
+        if ($this->injected instanceof Throwable) {
+            throw $this->injected;
+        }
+        return $this->injected;
+    }
+}

--- a/app/Test/Integration/SettingValidatorExecutionTest.php
+++ b/app/Test/Integration/SettingValidatorExecutionTest.php
@@ -1,0 +1,90 @@
+<?php
+
+require_once __DIR__ . '/IntegrationTestCase.php';
+
+/**
+ * Executes every server setting validator against representative input.
+ *
+ * These 50-odd methods are the largest string-dispatched family in MISP: they
+ * are named in Server::$serverSettings as `'test' => 'testForNumeric'` and
+ * invoked by name, so nothing calls them statically and no test had ever run
+ * one. A validator that fatals on unexpected input takes the whole settings
+ * page down, and the failure surfaces nowhere near the setting that caused it.
+ *
+ * The contract (see Server::testForNumeric) is: take a value, return `true`
+ * when acceptable or a message STRING when not. Never throw, never fatal.
+ *
+ * DiagnosticsTest-style validators that reach for the filesystem or a remote
+ * service are exercised too - the point is that they degrade gracefully.
+ */
+class SettingValidatorExecutionTest extends IntegrationTestCase
+{
+    /**
+     * Scalars only, deliberately.
+     *
+     * ServersController::serverSettingsEdit() rejects any non-scalar value
+     * before a validator is reached (`!is_scalar(...)` at
+     * ServersController.php:47), so probing with arrays or null would test a
+     * state the application cannot produce - and 17 validators do throw on an
+     * array, which is harmless precisely because they never see one.
+     */
+    private const PROBES = [
+        'empty string'   => '',
+        'zero'           => 0,
+        'one'            => 1,
+        'negative'       => -1,
+        'large number'   => 999999,
+        'numeric string' => '42',
+        'plain text'     => 'not-a-number',
+        'bool true'      => true,
+        'bool false'     => false,
+        'url'            => 'https://misp.test/path',
+        'uuid'           => '5f7b1a2c-0000-4000-8000-000000000001',
+    ];
+
+    public function validatorProvider(): array
+    {
+        $path = APP . 'Model/Server.php';
+        if (!is_file($path)) {
+            throw new RuntimeException('Model/Server.php is missing');
+        }
+        $src = (string)file_get_contents($path);
+        preg_match_all("/'test'\s*=>\s*'(\w+)'/", $src, $declared);
+        preg_match_all("/\\\$setting\['test'\]\s*=\s*'(\w+)'/", $src, $assigned);
+        $names = array_unique(array_merge($declared[1], $assigned[1]));
+        sort($names);
+        return array_combine($names, array_map(static fn($n) => [$n], $names));
+    }
+
+    /**
+     * @dataProvider validatorProvider
+     */
+    public function testValidatorSurvivesEveryProbe(string $validator): void
+    {
+        $server = $this->model('Server');
+        if (!method_exists($server, $validator)) {
+            $this->fail("Server::$validator() is referenced by a setting but does not exist");
+        }
+
+        $failures = [];
+        foreach (self::PROBES as $label => $value) {
+            try {
+                $result = $server->$validator($value);
+            } catch (\Throwable $e) {
+                // A validator must not throw: the settings page calls it with
+                // whatever the admin typed.
+                $failures[] = sprintf('%s => %s: %s', $label, get_class($e), $e->getMessage());
+                continue;
+            }
+            if ($result !== true && !is_string($result) && $result !== false && $result !== null) {
+                $failures[] = sprintf('%s => returned %s, expected true|string', $label, gettype($result));
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $failures,
+            sprintf("Server::%s() mishandled input:\n  %s", $validator, implode("\n  ", $failures))
+        );
+    }
+}

--- a/app/Test/bootstrap_integration.php
+++ b/app/Test/bootstrap_integration.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Bootstrap for MISP's PHP integration suite (layer 2).
+ *
+ * Unlike the unit bootstrap, this boots the REAL CakePHP stack against the
+ * real database, so integration tests can drive genuine models. The two
+ * bootstraps are mutually exclusive - the unit layer's framework stubs would
+ * collide with the classes loaded here - which is why the integration suite
+ * has its own phpunit-integration.xml rather than sharing phpunit.xml.
+ */
+if (!defined('DS'))                     { define('DS', DIRECTORY_SEPARATOR); }
+if (!defined('ROOT'))                   { define('ROOT', dirname(dirname(__DIR__))); }
+if (!defined('APP_DIR'))                { define('APP_DIR', 'app'); }
+if (!defined('WEBROOT_DIR'))            { define('WEBROOT_DIR', 'webroot'); }
+if (!defined('WWW_ROOT'))               { define('WWW_ROOT', ROOT . DS . APP_DIR . DS . 'webroot' . DS); }
+if (!defined('CAKE_CORE_INCLUDE_PATH')) { define('CAKE_CORE_INCLUDE_PATH', ROOT . DS . APP_DIR . DS . 'Lib' . DS . 'cakephp' . DS . 'lib'); }
+if (!defined('CORE_PATH'))              { define('CORE_PATH', CAKE_CORE_INCLUDE_PATH . DS); }
+if (!defined('APP'))                    { define('APP', ROOT . DS . APP_DIR . DS); }
+if (!defined('TMP'))                    { define('TMP', APP . 'tmp' . DS); }
+
+require_once CAKE_CORE_INCLUDE_PATH . DS . 'Cake' . DS . 'bootstrap.php';
+
+App::uses('ClassRegistry', 'Utility');
+App::uses('ConnectionManager', 'Model');

--- a/app/phpunit-integration.xml
+++ b/app/phpunit-integration.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  The integration suite boots the real CakePHP stack and needs a configured
+  database, so it is kept out of phpunit.xml: the unit layer's framework
+  stubs and the real Cake classes cannot coexist in one process.
+
+  Run with:  ./Vendor/bin/phpunit -c phpunit-integration.xml
+-->
+<phpunit bootstrap="Test/bootstrap_integration.php"
+         colors="true"
+         convertDeprecationsToExceptions="false"
+         cacheResultFile="tmp/.phpunit-integration.result.cache">
+  <testsuites>
+    <testsuite name="integration">
+      <directory suffix="Test.php">Test/Integration</directory>
+    </testsuite>
+  </testsuites>
+  <coverage processUncoveredFiles="false">
+    <include>
+      <directory suffix=".php">Model</directory>
+      <directory suffix=".php">Controller</directory>
+      <directory suffix=".php">Lib</directory>
+      <directory suffix=".php">Console</directory>
+    </include>
+    <exclude>
+      <directory>Lib/cakephp</directory>
+      <directory>Vendor</directory>
+      <directory>Plugin/DebugKit</directory>
+      <directory>Plugin/CakeResque</directory>
+    </exclude>
+  </coverage>
+</phpunit>


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Adds an integration harness so Model-level tests run against real CakePHP and a real database.

- **Problem** — MISP's tests are either unit tests that stub CakePHP away or Python suites driving a deployed instance over HTTP, leaving the Model layer testable only by standing up Apache or by stubbing the database under test.
- **Fix** — `bootstrap_integration.php` boots real CakePHP against the configured database, `phpunit-integration.xml` keeps it apart from the stub-based unit config, and `IntegrationTestCase` gives each test a self-cleaning fixture.
- **Effect** — Five suites use it to cover sync version compatibility, pull transforms, push rule filters and the server-setting validators.
<!-- /bluf -->

**Branch:** `elhoim/MISP:test/integration-harness` → `MISP/MISP:2.5`
**9 files, +1472**

## What this adds

A third test layer, between the two MISP already has, plus five suites in it.

MISP's tests today are either unit tests that stub the framework away (`app/Test/`), or Python suites that drive a fully deployed instance over HTTP (`tests/`). Between them sits everything that needs real models and a real database but not a web server — and that is most of `Model/`, where MISP's logic actually lives. Testing it through HTTP means standing up Apache, a session and an auth stack to assert something about a `find()`; testing it as a unit means stubbing the database, which is exactly the part whose behaviour is in question.

### The harness

- **`app/Test/bootstrap_integration.php`** boots genuine CakePHP against the configured database.
- **`app/phpunit-integration.xml`** is its own config, deliberately not shared with `phpunit.xml`: the unit layer's framework stubs and the real Cake classes cannot coexist in one process.
- **`app/Test/Integration/IntegrationTestCase.php`** gives each test a transactional fixture — it records what it creates and tears it down — so suites run in any order against a live schema without leaving rows behind.

### The suites

- **`ServerVersionCompatibilityTest`**, **`ServerPullTransformTest`**, **`ServerPushRuleFilterTest`** — the sync layer decides what to send to and accept from a remote, and gets it wrong *quietly*: a push rule that stops filtering, or a pull transform that drops a field, produces no error, just wrong data on someone else's instance. These drive the real `Server` model and assert those decisions directly.
- **`SettingValidatorExecutionTest`** — executes every validator in the server settings schema, catching the ones that fatal on a value a user can type.
- **`CorrelationEngineTest`** — correlation is what MISP is for, it runs across several engines, and its behaviour depends on the database rather than on anything a unit test can stub.

163 tests / 418 assertions, green on the branch this was developed on.

### CI

One step in `.github/workflows/main.yml`, placed **after** the Python suites rather than beside the unit run. That placement is load-bearing and is worth a maintainer's attention:

> This suite writes to the `events` table, and although it deletes its own
> rows, InnoDB does not roll `AUTO_INCREMENT` back. `tests/curl_tests_GH.sh`
> hardcodes event id 1 — it POSTs `tests/event.json` and then diffs
> `GET /events/csv/download/1` against `tests/event.csv` — so running the
> integration suite before it makes that diff fail, and because the script
> runs under `set -e` it aborts **before** its own cleanup
> `POST /events/delete/1`, leaving 38 attributes behind that then break
> `test_attribute`, `test_statistics` and their neighbours for the rest of the
> job.

## Why upstream benefits

It makes the sync and correlation paths testable at all. Those are the two places where a subtle regression is most expensive and least visible, and neither is reachable from the existing layers at a sensible cost.

## Depends on / merge order

1. **#10964** — for the PHPUnit 9.6 bump in `app/composer.json`.
2. **`test/unit-conformance-suites`** — that branch adds `<exclude>Test/Integration</exclude>` to `app/phpunit.xml`. Without it the unit config, which scans `Test` recursively, would also pick these suites up and they would fail for want of a bootstrap. Nothing else here needs that branch; the exclusion is placed there rather than here so this PR touches no shared config file.

Merge order: **#10964 → unit-conformance-suites → this**.

## Running it locally

Against a configured instance (it uses `app/Config/database.php`):

```bash
sudo -u www-data ./app/Vendor/bin/phpunit -c app/phpunit-integration.xml
```

It writes to and deletes from the configured database. Point it at a test instance, not production.

## What this does not do

- Does not go through HTTP, routing, sessions or the auth stack — anything that needs those belongs in the Python layer.
- Does not add fixtures files: each suite creates what it needs and removes it.
- Does not record golden output. The Event characterization suites that do are the next PR in this series, and they need this harness.
- Does not touch application code.
- Does not measure coverage.

## What was not verified

Not run from this branch: the container available here serves a different working tree, and these suites need a configured database. They are green at 163 tests / 418 assertions on the branch they were developed on, at the same `2.5` base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Where this sits in the series

This is one of seven small PRs that together add a test and coverage capability to MISP. They were deliberately split so each can be reviewed, accepted or rejected on its own.

| PR | What it adds | Depends on |
|---|---|---|
| #10964 | PHPUnit 9.6 + `app/phpunit.xml` so coverage can run on PHP 8 | — |
| #10999 | Unit conformance suites (widgets, workflow modules, exports, tools) | #10964 |
| #11000 | Integration harness — model tests against a real database | #10964, #10999 |
| #11001 | Characterization of `Event`'s read and write paths | #11000 |
| #11002 | Live behavioural suites (dashboards, workflows, exports, console) | — |
| #11003 | Golden-snapshot contract for the restSearch API | #11002 |
| #11004 | Coverage job measuring the unit and live suites | #10964 |
| #11005 | Documentation of the three test layers | merge last |

**Suggested merge order:** #10964 → #10999 → #11000 → #11001, and independently #11002 → #11003. #11004 can land any time after #10964. #11005 last, since it documents whatever ends up merged.

#11002 and #11003 touch no PHP at all and are independent of the rest.


