### PR TITLE
fix: [installer] show accepted DB update errors as skipped, not failures (#10713)

### DIFF
--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -2880,6 +2880,7 @@ class AppModel extends Model
                         }
                     } else {
                         $logMessage['change'] = $logMessage['change'] . PHP_EOL . __('However, as this error is allowed, the update went through.');
+                        $this->__setUpdateResMessages($i, __('The SQL query for `%s` was skipped, as the change is already applied.', $command));
                     }
                     $this->Log->saveOrFailSilently($logMessage);
                 }


### PR DESCRIPTION
## What does it do?

Fixes #10713.

On upgrade, the `addIPLogging` step runs `ALTER TABLE logs ADD ip ...`. If the `ip` column is already present (fresh installs ship it in the base schema), MySQL returns "Duplicate column name 'ip'". That error is already on the accepted-error allow-list (`isAcceptedDatabaseError`), so the update is not blocked and completes, but the diagnostics progress screen still shows it as "Issues executing the SQL query", which reads like a failure. Users on 2.5.33 through 2.5.44 hit this and think the update is broken.

This updates the progress message for accepted database errors (duplicate column, duplicate index, drop-missing) to read as skipped/already-applied instead of as an error. Real, non-accepted errors keep the original "Issues executing" message, so nothing about genuine failures changes.

## Questions
- [ ] Does it require a DB change? No
- [ ] Are you using it in production? No
- [ ] Does it require a change in the API (PyMISP for example)? No
