### PR TITLE
[high] fix: [workflow] the invalid-start-node guard runs after the dereference it protects

### DIFF
--- a/app/Model/Workflow.php
+++ b/app/Model/Workflow.php
@@ -499,10 +499,8 @@ class Workflow extends AppModel
         $workflow = $this->fetchWorkflow($workflow_id, true);
         $graphData = !empty($workflow['Workflow']) ? $workflow['Workflow']['data'] : $workflow['data'];
         $startNode = $this->workflowGraphTool->extractTriggerFromWorkflow($graphData, true);
-        $startNodeID = $startNode['id'];
-        $trigger_id = $startNode['data']['id'];
-        if ($startNode  == -1) {
-            $message = __('Invalid start node `%s`', $startNodeID);
+        if (empty($startNode) || !isset($startNode['id']) || !isset($startNode['data']['id'])) {
+            $message = __('Invalid start node for workflow `%s`', $workflow_id);
             $blockingErrors[] = $message;
             return [
                 'outcomeText' => 'failure' . sprintf(' %s', $message),
@@ -510,6 +508,8 @@ class Workflow extends AppModel
                 'success' => false,
             ];
         }
+        $startNodeID = $startNode['id'];
+        $trigger_id = $startNode['data']['id'];
 
         $triggerModule = $this->getModuleClassByType('trigger', $trigger_id, true);
         if (!empty($triggerModule->disabled)) {


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A workflow with no trigger node returns a 500 instead of the intended error.

- **Problem** — `Workflow::executeWorkflow()` dereferences the start node before the guard meant to protect it, and compares the node against `-1` when `extractTriggerFromWorkflow()` actually returns `null`, making the guard dead code.
- **Fix** — Move the guard ahead of the dereferences and test the values it actually needs.
- **Effect** — Executing a trigger-less workflow no longer raises array-offset-on-null notices and an uncaught `TypeError` in `walkGraph()`; the user gets the blocking `Invalid start node` message.
<!-- /bluf -->

`Workflow::executeWorkflow()` dereferences the start node **before** the guard meant to protect that dereference, and the guard compares against the wrong sentinel:

```php
$startNode = $this->workflowGraphTool->extractTriggerFromWorkflow($graphData, true);
$startNodeID = $startNode['id'];        // deref happens first
$trigger_id = $startNode['data']['id'];
if ($startNode  == -1) {                // can never be true
    $message = __('Invalid start node `%s`', $startNodeID);
```

`WorkflowGraphTool::extractTriggerFromWorkflow()` returns **`null`** when the graph contains no trigger node; `-1` is the sentinel of a different method, `getNodeIdForTrigger()`. So the check is wrong twice over: it runs after the dereferences it guards, and `null == -1` is `false` on PHP 8 (as is `array == -1` in the normal case). The branch is dead code.

**Scenario:** a workflow whose trigger node was deleted in the editor, or one imported from a blueprint that carries no trigger, executed through `WorkflowsController::executeWorkflow`. `$startNode` is `null`, both lines raise `Trying to access array offset on null`, `$trigger_id` becomes `null`, and execution proceeds into `__runWorkflow()` → `walkGraph(array $workflow, int $startNode, …)`, which raises an uncaught `TypeError`. The user gets a 500 instead of the intended blocking `Invalid start node` error the author wrote.

The fix moves the guard ahead of the dereferences and tests the values it actually needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

