### PR TITLE
[cosmetic] fix: [view] compare thehive-project strpos() result strictly in UserNameHelper::prepend()

### DIFF
--- a/app/View/Helper/UserNameHelper.php
+++ b/app/View/Helper/UserNameHelper.php
@@ -22,7 +22,7 @@ class UserNameHelper extends AppHelper
     {
         $lower_email = strtolower($email);
         if (
-            (strpos($lower_email, 'saad') !== false && strpos($lower_email, 'thehive-project')) ||
+            (strpos($lower_email, 'saad') !== false && strpos($lower_email, 'thehive-project') !== false) ||
             strpos($lower_email, 'saad.kadhi') !== false
         ) {
             return '<i class="fas fa-smile white"></i>&nbsp;';


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A `strpos()` result compared under bare truthiness drops an icon on a match at offset 0.

- **Problem** — `UserNameHelper::prepend()` checks `strpos($lower_email, 'thehive-project')` under bare truthiness rather than `!== false`, so a match at offset 0 returns `int(0)` and is read as no match.
- **Fix** — Adds the strict `!== false` comparison, matching every other `strpos()` call in the same file.
- **Effect** — The decorative icon is shown for addresses starting with that string.
<!-- /bluf -->

## Summary

`UserNameHelper::prepend()` drops the "saad/thehive-project" icon when the substring `thehive-project` matches at offset 0 of the lowercased email, because the second `strpos()` call in the condition is compared under bare truthiness instead of `!== false`.

## Current code

```php
public function prepend($email)
{
    $lower_email = strtolower($email);
    if (
        (strpos($lower_email, 'saad') !== false && strpos($lower_email, 'thehive-project')) ||
        strpos($lower_email, 'saad.kadhi') !== false
    ) {
        return '<i class="fas fa-smile white"></i>&nbsp;';
    } else if (strpos($lower_email, 'enrico.lovat') !== false) {
        ...
```
(`app/View/Helper/UserNameHelper.php`, line 25)

## Mechanism

`strpos($haystack, $needle)` returns the integer offset of the first match, or `false` if no match is found. When the match happens at position 0, `strpos()` returns `int(0)`. PHP treats `int(0)` as falsy under bare boolean coercion, so `int(0)` and `bool(false)` ("not found") become indistinguishable once you drop the `!== false` comparison. That's exactly what happens on line 25's second `strpos()` call — every other `strpos()` call in this file (and in the rest of the condition on the very same line) already uses the strict `!== false` form; this one call was missed.

## Reproduction actually performed

Isolated repro via `podman exec mispapp php -r`:

```php
$lower_email = 'thehive-project@saad-test.example';
strpos($lower_email, 'saad')             !== false   // bool(true)
strpos($lower_email, 'thehive-project')              // int(0)
(bool) strpos($lower_email, 'thehive-project')       // bool(false)  <- bug: truthiness of int(0)
```

Then ran the actual pinning test against the real, unmodified helper code in the running container (main clone, `test-coverage-foundation` branch):

```
$ podman exec mispapp bash -c 'cd /var/www/MISP && ./app/Vendor/bin/phpunit -c app/phpunit.xml --filter testPrependMissesTheSaadRuleWhenTheSecondSubstringStartsAtPositionZero app/Test/Unit/View/SmallHelpersTest.php'
OK (1 test, 1 assertion)
```

This confirms `prepend('thehive-project@saad-test.example')` returns `''` instead of the expected `<i class="fas fa-smile white"></i>&nbsp;'` markup.

This behavior is pinned by `app/Test/Unit/View/SmallHelpersTest.php::testPrependMissesTheSaadRuleWhenTheSecondSubstringStartsAtPositionZero`, which lives on another branch in this repository's development flow. That test file is **not modified in this PR** — its annotation will be updated separately once this fix merges.

## User-visible impact

Any user whose lowercased email address begins with the literal substring `thehive-project` (and also contains `saad` anywhere in the address) silently loses the special icon that should prepend their display name in the MISP UI header. No error is raised — the icon is simply missing for that specific address shape. This is a narrow, cosmetic bug: it affects one hardcoded easter-egg icon rule for a specific known contributor's email pattern, not general application behaviour.

## Fix and why alternatives were rejected

```php
(strpos($lower_email, 'saad') !== false && strpos($lower_email, 'thehive-project') !== false) ||
```

Add the missing `!== false` comparison to the second `strpos()` call. This is a single-character-class, one-line change.

No alternative fix was considered: this is the exact same comparison pattern already used immediately to the left of it on the same line (`strpos($lower_email, 'saad') !== false`), three lines below (`strpos($lower_email, 'saad.kadhi') !== false`), and throughout the rest of the file. Matching the established idiom is strictly better than introducing a different pattern (e.g. `> -1` or a helper function) for a single call site.

## BEHAVIOUR CHANGE flag

This fix **changes observable output** for the narrow input class described above: an email containing `saad` where `thehive-project` matches at offset 0 will now correctly render the icon `<i class="fas fa-smile white"></i>&nbsp;` where it previously rendered `''` (nothing). No other input class changes behaviour — this is a pure bug fix restoring intended behaviour for a previously-broken edge case, not a new error path or exception. There is no error handling involved; the function has always returned an empty string as its "no match" fallback and continues to do so for all inputs where no rule matches.

## Scope

This PR fixes only the CONFIRMED defect above. The validation pass that found this also checked every other `strpos()` call in `UserNameHelper.php` and in every sibling helper under `app/View/Helper/` (`ScopedCSSHelper.php`, `NavbarHelper.php`, `TimeHelper.php` — the only other `strpos()` users) for the same bug shape (bare truthiness on a `strpos()` result). No other instance was found:
- `ScopedCSSHelper.php` uses `strpos()` results only in arithmetic (offset calculation), not boolean logic.
- `NavbarHelper.php` correctly compares `=== 0`.
- `TimeHelper.php` correctly uses `=== false` / `!== false`.

Nothing else in this file or its siblings is changed.

## Why this analysis might be wrong

- The `prepend()` method encodes a set of hardcoded, undocumented easter-egg rules tied to specific individuals' email addresses. It's possible the offset-0 truthiness gap was never actually reachable in practice (i.e. no real address matching this exact shape has ever been used), making this a latent rather than an observed-in-production bug — the validator did not check production logs or user records for this.
- It's possible the intended semantics of the original `&&` clause were narrower than "contains both substrings" (e.g. deliberately excluding an edge case), though there is no comment or test history suggesting that, and every other clause in the file uses strict `!== false` consistently, so this reading seems unlikely.
- The reproduction test (`testPrependMissesTheSaadRuleWhenTheSecondSubstringStartsAtPositionZero`) is a hypothesis-confirming test built by the validating agent's own analysis, then run against the unmodified helper to confirm it fails as predicted (`OK` means the test's own assertion — that the buggy behaviour occurs — passed). It is not an existing project regression test that predates this investigation; the test file itself is on a separate branch and not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

