### PR TITLE
[high] fix: [dashboard] a failed widget render permanently leaks a scheduler slot

### DIFF
--- a/app/webroot/js/dashboard/scheduler.module.mjs
+++ b/app/webroot/js/dashboard/scheduler.module.mjs
@@ -121,6 +121,10 @@ export class Scheduler {
     if (this._tickHandle) return;
     this._docHidden = typeof document !== 'undefined' && document.hidden === true;
     this.boardRoot.addEventListener('misp-board:widget-rendered', this._onRenderedBound);
+    // A failed render must free its slot too, otherwise the tile stays
+    // inFlight forever and, after INFLIGHT_CAP failures, the whole board
+    // stops refreshing.
+    this.boardRoot.addEventListener('misp-board:widget-error', this._onRenderedBound);
     if (typeof document !== 'undefined') {
       document.addEventListener('visibilitychange', this._onVisibilityBound);
     }
@@ -133,6 +137,7 @@ export class Scheduler {
       this._tickHandle = null;
     }
     this.boardRoot.removeEventListener('misp-board:widget-rendered', this._onRenderedBound);
+    this.boardRoot.removeEventListener('misp-board:widget-error', this._onRenderedBound);
     if (typeof document !== 'undefined') {
       document.removeEventListener('visibilitychange', this._onVisibilityBound);
     }


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A failed dashboard widget render pins its scheduler slot forever and eventually kills board refresh.

- **Problem** — `RenderScheduler` in `scheduler.module.mjs` marks a tile in-flight before dispatching a render but only clears that state on `misp-board:widget-rendered`, which `Board._renderWidget()` emits on success alone; its `catch` arm dispatches `misp-board:widget-error` instead.
- **Fix** — Subscribes the existing handler to `misp-board:widget-error` as well, and unsubscribes it in `stop()`.
- **Effect** — A 500, non-2xx response or network blip no longer pins `entry.inFlight` true forever with `_tick()` skipping the tile permanently, which re-saving the config could not recover since `enqueueWidget` carries `inFlight` across re-enqueues; nor does `_inFlightCount` creep to `INFLIGHT_CAP` after four failed tiles and kill auto-refresh for the whole board.
<!-- /bluf -->

`RenderScheduler` marks a tile in-flight before dispatching a render and only ever clears that state from `_onRendered`, which is subscribed to **`misp-board:widget-rendered`** alone:

```js
this.boardRoot.addEventListener('misp-board:widget-rendered', this._onRenderedBound);
```

But `Board._renderWidget()` dispatches `widget-rendered` only on the success path; its `catch` arm dispatches `misp-board:widget-error` instead:

```js
} catch (err) {
  ...
  this._dispatchEvent('widget-error', { instanceId: id, widgetName: name, error: String(err) });
}
```

So any HTTP 500, non-2xx response or network blip leaves that tile's `entry.inFlight === true` permanently. `_tick()` then skips it forever (`if (entry.inFlight) continue;`), and `enqueueWidget` deliberately carries `existing.inFlight` across re-enqueues, so saving the widget's configuration does not recover it either.

**Scenario:** a widget whose server-side handler throws — for example a `CsseCovidTrendsWidget` tile configured for a country with no confirmed cases, which 500s. That tile never auto-refreshes again. `_inFlightCount` is also never decremented, so once **four** distinct tiles have failed, `INFLIGHT_CAP` is reached and

```js
if (this._inFlightCount >= INFLIGHT_CAP) return;
```

makes every subsequent tick a no-op: the entire board's auto-refresh is dead until the page is reloaded, with no visible cause.

The sibling `RefreshIndicator` explicitly handles `widget-error`, which is what marks this as an oversight rather than a decision.

The fix subscribes the same handler to `misp-board:widget-error` (and unsubscribes it in `stop()`). `_onRendered` already no-ops on an unknown instance id and on a tile that was not in flight, so it is safe for both events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

