### PR TITLE
fix: [sync] POST the UUID list when pulling analyst data to avoid 414 (#10958)

### DIFF
--- a/app/Lib/Tools/ServerSyncTool.php
+++ b/app/Lib/Tools/ServerSyncTool.php
@@ -265,14 +265,12 @@ class ServerSyncTool
             throw new RuntimeException("Remote server do not support analyst data");
         }
 
-        $params = [
-            'uuid' => $uuids,
-        ];
-
-        $url = '/analyst_data/index/' . $type;
-        $url .= $this->createParams($params);
-        $url .= '.json';
-        return $this->get($url);
+        // Send the UUID list in the POST body rather than the URL. As a GET
+        // every UUID rode in the request line as a named parameter, so a large
+        // batch overran the web server limit and the pull failed with 414. The
+        // analyst_data/index action already harvests its filters (uuid among
+        // them) from a POST body, the same shape fetchIndexMinimal() uses.
+        return $this->post('/analyst_data/index/' . $type, ['uuid' => $uuids]);
     }
 
     /**


### PR DESCRIPTION
#### What does it do?

Fixes #10958.

`ServerSyncTool::fetchAnalystData` builds `/analyst_data/index/{type}` with every UUID appended as a named parameter and sends it as a GET. A large batch (around 100 UUIDs and up) pushes the request line past the web server limit (Apache `LimitRequestLine` / nginx `large_client_header_buffers`) and the pull fails with 414, which matches the ~40-ok / ~100-fail split in the report. This sends the UUID list in the POST body instead, the same shape `fetchIndexMinimal()` already uses; the `analyst_data/index` action harvests its filters (uuid included) from the POST body, so the receiving side is unchanged. Same GET-to-POST move as #5500.

Scope note: `fetchCollections()` carries the same GET-with-uuid shape and can hit 414 too, but its `collections/index` action reads the UUID list specifically from named params (there is a comment there on why a bare POST `uuid` filter would be ambiguous against the joined columns), so switching it needs a coordinated server-side change and is left out of this PR.

#### Questions

- [ ] Does it require a DB change? No
- [ ] Are you using it in production? No
- [ ] Does it require a change in the API (PyMISP for example)? No
