### PR TITLE
[critical] fix: [object] stop MispObject write paths reporting success on silent drops

### DIFF
--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -1194,6 +1194,14 @@ class MispObject extends AppModel
         if (!isset($object['Object'])) {
             $object = array('Object' => $object);
         }
+        // saveObject()/deltaMerge() take attributes in a sibling 'Attribute'
+        // key ($object['Attribute']); captureObject() itself only ever
+        // consumed the nested $object['Object']['Attribute']. Accept the
+        // sibling shape too so a caller that builds the saveObject()-style
+        // payload does not silently lose every attribute.
+        if (empty($object['Object']['Attribute']) && !empty($object['Attribute'])) {
+            $object['Object']['Attribute'] = $object['Attribute'];
+        }
         $duplicationCheckCacheKey = null;
         if (!empty($object['Object']['breakOnDuplicate']) || $breakOnDuplicate) {
             $duplicatedObjectId = null;
@@ -1204,7 +1212,12 @@ class MispObject extends AppModel
                     __('Object dropped due to it being a duplicate (ID: %s, UUID: %s) and breakOnDuplicate being requested for Event %s', $duplicatedObjectId, $duplicateObjectUuid, $eventId),
                     'Duplicate object found.'
                 );
-                return true;
+                // Distinguishable from the boolean `true` returned on a real
+                // save, matching the existing 'fail' precedent below for
+                // validation failures - a caller that only checks truthiness
+                // still treats this as non-fatal, but one that cares can
+                // tell "captured" apart from "dropped as a duplicate".
+                return 'duplicate';
             }
         }
         unset($object['Object']['id']);
@@ -1297,7 +1310,12 @@ class MispObject extends AppModel
                 if ($existingObject['Object']['event_id'] != $eventId) {
                     $change = 'An object was blocked from being saved due to a duplicate UUID. The uuid in question is: ' . $object['uuid'] . '. This can also be due to the same object (or an object with the same UUID) existing in a different event)';
                     $this->loadLog()->createLogEntry($user, 'edit','MispObject', 0, 'Duplicate UUID found in object', $change);
-                    return true;
+                    // Not `true`: the edit was dropped, not applied. Event::_edit()
+                    // already treats any non-true editObject() result as an error
+                    // to surface (`if ($result !== true) { $validationErrors['Object'][] = $result; }`),
+                    // so returning a message here - rather than the same `true`
+                    // a real edit returns - lets that existing handling work.
+                    return 'Duplicate UUID found in object: the uuid ' . $object['uuid'] . ' is owned by another event.';
                 }
                 if (isset($object['timestamp'])) {
                     if ($force || $existingObject['Object']['timestamp'] >= $object['timestamp']) {


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Three `MispObject` write paths discard input yet report success; this PR reports the drop.

- **Problem** — `MispObject::captureObject()` and `editObject()` have three branches that silently discard input while returning the same true value as a real success: attributes passed under the sibling `Attribute` key are ignored, a `breakOnDuplicate` drop reports success, and `editObject()` drops an object whose UUID belongs to another event.
- **Fix** — Makes those three paths report the drop instead of faking success.
- **Effect** — Callers on the capture and sync paths see failures rather than losing object data with no signal.
<!-- /bluf -->

## Summary

`MispObject::captureObject()` and `MispObject::editObject()` each have a branch where input is silently discarded but the return value is identical to the one used for a real success. This PR fixes the three CONFIRMED instances of that pattern; it does not touch anything else.

Pinned by `app/Test/Integration/MispObjectWriteCharacterizationTest.php` (lives on a separate, not-yet-merged branch — not modified by this PR). That file currently asserts the *old*, defective behaviour under `KNOWN-DEFECT` comments (`testCaptureObjectSilentlyDropsAttributesGivenAsASiblingKeyInsteadOfNested`, `testCaptureObjectWithBreakOnDuplicateDropsSilentlyAndReturnsTheSameTrueAsSuccess`, `testEditObjectWithAUuidOwnedByAnotherEventIsDroppedButReportsTrue`); once this fix merges those three tests will need their assertions/annotations updated, which the branch that owns that file will do.

## Defect 1 — `captureObject()` drops attributes given via the sibling `Attribute` key

**Current code** (`app/Model/MispObject.php`, pre-patch):

```php
public function captureObject($object, $eventId, $user, $unpublish = true, $breakOnDuplicate = false, $parentEvent = false)
{
    $this->create();
    if (!isset($object['Object'])) {
        $object = array('Object' => $object);
    }
    $duplicationCheckCacheKey = null;
    ...
    if (!empty($object['Object']['Attribute'])) {
        foreach ($object['Object']['Attribute'] as $attribute) {
            ...
            $this->Attribute->captureAttribute($attribute, $eventId, $user, $objectId, false, $parentEvent);
        }
    }
    ...
    return true;
}
```

**Mechanism**: `captureObject()` only ever reads attributes from the *nested* key `$object['Object']['Attribute']`. But `saveObject()` and `deltaMerge()` — the model's other two object-write entry points, for the exact same underlying concept — read attributes from the *sibling* key `$object['Attribute']`. A caller that builds the `saveObject()`/ `deltaMerge()`-shaped payload (`['Object' => [...], 'Attribute' => [...]]`) and passes it to `captureObject()` gets an object row with zero attributes, no error, and a `true` return.

**Reproduction actually performed** (quoted from the validating agent):

> Ran the pinning test `testCaptureObjectSilentlyDropsAttributesGivenAsASiblingKeyInsteadOfNested` via `podman exec mispapp ./app/Vendor/bin/phpunit -c app/phpunit-integration.xml --filter ... --testdox` against the live DB-backed MISP instance: `✔ Capture object silently drops attributes given as a sibling key instead of nested` (OK, 16 assertions across the 3-test run). This calls captureObject() with the saveObject()/deltaMerge()-shape payload ['Object'=>[...], 'Attribute'=>[...]]; result is boolean true, the Object row is created (count=1), and the attribute count for the event is 0.

**User-visible consequence**: a sync/import caller (or a future caller of `captureObject()` built against the shape the other two entry points already accept) silently loses real IOC data with no signal at all — no error, no log entry, `true` all the way through.

**Fix**: normalize the sibling key onto the nested one before it is read, only when the nested key is empty:

```php
if (empty($object['Object']['Attribute']) && !empty($object['Attribute'])) {
    $object['Object']['Attribute'] = $object['Attribute'];
}
```

placed immediately after the existing `if (!isset($object['Object']))` wrap, so it runs once per call regardless of which shape came in.

**Alternatives rejected**:
- *Log-only ("distinguish ignored sibling key from genuinely empty"), without accepting the data* — this was the task's fallback suggestion, but it leaves the actual data loss in place; a caller using the sibling shape still gets an object with no attributes. Since both shapes describe the same information and the target field name (`Attribute`) is unambiguous, accepting it is strictly better than logging its loss.
- *Always overwrite `$object['Object']['Attribute']` with `$object['Attribute']` when the latter is present* — rejected because a caller that deliberately used the correct nested shape and also happened to have an unrelated stray top-level `Attribute` key (there is no such caller today, but the guard costs nothing) would have its real attributes silently replaced. The `empty(...) &&` guard makes the sibling key purely additive/normalizing, never destructive.

**BEHAVIOUR CHANGE**: yes. Any caller that was relying on the *old* silent-drop (i.e. passing the sibling shape and expecting zero attributes to be captured) will now see those attributes actually saved. No caller in this codebase does this on purpose — every existing in-tree call site (`Event::_add()`, `AttributesController`, `EventsController`, `ObjectsController::attributesToObject`) already passes the nested `Object.Attribute` shape, so this normalization is a no-op for all of them and only changes behaviour for a caller using the sibling shape, where it turns a silent data loss into a save.

## Defect 2 — `captureObject()` with `breakOnDuplicate` returns the same `true` for "saved" and "dropped as duplicate"

**Current code**:

```php
if (!empty($object['Object']['breakOnDuplicate']) || $breakOnDuplicate) {
    ...
    $duplicate = $this->checkForDuplicateObjects(...);
    if ($duplicate) {
        $this->loadLog()->createLogEntry($user, 'add', 'Object', 0,
            __('Object dropped due to it being a duplicate ...'),
            'Duplicate object found.'
        );
        return true;
    }
}
...
return true; // the real-success return, further down
```

**Mechanism**: the duplicate-drop branch and the real-success branch return the identical value. A caller cannot tell them apart from the return value alone.

**Reproduction actually performed** (quoted):

> Ran testCaptureObjectWithBreakOnDuplicateDropsSilentlyAndReturnsTheSameTrueAsSuccess against the live instance: `✔ Capture object with break on duplicate drops silently and returns the same true as success` (pass). First captureObject() call creates the object and returns true; second call with an identical duplicate payload and breakOnDuplicate=true also returns true, and the object count for the event stays at 1 (no second row).

**User-visible consequence**: a sync client doing a `breakOnDuplicate` import cannot distinguish "this object was newly captured" from "this object was silently dropped as a duplicate" without a separate DB query.

**Fix**: return the string `'duplicate'` instead of `true` from the drop branch.

**Alternatives rejected**:
- *Return an array carrying the existing object's id/uuid* — more informative, but every current call site treats a non-`true`, non-`'fail'` return as opaque/unused (see caller audit below), so the extra structure has no consumer today and would be dead weight; a scalar sentinel is the smaller change and mirrors the existing `'fail'` precedent a few lines below in the same method.
- *Return `false`* — rejected because `false` is what a naive `if (!$result)` check reads as "this failed / should be retried", which is wrong for a duplicate-drop (it's an expected, non-error outcome); a distinct truthy sentinel avoids that misreading while still being distinguishable via `===`/`!==`.

**BEHAVIOUR CHANGE**: yes, but narrow. Caller audit of every `captureObject()` call site in this tree:
- `Event.php:5429` (`Event::_add()`'s object-capture loop) — assigns the result to `$result` but never reads it. No behaviour change.
- `AttributesController.php:577`, `EventsController.php:4431`, `EventsController.php:6816` — result is discarded (not assigned). No behaviour change.
- `ObjectsController.php:1422` (`attributesToObject`) — the one call site that checks `$result === true` and branches on it — is called with `$breakOnDuplicate = false` explicitly, so the duplicate-drop branch (and this change) can never fire there.
- `MispObject::editObject()`'s no-uuid branch delegates straight to `captureObject()` and relays its return value unchanged. If a caller reaches `editObject()` with `$object['Object']['breakOnDuplicate']` set inside the payload (not the parameter — the parameter itself has no way to reach this path since `editObject()` doesn't accept a `$breakOnDuplicate` argument), a `'duplicate'` string can now surface from `editObject()` too, in place of `true`. `Event::_edit()` (see Defect 3 below) treats any `editObject()` result `!== true` as a validation error to collect — this is currently a dead branch in practice (see Defect 3's analysis of `$validationErrors`), so this has no observable effect through that path today either.

No call site in this tree relies on the old "always `true`" value in a way that would misbehave once it becomes `'duplicate'` on the drop branch, but any *external* caller (a sync client, a script) doing a strict `$result === true || $result === false` check would newly see a third value.

## Defect 3 — `editObject()` reports `true` when it drops an edit due to a uuid owned by another event

**Current code**:

```php
if ($existingObject['Object']['event_id'] != $eventId) {
    $change = 'An object was blocked from being saved due to a duplicate UUID. ...';
    $this->loadLog()->createLogEntry($user, 'edit','MispObject', 0, 'Duplicate UUID found in object', $change);
    return true;
}
```

**Mechanism**: identical shape to Defect 2 but on the edit path — the drop branch returns the same `true` the real-edit-applied branch returns a few lines later.

**Reproduction actually performed** (quoted):

> Ran testEditObjectWithAUuidOwnedByAnotherEventIsDroppedButReportsTrue against the live instance: `✔ Edit object with a uuid owned by another event is dropped but reports true` (pass). An object is captured on eventId=ownerId with a given uuid; editObject() is then called on a different event (otherId) with the same uuid. Result is boolean true, no object is created on otherId (count=0), and the original object row still belongs to ownerId.

**User-visible consequence**: a sync client pushing an edit that happens to collide on uuid with an object on another event believes the edit landed (`true`) when it was actually discarded; the only trace is an audit-log entry (`'Duplicate UUID found in object'`) the caller never reads.

**Fix**: return a descriptive string instead of `true`:

```php
return 'Duplicate UUID found in object: the uuid ' . $object['uuid'] . ' is owned by another event.';
```

**Why a string and not `false`**: `editObject()`'s one in-tree caller, `Event::_edit()` (`app/Model/Event.php` ~5803), already has handling for a non-`true` result:

```php
$result = $this->Object->editObject($object, $saveResult, $user, false, $force, $nothingToChange, $server);
if ($result !== true) {
    $validationErrors['Object'][] = $result;
}
```

`false` would land in `$validationErrors['Object']` as a bare `false` with no explanation of *why*; a string preserves the reason for anyone who does start reading `$validationErrors`. This also matches this method's own precedent a few lines above (the invalid-sharing-group branch already `return`s a human-readable string instead of `false`/ `true`).

**Traced what happens to that `$validationErrors` today**: `$result` is fed into a local `$validationErrors['Object'][]` array declared at the top of the `if ($saveResult)` block in `_edit()`. Grepping the rest of `_edit()` (and the whole file) shows that local variable is **never read again** after being populated — it is not returned, not checked to abort the save, and not merged into anything the caller of `_edit()` sees. `_edit()`'s actual return is either `true` (deep inside the `if ($jobId) { ... }` block) or `$this->validationErrors` — the *model's own* property from the earlier `$this->save()` call, an entirely different variable with the same name. So today, changing `editObject()`'s return value here has **no observable effect on `Event::_edit()`'s own return value or control flow** — the event edit still proceeds and still reports success exactly as before. The only externally visible change is that `$validationErrors['Object']` — a local that current code populates and then discards — now holds a string instead of never being reached for this branch (it already was reachable for other non-`true` `editObject()` results, e.g. save validation failures).

**Consistency note (not fixed here, out of scope)**: the sibling method `MispAttribute::editAttribute()` has the identical pattern for its own cross-event/cross-object uuid collision (`app/Model/MispAttribute.php` ~3246) — it also `return`s bare `true` on a silent drop. Its caller in `Event::_edit()` uses a different check (`is_array($result)`), so the divergence between "Object drop now reports as a string" and "Attribute drop still reports as `true`" is real but pre-existing and not part of the CONFIRMED defects in this task's group; flagging it for awareness, not fixing it here.

**BEHAVIOUR CHANGE**: yes — external/future callers of `editObject()` that do a strict `=== true`/`!== true` check will observe this branch differently. Per the trace above, the one in-tree caller (`Event::_edit()`) already guards with `!== true` and its use of the collected value is currently inert, so there is no observed regression in this codebase's own sync/edit flow. This is flagged as a behaviour change out of caution for any caller (in-tree or external) that does not yet exist but might reasonably be added.

## Why this analysis might be wrong

- **The pinning tests could not be re-run against the patched code from this worktree.** Per this task's constraints, the worktree used for this fix is a separate `git worktree` off `origin/2.5`, isolated from the main clone (which is on `test-coverage-foundation`, the branch that actually contains `MispObjectWriteCharacterizationTest.php`, and which this task explicitly forbids touching). The container that runs `phpunit` bind-mounts the main clone, not this worktree, so the three `KNOWN-DEFECT` tests were **not** re-executed against the patched `MispObject.php` — only `php -l` syntax-checked (via a temporary copy into the main clone's `app/tmp/`, then removed) and reasoned about by reading the code and tracing every caller. Those three tests will *fail* against this patch as written today, because they assert the old defective behaviour by design (`CHARACTERIZATION, not specification`) — that is expected, and the task states the branch owning that file will update its annotations once this merges.
- The `$validationErrors` dead-variable trace in Defect 3 was done by grepping for every occurrence of `validationErrors` inside `Event::_edit()`'s body and reading the surrounding control flow; it's possible a reflection-based caller, a plugin, or a subclass reads `Event::_edit()` by reference or inspects instance state in a way a static grep wouldn't surface — I did not find one, but did not exhaustively search every plugin under `app/Plugin/`.
- The caller audit for Defect 2 covers every `->captureObject(` and `->editObject(` call site found by grep across `app/Model`, `app/Controller`, `app/Console`, and `app/Lib` — it does not cover PyMISP or any out-of-tree/third-party sync client that might parse a raw JSON-RPC-style response body containing the literal string `true` versus any other value, if such a client exists.
- The `empty($object['Object']['Attribute']) && !empty($object['Attribute'])` guard in Defect 1 assumes the two keys never legitimately need to coexist with different content within a single call. I did not find a caller that sets both, but did not prove none can exist.

## Files changed

- `app/Model/MispObject.php` (`captureObject()`, `editObject()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


