### PR TITLE
fix: [workflow] Render attribute comment per attribute for jinja (#10898)

### DIFF
--- a/app/Model/WorkflowModules/action/Module_attribute_comment_operation.php
+++ b/app/Model/WorkflowModules/action/Module_attribute_comment_operation.php
@@ -35,6 +35,10 @@ class Module_attribute_comment_operation extends Module_attribute_edition_operat
         parent::exec($node, $roamingData, $errors);
         $rData = $roamingData->getData();
         $params = $this->getParamsWithValues($node, $rData);
+        // Keep the raw (un-rendered) comment template so _editAttribute can
+        // re-render it per attribute when it references the attribute (#10898).
+        $indexedParams = $node['data']['indexed_params'] ?? [];
+        $params['comment']['template'] = $indexedParams['comment'] ?? '';
         $user = $roamingData->getUser();
 
         $matchingItems = $this->getMatchingItemsForAttributes($node, $rData);
@@ -50,10 +54,22 @@ class Module_attribute_comment_operation extends Module_attribute_edition_operat
 
     protected function _editAttribute(array $attribute, array $rData, array $params): array
     {
-        $currentRData = $rData;
-        $currentRData['__currentAttribute'] = $attribute;
         $renderedComment = $params['comment']['value'];
-        if ($attribute['comment'] !== $params['comment']['value']) {
+        $template = $params['comment']['template'] ?? '';
+        // Render once per attribute only when the template reaches into the
+        // attribute being edited, so per-attribute values resolve instead of
+        // the event-level render being copied onto every match (#10898).
+        // Templates that do not reference the attribute keep a single render.
+        if (str_contains($template, '__currentAttribute')) {
+            $currentRData = $rData;
+            $currentRData['__currentAttribute'] = $attribute;
+            $currentRData['_env']['baseurl'] = Configure::read('MISP.baseurl');
+            $renderedComment = $this->render_jinja_template(
+                $template,
+                $currentRData
+            );
+        }
+        if ($attribute['comment'] !== $renderedComment) {
             $attribute['comment'] = $renderedComment;
         }
         return $attribute;


### PR DESCRIPTION
#### What does it do?

Fixes #10898.

The Attribute comment operation flags its comment field `jinja_supported` and already sets up a `__currentAttribute` per-attribute context, but never renders against it. Every matching attribute received the single event-level render of the template, so a comment template that reaches into the attribute being edited (an enrichment value on that attribute, for example) could not resolve per attribute: every attribute got the same event-level string.

This keeps the raw (un-rendered) comment template and, in `_editAttribute`, re-renders it once per attribute against the `__currentAttribute` context, but only when the template actually references `__currentAttribute`. Templates that do not reference it keep their single event-level render, so the common path makes no extra render calls and only per-attribute templates pay the per-attribute render.

#### Questions

- [ ] Does it require a DB change? No.
- [ ] Are you using it in production? No.
- [ ] Does it require a change in the API (PyMISP for example)? No.
