### PR TITLE
[medium] fix: [analyst data] captureOrg($returnUUID) returns null for a newly created org

### DIFF
--- a/app/Model/Organisation.php
+++ b/app/Model/Organisation.php
@@ -237,8 +237,12 @@ class Organisation extends AppModel
                 $organisation['uuid'] = $uuid;
             }
             $this->create();
-            $this->save($organisation);
-            return $returnUUID ? $organisation['uuid'] : $this->id;
+            if (!$this->save($organisation)) {
+                return false;
+            }
+            // beforeValidate() generates the uuid into $this->data, not into the
+            // local $organisation array, so read it back from there.
+            return $returnUUID ? $this->data[$this->alias]['uuid'] : $this->id;
         } else {
             $changed = false;
             if (isset($org['uuid']) && empty($existingOrg[$this->alias]['uuid'])) {


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `Organisation::captureOrg($returnUUID)` returns null for an organisation it has just created.

- **Problem** — `captureOrg()` returns `$organisation['uuid']` when `$returnUUID` is true, but that key is only set when the caller supplied an org array already carrying a `uuid`; the uuid MISP generates in `beforeValidate()` lands in `$this->data` and is never written back. The unchecked `$this->save()` also lets a failed save return `false` as though it were an organisation id.
- **Fix** — Reads the uuid back from `$this->data` after saving and returns `false` when the save fails.
- **Effect** — Its only such caller, `AnalystData::captureOrganisationAndSG()`, now gets a real uuid when syncing or importing a Note or Opinion whose `Orgc` names an organisation not present locally, instead of storing the analyst data with no creator organisation or failing validation.
<!-- /bluf -->

`Organisation::captureOrg()` returns `$organisation['uuid']` when called with `$returnUUID = true`, but that key is only ever assigned inside the `if (isset($uuid))` branch — i.e. only when the caller passed an organisation **array** that already carried a `uuid`:

```php
if (isset($uuid)) {
    ...
    $organisation['uuid'] = $uuid;
}
$this->create();
$this->save($organisation);
return $returnUUID ? $organisation['uuid'] : $this->id;
```

The UUID that MISP actually generates is written by `beforeValidate()` into `$this->data[$this->alias]['uuid']`, never back into the local `$organisation` array.

**Scenario:** the only `$returnUUID = true` caller is `AnalystData::captureOrganisationAndSG()`. A sync or REST import of a Note or Opinion carrying `"Orgc": "SomeNewOrg"` (a plain string) — or `{"Orgc": {"name": "SomeNewOrg"}}` with no uuid — for an organisation not present locally takes the capture path with `$uuid` never set. The `return` then hits an undefined array key (PHP 8 warning) and yields `null`, so `$element[$model]['orgc_uuid'] = null` and the analyst data is stored with no creator organisation, or fails validation.

Secondary defect on the same lines: `$this->save($organisation)` is unchecked, so a failed save makes the function return `$this->id === false` as though it were an organisation id — which callers such as `Event::captureSG` and `SharingGroup` then store.

The fix reads the uuid back from `$this->data` after the save, and returns `false` when the save failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

*Priority revised high -> medium: maintainer assessment — Wachizungu notes sync carries the orgc uuid, so this is only reachable via an API caller that omits it, which narrows the blast radius below 'high'.*
