### PR TITLE
[critical] fix: [shibboleth] a documented DefaultRole of false strips every user's role

### DIFF
--- a/app/Plugin/ShibbAuth/Controller/Component/Auth/ApacheShibbAuthenticate.php
+++ b/app/Plugin/ShibbAuth/Controller/Component/Auth/ApacheShibbAuthenticate.php
@@ -119,7 +119,10 @@ class ApacheShibbAuthenticate extends BaseAuthenticate
             return false; // Deny if the user is not in any egroup
         }
         // if a default role is set, override the currently parsed out selection and use that instead.
-        $roleId = Configure::check('ApacheShibbAuth.DefaultRole') ? Configure::read('ApacheShibbAuth.DefaultRole') : $roleId;
+        $defaultRole = Configure::read('ApacheShibbAuth.DefaultRole');
+        if (!empty($defaultRole)) {
+            $roleId = $defaultRole;
+        }
         if ($roleChanged) {
             CakeLog::write('info', "User role $roleId assigned.");
         }


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A documented Shibboleth `DefaultRole` of false strips every user's role.

- **Problem** — `ApacheShibbAuthenticate::getUser()` overrides the group-derived role via `Configure::check('ApacheShibbAuth.DefaultRole')`, but `check()` returns true for a configured value of `false`, which is exactly the example in the class docblock. An admin following that documentation has `$roleId` clobbered to `false` after egroup matching, so `updateUserRole()` writes `role_id = 0` for every returning user; a first-time user instead fails `User::save()` validation.
- **Fix** — Treats an empty or false `DefaultRole` as unset, as the docblock describes.
- **Effect** — Users keep the role their egroup resolves to, and first logins succeed.
<!-- /bluf -->

`ApacheShibbAuthenticate::getUser()` overrides the group-derived role with the `DefaultRole` setting using `Configure::check()`:

```php
$roleId = Configure::check('ApacheShibbAuth.DefaultRole') ? Configure::read('ApacheShibbAuth.DefaultRole') : $roleId;
```

`Configure::check()` is implemented as `Hash::get($values, $var) !== null`, so it returns **true** for a configured value of `false`. The class's own docblock documents the setting exactly that way:

```php
'DefaultRole' => false, // set to a specific value if you wish to hard-set users
```

An administrator who copies that documented example therefore gets `check()` → `true`, `read()` → `false`, and `$roleId` is clobbered to `false` *after* the egroup matching has already computed the correct role.

**Scenario:** an existing Shibboleth user in egroup `admin` (role 1) logs in. `getUserRoleFromGroup()` returns `[true, 1]`; the line above overwrites `$roleId` with `false`; `updateUserRole()` then evaluates `'1' != false` as true and calls `updateField($user, 'role_id', false)`, writing `role_id = 0`. The user loses every permission on the instance.

For a first-time user the same `false` lands in `$userData['role_id']`, `User::save()` fails validation, `_findUser()` returns `false`, and `extralog(false, 'login')` dereferences a bool.

The sibling `BlockRoleModifications` / `BlockOrgModifications` settings use the same idiom but are harmless because their fallback is also `false`; `DefaultRole` is the one place where the pattern is wrong. `config.default.php` does not ship the key, so this only bites installs that follow the plugin's own documentation.

The fix treats an empty/false `DefaultRole` as "not set", which is what the docblock describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

