### PR TITLE
[medium] perf: hoist the fast-lookup rebuild out of the tag_operation attribute loop

### DIFF
--- a/app/Model/WorkflowModules/action/Module_tag_operation.php
+++ b/app/Model/WorkflowModules/action/Module_tag_operation.php
@@ -142,9 +142,15 @@ class Module_tag_operation extends WorkflowBaseActionModule
                 $tags = $this->genTagObjectsFromTagNames($tagAttached, $options);
                 $updatedRData = $this->_addTag($tags, 'attribute', $roamingData->getData(), $attribute);
                 $roamingData->setData($updatedRData);
-                $this->_buildFastLookupForRoamingData($roamingData->getData());
             }
             $success = $success || !empty($saveSuccess);
+        }
+        // _addTag() only rewrites the Tag/_allTags entries of attributes that
+        // are already indexed, so the fast lookup arrays are unchanged by each
+        // iteration. Rebuilding them once after the loop instead of on every
+        // iteration avoids walking the whole event per tagged attribute.
+        if ($success) {
+            $this->_buildFastLookupForRoamingData($roamingData->getData());
         }
         return $success;
     }
@@ -159,9 +165,14 @@ class Module_tag_operation extends WorkflowBaseActionModule
                 $tags = $this->genTagObjectsFromTagNames($tagDetached, $options);
                 $updatedRData = $this->_removeTag($tags, 'attribute', $roamingData->getData(), $attribute);
                 $roamingData->setData($updatedRData);
-                $this->_buildFastLookupForRoamingData($roamingData->getData());
             }
             $success = $success || !empty($saveSuccess);
+        }
+        // See __addTagsToAttributes(): _removeTag() likewise leaves the
+        // attribute indexes untouched, so one rebuild after the loop is
+        // equivalent to one per iteration.
+        if ($success) {
+            $this->_buildFastLookupForRoamingData($roamingData->getData());
         }
         return $success;
     }


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** tag_operation rebuilt the event fast-lookup per attribute; this PR hoists it out of the loop.

- **Problem** — `Module_tag_operation::__addTagsToAttributes()` and `__removeTagsFromAttributes()` called `_buildFastLookupForRoamingData()` inside the per-attribute loop, and that helper walks the event's entire `Event.Attribute` array, every attribute of every `Event.Object` and the whole `_AttributeFlattened` array, plus the same again for `_unfilteredData` when filters are enabled.
- **Fix** — Hoists the rebuild to a single call after the loop, reducing that work from O(N x event size) to O(N + event size); the per-attribute `AttributeTag` writes and `touch()` calls are deliberately left unchanged.
- **Effect** — Workflows using the `tag_operation` action node on broadly filtered events complete noticeably faster with the same resulting tags.
<!-- /bluf -->

## What this changes

`Module_tag_operation::__addTagsToAttributes()` and `__removeTagsFromAttributes()` called `_buildFastLookupForRoamingData()` **inside** the per-attribute loop. This hoists that call to a single invocation after the loop.

## What the loop does and why it is expensive

`Module_tag_operation` is a live, user-configurable workflow action node. When its scope is `attribute`, it operates on `$matchingItems` — the filtered attribute set of the event, which for a broad filter (or no filter) is *every* attribute of the event. For each one it attaches or detaches the configured tags, and then rebuilt the fast-lookup arrays.

`_buildFastLookupForRoamingData()` (`WorkflowBaseModule.php:480`) walks the event's entire `Event.Attribute` array, every attribute of every `Event.Object`, and the whole `Event._AttributeFlattened` array — and does it all again for `_unfilteredData` when filters are enabled. Running that once per tagged attribute makes the loop **O(N × event size)** in PHP, independent of the database.

Realistic iteration count: 50–500 attributes for a mid-to-large MISP event matched by a workflow filter (events commonly hold hundreds of attributes). For an event of ~200 attributes that is ~200 full walks of a ~200-entry structure instead of one.

## The reduction

The defensible structural claim here is **loop complexity, not query count**: N full rebuilds of the lookup maps become 1. Each rebuild is O(event size), so the PHP work in this loop drops from O(N × event size) to O(N + event size).

**The per-attribute database writes are unchanged by this patch** — `attachTagsToAttributeAndTouch()` / `detachTagsFromAttributeAndTouch()` still issue their `AttributeTag` write plus `touch()` per attribute. See "What I deliberately did not do" below.

## Why the hoist is behaviour-preserving

Three facts, each checked against the code:

1. The maps are already built **before** the loop: `Module_tag_operation::exec()` calls `parent::exec()`, and `WorkflowBaseActionModule::exec()` calls `_buildFastLookupForRoamingData()` on the roaming data. So the first loop iteration was never depending on an in-loop rebuild.
2. `_addTag()` / `_removeTag()` only rewrite the `Tag` and `_allTags` entries of attributes **at their existing indexes** (`WorkflowBaseModule.php:546-670`). They never insert, remove, or reorder entries in `Event.Attribute`, `Event.Object[].Attribute`, or `Event._AttributeFlattened`.
3. Therefore every mid-loop rebuild recomputed byte-identical maps, and the builder is idempotent (it assigns `id => index` by key, it does not append). One rebuild after the loop leaves the instance state identical to N rebuilds.

The rebuild is kept under the same "something actually changed" guard: previously it ran only when an iteration's save succeeded, and now it runs only when `$success` is true — which is true exactly when at least one iteration's save succeeded.

## What I deliberately did not do

The original finding proposed also batching the DB writes: adding a `deferTouch` flag to `attachTagsToAttributeAndTouch()` / `detachTagsFromAttributeAndTouch()` in `MispAttribute.php` and issuing one `updateAll()` over the collected attribute ids after the loop. **I skipped that half on purpose.** `MispAttribute::touch()` is not a single-row `UPDATE`: called with an id it does a `find('first')` + `save()`, plus `Object->updateTimestamp()` for object attributes, plus `Event->unpublishEvent()`. A bare `updateAll()` over the collected ids would silently drop the object timestamp bump and the event unpublish, which sync/pull consumers key off. That is a correctness regression, not a perf win, so it is out of scope for this PR and `MispAttribute.php` is untouched — this diff is one file.

## No benchmark was run for this change

I did **not** run a before/after wall-clock measurement, and no profile is attached. The audit record carries a ~30% estimate; that is an **estimate of the enclosing operation, not a measurement**, and it was moreover written about the *database* batching described above rather than about this hoist. Treat the complexity argument as the claim and the percentage as neither measured nor directly applicable to this patch.

## Risk

Low, and lower than the finding's own risk note — that note ("batching must ensure the timestamp change is still applied to the parent event exactly once with correct semantics; needs a test around sync/pull triggers") applies to the DB-batching half that this PR does not implement. What remains is a pure in-process memoisation of derived index arrays, resting on facts 1–3 above. The one way it could bite is if a future change made `_addTag()`/`_removeTag()` structurally mutate the roaming data; today they do not.

## Provenance

This came from an automated performance sweep in which every candidate finding was handed to a second agent instructed to refute it; 30 of 55 candidates were refuted and dropped. This one survived, and the verifier materially changed it: it found that the original candidate had **missed the actual dominant cost in this loop** — it had focused on the DB writes, while `_buildFastLookupForRoamingData()` re-running inside every iteration makes the loop O(N²) in PHP regardless of the database — and it noted that hoisting that call is "cheaper and safer than the DB batching". It also corrected the candidate's claim that `touch()` is a single-row `UPDATE` (it is 3–5 statements, and repeats `unpublishEvent` for the same event on every iteration) and warned that the proposed "safe half" `updateAll()` is not behaviour-preserving on its own. This PR implements the verifier's recommendation and drops the candidate's original proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

