### PR TITLE
[critical] fix: [sync] self-signed servers disable peer verification even with a CA file

### DIFF
--- a/app/Lib/Tools/CurlClient.php
+++ b/app/Lib/Tools/CurlClient.php
@@ -26,7 +26,7 @@ class CurlClient extends HttpSocketExtended
     private $allowSelfSigned;
 
     /** @var bool */
-    private $verifyPeer;
+    private $verifyPeer = true;
 
     /** @var bool */
     private $compress = true;

--- a/app/Lib/Tools/SyncTool.php
+++ b/app/Lib/Tools/SyncTool.php
@@ -24,7 +24,7 @@ class SyncTool
             if (!empty($server[$model]['self_signed'])) {
                 $params['ssl_allow_self_signed'] = true;
                 $params['ssl_verify_peer_name'] = false;
-                if (!isset($server[$model]['cert_file'])) {
+                if (empty($server[$model]['cert_file'])) {
                     $params['ssl_verify_peer'] = false;
                 }
             }


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Self-signed sync servers with a custom CA run with TLS peer verification silently off.

- **Problem** — `SyncTool::setupHttpSocket()` guards its `ssl_verify_peer=false` override with `isset()` on `cert_file`, always a present database column, so the guard never fires and `ssl_verify_peer` is never passed. `CurlClient::$verifyPeer` has no default, stays null, and curl reads that as 0.
- **Fix** — Switches the guard to `empty()` and defaults `$verifyPeer` to `true`.
- **Effect** — A server with self-signed accepted and a CA uploaded verifies against that CA again; servers with no CA file behave exactly as before.
<!-- /bluf -->

`SyncTool::setupHttpSocket()` intends "allow self-signed **unless** the admin uploaded a CA to verify against":

```php
if (!empty($server[$model]['self_signed'])) {
    $params['ssl_allow_self_signed'] = true;
    $params['ssl_verify_peer_name'] = false;
    if (!isset($server[$model]['cert_file'])) {
        $params['ssl_verify_peer'] = false;
    }
}
```

`setupHttpSocket()` is called with a full `Server` find result, where `cert_file` is always a **present column** — an empty string when unset — so `isset()` is always true and the guard never fires. `ssl_verify_peer` is consequently never passed for *any* server.

That would be harmless if it left peer verification on, but `CurlClient::$verifyPeer` has no default:

```php
/** @var bool */
private $verifyPeer;        // stays null when ssl_verify_peer is not supplied
...
if ($this->allowSelfSigned) {
    $options[CURLOPT_SSL_VERIFYPEER] = $this->verifyPeer;   // null -> curl reads 0
}
```

**Net effect:** for a sync server with *"Accept self-signed certificates"* ticked **and** a custom CA uploaded, peer verification is switched off entirely — exactly the case the `cert_file` guard exists to protect. The intended "allow self-signed, but still validate against the supplied CA" configuration is unreachable, and nothing is logged or surfaced in the UI.

Two one-line changes make the documented behaviour reachable again:

* `isset()` → `empty()`, so the guard fires when no CA file is configured;
* `$verifyPeer` defaults to `true`, so an unset value means "verify", not "do not verify".

Servers with self-signed enabled and *no* CA file keep behaving exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

