### PR TITLE
[medium] fix: [sighting] STIX import errors are reported as "Reason: Array"

### DIFF
--- a/app/Controller/SightingsController.php
+++ b/app/Controller/SightingsController.php
@@ -23,6 +23,7 @@ class SightingsController extends AppController
             $values = false;
             $timestamp = false;
             $error = false;
+            $filters = false;
             if ($id === 'stix') {
                 $result = $this->Sighting->handleStixSighting(file_get_contents('php://input'));
                 if ($result['success']) {
@@ -68,9 +69,9 @@ class SightingsController extends AppController
             if (!$error) {
                 $publish_sighting = !empty(Configure::read('Sightings_enable_realtime_publish'));
                 $result = $this->Sighting->saveSightings($id, $values, $timestamp, $this->Auth->user(), $type, $source, false, $publish_sighting, false, $filters);
-            }
-            if (!is_numeric($result)) {
-                $error = $result;
+                if (!is_numeric($result)) {
+                    $error = $result;
+                }
             }
             if ($this->request->is('ajax')) {
                 if ($error) {


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** STIX sighting import errors reach the client as "Reason: Array" instead of the real explanation.

- **Problem** — On the `stix` branch of `SightingsController::add()`, `$result` still holds the array returned by `handleStixSighting()` when `$error` is set, and the later `is_numeric($result)` check overwrites the prepared message with that array; `$filters` is also undefined on the successful STIX path.
- **Fix** — Initialises `$filters` and moves the `is_numeric` check inside the `if (!$error)` block so it only inspects a `saveSightings()` return value.
- **Effect** — A `POST` to `/sightings/add/stix` with a document containing no extractable values returns the actual STIX import error text rather than "Could not add the Sighting. Reason: Array" plus an Array-to-string warning.
<!-- /bluf -->

Two defects in `SightingsController::add()`, both on the `stix` branch.

**1. The STIX error message is overwritten by an array.**

```php
if ($id === 'stix') {
    $result = $this->Sighting->handleStixSighting(...);   // $result is an ARRAY here
    ...
    $error = 'No valid values found that could be extracted from the sightings document.';
    ...
}
if (!$error) {
    $result = $this->Sighting->saveSightings(...);        // skipped when $error is set
}
if (!is_numeric($result)) {
    $error = $result;                                     // clobbers the message with the array
}
```

When the STIX branch sets `$error`, `saveSightings()` is skipped and `$result` still holds the array returned by `handleStixSighting()`. `is_numeric(array)` is false, so the carefully built message is replaced by the array.

**Scenario:** `POST /sightings/add/stix` with a document that parses but contains no extractable values. The client is told *"Could not add the Sighting. Reason: Array"*, plus an `Array to string conversion` warning, instead of *"No valid values found..."*. The same happens for a malformed document, where `$result['message']` is discarded the same way.

**2. `$filters` is undefined on the STIX success path.**

`$filters` is only assigned in the non-STIX branch. On a *successful* STIX import, `saveSightings()` is called with an undefined variable as its 11th argument -- a PHP 8 warning, and `null` rather than the `false` the parameter expects.

The fix initialises `$filters` alongside the other locals and moves the `is_numeric($result)` check inside the `if (!$error)` block, so it only ever inspects a `saveSightings()` return value.

Noted while here, not fixed because the intent is unclear: `SightingsController::quickAdd()` calls `$this->Sighting->add()` / `add($id)` in both of its branches, but `Sighting` (and `AppModel`) define no `add()` method -- `saveSightings()`, `bulkSaveSightings()` and `addUuids()` are all that exist. Any POST to `/sightings/quickAdd/<attributeId>` from a user with `perm_sighting` is therefore a hard 500. The shipped UI never exercises it (both `quickAddConfirmationForm.ctp` variants post to `/sightings/add/<id>`), which is why it has survived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

