### PR TITLE
fix: [ui] event delete confirmation fails with MISP.use_uuids_in_urls (#10631)

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -5093,7 +5093,7 @@ class EventsController extends AppController
                 $this->redirect(array('action' => 'index'));
             }
         } else {
-            $eventList = is_numeric($id) ? [$id] : $this->_jsonDecode($id);
+            $eventList = (is_numeric($id) || Validation::uuid($id)) ? [$id] : $this->_jsonDecode($id);
             $this->request->data['Event']['id'] = json_encode($eventList);
             $this->set('idArray', $eventList);
             $this->layout = false;


### PR DESCRIPTION
## What does it do?

Fixes #10631.

With `MISP.use_uuids_in_urls` enabled, the delete-event links point at `/events/delete/<uuid>`. The delete confirmation is fetched over GET, and that path only treated a numeric id as a single event; a UUID fell through to `_jsonDecode()` and threw "Invalid JSON input", so the confirmation popup never appeared and deleting an event from the UI silently did nothing.

The GET confirmation path now accepts a UUID id the same way it already accepts a numeric one, matching the check the POST branch of the same action already uses (`is_numeric($id) || Validation::uuid($id)`). The actual deletion already handled UUIDs, so this is the only spot that needed it.

## Questions
- [ ] Does it require a DB change? No
- [ ] Are you using it in production? No
- [ ] Does it require a change in the API (PyMISP for example)? No
