### PR TITLE
[high] fix: [feed] publish_timestamp pull rule filters on Event.timestamp

### DIFF
--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -952,12 +952,13 @@ class Feed extends AppModel
         }
         if (!empty($url_params['publish_timestamp'])) {
             $timestamps = $this->Attribute->setTimestampConditions($url_params['publish_timestamp'], [], '', true);
+            $publishTimestamp = $event['publish_timestamp'] ?? 0;
             if (is_array($timestamps)) {
-                if ($event['timestamp'] < $timestamps[0] || $event['timestamp'] > $timestamps[1]) {
+                if ($publishTimestamp < $timestamps[0] || $publishTimestamp > $timestamps[1]) {
                     return false;
                 }
             } else {
-                if ($event['timestamp'] < $timestamps) {
+                if ($publishTimestamp < $timestamps) {
                     return false;
                 }
             }


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** The `publish_timestamp` feed pull rule filters on `Event.timestamp` instead.

- **Problem** — `Feed::passesURLParamFilters()` implements the `publish_timestamp` pull rule by comparing against `$event['timestamp']`, the last-modification time, because the block was copied from the `timestamp` rule above it.
- **Fix** — Read `publish_timestamp`, defaulting to `0` for manifest entries that lack the key.
- **Effect** — A feed with `url_params` `publish_timestamp` `7d` stops silently skipping recently published but long-unedited events and stops pulling year-old events that were merely re-edited, and the preview no longer agrees with the wrong result.
<!-- /bluf -->

`Feed::passesURLParamFilters()` implements the `publish_timestamp` pull rule by resolving the delta correctly, then comparing it against `$event['timestamp']` — the last-modification timestamp — instead of `$event['publish_timestamp']`. It is a copy of the `timestamp` block directly above it, with only the `$url_params` key changed.

```php
if (!empty($url_params['publish_timestamp'])) {
    $timestamps = $this->Attribute->setTimestampConditions($url_params['publish_timestamp'], [], '', true);
    if (is_array($timestamps)) {
        if ($event['timestamp'] < $timestamps[0] || $event['timestamp'] > $timestamps[1]) {
```

**Scenario:** a feed configured with the pull rule `url_params: {"publish_timestamp": "7d"}`.

* An event **published yesterday** but last edited two months ago is rejected — `__prepareEvent()` returns `'blocked'` via `__checkIfEventBlockedByFilter()` and the event is silently skipped by `downloadFromFeed()`.
* An event **published a year ago** but edited today is accepted.

Both directions are wrong, and the same function backs the feed preview through `__filterEventsIndex()`, so the preview agrees with the (incorrect) pull. Neither branch of the `is_array()` test ever reads the publish field.

The fix reads `publish_timestamp`, defaulting to `0` for manifest entries that do not carry the key so an unpublished event is filtered out rather than raising an undefined-key warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

