### PR TITLE
[high] fix: [feed] exact tag matches are inverted in the feed index filter

### DIFF
--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -896,13 +896,14 @@ class Feed extends AppModel
                 continue;
             }
             if (isset($filterRules['tags']['OR']) && !empty($filterRules['tags']['OR'])) {
-                if (!isset($event['Tag']) || empty($event['Tag'])) {
+                if (empty($event['Tag'])) {
                     unset($events[$k]);
+                    continue;
                 }
                 $found = false;
                 foreach ($event['Tag'] as $tag) {
                     foreach ($filterRules['tags']['OR'] as $filterTag) {
-                        if (strpos(strtolower($tag['name']), strtolower($filterTag))) {
+                        if (strpos(strtolower($tag['name']), strtolower($filterTag)) !== false) {
                             $found = true;
                         }
                     }
@@ -917,7 +918,7 @@ class Feed extends AppModel
                     $found = false;
                     foreach ($event['Tag'] as $tag) {
                         foreach ($filterRules['tags']['NOT'] as $filterTag) {
-                            if (strpos(strtolower($tag['name']), strtolower($filterTag))) {
+                            if (strpos(strtolower($tag['name']), strtolower($filterTag)) !== false) {
                                 $found = true;
                             }
                         }


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Exact tag matches are inverted in the feed index filter, so feeds show the wrong events.

- **Problem** — `Feed::__filterEventsIndex()` uses `strpos()` for truthiness, so an exact tag match at offset 0 counts as no match: an OR rule drops events that do match and a NOT rule keeps events that should be blocked. A second defect unsets an untagged event without `continue`, so execution falls into a `foreach` over a missing `Tag` key.
- **Fix** — Compare against `!== false` in both the OR and NOT loops and add the missing `continue`.
- **Effect** — The feed index and preview honour exact tag rules cleanly, and untagged events no longer raise PHP 8 errors.
<!-- /bluf -->

Two defects in `Feed::__filterEventsIndex()`, the function that applies a feed's tag rules to the manifest shown in the feed preview / index.

**1. `strpos()` result used for truthiness, so a match at offset 0 counts as no match.**

```php
if (strpos(strtolower($tag['name']), strtolower($filterTag))) {
    $found = true;
}
```

`strpos()` returns `0` for a prefix or exact match, which is falsy.

* OR rule `tlp:white` against an event tagged exactly `tlp:white` → `$found` stays `false` and the event is **dropped** from the index, even though it matches.
* NOT rule `tlp:red` against an event tagged exactly `tlp:red` → `$found` stays `false` and the event is **kept**, even though it is blocked.

The sibling function `__checkIfEventBlockedByFilter()` writes the same comparison as `stripos(...) !== false`, which confirms the intent.

**2. The "OR rule set but event has no tags" branch unsets without `continue`.**

```php
if (!isset($event['Tag']) || empty($event['Tag'])) {
    unset($events[$k]);
}
$found = false;
foreach ($event['Tag'] as $tag) {   // reached with $event['Tag'] missing
```

Execution falls straight into the `foreach`, so every untagged event in the manifest emits an `Undefined array key "Tag"` warning plus `foreach() argument must be of type array|object, null given` on PHP 8.

The fix compares against `!== false` in both the OR and NOT loops and adds the missing `continue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

