### PR TITLE
[medium] perf: skip unchanged elements and batch stale-element deletes in CollectionElement::captureElements()

### DIFF
--- a/app/Model/CollectionElement.php
+++ b/app/Model/CollectionElement.php
@@ -225,11 +225,15 @@ class CollectionElement extends AppModel
                     $element['uuid'] = CakeText::uuid();
                 }
                 if (isset($oldElements[$element['uuid']])) {
-                    if (isset($element['description'])) {
-                        $oldElements[$element['uuid']]['description'] = $element['description'];
-                    }
-                    $elementsToSave[$k] = $oldElements[$element['uuid']];
+                    $existingElement = $oldElements[$element['uuid']];
                     unset($oldElements[$element['uuid']]);
+                    // Only queue an existing element for saving if something actually changed.
+                    // `description` is the only field that this capture updates on an existing row,
+                    // so an element whose description is unchanged needs no write at all.
+                    if (isset($element['description']) && $element['description'] !== $existingElement['description']) {
+                        $existingElement['description'] = $element['description'];
+                        $elementsToSave[$k] = $existingElement;
+                    }
                 } else {
                     $elementsToSave[$k] = [
                         'CollectionElement' => [
@@ -271,8 +275,9 @@ class CollectionElement extends AppModel
                     );
                 }
             }
-            foreach ($oldElements as $toDelete) {
-                $this->delete($toDelete['id']);
+            if (!empty($oldElements)) {
+                // Single DELETE for every element that no longer exists upstream.
+                $this->deleteAll(['CollectionElement.id' => array_column($oldElements, 'id')], false);
             }
             $temp = $this->find('all', [
                 'conditions' => ['CollectionElement.collection_id' => $data['Collection']['id']],


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Collection sync rewrote every element on each pull; this PR skips unchanged rows and batches deletes.

- **Problem** — `CollectionElement::captureElements()`, called during Collection sync from `Collection::captureCollection()` and on manual add/edit, re-saved every existing element unconditionally and deleted stale elements one at a time, each delete costing two queries because `beforeDelete()` looks up the parent `collection_id`. N elements with M dropped upstream cost N UPDATEs plus 2M queries on every pull.
- **Fix** — Only queues an existing element for saving when its `description` strictly differs from the stored value — the only field this capture path updates on an existing row — and replaces the delete loop with one guarded `deleteAll()`.
- **Effect** — Repeated syncs of unchanged collections become near-write-free, with an identical resulting element corpus.
<!-- /bluf -->

### What the loop does and why it is expensive

`CollectionElement::captureElements()` reconciles a Collection's element corpus against an authoritative upstream copy. It is called from `Collection::captureCollection()` during instance-to-instance Collection sync (`app/Model/Collection.php:532`, reached from `Collection.php:307` on a pull) and from `CollectionsController` on manual add/edit (`app/Controller/CollectionsController.php:48,237`).

Two things made it write far more than it needed to:

1. **Every existing element was re-saved unconditionally.** `$elementsToSave` was populated with the *stored* row for every element that already existed, whether or not anything about it had changed, and each one then went through `create()`/`save()`. A pull of a collection whose elements had not changed at all still issued one UPDATE per element.
2. **Every stale element was deleted one at a time**, and because `beforeDelete()` stashes the parent `collection_id` with a `field()` lookup, each `delete()` cost two queries.

So a sync of a collection with N elements of which M were dropped upstream cost N UPDATEs + 2M queries, every time, even for a no-op sync.

### The change

* An existing element is only queued for saving when its `description` actually differs from the stored value. `description` is the only field this capture updates on an existing row (`uuid`, `element_uuid`, `element_type` and `collection_id` are only set on the insert path), so an element with an unchanged description needs no write at all. The comparison is strict, so a `null`-versus-`''` difference still writes — the skip only happens on an exact match.
* The per-row delete loop becomes a single `deleteAll(['CollectionElement.id' => ...], false)`, guarded by a `!empty()` check so an empty removal set never reaches the query builder.

**Query-count reduction, stated structurally: one UPDATE per unchanged element becomes zero, and two queries per stale element become one DELETE total for the whole batch.** In the common case — a sync where the corpus is identical to what is already stored — `captureElements()` drops from N writes to zero.

### Behaviour preservation — what I checked

* **`collection_elements` has no `modified` column** (verified against `db_schema.json`: `id`, `uuid`, `element_uuid`, `element_type`, `collection_id`, `description`). A skipped no-op save is therefore byte-identical in the database — there is no timestamp that used to be bumped and now is not. This is the load-bearing claim for the change-detection half.
* **The per-row `try`/`catch (PDOException)` diagnostic logging is preserved**, because rows that actually changed, and all new rows, still go through the existing per-row `save()` loop. The review pass specifically flagged that logging as load-bearing and warned against replacing the loop with a bulk INSERT; this PR does not do that.
* **`deduceType()` is untouched.** New elements still go through `save()` → `beforeValidate()`, so the type deduction path for elements arriving without an `element_type` is unchanged. (A batch-insert path would have had to pre-resolve it; this one does not need to.)
* **Callback loss on `deleteAll()` is a non-issue here.** `CollectionElement`'s only behavior is `Containable`; `beforeDelete()` exists purely to stash `collection_id` for `afterDelete()`, and `afterDelete()`'s only action — `touchCollection()` — is already suppressed for the whole body of `captureElements()` by `$this->skipCollectionModifiedBump = true` (set at line 211, cleared in the `finally`). The parent Collection's `modified` is set authoritatively from the remote by `captureCollection()` either way. There are no `hasMany`/`hasOne` associations to cascade.
* The trailing re-fetch that rebuilds `$data['Collection']['CollectionElement']` re-reads from the database, so it is correct regardless of which rows were written.

### No benchmark

**No wall-clock benchmark was run for this change.** The audit that produced it carries an estimate of ~12% (low confidence) for `captureElements()`; that is an estimate of the enclosing operation, not a measurement. The review pass lowered the original 30% estimate to 12% and explicitly noted that nothing in the code bounds collection sizes — the "hundreds to thousands of elements" framing in the original finding is unverified. What *is* code-confirmed, and what this PR fixes, is the write amplification: the corpus was rewritten on every sync regardless of whether anything changed.

### Risk

Low. The only semantic change is that an existing element whose description is unchanged is no longer written, which is unobservable given the absence of a `modified` column, and that stale elements are removed in one statement instead of N. The one place this could have introduced a bug — `deleteAll()` with an empty id list generating degenerate SQL — is guarded.

### Provenance

This came out of an automated performance sweep of the codebase in which every candidate finding was handed to a second agent instructed to refute it; 30 of 55 candidates were refuted and dropped. This one survived, and the reviewer redirected the fix away from the originally proposed `insertMulti` batching toward change detection, on the grounds that skipping unchanged rows is both cheaper and safer — that redirection is what is implemented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

