### PR TITLE
[high] fix: [warninglist] Redis-less fallback reads the stale attribute copy

### DIFF
--- a/app/Model/Warninglist.php
+++ b/app/Model/Warninglist.php
@@ -127,7 +127,7 @@ class Warninglist extends AppModel
             foreach ($attributes as $pos => $attribute) {
                 $attributes[$pos] = $this->checkForWarning($attribute, $enabledWarninglists);
                 if (isset($attributes[$pos]['warnings'])) {
-                    foreach ($attribute['warnings'] as $match) {
+                    foreach ($attributes[$pos]['warnings'] as $match) {
                         $eventWarnings[$match['warninglist_id']] = $match['warninglist_name'];
                     }
                 }


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Without Redis, event-level warninglist summaries and entry comments silently disappear.

- **Problem** — In the Redis-less fallback of `Warninglist::attachWarninglistToAttributes()`, the loop tests the freshly returned array but then iterates the stale by-value copy `$attribute`, which never gains a `warnings` key because `checkForWarning()` returns a new array.
- **Fix** — Iterate the updated element instead of the stale copy.
- **Effect** — On instances where `RedisTool::init()` throws, event warnings and warninglist entry comments appear again, and matching attributes stop emitting undefined-key and foreach-on-null errors on PHP 8.
<!-- /bluf -->

In the Redis-less fallback of `Warninglist::attachWarninglistToAttributes()` the guard tests the freshly returned array but the loop body iterates the stale by-value copy:

```php
foreach ($attributes as $pos => $attribute) {
    $attributes[$pos] = $this->checkForWarning($attribute, $enabledWarninglists);
    if (isset($attributes[$pos]['warnings'])) {
        foreach ($attribute['warnings'] as $match) {     // <- $attribute, not $attributes[$pos]
            $eventWarnings[$match['warninglist_id']] = $match['warninglist_name'];
        }
    }
}
```

`checkForWarning()` takes its argument by value and returns a **new** array, so `$attribute` is the pre-call copy and never gains a `warnings` key.

**Scenario:** an instance where `RedisTool::init()` throws — Redis down, or the `redis` extension not installed — which is the only path that reaches this branch. `Event::fetchEvent()` assigns `$event['warnings'] = $eventWarnings` from the return value, so:

* the event-level warning summary is permanently empty, even though the per-attribute warnings still attach correctly;
* `$eventWarnings` stays empty, so `assignComments($attributes)` is never called and warninglist entry comments disappear;
* every attribute that *did* match emits `Undefined array key "warnings"` followed by `foreach() argument must be of type array|object, null given` on PHP 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

