### PR TITLE
[high] fix: [cerebrate] org sync renames organisations by colliding with themselves

### DIFF
--- a/app/Model/Cerebrate.php
+++ b/app/Model/Cerebrate.php
@@ -184,9 +184,13 @@ class Cerebrate extends AppModel
                 $this->Organisation->create();
             }
             if ($dirty) {
+                $nameCheckConditions = ['Organisation.name' => $orgToSave['name']];
+                if (!empty($orgToSave['id'])) {
+                    $nameCheckConditions['Organisation.id !='] = $orgToSave['id'];
+                }
                 $nameCheck = $this->Organisation->find('first', [
                     'recursive' => -1,
-                    'conditions' => ['Organisation.name' => $orgToSave['name']],
+                    'conditions' => $nameCheckConditions,
                     'fields' => ['Organisation.id']
                 ]);
                 if (!empty($nameCheck)) {


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Cerebrate org sync renames organisations by colliding with themselves.

- **Problem** — `Cerebrate::captureOrg()` probes for a name collision before saving but does not exclude the row it is updating, and in the existing-org branch `$orgToSave` is that row, carrying its own `id` and `name`. Whenever any other field changes the probe matches the record itself and the organisation is renamed with a random `_NNNN` suffix, again on every later sync that touches any field.
- **Fix** — Adds the missing `Organisation.id !=` exclusion on the edit path, leaving org creation unchanged.
- **Effect** — Stored organisation names stop drifting across syncs.
<!-- /bluf -->

`Cerebrate::captureOrg()` guards against name collisions by probing for an existing organisation with the same name, but does not exclude the record it is about to update:

```php
if ($dirty) {
    $nameCheck = $this->Organisation->find('first', [
        'conditions' => ['Organisation.name' => $orgToSave['name']],   // no id exclusion
        'fields' => ['Organisation.id']
    ]);
    if (!empty($nameCheck)) {
        $orgToSave['name'] = $orgToSave['name'] . '_' . mt_rand(0, 9999);
    }
```

In the existing-org branch `$orgToSave = $existingOrg['Organisation']`, which carries the record's own `id` **and** its current `name`. So whenever any *other* field changed, the probe matches the very row being updated and the organisation is renamed.

**Scenario:** a Cerebrate org sync where a local organisation (uuid `U`, name `ACME`) gains a `sector` value. The `name` iteration finds no difference; the `sector` iteration sets `$dirty = true`; `$nameCheck` then finds `ACME` — itself — and the save renames the organisation to `ACME_1234`. Each subsequent sync that touches any field renames it again.

The `__compareNames()` helper right below, which strips a trailing `_NNNN` so the next sync does not re-diff the name, is direct evidence that the random suffix was only ever meant to fire on a genuine cross-record collision. `Organisation::$validate['name']['unique']` already uses `isUnique`, which correctly excludes the current record on update.

The fix adds the missing `Organisation.id !=` exclusion when editing; the create path (no `id`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

*Priority revised critical -> high: my own rubric correction, not a maintainer request. Wachizungu confirmed the defect but did not assess severity. Under the scale used across this batch, 'critical' is reserved for remote code execution, memory corruption, or a shipped production credential; silent data corruption of organisation records is 'high'.*
