### PR TITLE
[high] fix: [export] stop XML attribute SharingGroup loss and remove dead code

### DIFF
--- a/app/Lib/Tools/IOCExportTool.php
+++ b/app/Lib/Tools/IOCExportTool.php
@@ -29,11 +29,6 @@ class IOCExportTool
         return $final;
     }
 
-    public function getResult()
-    {
-        return $this->__final;
-    }
-
     // generates the top with the event information
     public function generateSingleTop($event)
     {

--- a/app/Lib/Tools/XMLConverterTool.php
+++ b/app/Lib/Tools/XMLConverterTool.php
@@ -59,12 +59,6 @@ class XMLConverterTool
     {
         foreach ($attributes as $key => $value) {
             unset($attributes[$key]['value1'], $attributes[$key]['value2'], $attributes[$key]['category_order']);
-            if (isset($event['Event']['RelatedAttribute']) && isset($event['Event']['RelatedAttribute'][$value['id']])) {
-                $attributes[$key]['RelatedAttribute'] = $event['Event']['RelatedAttribute'][$value['id']];
-                foreach ($attributes[$key]['RelatedAttribute'] as &$ra) {
-                    $ra = array('Attribute' => array(0 => $ra));
-                }
-            }
             if (isset($attributes[$key]['ShadowAttribute'])) {
                 foreach ($attributes[$key]['ShadowAttribute'] as $skey => $svalue) {
                     $attributes[$key]['ShadowAttribute'][$skey]['Org'] = array(0 => $attributes[$key]['ShadowAttribute'][$skey]['Org']);
@@ -84,8 +78,8 @@ class XMLConverterTool
                 }
             }
             if (isset($attributes[$key]['SharingGroup'])) {
-                $attributes[$key]['SharingGroup'][0] = $attributes[$key]['SharingGroup'];
-                unset($attributes[$key]['SharingGroup']);
+                $sharingGroup = $attributes[$key]['SharingGroup'];
+                $attributes[$key]['SharingGroup'] = array(0 => $sharingGroup);
             }
             if (isset($attributes[$key]['AttributeTag'])) {
                 foreach ($attributes[$key]['AttributeTag'] as $atk => $tag) {


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** XML exports silently drop attribute-level `SharingGroup`; this PR fixes the wrap.

- **Problem** — `XMLConverterTool::__rearrangeAttributes()` wraps an attribute's `SharingGroup` into `[0]` on the same array key it then `unset()`s, so attribute-level `SharingGroup` data never reaches the XML export at all. `IOCExportTool::getResult()` is a confirmed-dead method.
- **Fix** — Reorders the wrap so the sharing group survives the `unset()`, and deletes `IOCExportTool::getResult()`.
- **Effect** — XML exports of attributes start carrying their `SharingGroup` block, which consumers currently never see.
<!-- /bluf -->

## Summary

Fixes two confirmed data-loss/dead-code defects in `app/Lib/Tools/XMLConverterTool.php::__rearrangeAttributes()` and removes one confirmed-dead method in `app/Lib/Tools/IOCExportTool.php::getResult()`. All three are pinned by `app/Test/Unit/Tools/ConverterToolsTest.php`, which lives on a different branch (`test-coverage-foundation`) and is **not** part of this PR — per that branch's convention, its author will update the two KNOWN-DEFECT test annotations once this merges. Test names are quoted below so the mapping is unambiguous.

---

## 1. Attribute-level `SharingGroup` is silently dropped from XML exports (BEHAVIOUR CHANGE)

**Current code** (`__rearrangeAttributes()`):
```php
if (isset($attributes[$key]['SharingGroup'])) {
    $attributes[$key]['SharingGroup'][0] = $attributes[$key]['SharingGroup'];
    unset($attributes[$key]['SharingGroup']);
}
```

**Mechanism:** this reads and writes the *same* array key (`$attributes[$key]['SharingGroup']`), then immediately unsets that same key. PHP evaluates the RHS of the assignment first, so `[0]` briefly holds the wrapped copy — and then `unset()` deletes the whole `SharingGroup` entry, wrapped copy included. Nothing survives.

Contrast with the *event*-level wrap a few lines earlier in `convertArray()`, which reads from a distinct top-level location and writes into a different nested one, so there is no self-overwrite-then-delete:
```php
if (isset($event['SharingGroup'])) {
    $event['Event']['SharingGroup'][0] = $event['SharingGroup'];
}
```

**Reproduction performed:** ran the pinning test directly inside the running container:
```
podman exec -w /var/www/MISP/app mispapp bash -lc "./Vendor/bin/phpunit --configuration phpunit.xml --filter testConvertArrayDropsAnAttributesSharingGroupEntirely Test/Unit/Tools/ConverterToolsTest.php --testdox"
```
→ `OK (1 test, 1 assertion)`: an attribute with a `SharingGroup` produced XML with no `SharingGroup` key at all. Test: `testConvertArrayDropsAnAttributesSharingGroupEntirely`.

I additionally re-verified against the *fixed* code with a standalone harness (`Configure`/`h()` stubbed, `XMLConverterTool` loaded directly, `php -l` clean) feeding `convertArray()` an event whose attribute has a `SharingGroup`:
```
SharingGroup key present: bool(true)
SharingGroup[0][name]:   string(2) "SG"
```

**User-visible impact:** every attribute-level SharingGroup is silently missing from any XML export (`EventsController`'s XML export path → `XMLConverterTool::convertArray()`), even when the underlying event genuinely has one.

**Fix:**
```php
if (isset($attributes[$key]['SharingGroup'])) {
    $sharingGroup = $attributes[$key]['SharingGroup'];
    $attributes[$key]['SharingGroup'] = array(0 => $sharingGroup);
}
```
A temp variable breaks the read/write/delete collision; no `unset()` is needed since we overwrite the same key with its wrapped form. This is the same "stash, then reassign" shape as the event-level code, translated to a single-location key instead of two distinct ones.

**Alternatives rejected:** writing to a differently-named key (mirroring the event-level code's *two-location* pattern literally) would require call-site changes wherever `Attribute['SharingGroup']` is read downstream (recursive XML rendering, other export consumers) for no behavioural benefit over the temp-variable form, which is a strictly local, minimal-diff fix.

**⚠️ BEHAVIOUR CHANGE:** attribute-level `SharingGroup` will now appear in XML exports where it was previously always absent. `Test/Unit/Tools/ConverterToolsTest.php::testConvertArrayDropsAnAttributesSharingGroupEntirely` (on the `test-coverage-foundation` branch, not part of this PR) currently asserts the *old, broken* behaviour and will fail once this merges — it needs its assertion flipped from `assertArrayNotHasKey` to a positive check, which is exactly the KNOWN-DEFECT annotation update mentioned above.

---

## 2. `RelatedAttribute` enrichment guard references an undefined `$event` (dead code — removed, not fixed)

**Current code:**
```php
private function __rearrangeAttributes($attributes)
{
    foreach ($attributes as $key => $value) {
        unset($attributes[$key]['value1'], $attributes[$key]['value2'], $attributes[$key]['category_order']);
        if (isset($event['Event']['RelatedAttribute']) && isset($event['Event']['RelatedAttribute'][$value['id']])) {
            $attributes[$key]['RelatedAttribute'] = $event['Event']['RelatedAttribute'][$value['id']];
            foreach ($attributes[$key]['RelatedAttribute'] as &$ra) {
                $ra = array('Attribute' => array(0 => $ra));
            }
        }
        ...
```

**Mechanism:** `__rearrangeAttributes($attributes)` takes no `$event` parameter, captures no closure, and has no `global $event` — `$event` is simply undefined in this scope. `isset()` on an undefined variable evaluates `false` (no fatal), so this branch can never execute.

**Root cause (git blame):** this method was extracted from an inline loop that used to live directly inside `convertArray()`, where `$event` genuinely was in scope (see history around commit `864b6807`). The extraction into a private helper dropped `$event` from the parameter list without updating the guard, silently orphaning the branch.

**Reproduction performed:**
```
podman exec -w /var/www/MISP/app mispapp bash -lc "./Vendor/bin/phpunit --configuration phpunit.xml --filter testConvertArrayNeverPopulatesRelatedAttributeBecauseEventIsUndefinedInsideTheHelper Test/Unit/Tools/ConverterToolsTest.php --testdox"
```
→ `OK (1 test, 1 assertion)`: an event with `Event.RelatedAttribute` populated for the attribute's id still produced an `Attribute` node with no `RelatedAttribute` key. Test: `testConvertArrayNeverPopulatesRelatedAttributeBecauseEventIsUndefinedInsideTheHelper`.

**Why this is removed, not restored:** simply adding `$event` as a parameter and passing it in at the two call sites would *not* actually restore the enrichment. `convertArray()` unsets `$event['Event']['RelatedAttribute']` (line ~134) *before* either call to `__rearrangeAttributes()` (lines ~146/~151), so by the time the helper would run, the data it needs is already gone regardless of the `$event` scoping bug. Making the guard "work" without also relocating that `unset()` — a second, independent behavioural change with its own risk — would still be a silent no-op. Given no evidence of which behaviour (working enrichment, vs. its current absence) is actually desired going forward, and that the branch is inert either way, the smallest safe change is deleting the dead branch outright.

**User-visible impact of the removal:** none — this reproduces the *existing* observable behaviour (`RelatedAttribute` never appears on an attribute node), it does not change it. Confirmed with the same standalone harness used above: `RelatedAttribute key present: bool(false)` both before and after this change.

**Not a behaviour change.** `testConvertArrayNeverPopulatesRelatedAttributeBecauseEventIsUndefinedInsideTheHelper` continues to pass unmodified against this code (its assertion — the key is absent — remains true).

**Possible follow-up (out of scope here):** if attribute-level `RelatedAttribute` enrichment in XML exports is actually wanted, it would need `$event`'s relevant slice passed into `__rearrangeAttributes()` *and* the `unset($event['Event']['RelatedAttribute'])` in `convertArray()` moved to after both call sites (or the needed data captured before the unset). That's a real feature-restoration change, not a bug fix, so it's left for a separate discussion/PR.

---

## 3. `IOCExportTool::getResult()` is dead code that warns on an undefined property

**Current code** (`app/Lib/Tools/IOCExportTool.php`):
```php
public function getResult()
{
    return $this->__final;
}
```

**Mechanism:** `$this->__final` is never assigned anywhere in the class (there is no `__final` property and no other method sets one), so calling this emits `Undefined property: IOCExportTool::$__final` and returns `null`.

**Reproduction performed:** standalone harness inside the container:
```
podman exec -w /var/www/MISP/app mispapp php -r 'require_once "Lib/Tools/IOCExportTool.php"; $caught=null; set_error_handler(function($e,$s) use (&$caught){$caught=$s;return true;}, E_WARNING); $r=(new IOCExportTool())->getResult(); restore_error_handler(); var_dump($caught,$r);'
```
→ `string(43) "Undefined property: IOCExportTool::$__final"` / `NULL`.

Also confirmed by the pinning test: `testGetResultIsDeadCodeThatWarnsOnAnUndefinedProperty` in `Test/Unit/Tools/ConverterToolsTest.php` — `OK (1 test, 1 assertion)`.

**Caller search:** `grep -rn getResult app --include=*.php --include=*.ctp --exclude-dir=Vendor --exclude-dir=tmp --exclude-dir=webroot --exclude-dir=Test` returns only the method's own definition — no call site anywhere in PHP or CTP source, including no string-literal (`'getResult'`) dispatch. `IOCExportTool` is used elsewhere (`EventsController.php`, `IOCExportComponent.php`) exclusively via `buildAll()`/`convert()`.

**User-visible impact:** none currently — no caller exists. If ever called, it would emit a PHP warning and return `null` instead of a built document.

**Fix:** removed the method outright. No evidence exists (in source or in any caller) of what `$this->__final` was ever supposed to be assigned from, so there's no safe way to "fix" it into working code, and nothing consumes it.

**Not a behaviour change** for any real caller (there are none); `testGetResultIsDeadCodeThatWarnsOnAnUndefinedProperty` on the other branch will need updating to reflect the method's removal (e.g. asserting `method_exists` is now `false`) — flagged for the same test-annotation follow-up as above.

---

## Why this analysis might be wrong

- **SharingGroup fix scope:** I only verified the wrap survives structurally (`SharingGroup[0]['name'] === 'SG'`) via a standalone harness, not a full XML render through `recursiveEcho()` against a live MISP instance's actual export endpoint. If some downstream consumer of the XML export specifically depended on attribute-level `SharingGroup` being absent (unlikely, but not something I could rule out by static search alone), this is a behaviour change that could surprise it.
- **RelatedAttribute removal vs. restoration:** I concluded deletion is safer than restoration because of the `unset()` ordering in `convertArray()`, but I did not exhaustively check every historical commit for intent — it's possible a maintainer intended the enrichment to work and would prefer the ordering bug fixed instead of the branch deleted. I flagged this explicitly as a possible follow-up rather than guessing.
- **getResult() removal:** the caller search covers `.php`/`.ctp` under `app/`, excluding `Vendor`/`tmp`/`webroot`/`Test`. It does not cover PyMISP, JS, or any external/third-party integration that might call into MISP's PHP reflectively (very unlikely for a private-ish internal Tool class, but not something I can rule out with 100% certainty from static grep alone).
- I did not run the full `ConverterToolsTest.php` suite against this exact diff (it lives on another branch not merged into `2.5`); verification was done via the file-copy-into-`app/tmp` + standalone-harness method described above, following this repo's documented workaround for linting/testing a worktree file against the container's bind-mounted main clone.

---

## Testing

- `php -l` clean on both changed files (via the running `mispapp` container).
- Standalone harness reproduction of all three defects against the pre-fix code, and confirmation of the fixed behaviour against the post-fix code (see above).
- Full pinning suite (`Test/Unit/Tools/ConverterToolsTest.php`, 47 tests) run against pre-fix code on `test-coverage-foundation` passes clean, confirming the pre-fix characterization exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

