### PR TITLE
[high] fix: [ldap] one unresolvable organisation aborts the whole validity sweep

### DIFF
--- a/app/Plugin/LdapAuth/Lib/LdapSync.php
+++ b/app/Plugin/LdapAuth/Lib/LdapSync.php
@@ -83,7 +83,15 @@ class LdapSync extends LdapAuthenticate
             return false;
         }
 
-        $orgId = $this->getOrganisationId($this->User, $entry, $groups);
+        // getOrganisationId() was written for the login path and throws when the
+        // directory resolves no organisation. In a batch sweep that would abort
+        // the whole run, so treat it like an unresolved role: this user is invalid.
+        try {
+            $orgId = $this->getOrganisationId($this->User, $entry, $groups);
+        } catch (UnauthorizedException $e) {
+            $this->report($verbose, $user, 'no organisation resolved from LDAP');
+            return false;
+        }
 
         if ($update) {
             $this->applyChanges($user, $orgId, $roleId, $verbose);


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** One unresolvable LDAP organisation aborts the whole user validity sweep.

- **Problem** — `LdapSync::isUserValid()` calls `getOrganisationId()`, a login-path helper that throws `UnauthorizedException` when no organisation resolves, from a batch context with no handler. `UserShell::check_validity()` loops over every enabled user with no try/catch, so the first account whose directory group maps to an unknown organisation kills the shell.
- **Fix** — Catches the exception and reports that user invalid, matching the `roleId` branch above it; the login path is untouched.
- **Effect** — Every remaining user is still checked, instead of being silently skipped while the run still looks complete.
<!-- /bluf -->

`LdapSync::isUserValid()` reuses `LdapAuthenticate::getOrganisationId()`, which was written for the **login** path: when `ldapOrgField` / `ldapOrgGroupMapping` is configured and nothing resolves, it logs and throws `UnauthorizedException`. `LdapSync` calls it from a batch context that has no handler.

```php
$roleId = $this->getRoleId($this->User, $entry, $groups);
if ($roleId === null) {
    $this->report($verbose, $user, 'no role resolved from LDAP');
    return false;                 // role failure -> this one user is invalid
}
$orgId = $this->getOrganisationId($this->User, $entry, $groups);   // org failure -> throws
```

`UserShell::check_validity()` loops over every enabled user calling `isUserValid()` / `blockInvalidUser()` with no try/catch.

**Scenario:** an admin runs `cake User check_validity --block_invalid --update`, or the scheduled `Admin blockInvalidUsers` task fires. The first account whose directory group now maps to an organisation MISP does not have raises the exception, the shell dies, and **every user after it in the list is silently never checked** — the sweep reports partial results that look like a completed run.

The asymmetry with the `roleId === null` branch three lines above — which correctly returns `false` for exactly the equivalent "the directory was meant to decide and did not" condition, per the comment right above it — is what marks this as an oversight rather than intent.

The fix catches the exception and reports the user as invalid, matching the role branch. The login path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

