### PR TITLE
[low] fix: [view] ScopedCSSHelper::createScopedCSS() slices with an end index instead of a length — LATENT (no in-tree caller), POSSIBLE BEHAVIOUR CHANGE, needs maintainer decision: fix or delete the helper

### DIFF
--- a/app/View/Helper/ScopedCSSHelper.php
+++ b/app/View/Helper/ScopedCSSHelper.php
@@ -68,10 +68,11 @@ App::uses('AppHelper', 'View/Helper');
             $htmlStyleTag = "<style widget-scoped>";
             $styleClosingTag = "</style>";
             $styleTagIndex = strpos($html, $htmlStyleTag);
-            $closingStyleTagIndex = strpos($html, $styleClosingTag, $styleTagIndex) + strlen($styleClosingTag);
-            if ($styleTagIndex !== false && $closingStyleTagIndex !== false && $closingStyleTagIndex > $styleTagIndex) { // enforced scoped css
+            $closingStyleTagIndex = $styleTagIndex === false ? false : strpos($html, $styleClosingTag, $styleTagIndex);
+            if ($styleTagIndex !== false && $closingStyleTagIndex !== false) { // enforced scoped css
                 $seed = mt_rand();
-                $css = substr($html, $styleTagIndex, $closingStyleTagIndex);
+                $closingStyleTagEnd = $closingStyleTagIndex + strlen($styleClosingTag);
+                $css = substr($html, $styleTagIndex, $closingStyleTagEnd - $styleTagIndex);
                 $html = str_replace($css, "", $html); // remove CSS part
                 $css = str_replace($htmlStyleTag, "", $css); // remove the style node
                 $css = str_replace($styleClosingTag, "", $css); // remove closing style node


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `ScopedCSSHelper::createScopedCSS()` slices with an end index instead of a length, truncating output.

- **Problem** — In `app/View/Helper/ScopedCSSHelper.php`, `createScopedCSS()` passes an end index where a length is expected, so returned `html`/`bundle` content is silently truncated and an unterminated `<style widget-scoped>` at offset 0 yields a mangled slice.
- **Fix** — Corrects the slice arithmetic in `createScopedCSS()`.
- **Effect** — Callers of the helper get the full scoped CSS back instead of a truncated or mangled string.
- **Cost** — Nothing in `2.5` calls the helper, so the fix is latent; only an out-of-tree theme, fork or `Custom/` widget calling it directly would see output change. The author's caller hunt against `origin/2.5` found only docs references, and offers deleting the helper as an equally valid answer.
<!-- /bluf -->

## ⚠️ Risk first — read before the diff

**This helper has no caller in `2.5`. The fix is latent, and "delete the helper instead" is a legitimate answer.**

| | |
|---|---|
| **What could break** | Nothing that runs today, as far as I can find. The changed function is unreachable from the shipped tree. If an out-of-tree consumer (a custom theme, a fork, a plugin, a downstream `Custom/` widget) *does* call `createScopedCSS()`, its output changes: the returned `html`/`bundle` will now retain content that is currently being silently deleted, and an unterminated `<style widget-scoped>` at offset 0 will now be left alone instead of producing a mangled slice. Anyone who has been compensating for the truncation would see doubled content. |
| **Who would notice** | Only someone who calls the helper directly. Not reachable through any core controller, view, element, ACL entry, or `$helpers` array. |
| **Safe alternative** | Delete `app/View/Helper/ScopedCSSHelper.php` outright and drop the `docs/dev/dashboard-prd.md` reference. That is a smaller footprint than shipping a fix for code nobody calls. **I have deliberately not done this** — see the "keep or delete" note below — but I will happily convert this PR to a deletion if that is what you want. |

## The caller hunt — what I actually searched

Everything below was run against `origin/2.5` (`git grep <term> origin/2.5`), not a working tree, so local scratch files could not contaminate it.

| Search | Result |
|---|---|
| `git grep -i 'scopedcss' origin/2.5 -- .` | the helper file itself, 3 `docs/Changelog.md` lines from 2018, and one `docs/dev/dashboard-prd.md` line |
| `git grep -l 'createScoped' origin/2.5 -- '*.ctp' '*.js' '*.mjs' '*.json' '*.php' '*.xml' '*.yml'` | `app/View/Helper/ScopedCSSHelper.php` only |
| `git grep -l 'ScopedCSSHelper' origin/2.5 -- <same globs>` | `app/View/Helper/ScopedCSSHelper.php` only |
| `git grep -n 'widget-scoped\|data-scoped' origin/2.5` | only the helper's own literals and its docblock — **no view or widget in the tree emits `<style widget-scoped>`**, so even the input format has no producer |
| `git grep -n 'public $helpers' origin/2.5` | `AppController` (`OrgImg`, `FontAwesome`, `UserName`, `Navbar`), `EventTemplatesController`, `EventsController`, `TagsController`, `NavbarHelper` — `ScopedCSS` is in none of them, so `$this->ScopedCSS->…` string dispatch from a `.ctp` would not resolve |
| `git grep -i 'scoped' origin/2.5 -- app/Controller/Component/ACLComponent.php` | no hits — no ACL/registry entry |

**How it became orphaned** (`git log --oneline -S 'createScopedCSS' --all`):

```
4633d25418  new: [helper:scopedCSS] Moved implementation in a helper      (introduced)
4a0432df12  chg: [dashboard-v2] delete v1 app/View/Dashboards/ view tree  (last caller removed, 2026-05-13)
```

`4a0432df12` deleted `app/View/Dashboards/widget_loader.ctp`, whose body was:

```php
$widgetHtml = $this->element('/dashboard/Widgets/' . $config['render']);
$scopedHtml = $this->ScopedCSS->createScopedCSS($widgetHtml);
```

So the helper is not "dead code that never worked" — it was live under the v1 dashboard and became latent when the v1 view tree was removed. `docs/dev/dashboard-prd.md:640` still lists `widget_loader.ctp` as "uses `ScopedCSS` helper", which is why I am leaning fix-rather-than-delete: the dashboard-v2 work may still intend to bring it back.

## The two defects

### 1. `substr()` gets an end index where it wants a length

```php
$closingStyleTagIndex = strpos($html, $styleClosingTag, $styleTagIndex) + strlen($styleClosingTag);
...
$css = substr($html, $styleTagIndex, $closingStyleTagIndex);
```

`$closingStyleTagIndex` is an **absolute offset**; `substr()`'s third argument is a **length**. The slice overshoots by exactly `$styleTagIndex` bytes. Because the very next line is `str_replace($css, "", $html)`, those extra bytes are then deleted from the page.

The bug is invisible when the style block starts at offset 0 (`length == end`), which is presumably why it survived.

Repro on the container's PHP:

```php
$html = "<p>before</p><style widget-scoped>\np {\ncolor:red;\n}\n</style><p>AFTER-CONTENT</p>";
```

```
styleTagIndex=13 closingStyleTagIndex=60
BUGGY slice  : "<style widget-scoped>\np {\ncolor:red;\n}\n</style><p>AFTER-CONT"
FIXED slice  : "<style widget-scoped>\np {\ncolor:red;\n}\n</style>"
html after str_replace(BUGGY): "<p>before</p>ENT</p>"
html after str_replace(FIXED): "<p>before</p><p>AFTER-CONTENT</p>"
```

13 bytes of page content eaten, and the CSS handed to `prependScopedId()` has HTML glued onto its tail.

### 2. The `!== false` guard cannot fire

`strpos(...) + strlen('</style>')` is always an `int`, so `$closingStyleTagIndex !== false` is always true. When there is no closing tag, `strpos()` returns `false`, `false + 8 == 8`, and the guard is satisfied by the constant 8:

```
no closing tag, tag at offset 0: styleTagIndex=0 closingStyleTagIndex=8 guardPasses=true
slice taken: "<style w"
```

The `$closingStyleTagIndex > $styleTagIndex` clause masks this whenever the tag is not at offset 0 — but at offset 0 it does not, and the helper happily scopes the string `"<style w"`.

## The change

```diff
-$closingStyleTagIndex = strpos($html, $styleClosingTag, $styleTagIndex) + strlen($styleClosingTag);
-if ($styleTagIndex !== false && $closingStyleTagIndex !== false && $closingStyleTagIndex > $styleTagIndex) {
+$closingStyleTagIndex = $styleTagIndex === false ? false : strpos($html, $styleClosingTag, $styleTagIndex);
+if ($styleTagIndex !== false && $closingStyleTagIndex !== false) {
     $seed = mt_rand();
-    $css = substr($html, $styleTagIndex, $closingStyleTagIndex);
+    $closingStyleTagEnd = $closingStyleTagIndex + strlen($styleClosingTag);
+    $css = substr($html, $styleTagIndex, $closingStyleTagEnd - $styleTagIndex);
```

`$closingStyleTagIndex` now holds the raw `strpos()` result, so `!== false` is a live test; the `> $styleTagIndex` clause is redundant once the offset argument is guaranteed valid and is dropped; the length is computed as `end - start`.

`php -l` clean.

## Why this analysis might be wrong

- **The caller hunt could still be incomplete.** I searched `origin/2.5` only. A caller could live in a MISP module, a downstream theme, `app/Lib/Dashboard/Custom/`, or a branch I did not look at. My searches also cannot see a caller built from a runtime-assembled string (`$this->{$helperName}->{$method}()`), though I found no such dispatch pattern for helpers anywhere in the tree.
- **The truncation might be load-bearing somewhere.** If some consumer relies on `bundle` being shorter than the input, fixing the length changes its output.
- **`docs/dev/dashboard-prd.md` may be describing the deleted v1 architecture**, not a v2 intention — in which case "delete the helper" is clearly the better call and this PR is the wrong shape.
- **You may prefer to leave latent code alone.** Touching an unreachable function has a nonzero cost and zero user-visible benefit today.

## Please close this if the current behaviour is intentional

If `ScopedCSSHelper` is scheduled for deletion, if the dashboard-v2 work has replaced scoped CSS with a different mechanism, or if you would simply rather not carry a fix for code with no caller — **close this PR**. I would rather it be closed than have you carry a change you did not want. If you want the deletion variant instead, say so and I will push it to this same branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

