### PR TITLE
[medium] fix: [restSearch] stop MispObject::buildFilterConditions() from mutating the caller's $params array

### DIFF
--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -139,7 +139,7 @@ class MispObject extends AppModel
         $this->_schema['distribution']['default'] = Configure::read('MISP.default_object_distribution') ?? 5;
     }
 
-    public function buildFilterConditions(&$params)
+    public function buildFilterConditions($params)
     {
         $conditions = [];
         if (isset($params['wildcard'])) {


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `MispObject::buildFilterConditions()` mutates the caller's `$params`; this PR takes it by value.

- **Problem** — `buildFilterConditions()` takes `$params` by reference, so its `ignore`-driven injection of `to_ids`/`published` and the pop-driven unsets of `last`, `timestamp`, `event_timestamp` and `tags` leak back into the caller's array in `restSearch()`.
- **Fix** — Drops the `&` so PHP hands the function its own copy, matching `GalaxyCluster::buildFilterConditions()`.
- **Effect** — No shipped export tool reads the affected keys today, so this closes a latent state leak before a plugin or a second caller trips over it.
<!-- /bluf -->

## Current code

```php
public function buildFilterConditions(&$params)
{
    $conditions = [];
    if (isset($params['wildcard'])) {
        ...
    } else {
        if (isset($params['ignore'])) {
            $params['to_ids'] = array(0, 1);
            $params['published'] = array(0, 1);
        }
        $simple_params = array(
            'Object' => array( ... ),
            'Event' => array(
                ...
                'last' => array('function' => 'set_filter_timestamp', 'pop' => true),
                'timestamp' => array('function' => 'set_filter_timestamp', 'pop' => true),
                'event_timestamp' => array('function' => 'set_filter_timestamp', 'pop' => true),
                ...
            ),
            'Attribute' => array(
                'tags' => array('function' => 'set_filter_tags', 'pop' => true),
                ...
            )
        );
        foreach ($params as $param => $paramData) {
            foreach ($simple_params as $scope => $simple_param_scoped) {
                if (isset($simple_param_scoped[$param]) && isset($params[$param]) && $params[$param] !== false) {
                    ...
                    $conditions = $this->Event->{$simple_param_scoped[$param]['function']}($params, $conditions, $options);
                }
            }
        }
    }
    return $conditions;
}
```

(`app/Model/MispObject.php`, `buildFilterConditions()`, currently declared `&$params`.)

## Mechanism

`buildFilterConditions()` takes `$params` **by reference**. Two things inside it write to that same variable:

1. `if (isset($params['ignore'])) { $params['to_ids'] = [0,1]; $params['published'] = [0,1]; }` — an unconditional injection whenever `ignore` is set.
2. The `simple_params` loop forwards `$params` by reference into `Event::set_filter_timestamp()` / `Event::set_filter_tags()` for the `last`, `timestamp`, `event_timestamp` and `tags` keys with `'pop' => true`; those helpers themselves take `&$params` and do `unset($params[$options['filter']])` after consuming the value.

Because `buildFilterConditions()`'s own parameter is a reference, both the injection and the pop-driven `unset()` propagate straight back into the caller's array — not just intra-function state.

The single production call site is `MispObject::restSearch()`:

```php
$conditions = $this->buildFilterConditions($filters);
```

`restSearch()`'s `$filters` is itself passed **by value** from its own callers, so the mutation stays confined to `restSearch()`'s local `$filters` — HTTP/controller callers are unaffected. But `restSearch()` goes on to reuse that same, now-mutated `$filters`, eventually passing it downstream as `$exportToolParams['filters']` into `$exportTool->header($exportToolParams)`.

A second call site exists in `app/Lib/EventReport/ReportFromEvent.php::getObjects()`, but there `$filters` is a fresh local built immediately before the call (`$filters = array_merge(['eventid' => ...], $this->__options['conditions']); ... buildFilterConditions($filters);`) and is never read afterward, so it is unaffected either way.

## Reproduction (from the validating agent)

> Ran the pinning test directly inside the running mispapp container: `podman exec mispapp bash -lc 'cd /var/www/MISP/app && ./Vendor/bin/phpunit -c phpunit-integration.xml --filter testIgnoreParamInjectsToIdsAndPublishedIntoCallersParams Test/Integration/MispObjectFetchCharacterizationTest.php'` -> output: `PHPUnit 9.6.36 ... OK (1 test, 6 assertions)`. Also read the source: MispObject.php:142 declares `buildFilterConditions(&$params)`, and lines 155-158 execute `if (isset($params['ignore'])) { $params['to_ids'] = array(0,1); $params['published'] = array(0,1); }` unconditionally writing into the by-reference parameter.

This PR's own additional check (since the pinning test lives on another branch and this worktree could not touch the main clone to re-run it against the fix): an isolated `php` snippet reproducing just the by-ref vs by-value mechanism, run inside the same container —

```
BEFORE fix - caller's array after call: array (
  'ignore' => 1,
  'to_ids' => array (0 => 0, 1 => 1),
  'published' => array (0 => 0, 1 => 1),
)
AFTER fix - caller's array after call: array (
  'ignore' => 1,
)
```

confirming the fix removes exactly the caller-visible mutation and nothing else (the intra-function widening that feeds the `simple_params` loop still reads back correctly from PHP's normal by-value copy).

The behavior is pinned by `app/Test/Integration/MispObjectFetchCharacterizationTest.php::testIgnoreParamInjectsToIdsAndPublishedIntoCallersParams`, which lives on another branch and is **not modified by this PR**. Its two `KNOWN-DEFECT` assertions will start failing once this fix lands; the main session will update that annotation once this merges (per ADR 0002 — pin known defects, update the pin when they're fixed).

## User-visible consequence

`restSearch()`'s own `$filters` variable silently gains `to_ids => [0,1]` and `published => [0,1]` it never received whenever `ignore` is set, and separately *loses* `last` / `timestamp` / `event_timestamp` / `tags` keys whenever those filters are used (because the `pop` unset also propagates back). Both directions currently reach only `$exportToolParams['filters']` passed to `$exportTool->header()`. I grepped every `header()` implementation under `app/Lib/Export/*.php` for reads of `['filters']['to_ids']`, `['filters']['published']`, `['filters']['last']`, `['filters']['timestamp']`, `['filters']['event_timestamp']`, `['filters']['tags']` — none currently read any of these keys, so today this is a **latent API hazard**, not an observed live misbehavior. It becomes a real bug the moment any export tool (shipped or third-party plugin) inspects those keys on `$options['filters']`, or the moment `buildFilterConditions()` gains a second production caller whose own array gets clobbered the same way.

## Fix, and why alternatives were rejected

Drop the by-reference signature: `buildFilterConditions(&$params)` → `buildFilterConditions($params)`. PHP then hands the function its own copy, so the injection and the pop-driven unsets still work exactly as before *inside* the function (the `simple_params` loop reads back from the same local variable), but nothing leaks back to the caller. This is a one-character diff with an existing in-codebase precedent: `GalaxyCluster::buildFilterConditions($user, $filters)` already takes its filter array by value.

Alternatives considered and rejected:
- **Keep `&$params` but explicitly copy to a local before mutating** (`$local = $params; ... use $local ...`) — strictly more code for the same outcome as just removing `&`, with no benefit.
- **Fix only the `ignore` injection, leave `&$params`** — would leave the pop-propagation half of the same defect (see above) unaddressed while touching the same line; not a smaller or safer diff, just an incomplete one.
- **Also fix `MispAttribute.php:3550`**, which has the identical by-reference pattern (`buildFilterConditions(array $user, array &$params, ...)`) — left out of this PR. It is a distinct call site with its own callers and its own blast-radius analysis that this group's validation did not perform; fixing it here would be scope creep beyond what was confirmed. Flagging it here so it isn't lost.

## BEHAVIOUR CHANGE

Yes — this silently changes what `restSearch()`'s local `$filters` variable contains after the `buildFilterConditions()` call, in two ways: it will no longer gain the phantom `to_ids`/`published` keys, and it will no longer lose the `last`/`timestamp`/`event_timestamp`/`tags` keys that used to be popped out by reference. As documented above, no currently-shipped code path visibly consumes any of the affected keys from `$exportToolParams['filters']`, so this should be behaviorally silent in the current codebase — but because the whole class of bug is "silent state leak," anyone relying on the old (buggy) propagation, in-tree or in a plugin, would see previously-silent state now stay correctly scoped, which could surface as a visible behavior difference for them.

## Why this analysis might be wrong

- The grep for downstream consumers of `$filters['to_ids']` / `$filters['published']` / the popped keys covers `app/Lib/Export/*.php` `header()` implementations only; it does not cover third-party export modules, other code paths that might read `$exportToolParams['filters']`, or dynamic/reflective access patterns that wouldn't show up in a literal-string grep.
- The claim that `restSearch()`'s `$filters` parameter is by-value from its own callers was traced by reading `restSearch()`'s signature (`$filters` with no `&`), not by exhaustively testing every controller call path.
- No live/integration test was run against this exact fixed file (the pinning test lives on a different branch than this worktree's base, and the hard rule against editing the main clone meant the fix could not be exercised through the actual test harness before opening this PR); the isolated PHP snippet above proves the by-ref/by-value *mechanism* in general, not this specific 1200-line method's full behavior end-to-end.

## Scope

Only `app/Model/MispObject.php::buildFilterConditions()` is changed. `app/Model/MispAttribute.php:3550` has the identical by-reference pattern and is a real sibling issue, but is out of scope for this PR (different call site, not covered by this group's validation) — noted above, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

