### PR TITLE
fix: Evaluate local tags when showing where event will be pushed

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -902,7 +902,7 @@ class Event extends AppModel
             'org_id' => $event['Event']['orgc_id']
         );
         // Fetch event with details
-        $event = $this->fetchEvent($elevatedUser, ['eventid' => $event['Event']['id'], 'metadata' => true]);
+        $event = $this->fetchEvent($elevatedUser, ['eventid' => $event['Event']['id'], 'metadata' => true, 'excludeLocalTags' => false]);
         $event = $event[0];
 
         $this->Server = ClassRegistry::init('Server');


### PR DESCRIPTION
#### What does it do?

Fixes current logic so local tags are always considered when displaying a list of servers where an event will be pushed. The actual push logic considers local tags but the current listing does not.

Currently, the shown list of servers where event will be pushed might be wrong if a local tag of the event matches with a pull rule, as local tags are in some cases excluded by fetchEvent.

#### Questions

- [ ] Does it require a DB change? **No**
- [ ] Are you using it in production? **Not yet**
- [ ] Does it require a change in the API (PyMISP for example)? **No**
