### PR TITLE
[high] fix: [export:rpz] IPv6 CIDRs are emitted as malformed IPv4 rpz-ip records

### DIFF
--- a/app/Lib/Export/RPZExport.php
+++ b/app/Lib/Export/RPZExport.php
@@ -230,14 +230,13 @@ class RPZExport
 
     private function convertIp($input, $action)
     {
-        $isIpv6 = filter_var($input, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6);
-        if ($isIpv6) {
-            $prefix = '128';
-        } else {
-            $prefix = '32';
-        }
-        if (strpos($input, '/')) {
+        $prefix = null;
+        if (strpos($input, '/') !== false) {
             list($input, $prefix) = explode('/', $input);
+        }
+        $isIpv6 = (bool)filter_var($input, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6);
+        if ($prefix === null) {
+            $prefix = $isIpv6 ? '128' : '32';
         }
         $converted = $isIpv6 ? $this->__ipv6($input) : $this->__ipv4($input);
         return $prefix . '.' . $converted . '.rpz-ip CNAME ' . $action . PHP_EOL;
@@ -245,7 +244,7 @@ class RPZExport
 
     private function __ipv6($input)
     {
-        return implode('.', array_reverse(preg_split('/:/', str_replace('::', ':zz:', $input), null, PREG_SPLIT_NO_EMPTY)));
+        return implode('.', array_reverse(preg_split('/:/', str_replace('::', ':zz:', $input), -1, PREG_SPLIT_NO_EMPTY)));
     }
 
     private function __ipv4($input)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** RPZ export emits malformed `rpz-ip` records for IPv6 CIDRs, which BIND can reject.

- **Problem** — `RPZExport::convertIp()` runs `filter_var()` before stripping the CIDR netmask, so an IPv6 CIDR like `2001:db8::/48` is never detected as IPv6 and is handed to `__ipv4()`, producing a malformed `rpz-ip` line that BIND rejects and that can break the whole zone load.
- **Fix** — Strip the netmask first, then detect the version, and replace the PHP 8.1-deprecated `null` limit in `__ipv6()`'s `preg_split`.
- **Effect** — RPZ exports of IPv6 CIDR attributes become valid zone data instead of one bad record poisoning the feed.
<!-- /bluf -->

`RPZExport::convertIp()` decides the IP version **before** stripping the CIDR netmask, so `filter_var()` always sees a value like `2001:db8::/48` and rejects it:

```php
$isIpv6 = filter_var($input, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6);   // "/48" still attached
...
if (strpos($input, '/')) {
    list($input, $prefix) = explode('/', $input);
}
$converted = $isIpv6 ? $this->__ipv6($input) : $this->__ipv4($input);
```

**Scenario:** an `ip-dst` (or `ip-src`) attribute holding `2001:db8::/48` — MISP accepts CIDR notation for those types — exported via `/events/restSearch?returnFormat=rpz`. `$isIpv6` is `false`, the prefix is then correctly extracted as `48`, but the address is handed to `__ipv4()`, whose `explode('.', '2001:db8::')` returns a single element. The emitted record is

```
48.2001:db8::.rpz-ip CNAME .
```

instead of the required reversed-nibble `rpz-ip` form. That is not a valid zone line, so BIND rejects the record and, depending on configuration, the whole RPZ zone fails to load — one bad attribute breaks the entire feed. Bare (non-CIDR) IPv6 addresses are unaffected, which is why this has gone unnoticed.

The fix splits the netmask off first, then tests the address, and only falls back to the `/128` `/32` defaults when no prefix was supplied.

Also folded in: `preg_split(..., null, PREG_SPLIT_NO_EMPTY)` in `__ipv6()` passes `null` for the `int $limit` parameter, which is deprecated since PHP 8.1 and emits a notice on every IPv6 line produced. `-1` is the documented default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

