### PR TITLE
[medium] perf: collapse UsersEvolutionWidget's 30-180 per-bucket COUNT queries into 2

### DIFF
--- a/app/Lib/Dashboard/UsersEvolutionWidget.php
+++ b/app/Lib/Dashboard/UsersEvolutionWidget.php
@@ -47,31 +47,38 @@ class UsersEvolutionWidget
             throw new InvalidArgumentException("Number of days, weeks or months must be a number between 1 and 180.");
         }
 
+        // Users without a creation date are counted in every bucket, exactly as the
+        // previous per-bucket `date_created IS NULL OR date_created <= $time` condition did.
+        $undatedUsers = $this->User->find('count', array(
+            'recursive' => -1,
+            'conditions' => array('date_created' => null)
+        ));
+        $creationTimes = $this->User->find('column', array(
+            'recursive' => -1,
+            'conditions' => array('NOT' => array('date_created' => null)),
+            'fields' => array('User.date_created')
+        ));
+        $creationTimes = array_map('intval', $creationTimes);
+        sort($creationTimes);
+
         $data = array();
         $data['data'] = array();
+        // $itemTime strictly decreases with every iteration, so a single backwards
+        // moving pointer yields the number of users created at or before each bucket.
+        $pointer = count($creationTimes);
         // Add total users data for all timestamps
         for ($i = 0; $i < $limit; $i++) {
             $itemTime = strtotime('- ' . $i . $delta, $endOfDay);
+            while ($pointer > 0 && $creationTimes[$pointer - 1] > $itemTime) {
+                $pointer--;
+            }
             $item = array();
             $item['date'] = strftime('%Y-%m-%d', $itemTime);
-            $item['users'] = $this->usersAtTime($itemTime);
+            $item['users'] = $undatedUsers + $pointer;
             $data['data'][] = $item;
         }
 
         return $data;
-    }
-
-    private function usersAtTime($time)
-    {
-        return $this->User->find('count', array(
-            'recursive' => -1,
-            'conditions' => array(
-                'OR' => array(
-                    array('date_created' => null),
-                    array('date_created <=' => $time),
-                )
-            )
-        ));
     }
 
     public function checkPermissions($user)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `UsersEvolutionWidget` replaces its 30-180 per-bucket `COUNT` queries with 2 queries.

- **Problem** — `UsersEvolutionWidget::handler()` in `app/Lib/Dashboard/UsersEvolutionWidget.php` issues a `User->find('count')` per time bucket, 30 by default and up to the documented 180, and nothing caches it: the widget declares `$cacheLifetime` while `WidgetCache::remember()` only honours `$cache_duration`, so the handler runs live on every render.
- **Fix** — Replaces the per-bucket counts with one count of NULL `date_created` rows plus one `find('column')` of timestamps, swept in memory by a single backwards pointer.
- **Effect** — The widget costs 2 queries at any bucket count.
<!-- /bluf -->

### What the loop does and why it is expensive

`UsersEvolutionWidget::handler()` builds one data point per time bucket and, for each bucket, calls the private `usersAtTime()` helper, which issues a `User->find('count', ...)` with an `OR (date_created IS NULL, date_created <= $itemTime)` condition. The loop runs `$limit` times: 30 by default, and the widget's own parameter documentation advertises values up to 180 ("Value between 1 and 180"), so a site admin who configures `{"days": "180"}` gets 180 sequential `COUNT` round trips.

The concrete caller is the dashboard: `Dashboard::loadWidget()` (`app/Model/Dashboard.php`) → `DashboardsController`, on page load and on widget refresh. Worth noting a correction the verification pass made to the original finding: the finding claimed the widget was protected by a 10-second cache. That is wrong, and wrong in the direction that strengthens the case — `DashboardsController::renderWidget()` caches through `WidgetCache::remember()`, which only opts in when a widget declares `$cache_duration` (`WidgetCache.php:171`). This widget declares `$cacheLifetime`, which nothing reads, so the handler runs live on every render.

### Query-count reduction

**30 queries become 2** by default; **180 queries become 2** at the documented maximum. The count of the buckets no longer influences the number of queries at all: one `find('count')` for users with a NULL `date_created`, one `find('column')` for the non-NULL creation timestamps, and then a pure in-memory sweep. That structural reduction is the defensible claim here.

The bucket timestamps are strictly decreasing across iterations for all three deltas (day/week/month), so a single backwards-moving pointer over the sorted timestamp array gives the per-bucket count in O(n + buckets) total, with no per-bucket search.

### No benchmark was run

**No wall-clock benchmark was run for this change.** The automated audit attached an estimated 75% improvement to the enclosing widget render; that is an estimate of the operation, not a measurement of it, and it should not be read as one. The honest claim is the query-count reduction above. The audit's own verification pass trimmed this estimate from 80% down to 75% precisely because the `users` table on a MISP instance is small (hundreds to low thousands of rows), so the absolute saving is on the order of tens of milliseconds on a site-admin-only widget — real, but modest.

### Behaviour preservation

- The `date_created IS NULL OR date_created <= $itemTime` semantics are preserved exactly: users with no creation date are counted once, up front, and that count is added to **every** bucket, which is what the `OR ... IS NULL` arm did before.
- Bucket ordering, bucket count, the `strftime('%Y-%m-%d', ...)` date formatting, the `$limit`/`$delta` parameter handling and the 1–180 `InvalidArgumentException` are all untouched.
- `recursive => -1` is kept on both queries, so no associated models are pulled in and no model callbacks change.
- Empty instance: the timestamp array is empty, the pointer starts at 0, and every bucket reports the NULL-`date_created` count — matching the old per-bucket `COUNT`.
- Timestamps are cast with `intval()` before sorting so the PHP comparison matches the numeric comparison the SQL `<=` was doing against the `bigint(20)` column, rather than a string comparison.
- `checkPermissions()` (site admin only) is unchanged.

### Risk

Low. The one new consideration is memory: all non-NULL `date_created` values are now held in a PHP array. For a MISP instance that is typically hundreds to low thousands of integers, so this is negligible; on an implausibly large user table it would be a bounded array of integers, not of rows. The behavioural surface is a single private helper that no longer exists and one loop body, both inside one widget.

### Provenance

This came out of an automated performance sweep of the codebase in which every candidate finding was handed to a second agent instructed to refute it. 30 of 55 candidates were refuted and discarded. This one survived, with the cache correction and the estimate trim described above applied by that reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

