### PR TITLE
[low] chg: [export:bro] expose the Bro header through header(), like every other export

### DIFF
--- a/app/Lib/Export/BroExport.php
+++ b/app/Lib/Export/BroExport.php
@@ -140,6 +140,35 @@ class BroExport
 
     private $whitelist = null;
 
+	/**
+	 * The '#fields ...' line that opens a Bro/Zeek intel file.
+	 *
+	 * Every other class in app/Lib/Export exposes its header through this
+	 * method; BroExport held the same string in a public property instead, so
+	 * callers had to know it was the one export tool to reach into rather than
+	 * call. The property is kept so nothing outside the repository breaks.
+	 *
+	 * No trailing newline: separator() supplies it, exactly as it does between
+	 * the rules that follow.
+	 */
+	public function header($options = array())
+	{
+		return $this->header;
+	}
+
+	/**
+	 * Deliberately a no-op.
+	 *
+	 * 'bro' is not present in any model's $validFormats, so restSearch() never
+	 * reaches this class - MispAttribute::bro() and Job.php call export()
+	 * directly instead. Implementing this method would mean deciding how a
+	 * single event maps onto Bro intel lines, which is a feature, not a fix.
+	 *
+	 * Do NOT add 'bro' to a $validFormats map until it is implemented: with
+	 * this returning null, restSearch()'s `if ($temp !== '')` guard is true, so
+	 * every event would append an empty line and the export would silently
+	 * yield a header and nothing else.
+	 */
 	public function handler($data, $options = array())
 	{
 

--- a/app/Model/MispAttribute.php
+++ b/app/Model/MispAttribute.php
@@ -3934,7 +3934,7 @@ class MispAttribute extends AppModel
         natsort($intel);
         $intel = array_unique($intel);
         if (empty($skipHeader)) {
-            array_unshift($intel, $export->header);
+            array_unshift($intel, $export->header());
         }
         return $intel;
     }


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `BroExport` gains a `header()` method so it matches every other export's interface.

- **Problem** — `BroExport` is the only class in `app/Lib/Export` that exposes its header as a public property rather than through a `header()` method, so `MispAttribute.php` reaches into `$export->header` for this one export while calling `header()` on every other.
- **Fix** — Add the method returning the same string, update the single in-tree caller, and document the precondition, keeping the property so external callers still work.
- **Effect** — Emitted intel files are byte-identical; this is an interface-consistency change with no user-visible effect.
<!-- /bluf -->

`BroExport` is the only class in `app/Lib/Export` that does not expose its header through a `header()` method. It holds the string in a public property instead, so callers have to know it is the exception:

```php
// app/Model/MispAttribute.php:3937 — reaches into the property
array_unshift($intel, $export->header);

// app/Model/MispAttribute.php:3765 — calls the method on everything else
$tmpfile->write($exportTool->header($exportToolParams));
```

This adds the method, returns the same string, and updates the one in-tree caller. The property stays, so nothing outside this repository breaks.

No trailing newline is added — `separator()` supplies it, exactly as it does between the rules that follow — so the emitted intel file is byte-identical. Verified: `header() === $export->header` is `true`, and the returned value does not end in a newline.

## Why `handler()` is left as a no-op

`BroExport::handler()` has an empty body and returns `null`. It is tempting to treat "add `header()`" as completing the export-tool interface, and it is not.

`bro` is absent from every model's `$validFormats`, so `Event::restSearch()` and `MispAttribute::restSearch()` never reach this class — `MispAttribute::bro()` and `Job.php:63` call `export()` directly. If somebody added `bro` to a `$validFormats` map today, `restSearch()` would fatal on `header()` being undefined.

Adding `header()` removes that fatal — and **that is precisely the risk**. `restSearch()` guards each element with `if ($temp !== '')`, which is true for `null`, so every event would append an empty line through `writeWithSeparator()` and the export would silently produce a header followed by nothing. A loud fatal is better than a quiet wrong answer.

So this PR states the precondition in a docblock rather than removing the guard rail. Implementing `handler()` properly means deciding how a single event maps onto Bro intel lines, which is a feature and belongs in its own change.

## Why this analysis might be wrong

- **The property may be read outside this repository.** MISP modules, custom exports or downstream forks could use `$export->header`. That is why the property is kept and only the in-tree caller moved; the change is additive.
- **Maintainers may prefer the property and consider the inconsistency deliberate**, on the grounds that `BroExport` is not a restSearch export tool at all and should not look like one. That is a coherent position — in which case the useful half of this PR is the `handler()` docblock, and the rest can be dropped.
- **`header()` shadows the property name.** PHP allows a method and property with the same name, and both are now public. That is legal and unambiguous, but if MISP would rather rename the property (e.g. `$headerLine`) I am happy to do that instead.

## Context

Found while writing unit tests for the export classes that the existing contract suite leaves uncovered. A companion PR, #11015, fixes two live PHP 8 deprecations in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

