### PR TITLE
[high] fix: [api] two REST branches discard their response instead of returning it

### DIFF
--- a/app/Controller/CorrelationsController.php
+++ b/app/Controller/CorrelationsController.php
@@ -163,9 +163,9 @@ class CorrelationsController extends AppController
                 $message = $result ? __('Table truncated.') : __('Could not truncate table');
                 if ($this->_isRest()) {
                     if ($result) {
-                        $this->RestResponse->saveSuccessResponse('Correlations', 'truncate', false, $this->response->type(), $message);
+                        return $this->RestResponse->saveSuccessResponse('Correlations', 'truncate', false, $this->response->type(), $message);
                     } else {
-                        $this->RestResponse->saveFailResponse('Correlations', 'truncate', false, $message, $this->response->type());
+                        return $this->RestResponse->saveFailResponse('Correlations', 'truncate', false, $message, $this->response->type());
                     }
                 } else {
                     $this->Flash->{$result ? 'success' : 'error'}($message);

--- a/app/Controller/SightingsController.php
+++ b/app/Controller/SightingsController.php
@@ -269,7 +269,7 @@ class SightingsController extends AppController
             'unique' => true,
         ));
         if (empty($sightedEvents)) {
-            $this->RestResponse->viewData(array());
+            return $this->RestResponse->viewData(array());
         }
         $events = $this->Sighting->Event->fetchEventIds($this->Auth->user(), [
             'eventIdList' => $sightedEvents


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Two REST branches discard their response instead of returning it.

- **Problem** — Both branches build a response and fall out of their `if` without returning, unlike every sibling branch in the same files. In `CorrelationsController::truncate()`, a JSON POST with background jobs disabled truncates the correlation table then falls off the end of the action, so CakePHP auto-renders a non-existent view. In `SightingsController::index()` the early empty response is likewise discarded and execution falls through into `fetchEventIds()`.
- **Fix** — Adds the missing returns.
- **Effect** — Clients get their payload rather than a 500 on a destructive operation that already committed, which invites a retry.
<!-- /bluf -->

Two REST branches build a response and then throw it away by falling out of the `if` without returning it. The sibling branches in both files return correctly, so these are omissions rather than a style choice.

**1. `CorrelationsController::truncate()`**

```php
$result = $this->Correlation->truncate($this->Auth->user(), $engine);
if ($this->_isRest()) {
    if ($result) {
        $this->RestResponse->saveSuccessResponse('Correlations', 'truncate', ...);   // no return
    } else {
        $this->RestResponse->saveFailResponse('Correlations', 'truncate', ...);      // no return
    }
} else { ... }
```

The background-jobs branch 25 lines below does `return $this->RestResponse->saveSuccessResponse(...)`.

**Scenario:** a site admin does `POST /correlations/truncate/default` as JSON on an instance with `MISP.background_jobs` disabled. The correlation table is truncated, then execution falls off the end of the action with no render and no redirect. CakePHP auto-renders `Correlations/truncate.ctp`, which does not exist — `app/View/Correlations/` holds only `over_correlations.ctp`, `top.ctp` and the two `ajax/*_confirmation.ctp` files — so the client gets a `MissingViewException` 500 for an operation that already committed, and will reasonably retry a destructive action.

**2. `SightingsController::index()`**

```php
if (empty($sightedEvents)) {
    $this->RestResponse->viewData(array());   // no return
}
$events = $this->Sighting->Event->fetchEventIds($this->Auth->user(), [
    'eventIdList' => $sightedEvents
]);
```

The early empty response is discarded and execution continues with an empty `$sightedEvents`. `Event::fetchEventIds()` gates on `isset($options['eventIdList'])`, and an empty array *is* set, so `['Event.id' => []]` reaches the condition builder and `_parseKey` emits `Event.id IN ()` — a MySQL syntax error.

**Scenario:** the ACL for `sightings/index` is `['*']`, so any authenticated user calling `GET /sightings/index` on an instance with no sightings — or `GET /sightings/index/<eventId>` for an event nobody has sighted — gets a 500 instead of `[]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

