### PR TITLE
[high] fix: [decayingModel] $array(...) fatals in the enable/disable REST error branch

### DIFF
--- a/app/Controller/DecayingModelController.php
+++ b/app/Controller/DecayingModelController.php
@@ -463,7 +463,7 @@ class DecayingModelController extends AppController
                     $response = array('data' => $model, 'action' => 'enable');
                     return $this->RestResponse->viewData($response, 'application/json');
                 } elseif ($this->_isRest()) {
-                    $response = array('errors' => $array(__('Error while enabling decaying model')), 'action' => 'enable');
+                    $response = array('errors' => array(__('Error while enabling decaying model')), 'action' => 'enable');
                     return $this->RestResponse->viewData($response, 'application/json');
                 }
                 $this->Flash->error(__('Error while enabling decaying model'));
@@ -511,7 +511,7 @@ class DecayingModelController extends AppController
                     $response = array('data' => $model, 'action' => 'disable');
                     return $this->RestResponse->viewData($response, 'application/json');
                 } elseif ($this->_isRest()) {
-                    $response = array('errors' => $array(__('Error while enabling decaying model')), 'action' => 'disable');
+                    $response = array('errors' => array(__('Error while disabling decaying model')), 'action' => 'disable');
                     return $this->RestResponse->viewData($response, 'application/json');
                 }
                 $this->Flash->error(__('Error while disabling decaying model'));


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A `$array(...)` typo fatals the decaying model enable/disable REST error branch.

- **Problem** — `DecayingModelController::enable()` and `::disable()` build their REST error payload with `$array(...)` instead of `array(...)`. PHP treats that as a variable function call on an undefined variable, so on PHP 8 the branch fatals with "Value of type null is not callable" instead of returning the JSON error it exists to produce.
- **Fix** — Fixes both call sites and corrects the `disable()` message, which said "enabling".
- **Effect** — A REST client posting to `/decayingModel/enable/<id>` where the save fails gets the intended JSON error rather than a 500.
<!-- /bluf -->

`DecayingModelController::enable()` and `::disable()` both build their REST error payload with `$array(...)` instead of `array(...)`:

```php
} elseif ($this->_isRest()) {
    $response = array('errors' => $array(__('Error while enabling decaying model')), 'action' => 'enable');
    return $this->RestResponse->viewData($response, 'application/json');
}
```

`$array` is never defined anywhere in the file. PHP parses `$array(...)` as a **variable function call**, so on PHP 8 this raises `Undefined variable $array` and then throws `Error: Value of type null is not callable` — a fatal, instead of the JSON error payload the branch exists to produce.

**Scenario:** a REST (non-ajax) client POSTs `/decayingModel/enable/<id>` or `/decayingModel/disable/<id>` and `DecayingModel::save()` returns false. `DecayingModel::beforeValidate()` returns `false` when `attribute_types` or `parameters` is a non-array string that fails `json_decode`, which is the realistic trigger on a hand-crafted or corrupted model row. The client gets a 500 with an uncaught `Error` rather than the intended `{"errors": [...], "action": "enable"}`.

The happy path never touches these lines, which is why the typo has survived; a grep over the whole controller tree shows these are its only two occurrences. The `disable()` message text is also corrected — it said "enabling".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

