### PR TITLE
[high] fix: [export:kunai] return a string from the Event scope branch

### DIFF
--- a/app/Lib/Export/KunaiExport.php
+++ b/app/Lib/Export/KunaiExport.php
@@ -119,7 +119,7 @@ class KunaiExport
                 $temp = $this->__convertAttribute($attribute, $data['Event']);
                 if ($temp) $result[] = $temp;
             }
-            return $result;
+            return implode($this->separator(), $result);
         }
         return '';
     }


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** The `kunai` return format cannot produce a usable body for event exports.

- **Problem** — `KunaiExport::handler()` returns a PHP array from its Event-scope branch while the export contract requires a string, unlike `HashesExport`, `CacheExport` and `HostsExport` which `implode`.
- **Fix** — Join the results with the export's own `separator()`, matching the surrounding brackets.
- **Effect** — `GET /events/restSearch?returnFormat=kunai` emits valid JSON instead of reaching `TmpFileTool::write()` with an array, which gives a `TypeError` on the first event and array-to-string conversion afterwards.
<!-- /bluf -->

`KunaiExport::handler()` returns a PHP **array** from its Event-scope branch, while the export tool contract is a `string` (or a `Generator`). Every other export — `HashesExport`, `CacheExport`, `HostsExport` — ends that branch with an `implode()`.

```php
if ($options['scope'] === 'Event') {
    $result = [];
    foreach ($data['Attribute'] as $attribute) {
        $temp = $this->__convertAttribute($attribute, $data['Event']);
        if ($temp) $result[] = $temp;
    }
    return $result;   // <- array
}
```

**Scenario:** `GET /events/restSearch?returnFormat=kunai` over more than zero events (`kunai` is registered in `Event::$validFormats`). `Event::restSearch` does:

```php
$temp = $exportTool->handler($event, $exportToolParams);
if ($temp !== '') {
    $tmpfile->writeWithSeparator($temp, $separator);
}
```

An array is `!== ''` and is not a `Generator`, so `TmpFileTool::writeWithSeparator()` falls through to `$this->write($content)` on the first event — `fwrite()` with an array argument, which is a `TypeError` on PHP 8 — and to `$this->write($this->separator . $content)` on subsequent ones, which is an `Array to string conversion`. Either way the `kunai` return format cannot produce a usable body.

The fix joins with the export's own `separator()` (`', '`), matching the `[` / `]` header and footer so the result is valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

