### PR TITLE
[high] fix: [graph] Stale loop variable and wrong JSON property in tag/galaxy expansion

### DIFF
--- a/app/Lib/Tools/CorrelationGraphTool.php
+++ b/app/Lib/Tools/CorrelationGraphTool.php
@@ -186,7 +186,7 @@ App::uses('OrgImgHelper', 'View/Helper');
               $current_event_id = $this->__createNode('event', $event);
               $this->__addLink($current_tag_id, $current_event_id, 100);
           }
-          $this->_json['nodes'][$current_tag_id]['expanded'] = 1;
+          $this->data['nodes'][$current_tag_id]['expanded'] = 1;
       }
 
       private function __handleGalaxies($galaxies, $anchor_id)
@@ -216,7 +216,7 @@ App::uses('OrgImgHelper', 'View/Helper');
               $current_event_id = $this->__createNode('event', $event);
               $this->__addLink($current_event_id, $current_galaxy_id);
           }
-          $this->_json['nodes'][$current_galaxy_id]['expanded'] = 1;
+          $this->data['nodes'][$current_galaxy_id]['expanded'] = 1;
       }
 
       private function __addGalaxy($id)

--- a/app/Lib/Tools/EventGraphTool.php
+++ b/app/Lib/Tools/EventGraphTool.php
@@ -402,7 +402,7 @@
                 $added_value = array();
                 foreach ($obj['Attribute'] as $ObjAttr) {
                     // Record existing object_relation
-                    $this->__json['existing_object_relation'][$attr['object_relation']] = 0; // set-alike
+                    $this->__json['existing_object_relation'][$ObjAttr['object_relation']] = 0; // set-alike
                     $Tags = $ObjAttr['AttributeTag'];
                     foreach ($Tags as $tag) {
                         $tag = $tag['Tag'];


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Two graph-tool defects: a stale loop variable and a write to an unread JSON property.

- **Problem** — `EventGraphTool::get_tags()` records `$attr['object_relation']` inside a loop over `$ObjAttr`, so every object attribute inherits the stale value left by the previous top-level loop; `CorrelationGraphTool::__expandTag()`/`__expandGalaxy()` set the expanded flag on a property nothing reads.
- **Fix** — Uses the correct loop variable and the correct JSON property.
- **Effect** — Event graphs show each object attribute's own `object_relation`, and tag/galaxy expansion state is actually recorded.
<!-- /bluf -->

## Summary

Two independent bugs in the graph tools, both pinned by `app/Test/Unit/Tools/GraphToolsTest.php` (lives on another branch; not modified by this PR):

1. `EventGraphTool::get_tags()` records the wrong `object_relation` for object attributes because of a stale loop variable.
2. `CorrelationGraphTool::__expandTag()` / `__expandGalaxy()` write the `expanded` flag to a property that is never read.

Both are CONFIRMED by directly running the pinning tests inside the running `mispapp` container.

---

## Defect 1 — `get_tags()` records the wrong `object_relation`

**Current code** (`app/Lib/Tools/EventGraphTool.php`, inside `get_tags()`):

```php
foreach ($obj['Attribute'] as $ObjAttr) {
    // Record existing object_relation
    $this->__json['existing_object_relation'][$attr['object_relation']] = 0; // set-alike
    $Tags = $ObjAttr['AttributeTag'];
    ...
```

**Mechanism:** earlier in the same function there is a separate top-level-attribute loop (`foreach ($event['objects'] ... as $attr)`-style, lines ~356-382) that leaves `$attr` holding whatever the *last* top-level attribute was. The object-attribute loop shown above declares its own loop variable, `$ObjAttr`, but the line that records the object_relation reads the stale `$attr` instead — so every object attribute records the *same* leftover value (or `null`/`''` if no top-level attributes were seen) instead of its own `object_relation`.

**Reproduction actually performed** (quoted from the validator):
> Ran the pinning test directly via phpunit inside the mispapp container: `podman exec mispapp bash -lc 'cd /var/www/MISP && ./app/Vendor/bin/phpunit -c app/phpunit.xml --filter testGetTagsRecordsTheWrongObjectRelationBecauseOfAStaleLoopVariable app/Test/Unit/Tools/GraphToolsTest.php'` → `OK (1 test, ...)`.

I additionally re-ran the same test against the *fixed* code (copied into a container-internal scratch copy of the app tree, `/tmp/misp-fixed`, never touching the main clone or its branch) to confirm the fix actually flips the pinned assertion:

```
1) GraphToolsTest::testGetTagsRecordsTheWrongObjectRelationBecauseOfAStaleLoopVariable
the stale $attr (object_relation === null) is recorded instead of the object attribute's own value
Failed asserting that an array has the key ''.
```

The test now fails at exactly the assertion that pins the *old, buggy* behavior — i.e. the bogus `''` key is no longer produced, confirming the fix lands where intended. (This test is not being edited here; per instructions it stays as-is and will be re-annotated by the main session once this merges.)

**User-visible impact:** The Event Graph's tag-filter UI is shown a bogus "existing object relations" set for objects — it repeats the last top-level attribute's `object_relation` for every object attribute instead of the object's real relations, so users see wrong/misleading filter options (e.g. missing `first-seen`, spurious `''` entries) when building filter rules on the tag graph.

**Fix:** use the loop's own variable, `$ObjAttr['object_relation']`, instead of the stale `$attr['object_relation']`.

```diff
-                    $this->__json['existing_object_relation'][$attr['object_relation']] = 0; // set-alike
+                    $this->__json['existing_object_relation'][$ObjAttr['object_relation']] = 0; // set-alike
```

**Alternatives rejected:** Renaming/removing the outer `$attr` loop variable to avoid the shadow trap entirely was considered, but it's used correctly elsewhere in that outer scope — touching it would widen the diff and risk an unrelated regression for a one-line fix.

---

## Defect 2 — expansion writes to `$this->_json` instead of `$this->data`

**Current code** (`app/Lib/Tools/CorrelationGraphTool.php`):

```php
private function __expandTag($id)
{
    ...
    $this->_json['nodes'][$current_tag_id]['expanded'] = 1;
}

private function __expandGalaxy($id)
{
    ...
    $this->_json['nodes'][$current_galaxy_id]['expanded'] = 1;
}
```

**Mechanism:** `buildGraphJson()` returns `$this->data`, and every other read/write of node state in this class (creation, links, the analogous event-expansion path at line 357) uses `$this->data`. `$this->_json` is a nonexistent, undeclared property — written in exactly these two places and read nowhere in the codebase. PHP treats the assignment as creation of a dynamic property (deprecated as of PHP 8.2) that is immediately discarded; the real `$this->data['nodes'][...]['expanded']` flag is left at its creation-time (falsy) value.

**Reproduction actually performed** (quoted from the validator):
> Ran the pinning test via phpunit inside the container: `podman exec mispapp bash -lc 'cd /var/www/MISP && ./app/Vendor/bin/phpunit -c app/phpunit.xml --filter testExpandTagAddsEventsButLeavesExpandedFlagUnset app/Test/Unit/Tools/GraphToolsTest.php'` → passed, and PHP itself flagged the bug: `Deprecated: Creation of dynamic property CorrelationGraphTool::$_json is deprecated in .../CorrelationGraphTool.php on line 189`.

Re-ran the same test against the fixed code the same way as above:

```
2) GraphToolsTest::testExpandTagAddsEventsButLeavesExpandedFlagUnset
today, the node's expanded flag stays at its creation-time value (falsy) because the intended update writes to a nonexistent $this->_json instead of $this->data
Failed asserting that 1 is false.
```

The pinned "stays false" assertion now fails because the flag is correctly `1` — confirming the fix, and the PHP 8.2 dynamic-property deprecation warning is also gone.

**User-visible impact:** In the correlation graph view, after a user expands a tag or galaxy node, the returned graph JSON never has that node's `expanded` flag set, so the client can't tell the node was already expanded — re-clicking it re-runs `fetchSimpleEventsForTag()` and `cleanLinks()` and redoes the expansion work (only incidentally deduped via `graphJsonContains`).

**Fix:** write to `$this->data` instead of `$this->_json`, matching every other node-state write in the class.

```diff
-          $this->_json['nodes'][$current_tag_id]['expanded'] = 1;
+          $this->data['nodes'][$current_tag_id]['expanded'] = 1;
```
```diff
-          $this->_json['nodes'][$current_galaxy_id]['expanded'] = 1;
+          $this->data['nodes'][$current_galaxy_id]['expanded'] = 1;
```

**Alternatives rejected:**
- Declaring `$_json` as a real class property and having `buildGraphJson()` return it instead of `$this->data` was rejected — it would be a much larger, higher-risk change touching a property read/written throughout the class, to "fix" what is clearly a typo (every other line already uses `$this->data`).
- Adding `#[AllowDynamicProperties]` to silence the deprecation was rejected — it hides the symptom (the deprecation notice) without fixing the actual bug (the flag never reaching the JSON that's returned to the client).

---

## BEHAVIOUR CHANGE — please review carefully

Both fixes change previously-silent, previously-wrong output to correct output:

- **Defect 1:** the `existing_object_relation` key in the Event Graph JSON now contains the object attributes' *real* relations instead of one repeated stale value. Any client code or caching that depended on (or merely tolerated) the old, wrong content will see different data.
- **Defect 2:** expanded tag/galaxy nodes in the correlation graph now come back with `expanded: 1` where they previously always had it unset/falsy. Client logic that branches on this flag (e.g. to skip re-expanding) will now actually take that branch, which it never did before. The PHP 8.2 "dynamic property" deprecation warning on `CorrelationGraphTool::$_json` also disappears as a side effect.

Neither change alters any database schema, API contract, or externally documented behavior — both make the graph tools do what their own code around them already assumes they do.

---

## Why this analysis might be wrong

- I have not exercised these code paths through the actual running MISP web UI (Event Graph / correlation graph pages) with real data — only through the unit-level pinning tests and reading the surrounding code. It's possible some other UI code compensates for the wrong `object_relation` values today in a way that would need to change alongside this fix (I found no such compensation, but didn't have coverage of the JS graph-rendering code beyond a UI-impact read).
- For Defect 2, I've assumed `$this->data` is the sole intended sink because every other read/write in `CorrelationGraphTool` uses it and `buildGraphJson()` returns it — but I have not traced every possible external consumer of the class to rule out some other mechanism silently relying on `expanded` staying unset.
- Both fixes are one-line/two-line, mechanically obvious once the stale-variable/wrong-property pattern is seen, but "obvious" fixes to graph-state bugs can occasionally interact with caching/memoization elsewhere (e.g. `graphJsonContains` dedup mentioned above) in ways a unit-level pinning test won't surface.

---

## Out of scope

- Pre-existing PHP 8.2 "dynamic property" deprecation warnings on unrelated `EventGraphTool` properties (`$__Tag`, `$__filterRules`, `$__extendedEventUUIDMapping`, `$__extended_view`, `$__authorized_JSON_key`, `$__paletteTool`, all prefixed with `__` and clearly intentional private state, not a defect in the CONFIRMED set) — left untouched.
- The pinning test file itself, `app/Test/Unit/Tools/GraphToolsTest.php` — not modified, per instructions; it currently pins the pre-fix (buggy) behavior for both defects fixed here and will need re-annotating on the branch that owns it once this merges.

## Existing PR check

Searched `gh pr list --repo MISP/MISP --search "EventGraphTool"` / `"CorrelationGraphTool"` / `"expandTag OR expandGalaxy"`. Only #10983 ("add a to_ids filter to the correlation graph") came up, and its diff touches only `app/View/Events/view_graph.ctp`, the Overmind theme equivalent, and the correlation-graph CSS/JS files — no overlap with `app/Lib/Tools/EventGraphTool.php` or `app/Lib/Tools/CorrelationGraphTool.php`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

