### PR TITLE
fix: [UI] persist application log quick filter across pagination (#10687)

### DIFF
--- a/app/View/Logs/index.ctp
+++ b/app/View/Logs/index.ctp
@@ -103,7 +103,9 @@
             ],
             'fields' => $fields,
             'title' => __('Application Logs'),
-            'persistUrlParams' => $paramArray
+            // Persist the active quick filter (filter:<name>) across pagination
+            // and sort links, otherwise the next page drops it (#10687).
+            'persistUrlParams' => array_merge($paramArray, ['filter'])
         ],
         'passedArgsArray' => $passedArgsArray,
     ]);


### PR DESCRIPTION
#### What does it do?

Fixes #10687. The application-log quick filters (`filter:<name>`, e.g. `filter:email`) were applied to the query but not carried into the pagination and sort links, so paging to the next page fell back to unfiltered results. This adds `filter` to the Logs index table's `persistUrlParams`, so the active filter is preserved across page and sort navigation.

Verified on 2.5.44: with `filter:email` active, paging to page 2 and 3 keeps the filter and the results stay scoped to the filtered action.

#### Questions

- [ ] Does it require a DB change? No
- [ ] Are you using it in production? No
- [ ] Does it require a change in the API (PyMISP for example)? No
