### PR TITLE
[medium] fix: [scheduler] a task due on an exact interval boundary runs twice

### DIFF
--- a/app/Console/Command/SchedulerWorkerShell.php
+++ b/app/Console/Command/SchedulerWorkerShell.php
@@ -252,7 +252,10 @@ class SchedulerWorkerShell extends AppShell
         $interval = (int)$task['timer'];
         $now = time();
 
-        $missed = max(1, ceil(($now - $previous) / $interval));
+        // floor()+1 rather than ceil(): when ($now - $previous) is an exact
+        // multiple of the interval, ceil() returns that multiple and $next
+        // lands on $now, so the loop re-selects the task immediately.
+        $missed = max(1, (int)floor(($now - $previous) / $interval) + 1);
         $next = $previous + $missed * $interval;
 
         $task['next_execution_time'] = $next;


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A scheduled task due on an exact interval boundary is dispatched twice, one loop tick apart.

- **Problem** — `SchedulerWorkerShell::setNextExecutionTime()` advances a task with `ceil(($now - $previous) / $interval)`, so when the elapsed time is an exact multiple of the interval the computed next run equals now, and the main loop selects tasks with `next_execution_time <= now` and re-dispatches the same task on its very next pass.
- **Fix** — Switches to `floor(...) + 1`, which matches `ceil()` for every non-multiple and pushes the exact-boundary case to the following interval, keeping the `max(1, ...)` floor.
- **Effect** — A boundary-aligned task such as an hourly `Server` pull no longer performs a duplicated unit of work about ten seconds later.
<!-- /bluf -->

`SchedulerWorkerShell::setNextExecutionTime()` advances a task's next run with `ceil()`:

```php
$missed = max(1, ceil(($now - $previous) / $interval));
$next   = $previous + $missed * $interval;
```

When `$now - $previous` is an **exact multiple** of `$interval`, `ceil()` returns that multiple unchanged, so `$next === $now`. The scheduler's main loop selects tasks with `next_execution_time <= now`, so it re-selects the same task on its very next pass and runs it a second time before the counter advances.

**Scenario:** a task with `timer = 3600` whose `next_execution_time` is `T`, picked up at exactly `T + 3600` -- which happens when the worker was restarted, or simply when the 10-second tick lands on the boundary. `$missed = 1`, `$next = T + 3600 = $now`, and the task's action (a `Server pull`, say) is dispatched again roughly ten seconds later.

`floor(...) + 1` is the correct form: it produces the same value as `ceil()` for every non-multiple, and `$previous + 2 * $interval` for the exact-multiple case. The `max(1, ...)` floor is retained for a `next_execution_time` in the future.

The double-run window is one loop tick, hence low severity -- but for a pull or a cache job it is a duplicated unit of real work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

