### PR TITLE
[medium] fix: [api] _harvestParameters() wildcard branch harvests only the FIRST matching key — BEHAVIOUR CHANGE: all matching keys would now reach restSearch filters, needs maintainer decision

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -1162,7 +1162,6 @@ class AppController extends Controller
                                     preg_match('/^[\w.\- ]+$/', $leftover) == 1
                                 ) {
                                     $data[$existingParamKey] = $temp[$existingParamKey];
-                                    break;
                                 }
                             }
                         } else if (isset($temp[$param])) {


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `_harvestParameters()` keeps only the first key under a wildcard prefix; this PR keeps them all.

- **Problem** — In `app/Controller/AppController.php`, the wildcard-prefix branch of `AppController::_harvestParameters()` stops at the first matching key, so a request passing several keys under one wildcard prefix silently loses all but the first before the filters reach `restSearch`.
- **Fix** — Removes that `break` so every matching key survives into `$filters`.
- **Effect** — The only wildcard entry in the tree is `galaxy.*` in the Event scope of `RestSearchComponent::$paramArray`, so Event `restSearch` clients sending several `galaxy.<x>` keys are narrowed by all of them and see fewer results.
- **Cost** — A deliberate semantic change with no in-tree consumer; the author offers documenting the current single-match behaviour instead, and asks for a maintainer decision.
<!-- /bluf -->

## ⚠️ Risk first — read before the diff

**This changes what a request means. It is a semantic change to parameter harvesting, not a crash fix, and it deserves a maintainer decision rather than a merge on sight.**

| | |
|---|---|
| **What could break** | Today, a request that passes several keys under one wildcard prefix has all but the first silently discarded. After this change **all** of them survive into `$filters` and are handed to `restSearch`. A client that currently sends `galaxy.type` *and* `galaxy.name` gets a result set narrowed by one filter; after the change it is narrowed by both — i.e. **fewer results**. Any consumer that had (knowingly or not) settled on the current "only one wins" outcome sees its result set change. |
| **Who would notice** | Only API clients using a wildcard parameter. The single wildcard entry in the tree is `'galaxy.*'` in the `Event` scope of `RestSearchComponent::$paramArray` (`app/Controller/Component/RestSearchComponent.php:159`), so the blast radius is Event restSearch clients that pass more than one `galaxy.<something>` key. Nothing in the shipped UI does this. |
| **Extra wrinkle** | I could find **no in-tree consumer** of a `galaxy.<x>` filter key — `git grep "galaxy\." origin/2.5 -- app/Model app/Lib app/Controller` returns only the `RestSearchComponent` declaration itself. These filters are harvested and forwarded to `Event::restSearch`, which passes `$filters` on to export/MISP modules. **The actual consumer is out of tree**, so I cannot demonstrate the end-to-end effect and cannot rule out that an export module is written against the one-key assumption. This is the main reason I am filing this as a proposal. |
| **Safe alternative** | Leave the `break` and **document the single-match behaviour** instead — a comment on the loop plus a line in the restSearch docs saying that a wildcard `paramArray` entry harvests at most one key. That is a zero-risk change and a perfectly reasonable resolution if the current behaviour is deliberate. |

## Relationship to #10928 (merged)

[#10928](https://github.com/MISP/MISP/pull/10928) fixed the invalid character class in this same loop (`/^[\w_-. ]+$/` → `/^[\w.\- ]+$/`, a descending range that made `preg_match()` return `false` and discarded *every* wildcard parameter). **This PR is built on top of that fix and does not touch the regex.** The two are complementary, not overlapping:

- Before #10928: *zero* wildcard keys were harvested (the match never succeeded).
- After #10928: exactly *one* wildcard key is harvested (the `break` stops the loop).
- With this PR: *all* matching wildcard keys are harvested.

#10928 is arguably what makes this second bug observable at all — while the regex was broken, the `break` was unreachable in practice.

## The defect

`app/Controller/AppController.php`, `_harvestParameters()`:

```php
foreach ($options['paramArray'] as $param) {
    if (str_ends_with($param, '*')) {
        $root = substr($param, 0, strlen($param)-1);
        foreach ($temp as $existingParamKey => $v) {
            $leftover = substr($existingParamKey, strlen($param)-1);
            if (
                $root == substr($existingParamKey, 0, strlen($root)) &&
                preg_match('/^[\w.\- ]+$/', $leftover) == 1
            ) {
                $data[$existingParamKey] = $temp[$existingParamKey];
                break;              // <-- stops after the first match
            }
        }
    }
```

The `break` exits the loop over the *request's* keys, not the loop over `paramArray`. The wildcard is therefore a "match one" pattern, not a "match all" pattern, which is the opposite of what `prefix*` reads as.

Which key survives is whichever comes first in `$temp` — i.e. it depends on JSON key order in the client's POST body, which is not something a client controls meaningfully.

Demonstrated with the loop body extracted verbatim (post-#10928 regex), `paramArray = ['galaxy.*']`, POST body `{"galaxy.type": "mitre-attack-pattern", "galaxy.name": "APT29", "eventid": 5}`:

```
CURRENT (break)  : {"galaxy.type":"mitre-attack-pattern"}
PROPOSED (no brk): {"galaxy.type":"mitre-attack-pattern","galaxy.name":"APT29"}
```

## Exactly which request shapes change

- **POST** bodies only. The wildcard branch lives under `if ($request->is('post'))`; URL/named params take the non-wildcard path below and are unaffected.
- Only when `paramArray` contains a `prefix*` entry. In-tree that is exactly one: `galaxy.*` on Event restSearch.
- Only when **two or more** keys in the body share that prefix and pass the `[\w.\- ]+` leftover check. A body with zero or one matching key produces byte-identical output before and after.

Everything else — GET, named params, ordered URL params, non-wildcard `paramArray` entries, query-string merging, `additional_delimiters` — is untouched.

## The change

```diff
                                     $data[$existingParamKey] = $temp[$existingParamKey];
-                                    break;
                                 }
```

`php -l` clean.

## Why this analysis might be wrong

- **The `break` may be deliberate.** It could be a cheap guard against a client flooding the filter set with hundreds of `galaxy.*` keys — an unbounded loop over `$temp` writing into `$data` is a (mild) resource consideration that a `break` bounds. Nothing in the code or history says so, but nothing rules it out either.
- **I cannot see the consumer.** `galaxy.*` filters leave the tree. If an export module or MISP module reads `$filters['galaxy.…']` expecting a single key, passing several may produce a worse failure than dropping them. I have no way to test that from the core repo.
- **"Fewer results" is a real regression for someone.** A client that has been sending redundant `galaxy.*` keys and tuning against the one-filter result set gets a narrower answer with no version bump to explain it.
- **The documented contract may already be single-match** somewhere I did not find. I searched the tree and `app/webroot/doc/openapi.yaml` and found no statement either way — absence of documentation is not evidence of intent.

## Please close this if the current behaviour is intentional

If `prefix*` is meant to mean "harvest one", **close this PR** — and I would suggest taking the alternative above (a comment on the loop) so the next reader does not file the same thing. If you would like the documenting-comment variant instead of the behaviour change, say so and I will push it to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

