### PR TITLE
[high] fix: [sighting] an integer type=2 skips the expiration cleanup

### DIFF
--- a/app/Model/Sighting.php
+++ b/app/Model/Sighting.php
@@ -852,7 +852,7 @@ class Sighting extends AppModel
         }
         $sightingsAdded = 0;
         foreach ($attributes as $attribute) {
-            if ($type === '2') {
+            if ((int)$type === 2) {
                 // remove existing expiration by the same org if it exists
                 $this->deleteAll(array(
                     'Sighting.org_id' => $user['org_id'],
@@ -1288,7 +1288,7 @@ class Sighting extends AppModel
 
             list($attributeId, $eventId) = $attributes[$s['attribute_uuid']];
 
-            if ($s['type'] === '2') {
+            if ((int)$s['type'] === 2) {
                 // remove existing expiration by the same org if it exists
                 $this->deleteAll(array(
                     'Sighting.org_id' => $user['org_id'],


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A sighting posted with an integer `type` of 2 skips the expiration cleanup and duplicates a row.

- **Problem** — `Sighting::saveSightings()` and `bulkSaveSightings()` validate the type with a loose `in_array($type, array(0, 1, 2))` but gate the "remove the existing expiration by this org" cleanup on the strict `$type === '2'`, and `SightingsController::add()` forwards the client's JSON value untouched.
- **Fix** — Compares numerically in both methods.
- **Effect** — A REST or PyMISP client posting `{"type": 2}` as an integer no longer skips the cleanup and inserts a second expiration row for the same org and attribute, so the one-expiration-per-org invariant holds and behaviour no longer depends on how the caller typed its JSON.
<!-- /bluf -->

`Sighting::saveSightings()` and `Sighting::bulkSaveSightings()` gate the "remove the existing expiration by this org" cleanup on a **strict string** comparison, while the validity check a few lines above is loose:

```php
if (!in_array($type, array(0, 1, 2))) {          // loose: int 2 passes
    return 'Invalid type, ...';
}
...
foreach ($attributes as $attribute) {
    if ($type === '2') {                          // strict string: int 2 fails
        // remove existing expiration by the same org if it exists
        $this->deleteAll([...]);
    }
```

`SightingsController::add()` passes `$this->request->data['type']` straight through, so the PHP type of `$type` is whatever the client's JSON said.

**Scenario:** a REST/PyMISP client posts `{"value": "...", "type": 2}` — a JSON **integer**. It passes the loose validity check, but `$type === '2'` is false, so the cleanup is skipped and a second expiration row is inserted for the same org and attribute, breaking the one-expiration-per-org invariant. Quoting the value as `"2"` takes the branch. Behaviour therefore depends silently on how the caller typed its JSON.

The fix compares numerically in both methods, which matches the loose validity check that lets the value through in the first place.

Two related issues noted but deliberately left out of this diff to keep it minimal:

* `in_array($type, array(0, 1, 2))` is loose, so a non-numeric string such as `"abc"` also passes as type `0`.
* In `bulkSaveSightings()` the cleanup `deleteAll` filters on `Sighting.org_id => $user['org_id']`, while the row it subsequently inserts uses `$saveOnBehalfOf`. A sync user pushing an expiration on behalf of another org therefore deletes *its own* org's expiration and leaves the other org's stale one in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

