### PR TITLE
[medium] pushProposals: index existing proposals for dedup, send one alert per batch

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -6357,10 +6357,23 @@ class EventsController extends AppController
                 $message = "Event not found.";
                 $success = false;
             } else {
+                // Pre-index the event's existing proposals so the dedup check below scans only
+                // the candidates sharing the same (event_uuid, type, category) instead of every
+                // existing proposal for every incoming one. The value/to_ids comparison stays
+                // inside the loop with the original loose == semantics.
+                $oldShadowAttributes = array();
+                if (isset($event['ShadowAttribute'])) {
+                    foreach ($event['ShadowAttribute'] as $oldk => $oldsa) {
+                        $bucket = $oldsa['event_uuid'] . '|' . $oldsa['type'] . '|' . $oldsa['category'];
+                        $oldShadowAttributes[$bucket][$oldk] = $oldsa;
+                    }
+                }
+                $proposalAlertNeeded = false;
                 foreach ($this->request->data as $k => $sa) {
-                    if (isset($event['ShadowAttribute'])) {
-                        foreach ($event['ShadowAttribute'] as $oldk => $oldsa) {
-                            if ($sa['event_uuid'] == $oldsa['event_uuid'] && $sa['value'] == $oldsa['value'] && $sa['type'] == $oldsa['type'] && $sa['category'] == $oldsa['category'] && $sa['to_ids'] == $oldsa['to_ids']) {
+                    $bucket = $sa['event_uuid'] . '|' . $sa['type'] . '|' . $sa['category'];
+                    if (isset($oldShadowAttributes[$bucket])) {
+                        foreach ($oldShadowAttributes[$bucket] as $oldk => $oldsa) {
+                            if ($sa['value'] == $oldsa['value'] && $sa['to_ids'] == $oldsa['to_ids']) {
                                 if ($oldsa['timestamp'] < $sa['timestamp']) {
                                     $this->Event->ShadowAttribute->delete($oldsa['id']);
                                 } else {
@@ -6390,8 +6403,14 @@ class EventsController extends AppController
                         $counter++;
                     }
                     if (!$sa['deleted']) {
-                        $this->Event->ShadowAttribute->sendProposalAlertEmail($event['Event']['id']);
+                        $proposalAlertNeeded = true;
                     }
+                }
+                // The proposal e-mail lock means at most one alert is sent per event per lock
+                // window anyway, so send it once after the batch instead of paying an
+                // Event->read() lock check for every single proposal pushed.
+                if ($proposalAlertNeeded) {
+                    $this->Event->ShadowAttribute->sendProposalAlertEmail($event['Event']['id']);
                 }
             }
             if ($success) {


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Proposal push dedups against an index and sends one alert per batch instead of one per proposal.

- **Problem** — `EventsController::pushProposals()` in `app/Controller/EventsController.php`, the endpoint remote instances hit when syncing proposals, scans every existing `ShadowAttribute` of the event for each incoming proposal and calls `sendProposalAlertEmail()` in the loop, where every call after the first costs an `Event->read()` just to rediscover the proposal lock.
- **Fix** — Buckets existing proposals by (`event_uuid`, `type`, `category`) and moves the alert to one post-batch call.
- **Effect** — A push of n proposals does 1 lock-check read instead of n and an O(n+m) dedup; e-mail behaviour is unchanged.
<!-- /bluf -->

### What this changes

`EventsController::pushProposals()` (`app/Controller/EventsController.php`) is the endpoint a remote MISP instance hits when pushing proposals: `Server::syncProposals()` (`app/Model/Server.php:1576`, reached from `Event.php:6285` / `Server.php:1414`) POSTs the event's whole ShadowAttribute array to `/events/pushProposals/<uuid>`.

Two things in the per-proposal loop:

1. **Dedup scan.** For each incoming proposal it iterated *every* existing ShadowAttribute of the event to find a match on `(event_uuid, value, type, category, to_ids)` — O(n·m).
2. **Alert e-mail.** For each non-deleted proposal it called `ShadowAttribute::sendProposalAlertEmail($eventId)`.

This PR buckets the existing proposals by `(event_uuid, type, category)` once before the loop and scans only the matching bucket, and replaces the in-loop alert call with a flag that triggers a single call after the batch.

### Why this is expensive — corrected from the original finding

The original audit record claimed each `sendProposalAlertEmail()` cost "2 queries + N mail sends + 1 save". **That is wrong, and the reviewer caught it.** `ShadowAttribute::sendProposalAlertEmail()` (`app/Model/ShadowAttribute.php:573-604`) checks `proposal_email_lock` *first* and returns immediately when it is set; the first call sets the lock via `setProposalLock()`. So proposals 2..n each cost exactly one `Event->read()` SELECT and then bail. At most one e-mail was ever sent per event per lock window, before and after this change.

So the real per-row waste being removed here is:

- **N `Event->read()` lock-check SELECTs become 1.** For a push of n proposals, n-1 of those reads existed only to discover the lock was already set.
- **The O(n·m) in-PHP dedup scan becomes O(n+m).** This is CPU, not DB, and is the smaller of the two.

Realistic sync batches are tens to low hundreds of shadow attributes for an actively-worked event. The unavoidable `ShadowAttribute->create()` + `save()` with its model callbacks remains per row and still dominates the action's cost — this change does not touch it.

I deliberately did **not** batch or memoise the per-row `Orgc->captureOrg()` lookup that the original finding also suggested: `captureOrg` (`app/Model/Organisation.php:218`) can create or update an organisation as a side effect, so memoising it is not a mechanical change and I was not confident enough in it. That per-row SELECT is left as-is.

### No benchmark was run

**No wall-clock before/after measurement was taken for this change.** The percentage in the audit record (~20%) is an estimate of the enclosing operation, not a measurement. Please read only the structural claims above as verified.

### Behaviour preservation

- The dedup bucket key uses only `event_uuid`, `type` and `category` — fields that are never numeric strings — and the `value` and `to_ids` comparison stays inside the loop with the **original loose `==`** semantics. This deliberately avoids changing the comparison for numeric-string values or for `to_ids` arriving as a JSON bool vs. a DB `'0'`/`'1'` string.
- The inner `foreach` and its `continue 2` are structurally unchanged (still one `if` + one `foreach` inside the outer loop), so the "a newer proposal already exists, skip this incoming one" path and the "delete the older duplicate and keep scanning" path both behave as before, in the same iteration order (bucket entries keep their original keys and relative order).
- A deleted old ShadowAttribute is **not** removed from the index — the original did not remove it from `$event['ShadowAttribute']` either, so a later incoming proposal can still re-match it. That quirk is preserved intentionally.
- The alert flag is set on `!$sa['deleted']` regardless of whether the save succeeded, matching the original (which called the alert even after a failed save), and the call sits inside the event-found branch only.
- `$counter`, `$message`, `$success` and the serialised response are untouched.

### Risk

Moving `sendProposalAlertEmail()` after the loop changes timing slightly: the alert is attempted once all proposals are processed rather than after the first non-deleted one, and the `proposal_email_lock` is therefore set at the end of the batch rather than at the start. The existing lock already collapsed the batch to at most one e-mail, so the observable outcome is the same; a concurrent push arriving mid-batch would previously have found the lock already set and now might send its own alert. I judge that acceptable — it is the same one-alert-per-lock-window contract — but it is the one real behavioural edge, and I would rather name it than hide it.

The dedup index carries the theoretical risk that an incoming proposal with a `type`/`category` that is loosely-but-not-textually equal to an existing one no longer matches. Those fields are enum-like attribute types and categories, never numeric strings, so this should not occur in practice.

### Provenance

This came out of an automated performance sweep in which every candidate finding was handed to a second agent instructed to refute it; 30 of 55 candidates were refuted and dropped. This one survived, but the reviewer **corrected the estimate down from 40% to ~20% and lowered its confidence**, explicitly because the finding's stated cost basis for `sendProposalAlertEmail` was factually wrong (see above) and because real proposal batches are tens, not thousands. The corrected analysis is what this PR implements.

Unlike MISP/MISP#11047 earlier in this series, this PR carries **no** real before/after timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

