### PR TITLE
[medium] perf: batch the AttributeTag lookups in Event::includeRelatedTags

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -3646,10 +3646,64 @@ class Event extends AppModel
         return $eventTagCache;
     }
 
+    /**
+     * Fetch, in one query, the tags of every attribute referenced by the
+     * event's RelatedAttribute set.
+     *
+     * @param array $relatedAttributes event['RelatedAttribute']
+     * @param bool $excludeLocalTags
+     * @return array attribute_id => (tag id => tag)
+     */
+    private function __cacheRelatedAttributeTags(array $relatedAttributes, $excludeLocalTags)
+    {
+        $attributeIds = array();
+        foreach ($relatedAttributes as $relatedAttributeList) {
+            foreach ($relatedAttributeList as $relatedAttribute) {
+                $attributeIds[$relatedAttribute['attribute_id']] = true;
+            }
+        }
+        if (empty($attributeIds)) {
+            return array();
+        }
+        $params = array(
+            'contain' => array(
+                'Tag' => array(
+                    'fields' => array(
+                        'Tag.id', 'Tag.name', 'Tag.colour', 'Tag.numerical_value'
+                    )
+                )
+            ),
+            'recursive' => -1,
+            'conditions' => array(
+                'AttributeTag.attribute_id' => array_keys($attributeIds)
+            )
+        );
+        if ($excludeLocalTags) {
+            $params['conditions']['AttributeTag.local'] = 0;
+        }
+        $attributeTags = $this->Attribute->AttributeTag->find('all', $params);
+        $cache = array();
+        foreach ($attributeTags as $at) {
+            $cache[$at['AttributeTag']['attribute_id']][$at['Tag']['id']] = $at['Tag'];
+        }
+        return $cache;
+    }
+
     private function includeRelatedTags(array $event, array $options)
     {
         $eventTagCache = array();
         $excludeLocalTags = !empty($options['excludeLocalTags']);
+        // Fetch the tags of every correlated attribute in a single query
+        // instead of one query per (attribute, correlated attribute) pair.
+        $attributeTagCache = $this->__cacheRelatedAttributeTags($event['RelatedAttribute'], $excludeLocalTags);
+        // id => position map, so the lookup below stays O(1) rather than a
+        // linear scan of the event's attributes per related attribute.
+        $attributePosCache = array();
+        foreach ($event['Attribute'] as $k => $attribute) {
+            if (!isset($attributePosCache[$attribute['id']])) {
+                $attributePosCache[$attribute['id']] = $k;
+            }
+        }
         foreach ($event['RelatedAttribute'] as $attributeId => $relatedAttributes) {
             $tags = [];
             foreach ($relatedAttributes as $relatedAttribute) {
@@ -3657,35 +3711,14 @@ class Event extends AppModel
                 foreach ($eventTagCache[$relatedAttribute['id']] as $tagId => $tag) {
                     $tags[$tagId]= $tag;
                 }
-                $params = array(
-                    'contain' => array(
-                        'Tag' => array(
-                            'fields' => array(
-                                'Tag.id', 'Tag.name', 'Tag.colour', 'Tag.numerical_value'
-                            )
-                        )
-                    ),
-                    'recursive' => -1,
-                    'conditions' => array(
-                        'AttributeTag.attribute_id' => $relatedAttribute['attribute_id']
-                    )
-                );
-                if ($excludeLocalTags) {
-                    $params['conditions']['AttributeTag.local'] = 0;
-                }
-                $attributeTags = $this->Attribute->AttributeTag->find('all', $params);
-                foreach ($attributeTags as $at) {
-                    $tags[$at['Tag']['id']] = $at['Tag'];
+                if (isset($attributeTagCache[$relatedAttribute['attribute_id']])) {
+                    foreach ($attributeTagCache[$relatedAttribute['attribute_id']] as $tagId => $tag) {
+                        $tags[$tagId] = $tag;
+                    }
                 }
             }
             if (!empty($tags)) {
-                $attributePos = false;
-                foreach ($event['Attribute'] as $k => $attribute) {
-                    if ($attribute['id'] == $attributeId) {
-                        $attributePos = $k;
-                        break;
-                    }
-                }
+                $attributePos = isset($attributePosCache[$attributeId]) ? $attributePosCache[$attributeId] : false;
                 $event['Attribute'][$attributePos]['RelatedTags'] = array_values($tags);
             }
         }


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `Event::includeRelatedTags()` fires a query per correlation pair; this PR batches them into one.

- **Problem** — In `app/Model/Event.php`, `Event::includeRelatedTags()` issues a fresh `AttributeTag::find('all')` for every (attribute, correlated-attribute) pair, so an event with 50 correlating attributes averaging 20 correlations each fires roughly 1000 queries on MISP's hottest read path.
- **Fix** — Fetches the tags for all related attribute ids in one query, and replaces the linear scan that locates each attribute with a prebuilt id-to-position map.
- **Effect** — Event view and REST search with granular correlations enabled drop to a single `AttributeTag` query.
<!-- /bluf -->

## What this changes

`Event::includeRelatedTags()` ran a fresh `AttributeTag::find('all')` for **every (attribute, correlated-attribute) pair** in `$event['RelatedAttribute']`. This collects the distinct `attribute_id`s of the whole `RelatedAttribute` set up front, fetches their tags in one query, and looks them up in memory. It also replaces the linear scan that located each attribute's position in `$event['Attribute']` with an `id => position` map built once.

## Why this loop is hot

`includeRelatedTags()` is called from `Event::fetchEvent()` (gated on `includeGranularCorrelations` **and** `includeRelatedTags` — see the correction below), which is the hottest read path in MISP. Both flags are set by the first-class, user-facing consumers: the event index/view controller (`EventsController.php:1356-1360`, `1819-1820`) and the REST search component (`RestSearchComponent.php:136`).

The loop iterates once per (attribute, correlated-attribute) pair. A moderately popular IOC — a common IP or file hash — correlates to tens or hundreds of other attributes, and an event can hold many such attributes. An event with 50 correlating attributes averaging 20 correlations each issues roughly **1000** individual `AttributeTag` finds. (`__cacheRelatedEventTags()` alongside it was already correctly memoised per related event id; only the `AttributeTag` find was unbatched.)

## Query-count reduction

Stated structurally: **N `AttributeTag` queries become 1**, where N is the number of (attribute, correlated-attribute) pairs. Plus the `attributePos` lookup goes from an O(number of attributes) scan per related attribute to an O(1) hash lookup.

## No benchmark was run for this change

I did **not** run a before/after wall-clock measurement, and no profile is attached. The audit record's ~20% figure is an **estimate of the enclosing `fetchEvent()` call, not a measurement** — and `fetchEvent`'s cost is dominated by the correlation collection in `getRelatedAttributes()` plus the attribute/tag/object fetch, of which these round trips are one contributor. The query-count reduction above is the defensible claim; the percentage is not.

## Behaviour preservation

- **ACL / filter conditions carried over.** The batched query uses the identical `contain` (`Tag` with `Tag.id`, `Tag.name`, `Tag.colour`, `Tag.numerical_value`), the same `recursive => -1`, and carries `AttributeTag.local => 0` under the same `$excludeLocalTags` gate. The only change to the conditions is `attribute_id => <single id>` becoming `attribute_id => <array of ids>`.
- **Empty-input guard.** The batched find is skipped entirely when there are no related attribute ids, so no `IN ()` is ever generated.
- **Merge order into `$tags`.** Per related attribute, event tags are still merged first and attribute tags second, keyed by tag id, exactly as before — so dedup and last-writer-wins are unchanged.
- **Tag ordering within `RelatedTags`.** Grouping preserves the returned row order per `attribute_id`. Note that neither the old per-attribute query nor the batched one carries an `ORDER BY`, so this ordering was never guaranteed by the old code either; I deliberately did not add one, to keep the diff purely about the round trips.
- **`attributePos` lookup.** The map is built with a `!isset` guard, mirroring the old first-match `break`; on a miss it still yields `false`, so the pre-existing (arguably buggy) `$event['Attribute'][false]` → index-0 write is preserved verbatim. Fixing that is a behaviour change and does not belong in a perf patch.
- **Pure read path.** No writes, no model callbacks, no side effects touched.

## Risk

Low. The finding's own risk note is "pure read/aggregation path; the only care needed is preserving the `excludeLocalTags` filter semantics when batching" — which is done and called out above. The extra thing I'd flag myself is memory: one query now materialises the tag rows for all correlated attributes at once rather than a few at a time. For the sizes involved (tag rows restricted to four columns) that is small next to what `fetchEvent` already holds, but it is a real difference.

## Provenance

This came from an automated performance sweep in which every candidate finding was handed to a second agent instructed to refute it; 30 of 55 candidates were refuted and dropped. This one survived — but the verifier **corrected it in two ways**, and both corrections are reflected above. It **lowered the estimate from 30% to 20%**, on the grounds that the correlation collection and the attribute/tag/object fetch dominate `fetchEvent`; and it corrected the framing of the trigger condition — the loop is gated on `includeGranularCorrelations` AND `includeRelatedTags` (`Event.php:3362-3364`), not on `includeRelatedTags` alone, as the original candidate claimed. The event view and REST search paths do set both, so the hot path stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

