### PR TITLE
fix: [ui] focus URL lands on attributes outside the first page on large events (#10948)

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -7551,6 +7551,24 @@ class Event extends AppModel
                 }
             }
         }
+        // The pagination tool jumps to the page holding the focused element by matching
+        // top-level uuids only. An attribute inside an object is not a top-level entry, so
+        // translate the focus to its containing object's uuid to land on the right page.
+        // The client-side scroll still targets the original attribute uuid.
+        if (!empty($passedArgs['focus'])) {
+            $focus = $passedArgs['focus'];
+            foreach ($objects as $object) {
+                if ($object['objectType'] !== 'object' || empty($object['Attribute'])) {
+                    continue;
+                }
+                foreach ($object['Attribute'] as $objectAttribute) {
+                    if (!empty($objectAttribute['uuid']) && $objectAttribute['uuid'] === $focus) {
+                        $passedArgs['focus'] = $object['uuid'];
+                        break 2;
+                    }
+                }
+            }
+        }
         App::uses('CustomPaginationTool', 'Tools');
         $customPagination = new CustomPaginationTool();
         if ($all) {


### PR DESCRIPTION
## What does it do?

Fixes #10948.

On the event view, `focus:<attribute-uuid>` scrolls to the attribute once it is on the rendered page. On large events the target can sit on a later page and never render, so the scroll silently does nothing.

The pagination already jumps to the page of a focused top-level attribute, but it missed attributes nested inside an object, whose top-level list entry carries the object's uuid, not the attribute's. `rearrangeEventForView` now maps a focus that points at an object's attribute to that object's uuid, so the correct page renders and the existing client-side scroll lands on the attribute. It is a no-op when there is no focus or the focus is already a top-level entry, and it only reads the already ACL-filtered object list.

## Questions
- [ ] Does it require a DB change? No
- [ ] Are you using it in production? No
- [ ] Does it require a change in the API (PyMISP for example)? No
