### PR TITLE
[high] fix: [certauth] undefined existingUser and foreach over a null CertAuth.map

### DIFF
--- a/app/Plugin/CertAuth/Controller/Component/Auth/CertificateAuthenticate.php
+++ b/app/Plugin/CertAuth/Controller/Component/Auth/CertificateAuthenticate.php
@@ -81,7 +81,7 @@ class CertificateAuthenticate extends BaseAuthenticate
             } else {
                 self::$client = array();
             }
-            foreach($map as $n=>$d) {
+            foreach((array)$map as $n=>$d) {
                 if(isset($_SERVER[$n])) {
                     self::$client[$d] = $_SERVER[$n];
                 }
@@ -141,6 +141,7 @@ class CertificateAuthenticate extends BaseAuthenticate
                 $userModelKey = empty(Configure::read('CertAuth.userModelKey')) ? 'email' : Configure::read('CertAuth.userModelKey');
                 $userDefaults = Configure::read('CertAuth.userDefaults');
                 $this->User = ClassRegistry::init('User');
+                $existingUser = false;
                 if (!empty(self::$user[$userModelKey])) {
                     $existingUser = $this->User->find('first', array(
                         'conditions' => array($userModelKey => self::$user[$userModelKey]),


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `CertificateAuthenticate` reads an unassigned `$existingUser` and iterates a null `CertAuth.map`.

- **Problem** — In `CertificateAuthenticate`, `$existingUser` is only assigned inside an `if` block but read unconditionally afterwards, and the `CertAuth.map` lookup is iterated with `foreach` even though the block is gated on `CertAuth.ca` and the map is optional.
- **Fix** — Initialises `$existingUser` to `false` and casts the map to an array.
- **Effect** — A client certificate whose subject DN yields no value for `CertAuth.userModelKey` no longer falls through to the wrong create branch on an undefined variable, and an installation configuring `ca` without `map` no longer hits "foreach() argument must be of type array|object, null given" on every request. Correctly configured installations are unchanged.
<!-- /bluf -->

Two missing guards in the client-certificate authenticator.

**1. `$existingUser` is read on a path where it was never assigned.**

```php
$userModelKey = empty(Configure::read('CertAuth.userModelKey')) ? 'email' : Configure::read('CertAuth.userModelKey');
$this->User = ClassRegistry::init('User');
if (!empty(self::$user[$userModelKey])) {
    $existingUser = $this->User->find('first', array(...));
}
if ($existingUser) {          // undefined when the block above was skipped
```

**Scenario:** a client certificate whose subject DN yields no value for the configured `CertAuth.userModelKey` (default `email`) -- for example a DN carrying only `CN` and `O`, or a `CertAuth.map` that maps nothing to `email`. `self::$user['email']` is unset, so the `if` is evaluated on an undefined variable (PHP 8 warning, treated as `null`) and control falls through to the `else if ($sync && ...)` create branch, attempting to insert a user with no email.

It mostly fails closed -- with `syncUser` enabled `User::save()` then fails email validation and only logs an alert; with sync disabled the final `else` sets `self::$user = false` and access is denied -- but the variable is genuinely undefined and the branch taken is the wrong one.

**2. `foreach` over a null `CertAuth.map`.**

```php
if (self::$ca) {
    $map = Configure::read('CertAuth.map');
    ...
    foreach($map as $n=>$d) {
```

`CertAuth.map` is optional; `CertAuth.ca` is what gates this block. An installation that configures `ca` but not `map` hits `foreach() argument must be of type array|object, null given` on every request through this authenticator.

The fix initialises `$existingUser = false` and casts the map to an array. Neither changes behaviour for a correctly configured installation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

