### PR TITLE
[critical] fix: [aad] every auth log entry overwrites the previous one

### DIFF
--- a/app/Plugin/AadAuth/Controller/Component/Auth/AadAuthenticateAuthenticate.php
+++ b/app/Plugin/AadAuth/Controller/Component/Auth/AadAuthenticateAuthenticate.php
@@ -103,7 +103,6 @@ class AadAuthenticateAuthenticate extends BaseAuthenticate
 		self::$auth_property_name =  Configure::read('AadAuth.auth_property_name') ?? 'userPrincipalName';
 
 		$this->Log = ClassRegistry::init('Log');
-		$this->Log->create();
 
 		$this->settings['fields'] = ['username' => 'email'];
 	}
@@ -125,6 +124,9 @@ class AadAuthenticateAuthenticate extends BaseAuthenticate
 			'action' => 'auth',
 			'title' => $logmessage
 		];
+		// create() must precede every save, otherwise the shared Log instance
+		// still holds the previous row's id and this becomes an UPDATE.
+		$this->Log->create();
 		$this->Log->saveOrFailSilently($log);
 		CakeLog::write($level, $logmessage);
 


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Every AAD auth log entry overwrites the previous row, so the whole authentication trail is lost.

- **Problem** — `AadAuthenticateAuthenticate` calls `$this->Log->create()` once in its constructor while `_log()` saves with no `create()` in between, so after the first insert CakePHP 2 takes the update branch and every later `_log()` overwrites that same row.
- **Fix** — Moves `create()` to immediately before each save, the standard idiom used by other `Log` callers in the tree.
- **Effect** — A single Azure AD callback logs at least four entries, all of which are now retained instead of collapsing to the last message; because `Log` is the shared `ClassRegistry` instance, rows written by unrelated code between two calls are no longer at risk either.
<!-- /bluf -->

`AadAuthenticateAuthenticate` calls `$this->Log->create()` **once**, in the constructor, while `_log()` calls `$this->Log->saveOrFailSilently($log)` with no `create()` in between:

```php
// __construct()
$this->Log = ClassRegistry::init('Log');
$this->Log->create();

// _log()
$this->Log->saveOrFailSilently($log);
```

`Log::saveOrFailSilently()` is a bare `save()` wrapper, and CakePHP 2's `Model::_doSave()` takes the `$db->update()` branch whenever `$this->exists()` is true and `$this->id` is non-empty. After the first `_log()` inserts a row, `Log->id` holds that row's id, so **every subsequent `_log()` in the same request UPDATEs that same row** instead of inserting a new one.

**Scenario:** an Azure AD callback request calls `_log()` at least four times — *"Fetching user data from Azure."*, *"Successful AAD group check for X"*, *"Attempt AAD authentication for X"*, *"AAD authentication successful for X"*. The audit table ends up with a single row carrying only the last message; the entire intermediate authentication trail is silently lost, which is exactly what this logging exists to preserve.

`Log` is the shared `ClassRegistry` instance, so any log entry written by other code between two `_log()` calls is at risk of being overwritten too — confinement to this plugin's own rows is the best case, not a guarantee.

The fix moves `create()` from the constructor to immediately before each save, which is the standard CakePHP 2 idiom and what `Log`'s other callers in the tree do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

