### PR TITLE
[medium] perf: batch session lookups in SessionStore::eachSession with MGET

### DIFF
--- a/app/Lib/Dashboard/Tools/SessionStore.php
+++ b/app/Lib/Dashboard/Tools/SessionStore.php
@@ -160,14 +160,33 @@ class SessionStore
             $this->redis->setOption(Redis::OPT_SCAN, Redis::SCAN_RETRY);
             $it = null;
             while (($keys = $this->redis->scan($it, $this->prefix . '*', 500)) !== false) {
-                foreach ($keys as $key) {
-                    if ($processed++ >= self::SCAN_CAP) {
-                        return;
-                    }
-                    $uid = $this->extractUserId($this->redis->get($key));
+                $remaining = self::SCAN_CAP - $processed;
+                if ($remaining <= 0) {
+                    return;
+                }
+                // Trim the page to the remaining cap *before* fetching, so the
+                // mid-page truncation semantics stay identical to the old
+                // per-key walk (exactly SCAN_CAP keys are ever inspected).
+                $page = count($keys) > $remaining ? array_slice($keys, 0, $remaining) : $keys;
+                if (empty($page)) {
+                    continue;
+                }
+                $processed += count($page);
+                // One MGET per SCAN page instead of one GET per key. phpredis
+                // returns values aligned to the input order, false for keys
+                // that vanished between the SCAN and the MGET.
+                $values = $this->redis->mget($page);
+                if (!is_array($values)) {
+                    return;
+                }
+                foreach ($page as $i => $key) {
+                    $uid = $this->extractUserId(isset($values[$i]) ? $values[$i] : false);
                     if ($uid !== null) {
                         $cb($key, $uid);
                     }
+                }
+                if (count($page) < count($keys)) {
+                    return;
                 }
             }
         } catch (Exception $e) {


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Redis session lookups go from one `GET` per session to one `MGET` per 500-key `SCAN` page.

- **Problem** — `SessionStore::eachSession()` in `app/Lib/Dashboard/Tools/SessionStore.php` `SCAN`s the Redis session keyspace 500 keys per page and then issues one `GET` per key, so `LoggedInUsersWidget`, which declares no `cache_duration` and runs live on every 30-second dashboard refresh, makes one round trip per live session.
- **Fix** — Replaces the per-key `GET` with a single `MGET` per `SCAN` page.
- **Effect** — Session tallies and `DashboardsController::invalidateUserSessions` take 2 round trips for 1000 sessions instead of 1000. No benchmark was run.
<!-- /bluf -->

## What this changes

`SessionStore::eachSession()` walks the PHP→Redis session keyspace with `SCAN`, 500 keys per page — and then issued **one `GET` per key** inside each page. This replaces the per-key `GET` with a single `MGET` per `SCAN` page.

## Why this loop is hot

`eachSession()` is the shared walk behind two callers:

- `LoggedInUsersWidget::handler()` calls `SessionStore::tally()`. The widget declares no `$cache_duration`, so `WidgetCache::remember` is a pass-through and the walk runs live on **every render** — repeated by the dashboard's `autoRefreshDelay = 30` for each site admin with the widget open.
- `DashboardsController::invalidateUserSessions` shares the same walk via `keysForUser()`.

On a busy instance the live session count is in the hundreds to low thousands (bounded by `SCAN_CAP = 20000`).

## Query-count reduction

Stated structurally: **one Redis `GET` per live session becomes one `MGET` per 500-key `SCAN` page.** With 1000 active sessions that is 2 `MGET` round trips instead of 1000 sequential `GET` round trips. The `SCAN` calls themselves are unchanged, and `extractUserId()`'s regex work is unchanged — this removes round trips, not server-side work.

## No benchmark was run for this change

I did **not** run a before/after wall-clock measurement for this patch, and there is no profile attached. The audit record carries an estimate of ~28% of the enclosing `tally()`/`keysForUser()` call — that is an **estimate of the enclosing operation, not a measurement**, and it is deliberately modest precisely because Redis round trips on a local or adjacent connection are sub-millisecond; the win here is syscall and context-switch overhead, not Redis server work. Please read the percentage as an order-of-magnitude expectation, not a result.

## Behaviour preservation

- **`SCAN_CAP` truncation semantics.** The old code post-incremented per key, so exactly `SCAN_CAP` keys were ever inspected and it returned on key `CAP + 1`. The new code computes the remaining budget and slices the page to it **before** issuing the `MGET`, so the same set of keys is inspected, including on the truncating page.
- **Key order.** phpredis `mget()` returns values aligned to the input key order, so `$cb($key, $uid)` is invoked in the same order as before. `tally()` only counts and `keysForUser()` only filters, so neither is order-sensitive anyway.
- **Missing keys.** A key that expires between the `SCAN` and the `MGET` comes back as `false` in its slot; `extractUserId(false)` returns `null` via its `is_string()` guard, exactly as a missing `GET` did.
- **Connection shape.** `parseSavePath()` takes the first server of the save path and opens a single non-clustered `Redis` connection, and no `OPT_PREFIX` is set — so a multi-key `MGET` is safe here (as is the pre-existing multi-key `del()` in `destroy()`).
- `mget()` returning non-array (phpredis error) is guarded with `is_array` and stops the sweep, matching the existing "a mid-sweep failure stops early" contract.

## Risk

Low. The one honest behavioural nuance: an exception raised while fetching a page now costs that whole page's callbacks rather than leaving a partially-processed page. That still falls inside the method's documented contract ("a mid-sweep failure stops early; callers keep whatever was gathered"), and both callers degrade gracefully to a partial result, so I left it rather than engineering around it.

## Provenance

This came from an automated performance sweep of the codebase in which every candidate finding was handed to a second agent instructed to refute it; 30 of 55 candidates were refuted and dropped. This one survived. The verifier confirmed the hot path independently (the missing `$cache_duration` on `LoggedInUsersWidget`, the non-clustered connection, the absent `OPT_PREFIX`), **lowered** the original 30% estimate to 28%, and added the implementation caveat that the page must be sliced to the remaining `SCAN_CAP` budget *before* the `MGET` or the truncation semantics change — which is why the slice is where it is in this patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

