### PR TITLE
[high] fix: [background_jobs] a job writing to stderr is not a failed job

### DIFF
--- a/app/Lib/Tools/BackgroundJobs/BackgroundJob.php
+++ b/app/Lib/Tools/BackgroundJobs/BackgroundJob.php
@@ -91,7 +91,7 @@ class BackgroundJob implements JsonSerializable
 
         $this->pool($process, $pipes, $runningCallback);
 
-        if ($this->returnCode === 0 && empty($this->error)) {
+        if ($this->returnCode === 0) {
             $this->setStatus(BackgroundJob::STATUS_COMPLETED);
             $this->setProgress(100);
         } else {


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A background job that exits 0 but writes anything to stderr is recorded as a failed job.

- **Problem** — `BackgroundJob::run()` keys job status on the populated `$this->error` property, but `pool()` appends everything a child writes to fd 2 into it, and stderr here is routine: shells use `err()` for progress lines and CakePHP routes PHP notices there.
- **Fix** — Keys the status on the exit code instead.
- **Effect** — A job that exits 0 while printing one deprecation is no longer stored as `STATUS_FAILED`, so the Jobs index stops flagging successful work as failed.
<!-- /bluf -->

Follow-up to ccbc469650 (*fix: [background_jobs] Check the populated stderr property, not an unset variable*).

That commit was right that the old `empty($stderr)` referenced a variable which never existed in `run()` — but the replacement changes behaviour rather than restoring the original intent:

```php
if ($this->returnCode === 0 && empty($this->error)) {
    $this->setStatus(BackgroundJob::STATUS_COMPLETED);
    $this->setProgress(100);
} else {
    $this->setStatus(BackgroundJob::STATUS_FAILED);
}
```

Because `$stderr` was always undefined, `empty($stderr)` was always `true`, so for as long as that code has shipped the job status has been keyed on `returnCode` **alone**. Substituting the real property makes stderr suddenly load-bearing, and `pool()` appends *everything* the child writes to fd 2:

```php
$this->error = '';
...
$this->error .= stream_get_contents($pipes[2]);
```

Console output on fd 2 is not an error signal in this codebase. Shells use `$this->err()` for purely informational text on successful runs — `EventShell.php:719/721` prints *"N attributes fixed"*, `AdminShell.php:1624` prints *"Config file created in …"* — and `AppShell.php:106` writes its deprecation notice there too. CakePHP's `ConsoleErrorHandler` also routes every PHP notice/warning/deprecation to `php://stderr`, which on a 2.x codebase running PHP 8 is routine.

**Scenario:** a cake job runs to completion and exits `0`, but emits one deprecation notice or one `err()` progress line. The job is stored as `STATUS_FAILED`, `setProgress(100)` is never reached, and the Jobs index shows a red failure for work that actually succeeded — with no way for the operator to tell it apart from a genuine failure.

This PR keys the status on the exit code, which is the process-level success signal and what the code effectively did before ccbc469650. `$this->error` keeps its value and remains available as the diagnostic/failure message; nothing else changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

