### PR TITLE
[medium] perf: batch the per-object ObjectReference counts in SharingGraphWidget

### DIFF
--- a/app/Lib/Dashboard/SharingGraphWidget.php
+++ b/app/Lib/Dashboard/SharingGraphWidget.php
@@ -33,19 +33,44 @@ class SharingGraphWidget
         return 1;
     }
 
-    private function object_scoring($object) {
-        $score = 0;
-        $this->Object->bindModel(array('hasMany' => array('ObjectReference' => array('foreignKey' => 'object_id'))));
-        $o = $this->Object->find('first', array('conditions' => array('id' => $object['id'])));
+    private function object_scoring($object, array $referenceCounts = array()) {
         // We score for each object reference from this object
-        foreach ($o['ObjectReference'] as $reference ) {
-            //TODO more points for different types of references ?
-            $score += 2;
-        }
+        //TODO more points for different types of references ?
+        $score = 2 * (isset($referenceCounts[$object['id']]) ? $referenceCounts[$object['id']] : 0);
         return $score+50; // bonus for having an object
     }
 
-    private function event_scoring($event) {
+    /*
+    * Count the ObjectReferences of every object of every passed event in a single
+    * grouped query, keyed by object_id, instead of re-fetching them object by object.
+    */
+    private function fetch_object_reference_counts($events) {
+        $objectIds = array();
+        foreach ($events as $event) {
+            if (empty($event['Object'])) {
+                continue;
+            }
+            foreach ($event['Object'] as $object) {
+                $objectIds[$object['id']] = true;
+            }
+        }
+        if (empty($objectIds)) {
+            return array();
+        }
+        $rows = $this->ObjectReference->find('all', array(
+            'recursive' => -1,
+            'fields' => array('ObjectReference.object_id', 'COUNT(*) AS count'),
+            'conditions' => array('ObjectReference.object_id' => array_keys($objectIds)),
+            'group' => array('ObjectReference.object_id'),
+        ));
+        $referenceCounts = array();
+        foreach ($rows as $row) {
+            $referenceCounts[$row['ObjectReference']['object_id']] = (int) $row[0]['count'];
+        }
+        return $referenceCounts;
+    }
+
+    private function event_scoring($event, array $referenceCounts = array()) {
         $score = 0;
         $attr_count = 0;
         // Simple attribute scoring
@@ -58,7 +83,7 @@ class SharingGraphWidget
         }
         //Object scoring
         foreach($event['Object'] as $object) {
-            $score += $this->object_scoring($object);
+            $score += $this->object_scoring($object, $referenceCounts);
         }
         // Todo check use of taxonomies, tagging for extra points
         return $score;
@@ -85,8 +110,9 @@ class SharingGraphWidget
         if(!empty($eventIds)) {
             $params = array('Event.id' => $eventIds);
             $events = $this->Event->find('all', array('conditions' => array('AND' => $params)));
+            $referenceCounts = $this->fetch_object_reference_counts($events);
             foreach($events as $event) {
-                $total_score+= $this->event_scoring($event);
+                $total_score+= $this->event_scoring($event, $referenceCounts);
             }
         }
         return $total_score;
@@ -106,7 +132,6 @@ class SharingGraphWidget
         $this->Org = ClassRegistry::init('Organisation');
         $this->Event = ClassRegistry::init('Event');
         $this->Attribute = ClassRegistry::init('MispAttribute');
-        $this->Object = ClassRegistry::init('Object');
         $this->ObjectReference = ClassRegistry::init('ObjectReference');
         $orgs = $this->Org->find('all', array( 'conditions' => array('Organisation.local' => 1)));
         $current_month = date('n');


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** SharingGraphWidget counts object references two queries at a time; this PR batches them.

- **Problem** — `SharingGraphWidget` scores every organisation for every month by walking each event's objects and calling `object_scoring()`, which per object did a `bindModel()` plus a `find('first')` with a `hasMany` `ObjectReference` fetch just to count its references — two queries per object with the association rebound every call, while the widget's `cacheLifetime` is only 10.
- **Fix** — `org_scoring()` now collects the object ids of the events it is about to score and resolves all reference counts in one grouped `COUNT(*)` query keyed by `object_id`, with `event_scoring()` and `object_scoring()` reading from that map.
- **Effect** — Dashboards carrying this widget render with one query per org-month instead of two per object, and zero when an org's events have no objects.
<!-- /bluf -->

### What the loop does and why it is expensive

`SharingGraphWidget` is a live dashboard widget — `app/Model/Dashboard.php` (`loadAllWidgets`) auto-discovers every `*Widget.php` under `app/Lib/Dashboard`, so this one renders whenever a user has it on their dashboard.

Its scoring path is three nested loops. `handler()` loops over months (default 6, configurable via the `months` param) and, inside that, over every local organisation. `org_scoring()` loops over that org's events for the month. `event_scoring()` loops over each event's objects, and for **every single object** called `object_scoring()`, which did:

```php
$this->Object->bindModel(array('hasMany' => array('ObjectReference' => array('foreignKey' => 'object_id'))));
$o = $this->Object->find('first', array('conditions' => array('id' => $object['id'])));
foreach ($o['ObjectReference'] as $reference) { $score += 2; }
```

— purely to count the object's references. Since no `recursive` is set, that is **two queries per object** (the row, then the `hasMany` fetch), and `bindModel()`'s default `reset = true` means the association is rebound on every call. On a modest instance (say 20 local orgs x 6 months x a few object-bearing events x a handful of objects each) this is on the order of hundreds of extra round-trips per widget render, and the widget's `cacheLifetime` is only 10.

### The change

`org_scoring()` now collects the object ids of every event it is about to score and fetches all their reference counts in **one grouped `COUNT(*)` query** on `ObjectReference`, keyed by `object_id`. `event_scoring()`/`object_scoring()` take that map and look the count up in memory.

**Query-count reduction, stated structurally: 2 queries per object become 1 grouped query per org-month** (and zero when the org's events have no objects at all).

The now-unused `$this->Object = ClassRegistry::init('Object')` in `handler()` is also removed. There is no `app/Model/Object.php` and the Cake core class is `CakeObject` with no `class_alias`, so that call was resolving to a generic `AppModel` bound to the `objects` table; `object_scoring()` was its only consumer.

### Behaviour preservation — what I checked

* The `COUNT(*)` deliberately applies **no** extra conditions, matching the unconditioned `hasMany` bind it replaces (in particular it does not filter deleted references — that would change scores).
* The score arithmetic is identical: 2 points per reference, plus the flat +50 "bonus for having an object".
* Edge case, missing object row: the old code's `find('first')` returned empty and the `foreach` over the missing `ObjectReference` key contributed 0 (with a PHP warning), giving +50. The new code finds no count entry, also giving +50 — same score, minus the warning.
* Object ids arrive as numeric strings from the ORM; PHP array keys normalise numeric strings to ints, so lookups line up on both sides.
* `attribute_scoring()`, the 100-attribute cap, the ghost-org filtering, the blocklist handling and the returned data shape are untouched.

### No benchmark

**No wall-clock benchmark was run for this change.** The audit that produced it carries an estimate of ~10% (low confidence) for a widget render; that is an estimate of the enclosing operation, not a measurement, and should not be read as one. The review pass lowered the original 25% estimate to 10% for a reason worth repeating here: `org_scoring()` also calls `fetchSimpleEventIds()` plus `Event->find('all')` with the default `recursive = 1` **per org, per month**, which hydrates every Attribute, Object, ShadowAttribute and tag row of every matching event. That is very likely the dominant cost, and this PR does not touch it. The defensible claim is the structural query-count reduction above.

### Risk

Low. The file itself is labelled "very experimental" in its header comment, and the change is confined to how the per-object reference count is obtained. The reference count per `object_id` is identical to what the previous per-object fetch produced.

### Provenance

This came out of an automated performance sweep of the codebase in which every candidate finding was handed to a second agent instructed to refute it; 30 of 55 candidates were refuted and dropped. This one survived; the reviewer both corrected the estimate downward and found that the N+1 was *worse* than originally described (two queries per object rather than one, plus the repeated `bindModel()`), and separately flagged the bogus `ClassRegistry::init('Object')` that this PR removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

