### PR TITLE
[high] fix: [feed] pull results overwrite each other and edits are counted as adds

### DIFF
--- a/app/Controller/FeedsController.php
+++ b/app/Controller/FeedsController.php
@@ -669,11 +669,11 @@ class FeedsController extends AppController
             }
             $message = __('Fetching the feed has successfully completed.');
             if ($this->Feed->data['Feed']['source_format'] == 'misp') {
-                if (isset($result['add'])) {
-                    $message .= ' Downloaded ' . count($result['add']) . ' new event(s).';
+                if (isset($result['add']['success'])) {
+                    $message .= ' Downloaded ' . count($result['add']['success']) . ' new event(s).';
                 }
-                if (isset($result['edit'])) {
-                    $message .= ' Updated ' . count($result['edit']) . ' event(s).';
+                if (isset($result['edit']['success'])) {
+                    $message .= ' Updated ' . count($result['edit']['success']) . ' event(s).';
                 }
             }
         }
@@ -734,11 +734,11 @@ class FeedsController extends AppController
                 }
                 $message = __('Fetching the feed has successfully completed.');
                 if ($this->Feed->data['Feed']['source_format'] == 'misp') {
-                    if (isset($result['add'])) {
-                        $message['result'] .= ' Downloaded ' . count($result['add']) . ' new event(s).';
+                    if (isset($result['add']['success'])) {
+                        $message .= ' Downloaded ' . count($result['add']['success']) . ' new event(s).';
                     }
-                    if (isset($result['edit'])) {
-                        $message['result'] .= ' Updated ' . count($result['edit']) . ' event(s).';
+                    if (isset($result['edit']['success'])) {
+                        $message .= ' Updated ' . count($result['edit']['success']) . ' event(s).';
                     }
                 }
             }

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -764,14 +764,14 @@ class Feed extends AppModel
             try {
                 $result = $this->__addEventFromFeed($HttpSocket, $feed, $uuid, $user, $filterRules);
                 if ($result === true) {
-                    $results['add']['success'] = $uuid;
+                    $results['add']['success'][] = $uuid;
                 } else if ($result !== 'blocked') {
-                    $results['add']['fail'] = ['uuid' => $uuid, 'reason' => $result];
+                    $results['add']['fail'][] = ['uuid' => $uuid, 'reason' => $result];
                     $this->log("Could not add event '$uuid' from feed {$feed['Feed']['id']}: $result", LOG_WARNING);
                 }
             } catch (Exception $e) {
                 $this->logException("Could not add event '$uuid' from feed {$feed['Feed']['id']}.", $e);
-                $results['add']['fail'] = array('uuid' => $uuid, 'reason' => $e->getMessage());
+                $results['add']['fail'][] = array('uuid' => $uuid, 'reason' => $e->getMessage());
             }
 
             $this->__cleanupFile($feed, '/' . $uuid . '.json');
@@ -783,14 +783,14 @@ class Feed extends AppModel
             try {
                 $result = $this->__updateEventFromFeed($HttpSocket, $feed, $uuid, $user, $filterRules);
                 if ($result === true) {
-                    $results['add']['success'] = $uuid;
+                    $results['edit']['success'][] = $uuid;
                 } else if ($result !== 'blocked') {
-                    $results['add']['fail'] = ['uuid' => $uuid, 'reason' => $result];
+                    $results['edit']['fail'][] = ['uuid' => $uuid, 'reason' => $result];
                     $this->log("Could not edit event '$uuid' from feed {$feed['Feed']['id']}: " . json_encode($result), LOG_WARNING);
                 }
             } catch (Exception $e) {
                 $this->logException("Could not edit event '$uuid' from feed {$feed['Feed']['id']}.", $e);
-                $results['edit']['fail'] = array('uuid' => $uuid, 'reason' => $e->getMessage());
+                $results['edit']['fail'][] = array('uuid' => $uuid, 'reason' => $e->getMessage());
             }
 
             $this->__cleanupFile($feed, '/' . $uuid . '.json');


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Feed pull results overwrite each other and edits are counted as adds.

- **Problem** — `Feed::downloadFromFeed()` assigns each pull outcome instead of appending, and the edit loop files its results under `$results['add']`, so only the last uuid of each kind survives. `fetchFromFeed()` renders `count($result['add'])`, which counts the keys `success` and `fail`, so a pull importing 400 events reports "Downloaded 1 new event(s)."
- **Fix** — Appends in both loops, routes edit results to `$results['edit']`, counts the success arrays in the controller, and fixes a related message-building defect in `fetchFromAllFeeds()`.
- **Effect** — Pull summaries report real add and edit counts, so an operator can tell a working feed from a broken one.
<!-- /bluf -->

`Feed::downloadFromFeed()` records every pull outcome with a scalar assignment rather than an append, and the *edit* loop files its results under `add`:

```php
foreach ($actions['add'] as $uuid) {
    $result = $this->__addEventFromFeed(...);
    if ($result === true) {
        $results['add']['success'] = $uuid;              // overwrites
    } else if ($result !== 'blocked') {
        $results['add']['fail'] = ['uuid' => $uuid, ...];
    }
    ...
}
foreach ($actions['edit'] as $uuid) {
    $result = $this->__updateEventFromFeed(...);
    if ($result === true) {
        $results['add']['success'] = $uuid;              // 'add', not 'edit'
    } else if ($result !== 'blocked') {
        $results['add']['fail'] = ['uuid' => $uuid, ...];
    }
```

Only the `catch` block of the edit loop writes to `$results['edit']`. So only the last uuid of each kind survives, and successful edits are indistinguishable from adds.

`FeedsController::fetchFromFeed()` then renders `count($result['add'])`, which counts the **keys** `success`/`fail` — always 1 or 2.

**Scenario:** a MISP-format feed pull that imports 400 new events reports *"Downloaded 1 new event(s)."*, and *"Updated N event(s)."* only ever appears when an edit threw an exception. The same numbers are what an operator uses to tell a working feed from a broken one.

This PR:

* appends (`[] =`) instead of overwriting, in both loops and in both the success and failure branches;
* routes the edit loop's results to `$results['edit']`, matching its own `catch` block;
* counts `$result['add']['success']` / `$result['edit']['success']` in the controller.

It also fixes a second defect at `FeedsController::fetchFromAllFeeds()`, where the same message is built as `$message['result'] .= ...` while `$message` is a plain string — a string-offset write that is a fatal on PHP 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

