### PR TITLE
[high] fix: [dashboard] site admins cannot create an unrestricted template via the API

### DIFF
--- a/app/Model/Dashboard.php
+++ b/app/Model/Dashboard.php
@@ -256,7 +256,7 @@ class Dashboard extends AppModel
                 'user_id' => $user['id'],
                 'uuid' => CakeText::uuid()
             );
-            if (empty($user['role']['perm_site_admin'])) {
+            if (empty($user['Role']['perm_site_admin'])) {
                 $data['restrict_to_org_id'] = $user['org_id'];
             }
         }


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Site admins cannot create an unrestricted dashboard template through the API.

- **Problem** — `Dashboard::saveTemplate()` checks `$user['role']['perm_site_admin']` with a lower-case key while the auth array uses `Role`, so the check is always empty and every template is pinned to the creator's organisation.
- **Fix** — Correct the key so the site-admin branch is actually reached.
- **Effect** — A site admin posting to `/dashboards/saveTemplate` no longer silently gets an org-restricted row that `getDashboardTemplate()` hides from every other organisation; the web form was unaffected because it always posts `restrict_to_org_id`.
<!-- /bluf -->

`Dashboard::saveTemplate()` reads the role with a lower-case key when deciding whether to pin a new template to the creator's organisation:

```php
if (empty($user['role']['perm_site_admin'])) {
    $data['restrict_to_org_id'] = $user['org_id'];
}
```

The auth-user array uses the capitalised `Role` key — the very same function reads `$user['Role']['perm_site_admin']` 22 lines earlier when widening `$editableFields`. `$user['role']` is therefore always undefined, `empty()` is always true, and the org restriction is applied unconditionally.

**Scenario:** a site admin creates an instance-wide dashboard template over the API — `POST /dashboards/saveTemplate` with `name`, `description` and `selectable` but no explicit `restrict_to_org_id`. The row is silently saved with `restrict_to_org_id` set to the admin's own org, and `getDashboardTemplate()` then returns `array()` for every user in any other organisation, so the template never appears in their gallery.

The web form masks the bug because its site-admin fieldset always posts a `restrict_to_org_id` value, which the `$editableFields` loop below overwrites it with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

