### PR TITLE
[medium] perf: hoist per-row isReporter() COUNT(*) into one prefetch in Sighting::filterSightingsByAttributeACL

### DIFF
--- a/app/Model/Sighting.php
+++ b/app/Model/Sighting.php
@@ -403,6 +403,26 @@ class Sighting extends AppModel
             $attributesKeyed[$attribute['Attribute']['id']] = $attribute;
         }
         unset($attributes);
+        // Fetch reporter status for all relevant events at once instead of checking it for every sighting row
+        $reporterEvents = [];
+        if ($sightingsPolicy === self::SIGHTING_POLICY_SIGHTING_REPORTER) {
+            $eventIds = [];
+            foreach ($attributesKeyed as $attribute) {
+                if ($attribute['Event']['org_id'] != $userOrgId) {
+                    $eventIds[$attribute['Event']['id']] = true;
+                }
+            }
+            if (!empty($eventIds)) {
+                $reporterEvents = array_flip($this->find('column', [
+                    'conditions' => [
+                        'Sighting.event_id' => array_keys($eventIds),
+                        'Sighting.org_id' => $userOrgId,
+                    ],
+                    'fields' => ['Sighting.event_id'],
+                    'unique' => true,
+                ]));
+            }
+        }
         $sightings = $this->find('all', [
             'recursive' => -1,
             'conditions' => [
@@ -419,7 +439,7 @@ class Sighting extends AppModel
                         unset($sightings[$k]);
                     }
                 } else if ($sightingsPolicy === self::SIGHTING_POLICY_SIGHTING_REPORTER) {
-                    if (!$this->isreporter($attribute['Event']['id'], $userOrgId)) {
+                    if (!isset($reporterEvents[$attribute['Event']['id']])) {
                         unset($sightings[$k]);
                     }
                 } else if ($sightingsPolicy === self::SIGHTING_POLICY_HOST_ORG) {


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** The sightings ACL filter ran a `COUNT(*)` per row; this PR prefetches reporter status once.

- **Problem** — `Sighting::filterSightingsByAttributeACL` runs on every `/sightings/restSearch` response, and under `Plugin.Sightings_policy = 1` it called `isReporter()` once per returned sighting row, issuing a `SELECT COUNT(*)` round-trip whose arguments are event-invariant and so repeated for every row of the same event.
- **Fix** — Prefetches reporter status for the distinct cross-org event ids in one `find('column')` and replaces the per-row call with an `isset()` lookup, turning `2 + S` queries per 10000-id chunk into 3. `isReporter()` itself is untouched, so its four other callers are unaffected.
- **Effect** — The main beneficiary is sightings sync, where the serving instance runs this loop for every sighting handed to every partner.
<!-- /bluf -->

## What

`Sighting::filterSightingsByAttributeACL` (`app/Model/Sighting.php:396`) is the ACL filter that every `/sightings/restSearch` response passes through. Under `Plugin.Sightings_policy = 1` (`SIGHTING_POLICY_SIGHTING_REPORTER`) it decided, **once per returned sighting row**, whether the requesting org has itself reported a sighting on that row's event — by calling `$this->isreporter($eventId, $userOrgId)`, which is a `SELECT COUNT(*)` round-trip. Both arguments are event-invariant, so the same query was re-issued for every row of the same event. This patch hoists the check: before the row loop it collects the distinct event ids of cross-org events from `$attributesKeyed` and resolves reporter status for all of them with a single `find('column', [... 'unique' => true])`, then replaces the per-row call with an `isset()` lookup. Per 10000-id chunk this turns `2 + S` queries into 3, independent of `S`. `isReporter()` itself is untouched and all four of its other callers keep working exactly as before.

## Why it is hot

Tier as filed: **T1** for the loop itself (per-sighting-row). Verifiers corrected the entrypoint tier down: `getSightings` (`Sighting.php:216`) is private with exactly one caller — `restSearch` at `:1235`, inside the `array_chunk($sightingIds, 10000)` loop at `:1233` — so this is per-row work inside a per-export/per-sync operation rather than per-attribute across the instance. Honest tier: per-row cost inside a T4 entrypoint.

The dominant real-world driver is **sync**. A pulling instance posts to this server's `/sightings/restSearch/event` (`app/Lib/Tools/ServerSyncTool.php:392-405`, driven by `Sighting::pullSightings` `:1425`/`:1495` and `Server::pull` `:688`), so the serving side runs this loop for every sighting it hands to every sync partner. For a sync user the org differs from `Event.org_id` for essentially every locally-owned event, so the `!$ownEvent` test at `:416` is true for nearly every row and `S` approaches the full 10000-row chunk. Ids are collected *without* ACL checks (`:1210-1230`), so `S` is not pre-filtered.

**Gate, stated plainly:** this path only executes when `Plugin.Sightings_policy` is explicitly set to `1`. `sightingsPolicy()` (`:1712-1719`) returns `SIGHTING_POLICY_EVENT_OWNER` (0) when the setting is unset, and `Server.php:8388` ships `2` as the suggested value — so **default installs are unaffected**. It additionally requires `MISP.disable_sighting_loading` unset (`:1216`) and only bills rows whose `Event.org_id` differs from the requesting org. Policy 1 is a documented cross-org sharing policy, not a dead flag, so this is a frequency discount rather than a refutation.

## Mechanism

- `app/Model/Sighting.php:413` — `foreach ($sightings as $k => $sighting)` iterates every fetched sighting **row**.
- `app/Model/Sighting.php:422` — inside that loop, the `SIGHTING_POLICY_SIGHTING_REPORTER` branch calls `$this->isreporter($attribute['Event']['id'], $userOrgId)`. `$userOrgId` is fixed at `:401`, so the result is identical for every row of the same event, recomputed with no memo. (The lowercase `isreporter` resolves to `isReporter` — PHP method names are case-insensitive — so this is a live call, not dead code.)
- `app/Model/Sighting.php:1677-1682` — `isReporter()` is `$this->hasAny(['Sighting.event_id' => ..., 'Sighting.org_id' => ...])`.
- `app/Lib/cakephp/lib/Cake/Model/Model.php:2945-2947` — `hasAny()` is literally `(bool)$this->find('count', ...)`, i.e. a full `SELECT COUNT(*)`, **not** a `LIMIT 1` existence probe.
- `INSTALL/MYSQL.sql:1402-1418` — the `sightings` table has only separate `KEY event_id` (`:1414`) and `KEY org_id` (`:1415`); there is **no composite `(event_id, org_id)` index**. Each COUNT is therefore an index-range scan (in practice an index_merge intersect), not a point lookup.
- `filterSightingsByAttributeACL` (`:396-433`) also has no site-admin short-circuit, unlike the sibling `createConditionsByAttributes` at `:443-445`. See Risk — that is deliberately **not** changed here.

## Why existing caching does not already cover it

- **No reporter memo exists in the model.** The only instance cache in `Sighting.php` is `$orgCache` (`:23`, populated at `:1692-1707`, wiped at `:697`), which caches *organisations*, not reporter status.
- **The sibling branches already hoist — this one was simply missed.** `listSightings` builds `$eventsWithOwnSightings` keyed by event id (`:1017-1027`); `createConditionsByAttributes` merges attributes by event id and calls `isReporter` once per **event** (`:473`); `eventsStatistic` loops events, not sightings (`:505`). Only `:422` loops per row. This patch applies the pattern the same file already uses two functions down.
- **CakePHP's in-process query cache is inert here.** `DboSource` keeps a per-request SQL cache (`DboSource.php:151`, written `:3724`, read `:3736-3740`) and `fetchAll` defaults `['cache' => true]` (`:711`) — but `DboSource::read()` passes `$Model->cacheQueries` as the controlling flag (`:1226`, `:1564`), and `Model::$cacheQueries = false` by default (`Model.php:273`). `grep -rn cacheQueries` over `app/Model`, `app/Lib/Tools`, `app/Config` and `app/Controller` returns nothing — no model, config or controller ever enables it. Every repeated identical COUNT is a genuine DB round-trip.
- **No Redis / `Cache::` on this path.** The only cache-adjacent code in `Sighting.php` is sync-pull bookkeeping at `:1601`/`:1621`.
- **No index makes the COUNT cheap.** There is no composite `(event_id, org_id)` (`INSTALL/MYSQL.sql:1411-1417`).
- MySQL 8 has no server query cache and MariaDB defaults it off — an environment fact, counted neither way (and the benchmark used `SQL_NO_CACHE` regardless).

## Speedup

### DERIVED (query-count arithmetic)

Per 10000-id chunk (`Sighting.php:1233`), `getSightings` issues: 1 attribute ACL find (`:235`) + 1 sightings find (`:406`) + `S` `isReporter` COUNT queries, where `S` = returned sighting rows on events the user's org does not own. Total = `2 + S`. After the fix the total is `3` regardless of `S`.

```
ratio = (2 + S) / 3
S =     4  ->      2.0x   (break-even at 2x)
S =    30  ->     10.7x
S =   100  ->     34.0x
S = 10000  ->   3334.3x   (full-chunk / sync regime)
```

**Honest whole-request floor: 5x**, not the raw query ratio. The verifiers deliberately discounted the arithmetic: the attribute find with `subQueryGenerator` + `contain: Event, Object` (`:229-247`) and the `Sighting.id IN (<=10000)` find (`:406-412`) each cost many COUNT-equivalents, and the downstream JSON conversion plus per-row export-handler writes (`:1236-1239`) are untouched by this patch. The claimed 10x floor was **not** endorsed. The `k*k` "rows-scanned" second multiplier was also explicitly discounted — with a warm InnoDB buffer pool those index ranges are near-free; the real driver is round-trip count.

### MEASURED (real MariaDB, PHP 8.3, serialized under `flock`)

**Method.** Two-part benchmark. Both `filterSightingsByAttributeACL` variants (original per-row `isreporter()` vs patched per-chunk prefetch) were reimplemented verbatim in a standalone script, because the worktree is not mounted into the benchmark container.

*(a) Correctness.* Both variants run against an in-memory `FakeDb` whose `isReporter` mirrors `hasAny()` = `COUNT(*)` and whose `reporterEvents` mirrors `find('column', DISTINCT event_id)`. 4000 randomized cases sweeping all four sighting policies (0/1/2/3), 1-6 events per case with randomized event `org_id`s, 1-3 attributes per event, 0-4 sightings per attribute (so events present in `$attributesKeyed` with **zero** sighting rows are covered — the prefetch-superset case), random querying/host org, ~10% of rows deliberately excluded from the id chunk, ids shuffled. Outputs compared with `===` on `array_values`.

*(b) DB timing.* Real MariaDB in the container. Table created with `CREATE TABLE sightings_bench LIKE sightings` so the **real** index set applies (separate `KEY event_id`, `KEY org_id`, no composite — confirmed via `SHOW CREATE TABLE`). Original shape = one `SELECT id, attribute_id, event_id, org_id ... WHERE id IN (chunk) ORDER BY id` plus one **prepared** `SELECT COUNT(*) ... WHERE event_id = ? AND org_id = ?` per cross-org row. Patched shape = one `SELECT DISTINCT event_id ... WHERE event_id IN (...) AND org_id = ?` plus the same id-chunk fetch, then an `isset()` per row. `SQL_NO_CACHE` on both; prepared statements so round-trips are measured rather than parse time; `ANALYZE TABLE` after seeding; kept-row counts compared between shapes and equal. Two seeds grounded in the derivation: a modest chunk (20 events x 5 cross-org rows, `S=100`) and a full chunk (200 events x 50, `S=10000`, the `array_chunk(..., 10000)` regime at `:1233`), each event carrying extra background rows from other orgs so the per-event index range is non-trivial.

**Raw output.**

```
correctness: cases=4000 mismatches=0

run 2 (clean):
modest chunk  (S=100 rows, 20 events)       rows=  100 kept=  100  original=   79.15 ms  patched=   2.39 ms  speedup= 33.16x
full chunk    (S=10000 rows, 200 events)    rows=10000 kept= 5000  original=10588.88 ms  patched=  37.01 ms  speedup=286.13x

run 3 (clean):
modest chunk  (S=100 rows, 20 events)       rows=  100 kept=  100  original=  107.08 ms  patched=   6.03 ms  speedup= 17.75x
full chunk    (S=10000 rows, 200 events)    rows=10000 kept= 5000  original=10312.89 ms  patched=  57.44 ms  speedup=179.56x

final mismatches: 0   (includes the DB-side kept-count equality check on both seeds)

isolated calibration probes:
  SELECT 1 prepared round-trip: 0.2239 ms
  SELECT COUNT(*) WHERE event_id=? AND org_id=? : 0.62-0.68 ms
    (EXPLAIN: index_merge, Using intersect(event_id,org_id))
```

An independent re-run by the reviewer, also serialized, reproduced **40.43x** at `S=100` and **161.18x** at `S=10000`. A first run showing 67x/163x was **discarded as contention-polluted**: an isolated probe put the COUNT at 0.62-0.68 ms while that run implied 2.7 ms, so another workload was on the box. All reported numbers come from runs whose per-COUNT cost matches the isolated probe. The conservative figure quoted above (17.75x) is the low end across clean runs.

**Correctness assertion result: 4000 inputs, 0 mismatches**, plus DB-side kept-row-count equality on both timing seeds.

### Scope caveat — please read before quoting a number

The benchmark is **function-scoped**. It measures only what lives inside `filterSightingsByAttributeACL`; the attribute find in `getSightings` (`:229-245`) and the JSON conversion / export-handler writes in `restSearch` (`:1236-1239`) are untouched by the patch and excluded from **both** sides. That is why the measured ratio is far above the finding's honest 5x whole-request floor. **17.75x / 179.56x are not request-level speedups** — they are the speedup of the function the `(2 + S) / 3` derivation applies to. Note also that the benchmark's "original" shape is, if anything, *kinder* to the original than production: it re-executes one prepared COUNT statement, whereas the real path pays a full CakePHP `find('count')` build per row. The measurement is conservative, not a strawman. The full-chunk scenario uses a single sample (`reps=1`), though the magnitude makes noise irrelevant.

## Risk

**Low** (finding's assessment, confirmed on review). `isReporter` is a pure function of `(event_id, org_id)` against a table not written during the read, and the prefetch covers exactly the event ids reachable from `$attributesKeyed`. The only behavioural nuance is memory for the distinct-event id list, bounded by the number of distinct events in one 10000-sighting chunk.

Behaviour-preservation details:

- The prefetch collects event ids only from attributes where `$attribute['Event']['org_id'] != $userOrgId`, using the same loose comparison as the existing `$ownEvent` line, so it is a **superset** of exactly the events the old code could have queried. The prefetch filter uses `!=` and the loop uses `==` against the same `$userOrgId` — complementary loose comparisons, so no event can be collected-but-not-tested or tested-but-not-collected. Surplus entries are inert because the loop only ever looks up events that appear on a fetched row.
- `array_flip` + `isset` is set-equivalent to `hasAny(event_id, org_id)`: the `DISTINCT` query returns precisely the event ids for which at least one row with that org exists. PHP folds numeric-string keys to int on both the flip and the `isset`, so string-vs-int event ids from the DB layer are not an issue.
- `$reporterEvents` is initialised to `[]` unconditionally and the query is skipped when no cross-org events exist, so there is no undefined-variable path, no wasted round-trip, and no degenerate `IN ()` / `IN (NULL)`. A `NULL` org_id would produce `org_id IS NULL` on both sides.
- Under policies 0/2/3 the prefetch block is never entered; those branches are byte-identical and are covered explicitly by the correctness harness.
- Return shape (`array_values` of the surviving `$sightings`), field selection and the `'order' => 'Sighting.id'` sort are unchanged.
- `find('column')` with a dotted field plus `'unique' => true` is an established in-repo pattern. `AppModel::_findColumn` (`:4359-4390`) rewrites fields to `DISTINCT Sighting.event_id`, forces `recursive = -1` when unset, and extracts by splitting the column path; `DboSource::fields()` (`:2707-2709`) strips the `DISTINCT` prefix before quoting and re-prepends it, so results map back under `['Sighting']['event_id']`. `findMethods['column']` is registered in the `AppModel` constructor (`:121`), and the identical dotted+`unique` shape is already in production at `Organisation.php:568-571`, `Correlation.php:749`/`:1053` and `GalaxyCluster.php:225`. A silent empty result here would have over-filtered rows; it does not occur.

Reviewer-raised items, all deliberate scoping decisions rather than defects:

- **No site-admin short-circuit was added**, even though the finding lists it as an optional extra to match `createConditionsByAttributes:443`. It is **not** behaviour-preserving: `createConditionsByAttributes` already lets site admins through unfiltered, and `filterSightingsByAttributeACL` then drops their cross-org rows under policy 1. Adding the short-circuit would make site admins receive *more* rows than today. That may well be the intended semantics, but it is an ACL change and belongs in its own PR.
- **`isReporter()` itself is untouched**, so its four other callers (`:473`, `:507`, `:1020`, `:1743`) still pay the `COUNT(*)`. Switching it to a `find('first')` with `LIMIT 1` would fix the COUNT-vs-EXISTS waste globally but pulls those callers into review scope and is not what this benchmark measures. Left as a follow-up.
- **Pre-existing hazard, not introduced here:** `$attributesKeyed[$sighting['Sighting']['attribute_id']]` at `Sighting.php:414` is an undefined-index if a sighting's attribute was filtered out by the ACL find. Unchanged by this diff; noted only so it is not later attributed to it.

## Testing

- `php -l` clean on the patched file (PHP 8.3), verified against the worktree copy rather than the read-only mount.
- Benchmark and correctness harness as described above, run inside a container against real MariaDB with the real `sightings` schema, serialized under `flock` so concurrent workloads cannot pollute timings.
- Correctness harness: **4000 randomized cases across all four sighting policies, 0 mismatches**, plus DB-side kept-row-count equality on both timing seeds.
- Diff reviewed independently: 21 insertions, 1 deletion, one file, two hunks, no reformatting or drive-by edits.
- **No live MISP instance was available**, so there is no end-to-end test of `/sightings/restSearch` under `Plugin.Sightings_policy = 1`, and no sync-pair test. The equivalence argument rests on the correctness harness plus code reading, not on an integration run. Reviewers with an instance configured to policy 1 are the right people to confirm response equality against `2.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

