### PR TITLE
[cosmetic] doc: document the three test layers and how to run them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,9 +22,19 @@ cd app && composer install
 # Lint PHP files
 ./app/Vendor/bin/parallel-lint --exclude app/Lib/cakephp/ --exclude app/Vendor/ -e php,ctp app/
 
-# Run PHPUnit tests
-./app/Vendor/bin/phpunit app/Test/
+# Run the PHP unit suite (no database required)
+./app/Vendor/bin/phpunit -c app/phpunit.xml
+
+# ...with coverage
+./app/Vendor/bin/phpunit -c app/phpunit.xml --coverage-text
+
+# Run the PHP integration suite (needs a configured instance and database)
+sudo -u www-data ./app/Vendor/bin/phpunit -c app/phpunit-integration.xml
 ```
+
+`-c` is required: the unit tests load their framework stubs from
+`app/Test/bootstrap.php`, which the config file wires up. See
+`docs/testing.md` for the three test layers and what each may use.
 
 **Python Tests (PyMISP):**
 ```bash

--- a/docs/adr/0001-three-test-layers-with-a-capability-boundary.md
+++ b/docs/adr/0001-three-test-layers-with-a-capability-boundary.md
@@ -1,0 +1,33 @@
+# 1. Three test layers with a capability boundary
+
+Date: 2026-08-26
+
+## Status
+
+Accepted
+
+## Context
+
+MISP's tests were split by accident rather than design: 19 bare-PHPUnit files with no database, and a Python suite driving a fully deployed instance over HTTP. Nothing said which kind of test a new behaviour belonged in, and the two suites' coverage could not be compared because nothing measured them against a common denominator.
+
+Measurement showed the consequence. The Python suite covered ten times what the PHPUnit suite did, yet `Lib/Dashboard` and `Model/WorkflowModules` were at 0.00 % in *both* — each suite assumed the other covered them.
+
+## Decision
+
+Three layers, distinguished by *capability* rather than by taste:
+
+- **Layer 1 (unit)** — no database, Redis, HTTP or network.
+- **Layer 2 (integration)** — database and real models, but no HTTP.
+- **Layer 3 (live)** — the deployed system over HTTP.
+
+A behaviour is tested in the **highest-numbered layer that can assert it, and no higher**.
+
+Layers 1 and 2 cannot share a process: Layer 1 supplies stub framework classes, Layer 2 loads the real CakePHP ones. They therefore have separate bootstraps and separate PHPUnit configurations.
+
+## Consequences
+
+The rule is decidable without judgement, so a new test's home is not a debate. It also forces an uncomfortable answer occasionally: `View/Helper` looks like Layer 1 but its collaborators are injected by the framework, so a Layer 1 test of `NavbarHelper` executed 60 of its 886 statements. The rule says move it to Layer 2 rather than keep a test that runs but proves little.
+
+The split bootstrap is real overhead — two config files, two invocations, and a `-c` flag that is easy to forget. Forgetting it is not subtle: the suite fails immediately with `Undefined constant "APP"`.
+
+Some duplication between layers is accepted. An export format is Layer 1, but Layer 3 still asks the API to deliver it, because "the format is correct" and "the API can deliver it" are different claims.

--- a/docs/adr/0002-pin-known-defects-in-golden-snapshots.md
+++ b/docs/adr/0002-pin-known-defects-in-golden-snapshots.md
@@ -1,0 +1,27 @@
+# 2. Pin known defects in golden snapshots
+
+Date: 2026-08-26
+
+## Status
+
+Accepted
+
+## Context
+
+Characterization tests protect refactoring by recording what the code does today. Applied naively to MISP, they would record behaviour that is known to be wrong: `returnFormat=text` returns no values where `json`, `csv` and `netfilter` all return them, and `workflows/checkGraph` answers malformed input with HTTP 500.
+
+Recording those as the expected contract makes a future *fix* fail the suite, which teaches developers that a red build means "you fixed something". Excluding them instead leaves exactly the endpoints most likely to be touched unprotected during a refactor.
+
+## Decision
+
+Record the real current output, and annotate the snapshot `KNOWN-DEFECT` with a cross-reference to a specification test that asserts the desired behaviour and is skipped while the defect stands.
+
+## Consequences
+
+Refactors remain protected across defective endpoints, because the snapshot still detects unintended change.
+
+Fixing a defect produces exactly one expected snapshot diff plus one test flipping from skipped to passing. That pairing is the signal a reviewer looks for; a snapshot diff *without* it means the fix was accidental.
+
+The cost is that a snapshot no longer means "this is right", only "this is what happens". Anyone reading snapshots for documentation must check the annotation, which is why `KNOWN-DEFECT` is defined in the glossary rather than left as a comment convention.
+
+The alternative — fix the defects first, then snapshot — was rejected only for sequencing: it blocks the refactoring safety net behind unrelated bug-fix work.

--- a/docs/adr/0003-calibrate-the-coverage-ratchet-to-ci.md
+++ b/docs/adr/0003-calibrate-the-coverage-ratchet-to-ci.md
@@ -1,0 +1,29 @@
+# 3. Calibrate the coverage ratchet to CI, not to a local run
+
+Date: 2026-08-26
+
+## Status
+
+Accepted
+
+## Context
+
+The coverage floor was first set from a local measurement of 24.83 % union. Continuous integration measured 20.18 % for the same commit, because PyMISP's live suite does not complete on a clean runner and so contributes less coverage there.
+
+The gate consequently failed on a correct commit. Worse, an earlier run had passed while measuring nothing at all: the report was piped into `tee`, so the pipeline returned `tee`'s exit status and the ratchet was inert.
+
+## Decision
+
+The floor is a number the CI environment can itself reproduce, recorded alongside the local figure and the reason they differ. Both numbers are kept in the workflow, because the divergence is information, not noise.
+
+The gate's exit status must be observable: the report is not piped, and its failure is captured explicitly rather than allowed to be swallowed.
+
+## Consequences
+
+The gate is meaningful, and a red build indicates a real regression rather than an environment difference.
+
+The floor understates what the suites achieve on a fully provisioned instance. That is the correct trade: a floor CI cannot reach is a permanently red gate, which teams learn to ignore.
+
+The divergence is itself worth watching. CI reaching *more* than local in a subsystem — `Lib/Dashboard` is higher in CI — usually means a local run had polluted state, so the two numbers together diagnose the harness.
+
+A gate that cannot fail is worse than no gate, because it is mistaken for assurance. Any future check added here must be verified to fail before it is trusted to pass.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,117 @@
+# Testing MISP
+
+MISP has three test layers. A behaviour is tested in the **highest-numbered
+layer that can assert it, and no higher** — correlation strategies need model
+internals, so they belong in layer 2, not layer 3; export formats are pure
+transforms, so they belong in layer 1 even though the API also exercises them.
+
+| Layer | May use | May NOT use | Answers |
+|---|---|---|---|
+| 1. Unit (PHP) | pure PHP, on-disk fixtures | DB, Redis, HTTP, network | "is this function correct for this input?" |
+| 2. Integration (PHP) | DB, Redis, model internals | HTTP, auth stack | "do these components agree with each other?" |
+| 3. Live (Python) | the full HTTP stack | — | "does the deployed system behave?" |
+
+## Running the suites
+
+```bash
+# layer 1 - fast, no services required
+cd app && composer install
+./Vendor/bin/phpunit -c phpunit.xml
+
+# layer 1 with coverage
+./Vendor/bin/phpunit -c phpunit.xml --coverage-clover ../clover.xml
+
+# layer 2 - needs a configured instance and database; its own config,
+# because the unit stubs and the real CakePHP classes cannot share a process
+cd app && sudo -u www-data ./Vendor/bin/phpunit -c phpunit-integration.xml
+
+# layer 3 - needs a running, configured MISP instance
+cd tests
+export HOST=127.0.0.1 AUTH=<api key> PYTHONPATH=$PWD
+python testlive_comprehensive_local.py -v
+```
+
+## Measuring coverage
+
+The unit suite is measured by PHPUnit directly. The live suite drives MISP
+over HTTP, so PHPUnit cannot attribute it; instead pcov is hooked into every
+request and CLI call:
+
+```bash
+# 1. point php.ini (BOTH the web SAPI and CLI) at the collector
+pcov.enabled=1
+pcov.directory=/var/www/MISP/app
+auto_prepend_file=/var/www/MISP/build/coverage/covcollect.php
+
+# 2. arm collection only after the instance is set up, so install work
+#    (schema import, runUpdates, updateJSON) is not counted as coverage
+mkdir -p /cov && chmod 777 /cov && touch /cov/ENABLED
+
+# 3. run the live suite, then merge and report
+python3 build/coverage/merge_coverage.py /cov merged.json /var/www/MISP/app/
+python3 build/coverage/report.py clover.xml merged.json
+```
+
+`report.py` intersects both suites with the same statement map, so unit, live
+and union are directly comparable. Note that a line counted as covered was
+*executed*, not necessarily *asserted*: an export that ran once for one
+attribute type scores as covered regardless of whether it is correct for the
+other forty.
+
+Baseline on `ff132f4d`: **unit 1.77 %, live 18.46 %, union 19.67 %** of
+117,925 statements.
+
+## Environment preconditions
+
+Each of these produced a confusing failure rather than a clear error message,
+so check them first:
+
+- **The `zip` binary must be installed** — not just `libzip-dev` or `ext-zip`.
+  MISP shells out to `zip` when building attachment archives, and its absence
+  surfaces as `proc_open(): posix_spawn() failed: No such file or directory`
+  in an unrelated-looking part of the API.
+- **`app/files/scripts/*` submodules must be initialised** (`misp-stix`,
+  `cti-python-stix2`, `python-stix`, `python-cybox`, `mixbox`, `python-maec`),
+  or the STIX paths fail the same way.
+- **PyMISP needs its own `pymisp/data/misp-objects` submodule** plus
+  `pip install ".[fileobjects]"`. Without it, object-building tests raise
+  `NewAttributeError: The type of the attribute is required. Is the object
+  template missing?`, which reads like a MISP bug and is not one.
+- **`MISP.baseurl` must match the port the tests actually reach.** A mismatch
+  makes `testlive_security.py` follow a redirect to a dead port and fail at
+  `setUpClass` with a connection error.
+- **`MISP.host_org_id` can only be set after `cake User init`** has created
+  the organisation; setting it earlier is rejected with "Invalid organisation".
+- **`Security.allow_self_registration` must be true** for
+  `testlive_security.py`, which registers users.
+- **PyMISP's `fast_mode`** gates `load_default_feeds()` and the galaxy /
+  taxonomy / warninglist updates. With it on, `test_feeds` fails with an
+  `UnboundLocalError` because the feed it looks for was never loaded.
+
+## Never invoke a shell bare
+
+`cake <Shell>` with no subcommand can run that shell's DEFAULT action.
+**`cake Live` with no argument takes the instance OFFLINE.** Doing that once
+while probing the console set `MISP.live=false` mid-run, and every
+PyMISP-based suite afterwards failed to connect with an error that pointed at
+PyMISP rather than at the cause.
+
+`testlive_console.py` therefore probes each shell with an *invalid*
+subcommand, which forces the option parser to print usage and exit, and
+excludes `Live` and `Password` outright. A bare `cake` with no shell name is
+safe - it only lists the available commands.
+
+## Test isolation
+
+`testlive_security.py` mutates global server settings and only restores them
+on a clean exit. **Interrupting it leaves `Security.auth` set to
+`ShibbAuth.ApacheShibb` in `app/Config/config.php`**, after which the login
+page renders with no form and every later run fails at `setUpClass` — a
+failure that looks nothing like its cause.
+
+If that happens, remove the `'auth' => array('ShibbAuth.ApacheShibb')` entry
+from `app/Config/config.php` and clear `app/tmp/cache/persistent/`.
+
+Any live test that changes a server setting must record the previous value and
+restore it in `tearDownClass`, and register an `atexit` handler so an
+interrupted run still restores it.


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Nothing states which test layer a new MISP behaviour belongs in; this PR writes that rule down.

- **Problem** — MISP's tests were split by accident rather than design: nothing states which of the bare-PHPUnit files, the DB-backed tests or the Python live suite a new behaviour belongs in, and `CLAUDE.md` points at a stale `phpunit` invocation.
- **Fix** — Adds `docs/testing.md` with the layer rule and how to run each layer, three ADRs recording the reasoning, and corrected commands in `CLAUDE.md`.
- **Effect** — Contributors get a stated home for new tests.
<!-- /bluf -->

**Branch:** `elhoim/MISP:doc/testing-layers` → `MISP/MISP:2.5`
**5 files, +218 −2**

## What this adds

`docs/testing.md`, three ADRs, and an update to `CLAUDE.md`'s test commands.

MISP's tests were split by accident rather than design — 19 bare-PHPUnit files with no database, and a Python suite driving a fully deployed instance over HTTP. Nothing said which kind of test a new behaviour belonged in, and the two suites could not be compared because nothing measured them against a common denominator.

`docs/testing.md` states the rule:

> A behaviour is tested in the **highest-numbered layer that can assert it,
> and no higher.**

| Layer | May use | May NOT use | Answers |
|---|---|---|---|
| 1. Unit (PHP) | pure PHP, on-disk fixtures | DB, Redis, HTTP, network | "is this function correct for this input?" |
| 2. Integration (PHP) | DB, Redis, model internals | HTTP, auth stack | "do these components agree with each other?" |
| 3. Live (Python) | the full HTTP stack | — | "does the deployed system behave?" |

…plus how to run each layer and where a new test goes.

The three ADRs record the decisions behind it:

- **0001** — why three layers with a capability boundary, rather than "unit" and "the other ones".
- **0002** — why known defects are pinned in golden snapshots with an annotation naming what should happen instead, rather than quietly normalised. A snapshot that hides a defect teaches the next reader to distrust the others.
- **0003** — why the coverage ratchet is calibrated to what CI measures rather than to a developer machine, which measured 24.83% against CI's 20.18% for the same commit.

`CLAUDE.md`'s test section still says `./app/Vendor/bin/phpunit app/Test/`; this updates it to the config-driven invocations and points at `docs/testing.md`.

## Why upstream benefits

The most expensive question for a new contributor is not "how do I write a test" but "which kind of test is this, and where does it go". One page answers it. The ADRs mean the next person to disagree with a decision can see the argument it was based on rather than re-litigating it from scratch.

## Depends on / merge order

Documents the other PRs in this series, so it should merge **last**:

- `docs/testing.md` and `CLAUDE.md` reference `app/phpunit.xml` and `app/Test/bootstrap.php` → needs **#10964** and **`test/unit-conformance-suites`**.
- Both reference `app/phpunit-integration.xml` → needs **`test/integration-harness`**.
- `docs/testing.md`'s coverage section and ADR 0003 reference `build/coverage/*` → needs **`ci/coverage-harness`**.

Every commanded path is a documentation reference, not a code dependency, so merging it early breaks nothing — it would just describe things that are not there yet. If parts of the series are not taken, the corresponding sections should be dropped before this is merged.

## Running it locally

Nothing to run. The commands in `docs/testing.md` and `CLAUDE.md` are the subject of the review: they should be correct against whatever subset of this series was merged.

## What this does not do

- Does not touch application code, tests or CI.
- Does not propose a policy on required coverage for new code — the ratchet in `ci/coverage-harness` gates on total covered lines and deliberately does not fail a PR for adding untested code.
- Does not document PyMISP or the `tests/` suite's internals beyond how to run them.
- Does not carry `CONTEXT.md` or `docs/superpowers/*` from the working branch; those are scaffolding of the effort, not of MISP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Where this sits in the series

This is one of seven small PRs that together add a test and coverage capability to MISP. They were deliberately split so each can be reviewed, accepted or rejected on its own.

| PR | What it adds | Depends on |
|---|---|---|
| #10964 | PHPUnit 9.6 + `app/phpunit.xml` so coverage can run on PHP 8 | — |
| #10999 | Unit conformance suites (widgets, workflow modules, exports, tools) | #10964 |
| #11000 | Integration harness — model tests against a real database | #10964, #10999 |
| #11001 | Characterization of `Event`'s read and write paths | #11000 |
| #11002 | Live behavioural suites (dashboards, workflows, exports, console) | — |
| #11003 | Golden-snapshot contract for the restSearch API | #11002 |
| #11004 | Coverage job measuring the unit and live suites | #10964 |
| #11005 | Documentation of the three test layers | merge last |

**Suggested merge order:** #10964 → #10999 → #11000 → #11001, and independently #11002 → #11003. #11004 can land any time after #10964. #11005 last, since it documents whatever ends up merged.

#11002 and #11003 touch no PHP at all and are independent of the rest.



