### PR TITLE
[high] fix: [export:hosts] use the loop variable in Event scope

### DIFF
--- a/app/Lib/Export/HostsExport.php
+++ b/app/Lib/Export/HostsExport.php
@@ -28,8 +28,8 @@ class HostsExport
         if ($options['scope'] === 'Event') {
             $result = array();
             foreach ($data['Attribute'] as $attribute) {
-                if ($this->isNewDomain($data['Attribute'])) {
-                    $result[] = $this->__convertToRule($data['Attribute']);
+                if ($this->isNewDomain($attribute)) {
+                    $result[] = $this->__convertToRule($attribute);
                 }
             }
             return implode($this->separator(), $result) . "\n";


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** The `hosts` export emits one empty line per event instead of one entry per domain.

- **Problem** — `HostsExport::handler()` passes the whole `$data['Attribute']` list to `isNewDomain()` and `__convertToRule()` instead of the loop variable `$attribute`, so both helpers read a non-existent `value` key.
- **Fix** — Use the loop variable in the Event-scope branch; this is the same defect already corrected in `CacheExport`.
- **Effect** — `GET /events/restSearch?returnFormat=hosts` returns one host entry per attribute rather than a single empty `0.0.0.0 ` line plus undefined-key warnings on PHP 8, which the first cached empty domain caused.
<!-- /bluf -->

`HostsExport::handler()` iterates `$data['Attribute']` but passes the whole attribute *list* to `isNewDomain()` and `__convertToRule()` instead of the loop variable `$attribute`.

```php
foreach ($data['Attribute'] as $attribute) {
    if ($this->isNewDomain($data['Attribute'])) {          // <- list, not $attribute
        $result[] = $this->__convertToRule($data['Attribute']);
    }
}
```

Both helpers read `$attribute['value']`, which does not exist on a numerically indexed list, so on PHP 8 each iteration raises an `Undefined array key "value"` warning and evaluates to `null`.

**Scenario:** `GET /events/restSearch` with `returnFormat=hosts`. `Event::restSearch` sets `scope => 'Event'` and calls the handler once per event. `isNewDomain(null)` caches `addedDomain[''] = true` on the first iteration and returns `false` for every later one, so an event with N domain attributes emits a single `0.0.0.0 ` line rather than N host entries.

This is the same defect class already fixed in `CacheExport`; the Attribute-scope branch above it is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

