### PR TITLE
[high] fix: [sighting] SightingsController::quickAdd() POST calls a Sighting::add() that has never existed (hard 500) — UNCERTAIN FIX, BEHAVIOUR CHANGE: a dead endpoint becomes a live write path, needs maintainer decision

### DIFF
--- a/app/Controller/SightingsController.php
+++ b/app/Controller/SightingsController.php
@@ -192,13 +192,40 @@ class SightingsController extends AppController
             if (!isset($id)) {
                 return new CakeResponse(array('body' => json_encode(array('saved' => false, 'errors' => __('Invalid request.'))), 'status' => 200, 'type' => 'json'));
             } else {
+                $publish_sighting = !empty(Configure::read('Sightings_enable_realtime_publish'));
                 if ($onvalue) {
-                    $result = $this->Sighting->add();
+                    $this->loadModel('MispAttribute');
+                    $attribute = $this->MispAttribute->fetchAttributes(
+                        $this->Auth->user(),
+                        array('conditions' => array('Attribute.id' => $id, 'Attribute.deleted' => 0), 'flatten' => 1)
+                    );
+                    if (empty($attribute)) {
+                        throw new MethodNotAllowedException(__('Attribute not found'));
+                    }
+                    $result = $this->Sighting->saveSightings(
+                        false,
+                        array($attribute[0]['Attribute']['value']),
+                        time(),
+                        $this->Auth->user(),
+                        $type,
+                        '',
+                        false,
+                        $publish_sighting
+                    );
                 } else {
-                    $result = $this->Sighting->add($id);
+                    $result = $this->Sighting->saveSightings(
+                        $id,
+                        false,
+                        time(),
+                        $this->Auth->user(),
+                        $type,
+                        '',
+                        false,
+                        $publish_sighting
+                    );
                 }
 
-                if ($result) {
+                if (is_numeric($result) && $result > 0) {
                     return new CakeResponse(array('body' => json_encode(array('saved' => true, 'success' => __('Sighting added.'))), 'status' => 200, 'type' => 'json'));
                 } else {
                     return new CakeResponse(array('body' => json_encode(array('saved' => false, 'errors' => __('Sighting could not be added'))), 'status' => 200, 'type' => 'json'));


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `SightingsController::quickAdd()` POSTs call a `Sighting::add()` that has never existed, a hard 500.

- **Problem** — In `app/Controller/SightingsController.php`, a POST to `/sightings/quickAdd/<id>` calls `Sighting::add()`, a method that has never existed, so the action is a hard 500 that writes nothing, and its truthiness check also reports `saveSightings()` error strings as `saved: true`.
- **Fix** — Reconstructs the branch to call `saveSightings()` and tightens the success test to `is_numeric($result) && $result > 0`.
- **Effect** — The endpoint records sightings instead of erroring, and failures are no longer reported as successes.
- **Cost** — Merging turns a dead endpoint into a live write path, which is the maintainer decision being asked for; the author offers deleting the POST branch and returning 405 as the safer alternative.
<!-- /bluf -->

## ⚠️ Risk first — read before the diff

**The bug is certain. The fix is a reconstruction, and I am not confident it is the one you want.** `Sighting::add()` never existed, so there is no removed method to restore and no original intent to recover from the code — only from what the surrounding branch implies.

| | |
|---|---|
| **What could break** | Today a POST to `/sightings/quickAdd/<id>` is a hard 500 and writes nothing. After this patch it *writes sightings*. Turning a dead endpoint into a live write path is the risk: any client that has been POSTing there and treating the 500 as "no-op" starts creating sightings. There is also a smaller, deliberate change of contract — the success test is tightened from `if ($result)` to `is_numeric($result) && $result > 0`, because `saveSightings()` returns an error **string** on failure and the current truthiness test reports those as `saved: true`. |
| **Who would notice** | Only API clients hitting `/sightings/quickAdd` with POST. **Nothing in the shipped UI does.** Both confirmation forms — `app/View/Sightings/ajax/quickAddConfirmationForm.ctp` and the Overmind variant — POST to `/sightings/add/<id>`, and `misp.js:100` reaches `quickAdd` with `$.get()` only. That is exactly why the 500 has survived since 2018. |
| **Safe alternative** | Delete the POST branch and let `quickAdd()` be what it actually is — the GET action that renders the confirmation form — returning a 405 for POST. Smaller, guesses nothing, and matches how both themes behave. I did not do this because it removes an endpoint rather than fixing it, which is a call for you to make. |

## Relationship to #11041

I reported this inside the body of [#11041](https://github.com/MISP/MISP/pull/11041) rather than patching it there, because that PR is about `SightingsController::add()`'s STIX branch and this is a different method. **#11041 does not fix this and does not conflict with it.** What this PR adds over that note is the git history establishing that `Sighting::add()` never existed, plus a concrete proposed fix.

## The defect

`app/Controller/SightingsController.php`, POST branch of `quickAdd()`:

```php
if ($onvalue) {
    $result = $this->Sighting->add();
} else {
    $result = $this->Sighting->add($id);
}
```

`Sighting` defines no `add()`. Neither does `AppModel`. `Sighting::$actsAs` is `['Containable']` only, so no behaviour supplies one either — the call falls through CakePHP 2's `Model::__call` and fails hard. ACL grants the action to `perm_sighting` (`ACLComponent.php:842`), so this is reachable by any sighting-capable user via the API.

The `$onvalue` branch calling `add()` with **no arguments at all** is a second tell that the branch was never executed.

## Git-history evidence

```
$ git log --oneline -S 'function add(' -- app/Model/Sighting.php
(no output)

$ git log --oneline -S 'Sighting->add(' -- app/Controller/SightingsController.php
c20553dfd5 new: [search/sighting] Possiblity to quickly add sightings on ID or VALUE when searching
```

`Sighting::add()` has **never** appeared in `app/Model/Sighting.php` in the whole history of the file. Checking the model as it stood at the commit that introduced the caller (`git show c20553dfd5:app/Model/Sighting.php | grep 'function '`) confirms it: `captureSighting`, `getSighting`, `attachToEvent`, `saveSightings`, `handleStixSighting`, `generateRandomFileName`, `addUuids`, `explodeIdList`, `getSightingsForTag`, `getSightingsForObjectIds`, `restSearch`. No `add`.

`c20553dfd5` (mokaddem, 2018-10-30) added `quickAdd()`, the confirmation form, and the `misp.js` hook in one commit — and the form it added already posted to `/sightings/add/`, not to `quickAdd`. So the POST branch was dead on arrival and the mistake was never load-bearing.

**Conclusion: this is not a refactor that left a stale call behind. There is nothing to "restore".**

## Proposed fix — marked UNCERTAIN

The only signal for intent is `quickAdd()`'s own GET branch, which is unambiguous:

```php
if (!$onvalue) {
    $this->set('tosight', $attribute['id']);      // sight this attribute
} else {
    $this->set('tosight', $attribute['value']);   // sight this value, globally
}
```

So the reconstruction mirrors `SightingsController::add()` and needs no invented request contract — everything comes from the URL parameters `quickAdd()` already takes:

- `!$onvalue` → `saveSightings($id, false, time(), $user, $type, '', false, $publish)`
- `$onvalue` → resolve the attribute, then `saveSightings(false, [$value], time(), $user, $type, '', false, $publish)`

`$publish` follows `add()`: `!empty(Configure::read('Sightings_enable_realtime_publish'))`.

### Candidate replacements I considered, and why I picked this one

| Candidate | Verdict |
|---|---|
| **`Sighting::saveSightings()`** | Chosen. It is what `SightingsController::add()` uses for exactly these two cases, and the parameters are all derivable from `quickAdd()`'s existing arguments. |
| `Sighting::captureSightings()` | Rejected — sync/import path, takes an array of full sighting records and an explicit `$attributeId`/`$eventId` pair. Wrong shape for a UI quick-action. |
| `Sighting::bulkSaveSightings()` | Rejected — event-scoped bulk sync helper, needs `$eventId` and a sightings array. |
| `Tag::quickAdd()` on another model | Rejected — `$this->Sighting` is unambiguous; the name collision with `Tag::quickAdd()` is coincidental. |
| Internal redirect / `setAction('add')` | Rejected as more invasive than the direct call, but it *is* a defensible option if you prefer one code path. |
| **Delete the POST branch** | Not chosen, but genuinely reasonable — see the alternative in the risk table. |

**Which of these you want is your call, and I would rather be told than guess.** If none of them is right, treat this PR as a bug report for the 500 and I will rework or withdraw it.

`php -l` clean. Not smoke-tested against a live instance: exercising it means POSTing to an endpoint that currently 500s, which proves the 500 but not the correctness of the replacement semantics.

## Why this analysis might be wrong

- **`saveSightings()` may not be what was meant.** The author wrote `add()` with zero arguments in the `$onvalue` branch, which suggests the intended method carried its own request parsing — possibly a planned model method that was never written. In that case my reconstruction implements *a* sensible behaviour, not *the* intended one.
- **Making a dead endpoint live is a behaviour change in itself.** If `quickAdd` POST has been effectively "reserved" or is expected to be removed, the right patch is deletion, not repair.
- **`$onvalue` semantics might be narrower than I read them.** Sighting a raw value globally touches every attribute with that value across the instance; if `quickAdd` was meant to be more constrained than `add`, my version is too broad.
- **The tightened success check is a small contract change** on its own. If some client parses `saved: true` and ignores the body, it will now see `saved: false` for cases that previously (wrongly) reported success. I believe that is a fix, but it is a change.
- **`Sighting::TYPE` validation is not added here**, so an out-of-range `$type` from the URL reaches `saveSightings()` the same way it does today. Deliberately out of scope — [#11038](https://github.com/MISP/MISP/pull/11038) covers sighting type handling.

## Please close this if the current behaviour is intentional

If `quickAdd` should be GET-only, if the POST branch should be deleted rather than fixed, or if you would rather pick the replacement method yourself — **close this PR**. The valuable half of it is the bug report and the history; the patch is a proposal and I have no attachment to it. Tell me which option you want and I will push it to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

