### PR TITLE
fix: [feed] guard missing disable_correlation setting in saveFreetextFeedData (#11007)

### DIFF
--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -1355,7 +1355,7 @@ class Feed extends AppModel
             }
             $disableCorrelation = false;
             if (!empty($feed['Feed']['settings'])) {
-                $disableCorrelation = (bool) $feed['Feed']['settings']['disable_correlation'] ?? false;
+                $disableCorrelation = (bool)($feed['Feed']['settings']['disable_correlation'] ?? false);
             }
             $event = array(
                 'info' => $feed['Feed']['name'] . ' feed',


### PR DESCRIPTION
#### What does it do?

Fixes #11007.

`saveFreetextFeedData` builds the flag with `(bool) $feed['Feed']['settings']['disable_correlation'] ?? false`. The `(bool)` cast binds tighter than `??`, so the array key is read before the coalesce can guard it, and PHP 8 raises an "Undefined array key" warning for any feed whose `settings` array exists but does not carry `disable_correlation` (the case for several default freetext/CSV feeds). Wrapping the coalesce inside the cast resolves the key first, matching the guarded read a few lines up (Feed.php:1148-1149).

#### Questions

- [ ] Does it require a DB change? No
- [ ] Are you using it in production? No
- [ ] Does it require a change in the API (PyMISP for example)? No
