### PR TITLE
[medium] perf: fetch org activity for the org statistics page in one query instead of one per organisation

### DIFF
--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -2406,12 +2406,19 @@ class UsersController extends AppController
             'recursive' => -1,
             'fields' => array('Event.orgc_id', 'count(*)', 'sum(Event.attribute_count) as attributeCount')
         ));
+        $orgcIdsWithEvents = array();
         foreach ($events as $event) {
             $orgs[$event['Event']['orgc_id']]['eventCount'] = $event[0]['count(*)'];
             $orgs[$event['Event']['orgc_id']]['attributeCount'] = $event[0]['attributeCount'];
-            $orgs[$event['Event']['orgc_id']]['orgActivity'] = $this->User->getOrgActivity($event['Event']['orgc_id'], array('event_timestamp' => '365d'));
+            $orgcIdsWithEvents[] = $event['Event']['orgc_id'];
         }
         unset($events);
+        // Fetch the activity of every organisation in one query instead of one query per organisation
+        $orgActivity = $this->__orgActivityBulk($orgcIdsWithEvents, '365d');
+        foreach ($orgcIdsWithEvents as $orgcId) {
+            $orgs[$orgcId]['orgActivity'] = $orgActivity[$orgcId];
+        }
+        unset($orgActivity, $orgcIdsWithEvents);
         $orgs = Set::combine($orgs, '{n}.name', '{n}');
         // f*** php
         uksort($orgs, 'strcasecmp');
@@ -2427,6 +2434,60 @@ class UsersController extends AppController
             $this->set('orgs', $orgs);
             $this->render('statistics_orgs');
         }
+    }
+
+    /**
+     * Batched equivalent of User::getOrgActivity() for several organisations at once.
+     *
+     * Issues one Event query covering every passed organisation instead of one query per
+     * organisation, then buckets the rows per organisation in PHP the same way
+     * User::getOrgActivity() does.
+     *
+     * @param array $orgcIds List of organisation ids
+     * @param string $timeframe Timestamp delta understood by Event::set_filter_timestamp(), for example '365d'
+     * @return array Keyed by organisation id, each entry in the shape returned by User::getOrgActivity()
+     */
+    private function __orgActivityBulk(array $orgcIds, $timeframe)
+    {
+        $result = array();
+        if (empty($orgcIds)) {
+            return $result;
+        }
+        $filterParam = array('event_timestamp' => $timeframe);
+        $conditions = $this->User->Event->set_filter_timestamp($filterParam, array(), array('filter' => 'event_timestamp'));
+        $conditions['Event.orgc_id'] = $orgcIds;
+        $events = $this->User->Event->find('all', array(
+            'recursive' => -1,
+            'fields' => array('Event.orgc_id', 'Event.timestamp', 'Event.attribute_count'),
+            'conditions' => $conditions,
+            'order' => 'Event.timestamp'
+        ));
+        $sparklineData = array();
+        foreach ($events as $event) {
+            $date = date("Y-m-d", $event['Event']['timestamp']);
+            // Same last-write-wins behaviour as User::getOrgActivity()
+            $sparklineData[$event['Event']['orgc_id']][$date] = $event['Event']['attribute_count'];
+        }
+        unset($events);
+        $startDate = $this->User->Event->resolveTimeDelta($timeframe);
+        $endDate = time();
+        $dates = array();
+        for ($d = $startDate; $d < $endDate; $d = $d + 3600 * 24) {
+            $dates[] = date('Y-m-d', $d);
+        }
+        foreach ($orgcIds as $orgcId) {
+            $data = isset($sparklineData[$orgcId]) ? $sparklineData[$orgcId] : array();
+            $csv = 'Date,Close\n';
+            foreach ($dates as $date) {
+                $csv .= sprintf('%s,%s\n', $date, isset($data[$date]) ? $data[$date] : 0);
+            }
+            $result[$orgcId] = array(
+                'csv' => $csv,
+                'data' => $data,
+                'orgId' => $orgcId
+            );
+        }
+        return $result;
     }
 
     private function __statisticsUsers($params = array())


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** The org statistics page fetches activity for all organisations in one query instead of N+1.

- **Problem** — `UsersController::__statisticsOrgs()` in `app/Controller/UsersController.php`, behind the `/users/statistics/orgs` page that the ACL opens to all users, calls `User::getOrgActivity()` once per organisation inside its loop, each firing its own 365-day Event query.
- **Fix** — Fetches activity for every organisation in one query and buckets the rows per org in a new `__orgActivityBulk()` helper.
- **Effect** — The org statistics page costs 2 queries regardless of how many organisations are on the instance. No wall-clock benchmark was run.
<!-- /bluf -->

## What this changes

`UsersController::__statisticsOrgs()` (the `/users/statistics/orgs` page) builds one grouped `Event` query for event/attribute counts, then — inside the `foreach` over its result — calls `User::getOrgActivity($orgcId, ['event_timestamp' => '365d'])` once per organisation. Each of those calls issues its own `Event->find('all')` over the last 365 days and aggregates the rows into a sparkline in PHP.

This PR replaces those per-organisation calls with a single `Event` query covering every organisation at once, and buckets the rows per organisation in PHP the same way `getOrgActivity()` does. The bucketing lives in a new private helper, `UsersController::__orgActivityBulk()`; moving it into `User` as a public bulk method would be a reasonable follow-up, but it was kept in the controller here so the change stays confined to a single file.

## Why it is expensive

The concrete caller is `UsersController::statistics('orgs')` (`$this->__statisticsOrgs($this->params['named'])`). The ACL grants `'statistics' => array('*')`, so this is not restricted to site admins. The loop runs once per organisation that has at least one event, in the selected scope (`local` or `external`). On a mid-size community instance that is on the order of tens to a few hundred organisations, so the page fires that many extra `Event` queries on every render.

## The reduction

Stated structurally, and this is the defensible claim:

**N+1 queries become 2.** One grouped counts query plus one query per organisation becomes one grouped counts query plus one activity query total, regardless of how many organisations are on the instance.

## No benchmark was run

**No wall-clock before/after measurement was taken for this change.** The audit this came from carries a ~35% figure for the enclosing page render; that is an estimate, not a measurement, and it should not be read as one. The honest, verifiable statement is the query-count reduction above.

The verifier that reviewed this finding explicitly corrected the original estimate downward and corrected its reasoning: the original write-up called the per-organisation query an "unindexed full unbounded Event scan", which is wrong — `events.orgc_id` is indexed (`KEY orgc_id` in `INSTALL/MYSQL.sql`), and the find is `recursive => -1` with three fields and a 365-day timestamp filter, so each individual query is cheap. The win is the round-trip count and the repeated PHP aggregation, not scan elimination.

## Behaviour preservation

- **Conditions**: built by calling the same machinery `getOrgActivity()` uses — `Event::set_filter_timestamp($filterParam, array(), array('filter' => 'event_timestamp'))` with the identical `'event_timestamp' => '365d'` — rather than hand-writing SQL. The organisation restriction becomes `Event.orgc_id IN (...)` over exactly the ids the old loop iterated (the orgc_ids present in the grouped counts result), not every organisation in scope.
- **No `GROUP BY` / `FROM_UNIXTIME`**: `Event.timestamp` is a unix int column, so grouping by `DATE(timestamp)` in SQL would have introduced a MySQL-vs-PHP timezone difference in the day buckets. The verifier flagged this in the originally proposed fix; this PR deliberately keeps one un-grouped query and reuses the existing PHP `date("Y-m-d", ...)` bucketing verbatim, so the day boundaries are byte-identical to today's.
- **Ordering**: `'order' => 'Event.timestamp'` is preserved.
- **Result shape**: each entry is still `array('csv' => ..., 'data' => ..., 'orgId' => ...)`, so both the view (`statistics_orgs.ctp`, which reads `orgActivity['csv']`) and the REST response are unchanged. Organisations with events but none inside the 365-day window still get an empty `data` array and an all-zero csv, as before.
- **The csv `'\n'` literals** are copied byte-for-byte: `'Date,Close\n'` and `sprintf('%s,%s\n', ...)` are single-quoted and emit a literal backslash-n, which is what the sparkline element consumes. They were not "fixed".
- **A pre-existing quirk is deliberately preserved**: in `getOrgActivity()` the accumulation guard reads `if (!isset($sparklineData[$event['Event']['attribute_count']][$date]))`, which indexes by attribute count rather than by date and is therefore always false, so the `+=` branch is dead and each day ends up holding the attribute count of the *last* event on that day rather than the sum. This PR reproduces that last-write-wins behaviour exactly. Changing it would alter the rendered sparklines and belongs in a separate, behavioural PR.
- **No model callbacks are involved**: both the old and the new query are `recursive => -1` plain finds.
- `User::getOrgActivity()` itself is left untouched (this was its only caller in the tree).

## Risk

- The audit rated this **low-to-medium**. Two of its stated risks turned out to be moot: `getOrgActivity()` has no best/worst-day statistics beyond the sparkline/csv assembly, and the `GROUP BY`/timezone hazard is avoided by not grouping in SQL at all.
- **Peak memory is the one real tradeoff, and it is not in the original finding.** Today the N queries buffer one organisation's 365 days of rows at a time; this change buffers all organisations' rows at once. The total number of rows fetched is identical and only three columns are selected, but the peak is higher. On a very large instance that is tens of MB of CakePHP arrays on an admin statistics page. If maintainers would prefer a bounded peak, chunking the `orgc_id` list (e.g. 200 ids per query) would keep the same structure and still reduce N queries to `ceil(N/200)` — happy to change it.
- I did **not** run the test suite for this change (the integration suite in my environment needs a shared live database that other work was using). The file was syntax-checked with `php -l`.

## Provenance

This came from an automated performance sweep of the codebase in which every candidate finding was handed to a second agent instructed to refute it; 30 of 55 candidates were refuted and dropped. This one survived, with the estimate corrected downward and the proposed SQL approach corrected as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

