### PR TITLE
[high] fix: [gc] garbage collection deletes in-flight script temp files

### DIFF
--- a/app/Model/AdminSetting.php
+++ b/app/Model/AdminSetting.php
@@ -83,6 +83,7 @@ class AdminSetting extends AppModel
         }
         if ((time()) > ($last_collection + 3600)) {
             $this->__cleanTmpFiles();
+            $this->changeSetting('last_gc_timestamp', time());
         }
     }
 
@@ -103,7 +104,6 @@ class AdminSetting extends AppModel
                 if ($time > $tmp_file->lastChange() + 3600) {
                     $tmp_file->delete();
                 }
-                unlink($scripts_tmp_path . '/' . $file);
             }
         }
     }


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Garbage collection deletes in-flight script temp files.

- **Problem** — `AdminSetting::__deleteScriptTmpFiles()` calls a bare `unlink()` outside its one-hour age guard, so collection deletes every temp file in `app/files/scripts/tmp`, including ones a running STIX sighting import just wrote for a Python child process. Separately the hourly throttle never engages, because `last_gc_timestamp` is read but never written.
- **Fix** — Removes the unguarded `unlink()` and records the collection timestamp.
- **Effect** — In-flight temp files stop vanishing mid-import, and the directory walk runs at most hourly.
<!-- /bluf -->

Two defects in `AdminSetting`'s automatic garbage collection.

**1. `__deleteScriptTmpFiles()` unlinks every matching file regardless of age.**

```php
$tmp_file = new File($scripts_tmp_path . '/' . $file);
if ($time > $tmp_file->lastChange() + 3600) {
    $tmp_file->delete();
}
unlink($scripts_tmp_path . '/' . $file);   // outside the age check
```

The one-hour age guard is bypassed by the bare `unlink()` below it, so *every* file in `app/files/scripts/tmp` matching `^[a-zA-Z0-9]{12}$` is removed — and files that were old enough are deleted twice, emitting `unlink(): No such file or directory`.

Two producers write exactly that filename shape into exactly that directory and then hand the path to a Python process:

* `Sighting::handleStixSighting()` — `stixsighting2misp.py`
* `OpendataExport::__generateSetupFile()`

**Scenario:** `MISP.enable_automatic_garbage_collection` is on. A STIX sighting import is running; a concurrent web request wins the 1-in-100 draw in `AppController` and calls `garbageCollect()`, which unlinks the import's freshly written temp file out from under the still-running script. `File::delete()` already performs the unlink, so the extra call is pure collateral damage.

**2. The hourly throttle never engages.**

`garbageCollect()` reads the `last_gc_timestamp` setting, but nothing in the codebase ever writes it — `AdminSetting.php:76` is the only occurrence in the tree. `$last_collection` is therefore always `0`, `time() > 0 + 3600` is always true, and the full directory walk runs on every draw instead of at most hourly. The fix records the timestamp after a collection so the guard behaves as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

