### PR TITLE
[medium] Resolve API activity widget auth keys in one query instead of one per key

### DIFF
--- a/app/Lib/Dashboard/APIActivityWidget.php
+++ b/app/Lib/Dashboard/APIActivityWidget.php
@@ -134,26 +134,46 @@ class APIActivityWidget
         // chars of the live key, authkey_end the last 4 — both stored
         // for legacy-auth bookkeeping.
         $this->AuthKey->Behaviors->load('Containable');
+        // Resolve every key seen in the window with a single query instead of
+        // one find('first') per key. The match is a composite (start, end) pair
+        // rather than a single column, so the condition is an OR of AND blocks.
+        $keyConditions = [];
+        foreach (array_keys($counts) as $apikey) {
+            $keyConditions[] = [
+                'AuthKey.authkey_start' => substr($apikey, 0, 4),
+                'AuthKey.authkey_end' => substr($apikey, 4),
+            ];
+        }
+        $found = $this->AuthKey->find('all', [
+            'recursive' => -1,
+            'conditions' => ['OR' => $keyConditions],
+            'fields' => [
+                'AuthKey.id', 'AuthKey.authkey_start', 'AuthKey.authkey_end',
+                'AuthKey.user_id',
+            ],
+            'contain' => [
+                'User' => [
+                    'fields' => ['User.id', 'User.email'],
+                    'Organisation' => ['fields' => ['id', 'name', 'uuid']],
+                    'Role' => ['fields' => ['name']],
+                ],
+            ],
+        ]);
+        $byKey = [];
+        foreach ($found as $authKey) {
+            // start is the first 4 chars of the live key, end the rest, so the
+            // concatenation reproduces the redis log key exactly. Keep the first
+            // row for a duplicate pair, mirroring the previous find('first').
+            $composite = $authKey['AuthKey']['authkey_start'] . $authKey['AuthKey']['authkey_end'];
+            if (!isset($byKey[$composite])) {
+                $byKey[$composite] = $authKey;
+            }
+        }
+        // Every key gets an entry, misses included - the unknown-key counting
+        // below relies on empty entries being present.
         $resolved = [];
         foreach (array_keys($counts) as $apikey) {
-            $resolved[$apikey] = $this->AuthKey->find('first', [
-                'recursive' => -1,
-                'conditions' => [
-                    'AuthKey.authkey_start' => substr($apikey, 0, 4),
-                    'AuthKey.authkey_end' => substr($apikey, 4),
-                ],
-                'fields' => [
-                    'AuthKey.id', 'AuthKey.authkey_start', 'AuthKey.authkey_end',
-                    'AuthKey.user_id',
-                ],
-                'contain' => [
-                    'User' => [
-                        'fields' => ['User.id', 'User.email'],
-                        'Organisation' => ['fields' => ['id', 'name', 'uuid']],
-                        'Role' => ['fields' => ['name']],
-                    ],
-                ],
-            ]);
+            $resolved[$apikey] = isset($byKey[$apikey]) ? $byKey[$apikey] : [];
         }
 
         $unknownCount = 0;


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** The API Activity widget resolves every auth key in one query instead of one per key.

- **Problem** — `APIActivityWidget::handler()` in `app/Lib/Dashboard/APIActivityWidget.php` resolves each distinct API key from the Redis activity log with its own `AuthKey::find('first')`, so a 7-day window holding 20-150 active keys fires that many queries every 30 seconds while a dashboard is open.
- **Fix** — Builds the composite (`authkey_start`, `authkey_end`) conditions once, resolves every key in a single `find('all')`, and indexes the rows in memory.
- **Effect** — The API Activity widget renders with one `AuthKey` query whatever the key count. No benchmark was run.
<!-- /bluf -->

### What this changes

`APIActivityWidget::handler()` (`app/Lib/Dashboard/APIActivityWidget.php`) resolves the API keys seen in the Redis activity log to their owning `AuthKey`/`User`/`Organisation`/`Role`. It did that with one `AuthKey::find('first')` **per distinct key**, inside `foreach (array_keys($counts) as $apikey)`.

This builds the composite `(authkey_start, authkey_end)` condition list once and resolves every key with a single `find('all')`, then indexes the rows in memory by `authkey_start . authkey_end` (which reconstructs the Redis log key exactly, since `authkey_start` is the first 4 chars of the live key and `authkey_end` the rest).

### Why the loop is expensive

The widget is the render method for the "API Activity" dashboard widget. `$counts` is keyed by every unique authkey that made a request across the report window (7 days by default), pulled in one Redis pipeline. So the loop runs once per distinct key active in the window — on a moderately active instance (users with 1-3 keys each, plus feed/sync workers) that is realistically 20-150 keys. The widget's `autoRefreshDelay` is 30s, so a dashboard left open re-runs the whole thing every 30 seconds.

The match is a composite pair, not a single column, so the batched query is an OR of AND blocks rather than an `IN()`.

**Query-count reduction: one query per distinct API key becomes one query total.** That is the defensible claim here.

### No benchmark was run

**No wall-clock before/after measurement was taken for this change.** The percentage figure carried in the audit record that produced it (~20% of the widget's render) is an *estimate of the enclosing operation*, not a measurement, and should not be read as one. The structural claim (N queries → 1) is the part that is verifiable by inspection.

Note also that both matched columns are indexed (`auth_keys.authkey_start` and `auth_keys.authkey_end` appear under `indexes` in `db_schema.json`), so each removed iteration was a cheap single-row indexed SELECT. The saving is N round-trips, not N table scans, and at realistic N it is milliseconds — this is a structural cleanup, not a dramatic speedup.

### Behaviour preservation

- Same `recursive => -1`, same `fields`, same `contain` (User + Organisation + Role) as the per-key query.
- `$resolved` is still populated for **every** key in `$counts`, misses included as an empty entry — the `$unknownCount` loop below counts empty entries, and dropping misses would have silently removed the "N unknown" segment of the header.
- Duplicate `(start, end)` rows: the first row encountered wins, mirroring what `find('first')` did. (`find('first')` and a batched `find('all')` both resolve such duplicates arbitrarily anyway.)
- The lookup stays after the `if (empty($counts))` early return, so the OR list is never empty — an empty OR condition in CakePHP 2 would match every row.
- Read-only lookup; nothing downstream depends on per-key query ordering or side effects.

### Risk

Low. Read-only lookup feeding widget rendering only. The correctness hinge is that the OR-of-AND condition reproduces the composite match, and that the in-memory index key reproduces the Redis key — both are direct from the same `substr` split the original used.

### Provenance

This came out of an automated performance sweep of the codebase in which every candidate finding was handed to a second agent instructed to refute it; 30 of 55 candidates were refuted and dropped. This one survived, but the reviewer **corrected the original estimate down from 40% to ~20%**, specifically because both match columns are indexed and the Redis pipeline plus dashboard render overhead is a large share of the request — i.e. the original estimate overstated the win. I am reporting the corrected figure, and again: it is an estimate, not a measurement.

Unlike MISP/MISP#11047 earlier in this series, this PR carries **no** real before/after timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

