### PR TITLE
[medium] perf: bulk insert galaxy clusters during updateJSON - measured -46% galaxy ingestion, identical database content

### DIFF
--- a/app/Model/Galaxy.php
+++ b/app/Model/Galaxy.php
@@ -249,12 +249,16 @@ class Galaxy extends AppModel
         // Start transaction
         $this->getDataSource()->begin();
 
+        // Build every row first, then insert them in batches. The clusters used
+        // to be saved one Model::save() at a time, which is ~55k round trips for
+        // a full misp-galaxy and dominated `cake Admin updateJSON`.
+        $rows = [];
+        $pending = [];
         foreach ($cluster_package['values'] as $cluster) {
             if (empty($cluster['version'])) {
                 $cluster['version'] = 1;
             }
             $template['version'] = $cluster['version'];
-            $this->GalaxyCluster->create();
             $cluster_to_save = $template;
             if (isset($cluster['description'])) {
                 $cluster_to_save['description'] = $cluster['description'];
@@ -274,13 +278,18 @@ class Galaxy extends AppModel
             $cluster_to_save['published'] = false;
             $cluster_to_save['org_id'] = 0;
             $cluster_to_save['orgc_id'] = 0;
-            // We are already in transaction
-            $result = $this->GalaxyCluster->save($cluster_to_save, ['atomic' => false, 'validate' => false]);
-            if (!$result) {
-                $this->log("Could not save galaxy cluster with UUID {$cluster_to_save['uuid']}.");
+            $rows[] = $cluster_to_save;
+            $pending[] = $cluster;
+        }
+
+        $clusterIds = $this->__bulkInsertClusters($rows);
+
+        foreach ($pending as $i => $cluster) {
+            // null means the row could not be inserted; it was logged already.
+            if (!isset($clusterIds[$i])) {
                 continue;
             }
-            $galaxyClusterId = $this->GalaxyCluster->id;
+            $galaxyClusterId = $clusterIds[$i];
             if (isset($cluster['meta'])) {
                 foreach ($cluster['meta'] as $key => $value) {
                     if (!is_array($value)) {
@@ -328,6 +337,73 @@ class Galaxy extends AppModel
         $this->getDataSource()->commit();
 
         return [$elements, $relations];
+    }
+
+    /**
+     * Insert prepared galaxy cluster rows in batches, returning the ids assigned
+     * to them positionally aligned with $rows (null where the row was skipped).
+     *
+     * The ids cannot be recovered by looking the clusters up by uuid afterwards:
+     * misp-galaxy ships duplicate cluster uuids - 1033 across the corpus when
+     * this was written, 7 of them within a single galaxy - so uuid is not a key
+     * here. InnoDB does assign one contiguous block of auto increment values to
+     * a single multi row INSERT whose row count it knows up front, so the block
+     * beginning at LAST_INSERT_ID() maps onto the batch by position.
+     *
+     * If a batch cannot be inserted the whole batch is retried one row at a
+     * time, so that a single malformed cluster is skipped and logged rather than
+     * taking the other rows of its batch down with it - which is what saving
+     * row by row used to do.
+     *
+     * @param array $rows
+     * @return array
+     */
+    private function __bulkInsertClusters(array $rows)
+    {
+        $fields = [
+            'uuid', 'collection_uuid', 'type', 'value', 'tag_name', 'description',
+            'galaxy_id', 'source', 'authors', 'version', 'distribution',
+            'org_id', 'orgc_id', 'default', 'published',
+        ];
+        $db = $this->getDataSource();
+        $ids = [];
+        foreach (array_chunk($rows, 1000, true) as $chunk) {
+            $values = [];
+            foreach ($chunk as $row) {
+                $value = [];
+                foreach ($fields as $field) {
+                    $value[] = isset($row[$field]) ? $row[$field] : ($field === 'uuid' ? '' : null);
+                }
+                $values[] = $value;
+            }
+            $inserted = false;
+            try {
+                $inserted = $db->insertMulti('galaxy_clusters', $fields, $values);
+            } catch (Exception $e) {
+                $inserted = false;
+            }
+            if ($inserted) {
+                $firstId = (int)$db->lastInsertId();
+                $offset = 0;
+                foreach (array_keys($chunk) as $key) {
+                    $ids[$key] = $firstId + $offset;
+                    $offset++;
+                }
+                continue;
+            }
+            // Slow path: one row at a time, so one bad row only costs itself.
+            foreach ($chunk as $key => $row) {
+                $this->GalaxyCluster->create();
+                if ($this->GalaxyCluster->save($row, ['atomic' => false, 'validate' => false])) {
+                    $ids[$key] = $this->GalaxyCluster->id;
+                } else {
+                    $uuid = isset($row['uuid']) ? $row['uuid'] : '';
+                    $this->log("Could not save galaxy cluster with UUID {$uuid}.");
+                    $ids[$key] = null;
+                }
+            }
+        }
+        return $ids;
     }
 
     public function update($force = false)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Galaxy cluster ingestion switches to bulk inserts: measured 46% faster, identical database content.

- **Problem** — `Galaxy::__createClusters()` in `app/Model/Galaxy.php` saves each cluster with its own `Model::save()`, roughly 55,000 round trips for a full misp-galaxy ingest, even though elements and relations were already bulk-inserted.
- **Fix** — Batches clusters through `insertMulti()` in chunks of 1000 and maps rows back to ids by position rather than uuid, which is necessary because misp-galaxy ships 1033 duplicate cluster uuids that would otherwise attach elements to the wrong cluster.
- **Effect** — Measured 46% faster galaxy ingestion with identical database content, so `cake Admin updateJSON` and CI both get cheaper.
<!-- /bluf -->

`Galaxy::__createClusters()` saved every galaxy cluster with its own `Model::save()` — roughly 55,000 round trips for a full misp-galaxy. This batches them with `insertMulti()` in chunks of 1000 and maps the inserted rows back to their ids by position. Elements and relations were already bulk-inserted (`insertMulti`, `bulkSaveRelations`) before this change; clusters were the only row-by-row path left.

## The trap this had to survive

The obvious implementation — bulk insert, then look the rows up by uuid to recover their ids — is wrong here. misp-galaxy ships duplicate cluster uuids: 1033 across the corpus, and 7 of those duplicated *within a single galaxy*. Mapping by uuid would have silently attached galaxy elements to the wrong cluster. The implementation therefore maps by position instead.

Positional mapping is sound because InnoDB allocates one contiguous block of auto-increment values to a single multi-row INSERT whose row count it knows up front (a "simple insert"), under every `innodb_autoinc_lock_mode` setting. So `LAST_INSERT_ID() + offset` is a valid mapping within a batch. This was also verified empirically on MariaDB 10.11 by the equivalence check below.

## Why this matters beyond one install

In #11004 the point was made that *"we're already struggling with the CI length"*, and that *"The first step will be to come up with a sane set of mock data for the JSON ingested structures (galaxies, objects, etc) and avoid actually ingesting the sub modules, as that takes up 40%+ of the CI run."* This change attacks the same cost directly, and it is complementary to that plan rather than a substitute for it — mock data removes the ingestion from CI, while this makes the real ingestion cheaper for every install that runs `cake Admin updateJSON`.

Measured CI share, from GitHub Actions run 32854863121 on branch 2.5, the `build` jobs:

| | 8.1 job (ubuntu-22.04) | 8.3 job (ubuntu-24.04) |
|---|---|---|
| total job | 865s | 798s |
| `Update JSON` step | 225s (26.0%) | 216s (27.1%) |
| `checkout` (recursive submodules) | 77s (8.9%) | 67s (8.4%) |

Ingestion alone is ~26–27% of the job, ~35% with the submodule checkout.

## Measured effect

Cold ingestion into an empty database built from the live schema, with the current submodules. Before:

```
Galaxies              639.94s   (80.4% of the run)
Warninglists          101.98s
ObjectTemplates        29.49s
Taxonomies             20.29s
ObjectRelationships     4.09s
Noticelists             0.14s
total                 13m17s
```

After:

```
Galaxies              342.91s   (-46.4%)
total                  8m08s    (-38.8%)
```

Everything other than Galaxies is unchanged, as expected.

This environment is a container on a developer machine and is roughly 3x slower than a GitHub runner, so the absolute seconds do not transfer. The ratio is the transferable result.

## Equivalence

The same submodules were ingested both ways into a clean database and compared. Row counts and order-independent content hashes were identical:

```
clusters   = 55392
elements   = 367882
relations  = 63130
cluster_fp = 270805528385567381
elem_fp    = 826929597424496570
```

The hash is `BIT_XOR(CONV(SUBSTRING(MD5(CONCAT_WS('|', ...)),1,15),16,10))` over the relevant columns. It is order-independent, so differing row order and differing auto-increment ids do not affect it. Its one weakness is that `BIT_XOR` cancels identical rows pairwise, which is why it is paired with the exact row counts rather than relied on alone.

## Why bypassing the model layer is safe here

Ingestion already set `$this->GalaxyCluster->bulkEntry = true`, which disables the `afterSave` relation update, and already called `save()` with `['atomic' => false, 'validate' => false]`, which skips `beforeValidate`. The per-cluster `save()` was therefore already doing nothing but an INSERT plus CakePHP overhead. `galaxy_clusters` has no `created`/`modified` columns, so no Cake magic-field population is lost either. All columns that are NOT NULL without a default are supplied explicitly.

## Failure semantics are preserved

A per-row `save()` loop skips and logs one bad cluster; a plain batch insert would fail the whole batch instead. A failed batch is therefore retried one row at a time, so a single malformed cluster is skipped and logged exactly as before rather than taking its batch down with it.

## What this does not do

342.91s still remains in galaxy ingestion after the change. Cluster saves were roughly half the cost, not nearly all of it. The remaining time has not been attributed yet; `generateMissingRelations()` and the per-file pre-existing-cluster lookup are the untested suspects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

