### PR TITLE
[medium] perf: batch the per-attribute restSearch in Module_attach_decay_score

### DIFF
--- a/app/Model/WorkflowModules/action/Module_attach_decay_score.php
+++ b/app/Model/WorkflowModules/action/Module_attach_decay_score.php
@@ -57,16 +57,30 @@ class Module_attach_decay_score extends WorkflowBaseActionModule
             	return true;
         }
 		
+        $uuids = array_values(array_unique(array_column($matchingItems, 'uuid')));
+        if (empty($uuids)) {
+            // An empty uuid filter would be dropped by restSearch and match every
+            // attribute on the instance, so bail out the same way the per-attribute
+            // loop used to: without touching the data.
+            $roamingData->setData($rData);
+            return true;
+        }
+
+        $filters = [];
+        $filters['uuid'] = $uuids;
+        $filters['includeDecayScore'] = '1';
+        $filters['decayingModel'] = $params['decayingmodels']['value'];
+        $rParams = $this->Attribute->restSearch($user, 'json', $filters, true);
+        $attributesWithScore = $this->Attribute->fetchAttributes($user, $rParams);
+        $attributesWithScoreByUuid = [];
+        foreach ($attributesWithScore as $attributeWithScore) {
+            $attributesWithScoreByUuid[$attributeWithScore['Attribute']['uuid']] = $attributeWithScore['Attribute'];
+        }
+        unset($attributesWithScore);
+
         foreach ($matchingItems as $attribute) {
-            $filters = [];
-            $filters['uuid'] = $attribute['uuid'];
-            $filters['includeDecayScore'] = '1';
-            $filters['decayingModel'] = $params['decayingmodels']['value'];
-            $rParams = $this->Attribute->restSearch($user, 'json', $filters, true);
-            $attributeWithScore = $this->Attribute->fetchAttributes($user, $rParams);
-            if (!empty($attributeWithScore)) {
-                $attributeWithScore = $attributeWithScore[0]['Attribute'];
-                $rData = $this->_overrideAttribute($attribute, $attributeWithScore, $rData);
+            if (!empty($attributesWithScoreByUuid[$attribute['uuid']])) {
+                $rData = $this->_overrideAttribute($attribute, $attributesWithScoreByUuid[$attribute['uuid']], $rData);
             }
         }
         $roamingData->setData($rData);


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** The decay-score workflow node runs a full restSearch per attribute; this PR batches it into one.

- **Problem** — `Module_attach_decay_score::exec()` runs a full `MispAttribute::restSearch()` plus `fetchAttributes()` for every matched attribute, so a node with no filter matches every attribute of the triggering event and pays the whole search pipeline hundreds of times.
- **Fix** — Collects the matched uuids, issues one `restSearch` and one `fetchAttributes`, and indexes the results by uuid so the loop runs in memory.
- **Effect** — Workflows wiring in the decay-score action node cost 2 queries instead of 2N. No benchmark was run; the N-to-1 reduction is the verifiable claim.
<!-- /bluf -->

### What the loop does and why it is expensive

`Module_attach_decay_score::exec()` iterates over `getMatchingItemsForAttributes()` and, for **each** matched attribute, runs a full `MispAttribute::restSearch()` + `fetchAttributes()` pair filtered on that one attribute's uuid. `restSearch()` is the heavy query-building/permission/join pipeline used for full attribute exports — filter parsing, `convert_filters`, condition assembly, ACL scoping — and it was being paid once per attribute to fetch a single row.

The iteration count is the number of matched attributes. `getMatchingItemsForAttributes()` (`WorkflowBaseModule.php:171-184`) falls back to `Hash::extract` over `Event._AttributeFlattened.{n}` when the node has no filter configured, so with a permissive filter or none at all it matches **every attribute of the triggering event**. Events routinely carry hundreds to low thousands of attributes, giving hundreds to thousands of full search executions per workflow run.

**Hot-path caveat, stated plainly:** this is conditional, not a default code path. Workflows must be enabled *and* this module explicitly wired into a workflow for any of this to execute.

### Query-count reduction

**N restSearch + N fetchAttributes calls become 1 + 1.** The uuid list of all matched attributes goes into a single filter; results are indexed by uuid and the loop then runs purely in memory. This is the defensible structural claim.

### No benchmark was run

**No wall-clock benchmark was run for this change.** The audit's figure — 40%, trimmed down from an original 60% by the verification pass — is an estimate of the enclosing workflow-node execution, not a measurement of it. The verifier trimmed it specifically because batching removes N query-pipeline builds and N round trips, but the per-attribute decay-score and Sighting work *inside* `fetchAttributes` remains, so this is not a 60% cut. Please do not read that number as measured.

### Behaviour preservation

- **Array uuid filter is equivalent to the union of the single-uuid searches.** `MispAttribute::set_filter_uuid` (line 4006) runs `$params['uuid']` through `convert_filters` and handles the resulting `OR` array, producing `Attribute.uuid IN (...)`. The `pre_lookup` branch there only widens the search when one of the supplied uuids is an *event* uuid; these are attribute uuids from the triggering event's own attribute list, so that branch behaves the same batched as it did per-item.
- **No truncation.** `MispAttribute::restSearch` (line 3642) sets no default limit — it only applies one `if (isset($filters['limit']))` — so a large uuid list is not silently paginated and no chunking is required. Both of these points were open risks in the original finding that the verification pass resolved in the fix's favour.
- **Permission scoping is unchanged** — the same `$user` is passed to the same `restSearch`/`fetchAttributes` pair; ACL is applied by those methods, not by the loop.
- **Per-attribute override semantics are untouched.** `_overrideAttribute()` is still called once per matched attribute, in the original `$matchingItems` order, threading `$rData` through exactly as before. Attributes with no search result are skipped exactly as the old `if (!empty($attributeWithScore))` guard did.
- **Empty match set.** A non-`false` but empty `$matchingItems` would have produced an empty uuid filter, which `set_filter_uuid`'s `!empty($params['uuid'])` check drops — meaning the batched call would have returned *every attribute on the instance* rather than none. The old per-item loop simply never ran in that case. An explicit early return preserves the no-op. This is the one hazard introduced by batching and it is guarded.
- `includeDecayScore` and `decayingModel` are passed identically; duplicate uuids in the match set are deduplicated for the query but each matched item is still overridden individually.

### Risk

Medium-low. The uuid list now scales with the event's attribute count, so the `IN (...)` clause can get large on an event with thousands of attributes; there is no limit in `restSearch` that would truncate it, but it is a bigger single statement than before. If maintainers would prefer the batch chunked (e.g. 500 uuids at a time), that is a small change on top and I am happy to make it — the verification pass concluded chunking was unnecessary, so it is not included here.

### Provenance

This came out of an automated performance sweep in which each candidate finding was handed to a second agent instructed to refute it; 30 of 55 candidates were refuted and discarded. This one survived, with two of its stated risks (silent pagination, array-filter support) resolved against the code by that reviewer and the improvement estimate cut from 60% to 40%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

