### PR TITLE
[medium] perf: hoist the per-tag AttributeTag lookups out of the inner loop in AttributesController::addTag()

### DIFF
--- a/app/Controller/AttributesController.php
+++ b/app/Controller/AttributesController.php
@@ -3322,6 +3322,27 @@ class AttributesController extends AppController
                     $this->MispAttribute->Event->insertLock($this->Auth->user(), $attribute['Event']['id']);
                 }
                 $changeTimestamp = false;
+                // Fetch the tags already attached to this attribute once, rather than
+                // re-querying them for every entry of $tag_id_list. $attachedTagIds mirrors
+                // the previous AttributeTag::hasAny() check, which was not scoped by `local`
+                // (a local and a non-local attachment both count as already attached), while
+                // $tagsOnAttribute mirrors the local-scoped tag name list that the taxonomy
+                // exclusivity check consumes. Both are kept up to date below as tags are
+                // attached, so tags added earlier in this same request are still taken into
+                // account exactly as the per-pair queries did.
+                $attachedTagIds = array();
+                $tagsOnAttribute = array();
+                $attributeTags = $this->MispAttribute->AttributeTag->find('all', array(
+                    'conditions' => array('AttributeTag.attribute_id' => $id),
+                    'contain' => 'Tag',
+                    'fields' => array('AttributeTag.tag_id', 'AttributeTag.local', 'Tag.name'),
+                ));
+                foreach ($attributeTags as $attributeTag) {
+                    $attachedTagIds[$attributeTag['AttributeTag']['tag_id']] = true;
+                    if ((int)$attributeTag['AttributeTag']['local'] === $local && isset($attributeTag['Tag']['name'])) {
+                        $tagsOnAttribute[] = $attributeTag['Tag']['name'];
+                    }
+                }
                 foreach ($tag_id_list as $tag_id) {
                     if (!isset($tags[$tag_id])) {
                         // Tag not found or user don't have permission to add it.
@@ -3329,23 +3350,11 @@ class AttributesController extends AppController
                         continue;
                     }
                     $tagName = $tags[$tag_id];
-                    $found = $this->MispAttribute->AttributeTag->hasAny([
-                        'attribute_id' => $id,
-                        'tag_id' => $tag_id,
-                    ]);
-                    if ($found) {
+                    if (isset($attachedTagIds[$tag_id])) {
                         // Tag is already assigned to given attribute.
                         $fails++;
                         continue;
                     }
-                    $tagsOnAttribute = $this->MispAttribute->AttributeTag->find('column', array(
-                        'conditions' => array(
-                            'AttributeTag.attribute_id' => $id,
-                            'AttributeTag.local' => $local,
-                        ),
-                        'contain' => 'Tag',
-                        'fields' => array('Tag.name'),
-                    ));
                     $exclusiveTestPassed = $this->Taxonomy->checkIfNewTagIsAllowedByTaxonomy($tagName, $tagsOnAttribute);
                     if (!$exclusiveTestPassed) {
                         $fails++;
@@ -3353,6 +3362,8 @@ class AttributesController extends AppController
                     }
                     $this->MispAttribute->AttributeTag->create();
                     if ($this->MispAttribute->AttributeTag->save(array('attribute_id' => $id, 'tag_id' => $tag_id, 'event_id' => $attribute['Event']['id'], 'local' => $local))) {
+                        $attachedTagIds[$tag_id] = true;
+                        $tagsOnAttribute[] = $tagName;
                         if (!$local) {
                             $changeTimestamp = true;
                         }


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Bulk attribute tagging ran two reads per tag pair; this PR does one read per attribute.

- **Problem** — `AttributesController::addTag()` backs the bulk Add tag action from `misp.js` `quickSubmitAttributeTagForm()`, the taxonomy mass-tag confirmation and tag-collection expansion, running an `AttributeTag::hasAny()` duplicate check plus an `AttributeTag::find('column')` with `contain => Tag` for taxonomy exclusivity on every (attribute, tag) pair — up to 1500 iterations for a few hundred attributes by one to three tags.
- **Fix** — Answers both from one `find('all')` per attribute before the tag loop, building an attached-tag-id set not scoped by `local`, matching the old `hasAny()` semantics, plus the `local`-scoped tag-name list.
- **Effect** — Bulk tagging of large selections completes with far fewer round-trips and identical results.
<!-- /bluf -->

### What the loop does and why it is expensive

`AttributesController::addTag()` is the handler behind the bulk "Add tag" action on attributes. `app/webroot/js/misp.js:774` (`quickSubmitAttributeTagForm()`) POSTs to `/attributes/addTag/selected` with the selected attribute ids (form in `View/Attributes/ajax/attributeEditMassForm.ctp` / `View/Events/add_tag.ctp`); the same endpoint is reached from the taxonomy mass-tag confirmation (`View/Taxonomies/ajax/taxonomy_mass_confirmation.ctp`) and from `Elements/ajaxTags.ctp` / `ajaxTagCollectionTags.ctp`, which can expand a tag collection into several tag ids.

The handler loops over the selected attributes, and inside that, over the tag id list. For **every (attribute, tag) pair** it ran two separate reads before deciding anything:

* `AttributeTag::hasAny(['attribute_id' => $id, 'tag_id' => $tag_id])` — "is this tag already on this attribute?"
* `AttributeTag::find('column', ...)` with `contain => Tag` — the full list of tag *names* currently on that attribute, for the taxonomy exclusivity check.

Selecting a page or a filtered result of attributes and applying one or more tags is a routine workflow; a realistic bulk action is on the order of 200-500 attributes x 1-3 tags, i.e. 200-1500 pair iterations, each paying both reads even for pairs that are then skipped.

### The change

Both reads are answered from **one `find('all')` per attribute**, executed just before the tag loop, which returns `AttributeTag.tag_id`, `AttributeTag.local` and the contained `Tag.name`. From that single result set the code builds:

* `$attachedTagIds` — the "already attached" set, deliberately **not** scoped by `local`, because `hasAny()` was not scoped by `local` either.
* `$tagsOnAttribute` — the tag-name list scoped to the current `$local` value, exactly the list the old `find('column')` produced.

Both structures are updated in memory on each successful attach, so tags added earlier in the same request are visible to the later iterations — which is what the per-pair re-queries provided.

**Query-count reduction, stated structurally: 2 queries per (attribute, tag) pair become 1 query per attribute.** For 500 attributes x 3 tags that is 3000 reads down to 500. Nothing else in the request changes.

### Behaviour preservation — what I checked

* The dedup check keeps the unscoped-by-`local` semantics of `hasAny()`. This was a correction from the review pass: the originally proposed preload was `local`-scoped, which would have missed an existing global attachment and re-inserted a duplicate.
* `local` comes back from the DB as a string, so the local-scoped name list compares `(int)$row['AttributeTag']['local'] === $local`.
* The write half is untouched: the per-row `AttributeTag::create()` + `save()` and the per-row `Log::createLogEntry()` remain exactly as they were.
* Per-attribute `fetchAttributeSimple()` (with its ACL conditions), `__canModifyTag()`, `Event::insertLock()`, `touch()` and the `$changeTimestamp` handling are untouched, as are the `$success` / `$fails` counters and the JSON response shape.
* Attribute ids are resolved inside the loop as before (`__idToConditions()` accepts numeric ids *and* uuids), so the `NotFoundException` for an invalid id still fires at the same point in the same order. A single batched preload across the whole id list would have required resolving every id up front and would have moved that exception earlier; that was deliberately not done.

### Explicitly not done: batching the inserts

The audit originally suggested batching the `AttributeTag` inserts and the log rows with `insertMulti`/`saveMany`. That is **not** in this PR and should not be: `AttributeTag::afterSave` (`app/Model/AttributeTag.php:37`) fires ZMQ / Kafka / `tag-attached-after-save` workflow triggers per row, which a bulk insert would silently skip. Only the read half is safely batchable, and only the read half is changed here.

### No benchmark

**No wall-clock benchmark was run for this change.** The audit that produced it carries an estimate of ~15% for the enclosing bulk-tag operation; that is an estimate, not a measurement, and it should not be read as one. The defensible claim is the structural query-count reduction above. The review pass lowered the original 35% estimate to 15% precisely because both removed lookups hit indexed columns (`attribute_tags.attribute_id` and `.tag_id` are indexed in `db_schema.json`) and because the per-attribute costs this PR does *not* touch — `fetchAttributeSimple()` with its ACL joins, `insertLock()`, `touch()` — remain and likely dominate.

### Risk

Low-to-medium. The behaviour that has to stay correct is the taxonomy exclusivity check against tags added earlier in the same request, which the in-memory update reproduces, and the unscoped dedup set described above. No model callbacks are bypassed, since every insert still goes through `save()`.

### Provenance

This came out of an automated performance sweep of the codebase in which every candidate finding was handed to a second agent instructed to refute it; 30 of 55 candidates were refuted and dropped. This one survived, with its estimate corrected downward and its proposed fix narrowed to the read half, as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

