### PR TITLE
[high] fix: [taxonomies] the update API reports success when every library failed

### DIFF
--- a/app/Controller/TaxonomiesController.php
+++ b/app/Controller/TaxonomiesController.php
@@ -344,6 +344,9 @@ class TaxonomiesController extends AppController
             }
         }
         if ($this->_isRest()) {
+            if ($flashType === 'error') {
+                return $this->RestResponse->saveFailResponse('Taxonomy', 'update', false, $message, $this->response->type());
+            }
             return $this->RestResponse->saveSuccessResponse('Taxonomy', 'update', false, $this->response->type(), $message);
         } else {
             $this->Flash->{$flashType}($message);


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `/taxonomies/update.json` reports success even when every taxonomy library failed to update.

- **Problem** — `TaxonomiesController::update()` computes a `$flashType` that distinguishes `info`, `error` and `success`, then ignores it in the REST branch and always calls `saveSuccessResponse`.
- **Fix** — Routes the error case to `saveFailResponse`, leaving the already-up-to-date `info` case a success as before.
- **Effect** — A site admin posting to `/taxonomies/update.json` on a box with a stale, missing or unreadable taxonomy submodule no longer gets `{"saved": true, "success": true}` alongside "Could not update any of the taxonomy libraries", so automation keyed on `saved` or the HTTP status stops recording the update as applied while the instance runs stale taxonomies.
<!-- /bluf -->

`TaxonomiesController::update()` computes a `$flashType` that already distinguishes `info` / `error` / `success`, then ignores it in the REST branch and always emits a success response:

```php
} elseif ($successes == 0) {
    $flashType = 'error';
    $message = __('Could not update any of the taxonomy libraries');
} else { ... }

if ($this->_isRest()) {
    return $this->RestResponse->saveSuccessResponse('Taxonomy', 'update', false, $this->response->type(), $message);
} else {
    $this->Flash->{$flashType}($message);
```

**Scenario:** a site admin (the ACL for `taxonomies/update` is site-admin only) calls `POST /taxonomies/update.json` on a box where the taxonomy submodule is stale, missing or unreadable. Every library fails, so `$successes == 0` and `$fails > 0`. The response is nonetheless

```json
{"saved": true, "success": true, "message": "Could not update any of the taxonomy libraries", ...}
```

Any automation keying off `saved` / the HTTP status — which is the documented MISP REST contract — records the update as applied and moves on, while the instance keeps running stale taxonomies. The HTML path handles this correctly through `$this->Flash->{$flashType}()`; only the REST path is wrong.

The fix routes the `error` case to `saveFailResponse`. The `info` case ("all libraries are already up to date") stays a success, which is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

