### PR TITLE
[high] fix: [dashboard] mortality widget fatals on a country with no confirmed cases

### DIFF
--- a/app/Lib/Dashboard/CsseCovidTrendsWidget.php
+++ b/app/Lib/Dashboard/CsseCovidTrendsWidget.php
@@ -102,7 +102,7 @@ class CsseCovidTrendsWidget
         );
         $data['formula'] = sprintf(
             '%s%s',
-            (isset($options['insight']) && !empty($formulaData[$options['insight']])) ?
+            (isset($options['insight']) && !empty($formulaData['insight'][$options['insight']])) ?
                 $formulaData['insight'][$options['insight']] :
                 $formulaData['insight']['raw'],
             (isset($options['type']) && !empty($formulaData['type'][$options['type']])) ?
@@ -140,7 +140,10 @@ class CsseCovidTrendsWidget
         }
         if ($options['type'] === 'mortality') {
             foreach ($data as $k => $v) {
-                $data[$k]['mortality'] = round(100 * (empty($v['death']) ? 0 : $v['death']) / $v['confirmed'], 2);
+                $confirmed = empty($v['confirmed']) ? 0 : $v['confirmed'];
+                $data[$k]['mortality'] = $confirmed == 0
+                    ? 0
+                    : round(100 * (empty($v['death']) ? 0 : $v['death']) / $confirmed, 2);
             }
         }
         if (!empty($options['insight']) && $options['insight'] !== 'raw') {


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Mortality dashboard tiles fatal on PHP 8 for a country with deaths but no confirmed cases.

- **Problem** — `CsseCovidTrendsWidget::handler()` divides by `$v['confirmed']` without the `empty()` guard its sibling `death` value gets, and `__rearrangeResults()` omits that key entirely for a country with deaths but no confirmed cases in the window. A mortality-type widget then throws `DivisionByZeroError` on PHP 8 and the tile renders a 500 instead of a chart.
- **Fix** — Reports zero mortality in that case, and corrects the formula caption guard, which tested the wrong nesting level and so always fell back to the `raw` label.
- **Effect** — The mortality tile renders instead of erroring, and the caption matches the configured `insight` formula.
<!-- /bluf -->

Two defects in `CsseCovidTrendsWidget::handler()`.

**1. Unguarded division by `confirmed` — fatal `DivisionByZeroError` on PHP 8.**

```php
if ($options['type'] === 'mortality') {
    foreach ($data as $k => $v) {
        $data[$k]['mortality'] = round(100 * (empty($v['death']) ? 0 : $v['death']) / $v['confirmed'], 2);
    }
}
```

`death` is defensively guarded with `empty()`; `confirmed` is not. In `__rearrangeResults()` the mortality branch only writes `$data[$country][$type]` when `!empty($temp[$type])`:

```php
foreach (array('confirmed', 'death') as $type) {
    if (!empty($temp[$type])) {
        $data[$country][$type] = ...;
    }
}
```

so a country whose in-window CSSE daily reports carry deaths but zero (or absent) confirmed cases produces a row with a `death` key and **no** `confirmed` key.

**Scenario:** a dashboard widget configured with `"type": "mortality"` and such a country in `countries`. `$v['confirmed']` is an undefined key evaluating to `null`, `100 * n / null` throws `DivisionByZeroError`, `renderWidget` returns a 500 and the tile shows an error instead of the chart. The fix reports `0` mortality when there are no confirmed cases.

**2. The formula caption tests the wrong nesting level, so the insight label is always the "raw" one.**

```php
(isset($options['insight']) && !empty($formulaData[$options['insight']])) ?
    $formulaData['insight'][$options['insight']] :
    $formulaData['insight']['raw'],
```

The guard reads `$formulaData['growth']` while the value it selects is `$formulaData['insight']['growth']`. `$formulaData` only has the keys `insight` and `type`, so the guard is always false (the warning is swallowed by `empty()`) and the ternary always takes the `raw` arm.

**Scenario:** a user configures `"insight": "growth"`. The chart data is computed correctly, but the caption renders *"Confirmed cases"* instead of *"daily increase in confirmed cases"*. `percent` is mislabelled identically. The sibling `type` ternary immediately below already uses the correct two-level form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

