### PR TITLE
[high] fix: [acl] stray asterisk makes feeds/previewEventAttributes site-admin only

### DIFF
--- a/app/Controller/Component/ACLComponent.php
+++ b/app/Controller/Component/ACLComponent.php
@@ -470,7 +470,7 @@ class ACLComponent extends Component
             'index' => ['*'],
             'loadDefaultFeeds' => array(),
             'previewEvent' => ['*'],
-            'previewEventAttributes' => ['theming_enabled*'],
+            'previewEventAttributes' => ['theming_enabled'],
             'previewEventObjects' => ['theming_enabled'],
             'previewIndex' => ['*'],
             'searchCaches' => ['*'],


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A stray asterisk in the feeds ACL makes `previewEventAttributes` site-admin only.

- **Problem** — The feeds section of `ACLComponent::$aclList` lists `previewEventAttributes` under `theming_enabled*`, which is neither the wildcard token `checkAccess()` looks for nor a registered dynamic check. Resolution falls through to an undefined `Role` key, evaluates falsy, reaches the `perm_site_admin` test and throws `ForbiddenException`.
- **Fix** — Removes the stray character.
- **Effect** — A non-site-admin opening a feed preview no longer gets a 403 on the Attributes tab's ajax call and sees it stay empty while the Objects tab beside it loads.
<!-- /bluf -->

`ACLComponent::$aclList['feeds']` carries a stray asterisk in one permission token:

```php
'previewEvent'           => ['*'],
'previewEventAttributes' => ['theming_enabled*'],   // <- typo
'previewEventObjects'    => ['theming_enabled'],
```

`'theming_enabled*'` is not the wildcard form (`checkAccess()` tests `in_array('*', $rules, true)`, so the token must *be* `'*'`), it is not an `AND`/`OR` rule, and it is not a key in `$this->dynamicChecks` — the constructor registers only `theming_enabled`. Resolution therefore falls through to `$user['Role']['theming_enabled*']`, an undefined array key: PHP 8 emits a warning, the value is falsy, and the method drops to the final `perm_site_admin` check and throws `ForbiddenException`.

**Scenario:** a normal (non-site-admin) user opens a feed preview — `previewIndex` and `previewEvent` are both `['*']`, so they reach the page. `app/View/Themed/Overmind/Feeds/preview_event.ctp` then lazily fetches `/feeds/previewEventAttributes/...` over ajax, which returns 403 and leaves the Attributes tab permanently empty, while the correctly spelled Objects tab beside it loads fine.

I checked the whole `ACL_LIST` for permission tokens that are neither a `Role` column nor a registered dynamic check — this is the only occurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

