### PR TITLE
[medium] perf: replace per-event COUNT loop with grouped queries in EventReport::attachReportCountsToEvents

### DIFF
--- a/app/Model/EventReport.php
+++ b/app/Model/EventReport.php
@@ -385,31 +385,57 @@ class EventReport extends AppModel
      */
     public function attachReportCountsToEvents(array $user, $events)
     {
+        $ownEventIds = [];
+        $otherEventIds = [];
         if (!$user['Role']['perm_site_admin']) {
             $sgids = $this->SharingGroup->authorizedIds($user);
         }
-        foreach ($events as $k => $event) {
-            $conditions = [
-                'AND' => [
-                    [
-                        'Event.id' => $event['Event']['id']
-                    ]
-                ]
-            ];
+        foreach ($events as $event) {
             if (!$user['Role']['perm_site_admin'] && $event['Event']['org_id'] != $user['org_id']) {
-                $conditions['AND'][] = [
+                $otherEventIds[] = $event['Event']['id'];
+            } else {
+                $ownEventIds[] = $event['Event']['id'];
+            }
+        }
+        $counts = [];
+        if (!empty($ownEventIds)) {
+            $counts += $this->__fetchReportCounts($ownEventIds, []);
+        }
+        if (!empty($otherEventIds)) {
+            $counts += $this->__fetchReportCounts($otherEventIds, [
+                [
                     'EventReport.distribution' => [1, 2, 3, 5],
                     'AND' => [
                         'EventReport.distribution' => 4,
                         'EventReport.sharing_group_id' => $sgids,
                     ]
-                ];
-            }
-            $events[$k]['Event']['report_count'] = $this->find('count', [
-                'conditions' => $conditions
+                ]
             ]);
         }
+        foreach ($events as $k => $event) {
+            $eventId = $event['Event']['id'];
+            $events[$k]['Event']['report_count'] = isset($counts[$eventId]) ? (int)$counts[$eventId] : 0;
+        }
         return $events;
+    }
+
+    /**
+     * Fetch the number of reports per event for the given event IDs in a single grouped query.
+     *
+     * @param array $eventIds
+     * @param array $extraConditions Additional ACL conditions to apply
+     * @return array Event ID => report count
+     */
+    private function __fetchReportCounts(array $eventIds, array $extraConditions)
+    {
+        $conditions = ['AND' => array_merge([['EventReport.event_id' => $eventIds]], $extraConditions)];
+        $counts = $this->find('all', [
+            'conditions' => $conditions,
+            'fields' => ['EventReport.event_id', 'COUNT(EventReport.id) as count'],
+            'recursive' => -1,
+            'group' => ['EventReport.event_id'],
+        ]);
+        return Hash::combine($counts, '{n}.EventReport.event_id', '{n}.0.count');
     }
 
     public function getSummaryForEvent(array $user, $eventId)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** The events index fills `report_count` with one or two grouped queries, not 60 joined COUNTs.

- **Problem** — On the HTML events index, `EventReport::attachReportCountsToEvents()` filled `report_count` by looping the page with one `find('count')` per event, each an unintended three-table joined COUNT because no `recursive` or `contain` was passed.
- **Fix** — Replaces the loop with one grouped `GROUP BY event_id` query for site admins, or two otherwise, defaulting missing ids to `0`.
- **Effect** — With `MISP.showEventReportCountOnIndex` enabled, an index render drops from 60 joined COUNTs at the default page size to one or two queries, matching the already-bulk sibling counters.
<!-- /bluf -->

## What

On the HTML events index, `EventReport::attachReportCountsToEvents()` fills in the `report_count` column for the page of events being rendered. It did so by looping the whole page and issuing one `find('count')` per event, each of which — because no `recursive`/`contain` was passed — was a three-table joined COUNT. This PR replaces that loop with one (site admin) or two (non-site-admin) grouped `GROUP BY event_id` queries, mapping the results back onto `$events` and defaulting missing ids to `0`.

## Why it is hot

Tier: **T2 in kind, effectively T3 given the gate.**

- Caller: `app/Controller/EventsController.php:1138-1139`, inside `__attachInfoToEvents`, once per events-index render.
- Page size: `$paginate['limit'] => 60` (`app/Controller/EventsController.php:19-20`), `maxLimit` 9999 — so 60 round trips by default, more on request.
- **The gate, stated plainly:** this path only runs when `MISP.showEventReportCountOnIndex` is enabled, whose shipped default is `false` (`app/Model/Server.php:6710-6716`). Only then does `report_count` enter `$possibleColumns` (`app/Controller/EventsController.php:1071-1073`). It is also HTML-only: `index()` returns early for REST at `app/Controller/EventsController.php:754-759`, before `__attachInfoToEvents` is reached. So this costs nothing on a default install; it is 60 joined queries per index render on instances whose admin turned the setting on.
- The sibling counters invoked in the same block are already bulk (`attachObjectAndAttributeCountToEvents`, `EventsController.php:1118`), which makes this one the odd one out.

## Mechanism

- `app/Model/EventReport.php:391-411` (pre-patch): `foreach ($events as $k => $event)` with `$this->find('count', ['conditions' => ...])` at 408-410, conditioned on `Event.id` (395).
- No `'recursive' => -1` and no `'contain'` key is passed. `EventReport` declares no `$recursive` override (nor does `AppModel`), so Cake's default `Model::$recursive = 1` applies (`app/Lib/cakephp/lib/Cake/Model/Model.php:528`). `ContainableBehavior::beforeFind` does not lower it either: with no `contain` key `$noContain` stays false and the `recursive = -1` branch never fires (`app/Lib/cakephp/lib/Cake/Model/Behavior/ContainableBehavior.php:104-117`). `Model::_findCount` only rewrites `fields`/`order`.
- `EventReport` `belongsTo` `Event` and `SharingGroup` (`app/Model/EventReport.php:63-71`), so each of the N COUNTs LEFT JOINs both tables. The `Event.id` condition is in fact only resolvable *because* that join exists.
- Each call also pays the full Cake `Model::find` dispatch plus `beforeFind` across five attached behaviors (`app/Model/EventReport.php:13-23`).
- The replacement is a single-table `SELECT event_id, COUNT(id) ... WHERE event_id IN (...) [+ ACL] GROUP BY event_id` with `recursive => -1`, index-served by `KEY event_id` on `event_reports` (`INSTALL/MYSQL.sql:490`). This is exactly the in-tree pattern of `Event::attachObjectAndAttributeCountToEvents` and `Event::attachProposalsCountToEvents` (`app/Model/Event.php:717-759`).

## Why existing caching does not already cover it

`$sgids` is already hoisted out of the loop (`app/Model/EventReport.php:388-390`, and `SharingGroup::authorizedIds` is itself memoized at `app/Model/SharingGroup.php:79`) — that is the only optimisation present, and it is precisely why the remaining per-event COUNT stands out. There is no Cake `Cache::read/write`, no `RedisTool`, and no static or instance array caching report counts anywhere in `EventReport.php`. A grep for `report_count` shows the value is produced only here and at `app/Controller/EventsController.php:2015` (single event view). Nothing memoizes across renders or within one.

## Speedup

**MEASURED** — real MariaDB (full 98-table MISP schema, database `perf`) driven over PDO inside a container, runs serialized under `flock`. Seeded 5000 events across org_ids 1-5, 20 sharing groups, and 10195 event_reports with realistic skew (70% of events with 0 reports, 25% with 1-5, 5% with 20-30; distributions 0-5, `sharing_group_id` set where distribution = 4, ~10% deleted). The ORIGINAL shape reproduces the exact Cake-generated statement including both `recursive = 1` LEFT JOINs; the PATCHED shape is the bucket split plus 1-2 grouped queries and the PHP mapping pass. 40 distinct pages per case, warmed, same PDO connection for both shapes.

Raw output of the implementation run:

```
seeded 5000 events, 10195 reports
correctness trials=3000 mismatches=0 (pages with other-org events: 1986, empty-sgid trials: 1000)
N=60 site-admin  orig=50.06 ms/page  patched=1.418 ms/page  speedup=35.3x
N=60 non-admin   orig=34.20 ms/page  patched=1.129 ms/page  speedup=30.3x
N=200 non-admin  orig=100.48 ms/page  patched=2.370 ms/page  speedup=42.4x
```

An independent re-run by a second reviewer on the same harness gave 19.3x (N=60 site-admin), 37.2x (N=60 non-admin), 64.3x (N=200 non-admin), with 0 mismatches. The two runs disagree on the site-admin case; **the conservative floor across both runs is ~19x.**

**Correctness assertion (MEASURED):** 3000 randomized trials cycling site-admin / non-admin-with-sgids / non-admin-with-empty-sgids, random `org_id`, random page slices of 1-60 ids — 1986 trials contained other-org events and 1000 used empty sgids. Full `[id => count]` maps compared with strict `===` after int casting. **0 mismatches**, plus an empty-`$events` edge case.

**DERIVED** — the arithmetic behind the claim, independent of the timings: the step costs N round trips today, where N is the page size (60 by default). It becomes 1 grouped query for a site admin and 2 for a non-site-admin (own-org bucket unfiltered, other-org bucket with the ACL clause). So 60 → 2 = **30x** for a non-admin and 60 → 1 = **60x** for a site admin, in query count. Discounting for the wider single-query IN-list scan and the added PHP mapping pass, the finding's independently verified floor was **12x**.

**Caveat that runs in the patch's favour:** the benchmark models the SQL layer only. Cake's per-`find()` PHP dispatch and the five `beforeFind` behavior hooks × 60 calls are not modelled — and that cost exists *only* on the original side. The measured ratio is therefore a floor for the in-app gain, not an inflated number.

## Risk

- **Pre-existing bug preserved deliberately, not fixed here.** The non-site-admin other-org ACL clause (originally `app/Model/EventReport.php:400-406`) places `'EventReport.distribution' => [1, 2, 3, 5]` and a nested `'AND' => ['EventReport.distribution' => 4, 'EventReport.sharing_group_id' => $sgids]` as sibling keys of the same array, which Cake ANDs together — i.e. `distribution IN (1,2,3,5) AND distribution = 4`, unsatisfiable. Non-site-admins therefore see `0` for other-org events today. I copied that clause **byte-for-byte and at the same nesting depth** rather than repairing it to the apparently intended `OR`, so displayed counts are bit-identical to before. Consequence: the second grouped query can never return a row today. I did not short-circuit it to a hard-coded `0` either, because that would entrench and hide the bug. **This should be a separate follow-up fix**, and it is a behaviour change, not a perf change.
- **`EventReport.deleted` is still unfiltered**, exactly as before (`getSummaryForEvent` filters it, this path never did). Preserved so no displayed value changes.
- **`find('all')` rows now traverse behavior `afterFind`**, which `find('count')` rows effectively did not. The only `afterFind` present is `AnalystDataParentBehavior::afterFind`, gated on `$model->includeAnalystData`, which `EventsController` never sets on the `EventReport` model. Theoretical exposure only, and identical to the in-tree `Event::attachObjectAndAttributeCountToEvents` pattern this mirrors.
- `Event.id = X` → `EventReport.event_id IN (...)`: the original resolved `Event.id` only through the `recursive = 1` LEFT JOIN on a primary key, which can neither multiply nor drop rows, and every id comes from a real `events` row. `COUNT(*)` → `COUNT(EventReport.id)` is likewise identical: both joins are on primary keys and `event_reports.id` is a NOT NULL PK.
- Return type unchanged: `find('count')` returned `int`, the new path explicitly casts the driver's string to `(int)`. Array keys of `$events` are preserved by keeping the write-back loop keyed on `$k`. The two buckets are disjoint by construction, so the `+=` union never discards a key. Missing ids default to `0`, matching what a per-event count returned. Empty `$events` returns `[]` with no query issued.
- Style nit raised in review and left alone: the new private helper is named `__fetchReportCounts` while other private methods in this file use plain names. Cosmetic; happy to rename if maintainers prefer.

## Testing

- `php -l` on the patched file inside the benchmark container (PHP 8.3.33): *No syntax errors detected*.
- `git diff --check` clean; the diff is 39 insertions / 13 deletions, entirely inside the target function and its new helper — no reformatting, no drive-by edits.
- Benchmark as described above, run serialized under `flock`, and independently re-run by a second reviewer who reproduced 0 mismatches and comparable ratios.
- Correctness assertion: 3000 randomized trials, 0 mismatches, plus the empty-input edge case.
- **No live MISP instance was available, so there is no end-to-end test.** Nothing was exercised through the actual Cake stack, the events-index view, or a browser. The benchmark reproduces the generated SQL faithfully but is not the application. Reviewers should sanity-check the rendered `report_count` column on an instance with `MISP.showEventReportCountOnIndex` enabled, as both a site admin and a non-site-admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

