### PR TITLE
[medium] perf: batch the per-event N+1 queries in Log::findDeletedEvents

### DIFF
--- a/app/Model/Log.php
+++ b/app/Model/Log.php
@@ -615,18 +615,43 @@ class Log extends AppModel
         $users = [];
         $orgs = [];
         $deleted_event_ids = [];
+        if (empty($deletions)) {
+            return $deleted_events;
+        }
+        $candidateEventIds = array_unique(array_column(array_column($deletions, 'Log'), 'model_id'));
+        // Events that still exist have been restored already - fetch them all in one go
+        // instead of issuing one existence check per deletion entry.
+        $existingEventIds = array_flip($this->Event->find('column', [
+            'recursive' => -1,
+            'conditions' => ['Event.id' => $candidateEventIds],
+            'fields' => ['Event.id']
+        ]));
+        // Same for the creation log entries. Ordering by Log.id and keeping the first
+        // row seen per model_id reproduces the previous per-event find('first') result,
+        // including when an event id has more than one 'add' entry.
+        $creationEntries = [];
+        $creationEntryRows = $this->find('all', [
+            'recursive' => -1,
+            'conditions' => [
+                'model_id' => $candidateEventIds,
+                'model' => 'Event',
+                'action' => 'add'
+            ],
+            'order' => ['Log.id']
+        ]);
+        foreach ($creationEntryRows as $creationEntryRow) {
+            if (!isset($creationEntries[$creationEntryRow['Log']['model_id']])) {
+                $creationEntries[$creationEntryRow['Log']['model_id']] = $creationEntryRow;
+            }
+        }
+        unset($creationEntryRows);
         foreach ($deletions as $deletion_entry) {
             if (!empty($deleted_event_ids[$deletion_entry['Log']['model_id']])) {
                 continue;
             } else {
                 $deleted_event_ids[$deletion_entry['Log']['model_id']] = true;
             }
-            $event = $this->Event->find('first', [
-                'conditions' => ['Event.id' => $deletion_entry['Log']['model_id']],
-                'recursive' => -1,
-                'fields' => ['Event.id']
-            ]);
-            if (!empty($event)) {
+            if (isset($existingEventIds[$deletion_entry['Log']['model_id']])) {
                 // event is already restored / not deleted
                 continue;
             }
@@ -635,14 +660,7 @@ class Log extends AppModel
                 'user_id' => $deletion_entry['Log']['user_id'],
                 'created' => $deletion_entry['Log']['created']
             ];
-            $event_creation_entry = $this->find('first', [
-                'recursive' => -1,
-                'conditions' => [
-                    'model_id' => $temp['event_id'],
-                    'model' => 'Event',
-                    'action' => 'add'
-                ]
-            ]);
+            $event_creation_entry = $creationEntries[$temp['event_id']] ?? [];
             $event = $this->changeParser($event_creation_entry['Log']['change']);
             $temp['event_info'] = $event['info'];
             $temp['event_org_id'] = $event['org_id'];
@@ -660,17 +678,21 @@ class Log extends AppModel
                 }
                 $temp['event_' . $scope . '_name'] = $orgs[$temp['event_' . $scope . '_id']];
             }
-            $users[$temp['user_id']] = array_values($this->Event->User->find('list', [
-                'recursive' => -1,
-                'conditions' => array('id' => $temp['user_id']),
-                'fields' => array('id', 'email')
-            ]))[0];
+            if (empty($users[$temp['user_id']])) {
+                $users[$temp['user_id']] = array_values($this->Event->User->find('list', [
+                    'recursive' => -1,
+                    'conditions' => array('id' => $temp['user_id']),
+                    'fields' => array('id', 'email')
+                ]))[0];
+            }
             $temp['user_name'] = $users[$temp['user_id']];
-            $users[$temp['event_user_id']] = array_values($this->Event->User->find('list', [
-                'recursive' => -1,
-                'conditions' => array('id' => $temp['event_user_id']),
-                'fields' => array('id', 'email')
-            ]))[0];
+            if (empty($users[$temp['event_user_id']])) {
+                $users[$temp['event_user_id']] = array_values($this->Event->User->find('list', [
+                    'recursive' => -1,
+                    'conditions' => array('id' => $temp['event_user_id']),
+                    'fields' => array('id', 'email')
+                ]))[0];
+            }
             $temp['event_user_name'] = $users[$temp['event_user_id']];
             $deleted_events[] = $temp;
         }


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `Log::findDeletedEvents()` batches its per-event finds and repairs a dead memoisation: 2N queries become 2.

- **Problem** — `Log::findDeletedEvents()` in `app/Model/Log.php` runs an `Event->find('first')` and a `Log->find('first')` per deleted event, and re-queries the same admin's e-mail once per event because the `$users` array it writes into is never read, unlike the `$orgs` memoisation two lines above.
- **Fix** — Batches both finds and fixes that memoisation, turning 2N queries into 2.
- **Effect** — This is a cold path by the author's own account: the only caller is the admin restore-deleted-events tool, whose result is Redis-cached for 600 seconds.
<!-- /bluf -->

### Upfront: this is a cold path, not a hot one

I want to lead with the limitation rather than bury it, because the verification pass on this finding downgraded it. The sole caller of `Log::findDeletedEvents()` is `EventsController::restoreDeletedEvents()` — the admin "recover deleted events" tool, whose window is hardcoded (`2020-07-31` to the `fix_login` AdminSetting) and whose entire result is cached in Redis under `misp:event_recovery` for 600 seconds. So the N+1 is genuinely multiplicative *per invocation*, but the ongoing production payoff is close to zero. If a maintainer's view is that this code is not worth touching, that is a completely reasonable call and I will close it.

What is left is a real N+1 in a function that also contains an outright inconsistency (a memoization pattern applied to organisations and not to users, two lines apart), which seemed worth fixing while it was in front of me.

### What the loop does and why it is expensive

For each distinct deleted event id in the range, the loop issued:

- `Event->find('first')` to check whether the event has already been restored,
- `Log->find('first')` to fetch the matching `action = 'add'` entry,
- up to two `Orgc->find('list')` calls — these **were** memoized via `$orgs`,
- two `User->find('list')` calls — these were **not** memoized, despite assigning into a `$users` array that exists for exactly that purpose, so a bulk delete performed by one admin re-queried that admin's email once per event.

Realistic iteration count: tens to a couple of hundred deleted events per invocation — one bulk-delete incident or audit window.

### Query-count reduction

**2N queries become 2**, plus the user lookups drop from 2N to (number of distinct user ids), which for the bulk-delete case this tool exists to handle is typically a small handful. The Event existence check and the creation-entry lookup no longer scale with N at all.

### No benchmark was run

**No wall-clock benchmark was run for this change.** The audit's estimate — 50%, itself trimmed down from an original 65% by the verification pass — is an estimate of the enclosing function, not a measurement of it. The verifier trimmed it because batching removes the 2N round trips but the per-row `changeParser()` JSON work is untouched, and the user memoization only pays off when user ids repeat. Please do not read that number as measured.

### Behaviour preservation

- **Creation-entry ordering.** The original `find('first')` returned, in practice, the lowest-`Log.id` `add` entry for an event id. Event ids can be reused after deletion and recreation, so more than one `add` entry per id is possible. The batched query is ordered by `Log.id` and keeps the **first** row seen per `model_id`, reproducing that result. This was the specific correctness caveat the verifier raised against the original fix proposal; it is addressed here rather than glossed over.
- **Missing creation entry.** The original code did not guard against there being no `add` entry — it would have warned on `$event_creation_entry['Log']`. `$creationEntries[$id] ?? []` reproduces that path warning-for-warning rather than silently changing behaviour. I deliberately did not add a guard, as that would be a behaviour change outside the scope of a perf patch.
- **Existence check.** `find('first')` on one id becomes a membership test against a pre-fetched id set from one `Event.id IN (...)`. Equivalent, and the `!empty($event) → continue` skip is preserved.
- **Ordering and output shape.** The outer `$deletions` query, its `order => ['Log.id']`, the dedup-by-event-id skip, and the flat `$deleted_events` row shape rendered by the admin UI/API are all unchanged.
- **Early return.** `if (empty($deletions)) return [];` before the batch queries, so no `IN ()` is built from an empty list.
- **Memoization.** The `$users` guards use `empty()`, matching the `$orgs` pattern immediately above. Both remain function-local, so nothing persists across requests.
- `recursive => -1` retained on the batched queries; no model callbacks are affected.

### Risk

Low — this is a read-only reporting/preparation function; `recoverDeletedEvent()`, which performs the actual restore, is separate and untouched. The one thing to be aware of is that the `IN ()` lists now scale with the number of distinct deleted event ids in the window; for the realistic N here (tens to hundreds) that is unremarkable.

### Provenance

This came out of an automated performance sweep in which each candidate finding was handed to a second agent instructed to refute it; 30 of 55 candidates were refuted and discarded. This one survived but was corrected twice by that reviewer: the hot-path claim was downgraded to false (the cold-path caveat at the top of this description is theirs, not mine), and the lowest-`Log.id` requirement on the batched creation-entry lookup was a caveat the original fix proposal had missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

