### PR TITLE
[medium] perf: memoise sharing group resolution in SharingGroup::captureSG

### DIFF
--- a/app/Model/SharingGroup.php
+++ b/app/Model/SharingGroup.php
@@ -78,6 +78,15 @@ class SharingGroup extends AppModel
 
     private $authorizedIds = [];
 
+    /**
+     * Memoisation of captureSG() results, keyed by user, server, sharing group uuid and the incoming modified date.
+     * captureSG is invoked once per sharing group distributed element of an event, always with the same blob,
+     * so without this the same sharing group is re-resolved for every attribute and object.
+     *
+     * @var array
+     */
+    private $__capturedSGCache = array();
+
     public function beforeValidate($options = array())
     {
         if (empty($this->data['SharingGroup']['uuid'])) {
@@ -627,6 +636,16 @@ class SharingGroup extends AppModel
         if (!empty($server) && !empty($server['Server']['local'])) {
             $syncLocal = true;
         }
+        $cacheKey = null;
+        if (!empty($sg['uuid'])) {
+            $cacheKey = (isset($user['id']) ? $user['id'] : '') . '|' .
+                (!empty($server['Server']['id']) ? $server['Server']['id'] : '') . '|' .
+                $sg['uuid'] . '|' .
+                (isset($sg['modified']) ? $sg['modified'] : '');
+            if (array_key_exists($cacheKey, $this->__capturedSGCache)) {
+                return $this->__capturedSGCache[$cacheKey];
+            }
+        }
         $existingSG = !isset($sg['uuid']) ? null : $this->find('first', array(
                 'recursive' => -1,
                 'conditions' => array('SharingGroup.uuid' => $sg['uuid']),
@@ -648,6 +667,9 @@ class SharingGroup extends AppModel
         } else {
             $existingCaptureResult = $this->captureSGExisting($user, $existingSG, $sg);
             if ($existingCaptureResult !== true) {
+                if ($cacheKey !== null) {
+                    $this->__capturedSGCache[$cacheKey] = $existingCaptureResult;
+                }
                 return $existingCaptureResult;
             }
             $sg_id = $existingSG['SharingGroup']['id'];
@@ -660,7 +682,13 @@ class SharingGroup extends AppModel
             $this->captureCreatorOrg($user, $sg_id);
         }
         if (!empty($existingSG)) {
+            if ($cacheKey !== null) {
+                $this->__capturedSGCache[$cacheKey] = $existingSG[$this->alias]['id'];
+            }
             return $existingSG[$this->alias]['id'];
+        }
+        if ($cacheKey !== null) {
+            $this->__capturedSGCache[$cacheKey] = $this->id;
         }
         return $this->id;
     }


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Sharing group capture is memoised, collapsing per-element repeat lookups to one per group.

- **Problem** — `SharingGroup::captureSG()` resolves an incoming sharing group blob to a local id and is called once per element of an ingested event, not once per sharing group, so an event with N sharing-group-distributed attributes and objects reruns the same three-SELECT lookup on byte-identical rows.
- **Fix** — Adds a private memo keyed by user id, server id, sharing group uuid and incoming `modified` date, consulted before the `find('first')` and set at the three return points, with no signature or caller change.
- **Effect** — Sync pulls and REST ingest collapse those lookups to one per distinct group.
<!-- /bluf -->

## What

`SharingGroup::captureSG()` (`app/Model/SharingGroup.php:624`) resolves an incoming sharing group blob to a local `sharing_group_id`. It is called once per *element* of an ingested event, not once per sharing group, and it has no memo of any kind — so an event with N sharing-group-distributed attributes/objects re-runs the same three-SELECT lookup N times, on byte-identical rows. This PR adds a private instance memo `$__capturedSGCache`, keyed by user id, server id, sharing group uuid and the incoming `modified` date, consulted before the `find('first')` and populated at the three return points the function has. No signature change, no caller change, 28 added lines in one file.

## Why it is hot

Tier **T2** — per-event ingest, on the sync/REST path.

The call chain, verified by reading the code:

- `Event::__captureObjects()` calls `captureSGForElement()` for the event itself (`Event.php:4883`), for every attribute with `distribution == 4` (`Event.php:4890`), for every object (`4897`) and for every object attribute (`4902`); `captureSGForElement` calls `SharingGroup::captureSG()` whenever the element carries a `SharingGroup` blob (`Event.php:4854-4856`).
- `__captureObjects` has exactly one call site, `Event.php:5351`, under `if ($fromXml)`. On the `_edit` path each element pays it separately instead, at `MispAttribute.php:3288` and `MispObject.php:1274`.
- Pulled events really do carry the blob on every such element: the remote's `fetchEvent` copies one array onto all of them via `Event::__attachSharingGroups()` (`Event.php:3809-3819`, invoked at `3407`, `3461`, `3475`).
- Reached from the pull loop at `Server.php:489/491` (`_add`, `$fromXml = true`) and `Server.php:512` (`_edit`), and from REST ingest at `Event.php:5132`.

**Gate, stated honestly.** This is not ungated in the sense of always firing. It requires an event whose attributes/objects *individually* carry `distribution == 4` **plus** a `SharingGroup` blob, and whose sharing group already exists locally. It is **not** gated by any config setting. It does **not** fire for elements that inherit distribution (`5`) — in that case only the single event-level call at `Event.php:4883` runs and there is nothing to memoise. The win is therefore strictly proportional to N, the number of sharing-group-distributed elements in the ingested event: **N = 1 saves nothing.**

## Mechanism

Every call opens with the `find('first')` at `SharingGroup.php:630-638`:

```php
$existingSG = !isset($sg['uuid']) ? null : $this->find('first', array(
        'recursive' => -1,
        'conditions' => array('SharingGroup.uuid' => $sg['uuid']),
        'contain' => array(
            'Organisation',
            'SharingGroupServer' => array('Server'),
            'SharingGroupOrg' => array('Organisation')
        )
));
```

`Organisation` is `belongsTo` and is JOINed into the main query, but `SharingGroupServer` and `SharingGroupOrg` are `hasMany`, and Cake 2 issues one additional SELECT per `hasMany` association (`app/Lib/cakephp/lib/Cake/Model/Datasource/DboSource.php:1885-1897`, `case 'hasMany'`). `Containable` is attached (`SharingGroup.php:14-16`), so `recursive => -1` does not suppress the contain. That is **3 SELECTs per call**.

In steady state the rest is cheap, which is precisely why the repeated find dominates: `captureSGExisting()` (`SharingGroup.php:679`) returns the id at `701`/`704`, so `captureSG` returns immediately at `651` and skips `captureSGOrgs`/`captureSGServers`; and `checkIfAuthorised()` is already memoised by id (`SharingGroup.php:426-427`). The early return is stable across a pull because `beforeValidate()` stamps `modified = now` on every save (`SharingGroup.php:95`), so after at most one update the incoming `modified` is no longer newer than the local one (test at `SharingGroup.php:684`).

So the residual cost of the named path is exactly 3 indexed SELECTs multiplied by the element count, all returning the same rows.

## Why existing caching does not already cover it

Every cache on or near this path was checked:

- `$__sgAuthorisationCache` (`SharingGroup.php:74`) is read only by `checkIfAuthorised()` (`426-427`) and `captureSGNew()` (`721-725`). It stores authorisation booleans, never the resolved sharing group id, and is never consulted before the find at `630`.
- `$authorizedIds` (`SharingGroup.php:79`) serves `authorizedIds()` only.
- `Organisation::$__orgCache` (`Organisation.php:25`) is used only for display attachment (`461-478`); `MispObject::$__objectDuplicationCheckCache` (`MispObject.php:134`) covers object dedupe; `Event::$capturedTags` (`Event.php:4920`) dedupes tags. None touch sharing group resolution.
- Cake's own in-request query cache would have served these byte-identical repeat SELECTs for free, but `Model::$cacheQueries` defaults to `false` (`app/Lib/cakephp/lib/Cake/Model/Model.php:273`) with no override anywhere in `app/Model`, so `DboSource::_addToCache`/`getQueryCache` never engages.
- No Redis or `Cache::` use anywhere on `captureSG`/`captureSGForElement`.
- No caller pre-resolves ids in bulk — `Event.php:4890/4897/4902` hand over the raw per-element blob.

The one memo that would work is an instance-level one, and it is absent. It is also well placed: `Server.php:657` reuses a single `Event` model, and therefore a single `SharingGroup` submodel, across the whole pull loop, so the memo amortises across every event in one pull job.

## Speedup

**Derivation (DERIVED).** Let N be the number of sharing-group-distributed elements in the event carrying a blob for the same sharing group. A first call costs C queries — the 3-SELECT find plus the first, unmemoised `checkIfAuthorised` (`exists()`, the `org_id` find, and the `SharingGroupServer`/`SharingGroupOrg` checks) — and every element after it costs 3 more. So:

```
original =  C + 3(N-1)      patched = C      ratio = (C + 3(N-1)) / C
```

With the measured C = 7: N=4 → 16/7 = 2.29x, N=10 → 34/7 = 4.86x, N=100 → 304/7 = 43.4x. The finding's own agreed figure is **5x at N ≈ 10**.

**Benchmark method (MEASURED).** No live MISP instance was available, so both the original and the patched logic were mirrored in a standalone script (`bench.php`) issuing **real SQL** against the full MISP schema in a scratch database, PHP 8.3 over a unix socket, seeded with 40 sharing groups (ids/uuids namespaced so as not to collide), each with 4 `sharing_group_orgs` and 2 `sharing_group_servers`, plus 20 organisations and 10 servers. The original mirror is deliberately not a strawman: `sg_find_first()` reproduces the real query shape (main SELECT with `Organisation` LEFT JOINed, plus one extra SELECT per `hasMany`, matching `DboSource::queryAssociation`), `capture_sg_existing()` mirrors `SharingGroup.php:679-706` including the real `UPDATE sharing_groups SET modified = NOW()`, and `check_if_authorised()` mirrors `SharingGroup.php:423-461` **with its own by-id memo**, so the baseline is not inflated. The memo is reset per timed event, so each measured event starts cold.

Raw output:

```
correctness cases: 4000
correctnessMismatches: 0
queries original: 17586  patched: 6122

per-event captureSG aggregate (steady state, one SG, N SG-distributed elements)
  N=4    orig   21.163 ms/event ( 16 queries)  patched    7.703 ms/event ( 7 queries)  speedup   2.75x
  N=10   orig   36.452 ms/event ( 34 queries)  patched    6.638 ms/event ( 7 queries)  speedup   5.49x
  N=100  orig  451.800 ms/event (304 queries)  patched    8.109 ms/event ( 7 queries)  speedup  55.72x
```

The measured query counts (16 / 34 / 304 → 7) match the derivation exactly. An independent reviewer re-ran the benchmark and reproduced 2.56x / 5.51x / 57.16x with 0/4000 mismatches.

**Correctness assertion (MEASURED).** 4000 randomised calls over an interleaved sequence, both algorithms run from an identical freshly-seeded database state, return values compared element by element. The sequence varies the user (a sync user with `perm_sync`, a member org, an outsider with no permissions, a site admin — deliberately interleaved, so a per-user key leak would show up as one user receiving an id another user would have been refused), uuid case (upper and lower — `sharing_groups.uuid` is `utf8mb3_bin`, i.e. case-sensitive), the incoming `modified` (older / newer / empty string / key absent), and unknown uuids. **0 mismatches.**

**Scope, honestly.** These numbers are for the `captureSG` aggregate of one event — the path the finding names — **not** for whole-event ingest, where per-attribute save, dedupe and correlation work dwarfs three indexed SELECTs. N=1 saves nothing, N=4 is ~2.6x, N=100 is ~56x. The benchmark also omits Cake ORM hydration and behaviour callbacks per call, and PDO over a unix socket understates per-query cost — both of which work *against* the patch, so the measured ratio is a floor rather than a ceiling.

## Risk

Low, but there are several things a reviewer should see stated rather than discover.

**Deviation from the original proposal — the key uses the raw uuid, not `strtolower(uuid)`.** `sharing_groups.uuid` is `varchar(40)` with collation `utf8mb3_bin` (`SHOW FULL COLUMNS FROM sharing_groups LIKE 'uuid'`), so the `find('first')` on `SharingGroup.uuid` is **case-sensitive**. Lowercasing the key merges an uppercase-uuid blob (which finds nothing) with a lowercase one (which finds the sharing group) under one entry. A first benchmark run using a lowercased key produced 965 mismatches of exactly that shape (`orig = false`, `patched = <id>`). The shipped key is a faithful mirror of the find; since `beforeValidate` lowercases uuid on save (`SharingGroup.php:95`), a raw-uuid key can only ever cause an extra miss, never a wrong hit.

**Not shared across users or servers.** `captureSG`'s result depends on `$user` (role permissions and `org_id`, via `checkIfAuthorised` and `SharingGroup.php:681-689`) and on `$server` (only through `$syncLocal` and the `!empty($server)` guard on `captureCreatorOrg`). Both the user id and the server id are in the key, so a shared `SharingGroup` instance serving more than one user in a process — e.g. via `SharingGroupsController.php:52/212` or `Cerebrate.php:417` — cannot leak an id across them. The interleaved-user correctness run is the evidence.

**`false` is cached where it matters.** The unauthorised `false` returned by `captureSGExisting` (`SharingGroup.php:681-683`) is memoised via the `!== true` write at the `651` return point, so a rejected sharing group is not silently re-attempted. The two `false` returns in the new-sharing-group branch (`642`, missing `perm_sharing_group`; `646`, `captureSGNew` failure) are deliberately **not** cached — conservative, always behaviour-preserving, at the cost of still paying 3 SELECTs per element for an event whose sharing group cannot be created.

**Side-effect collapse in one degenerate branch (raised by the reviewer).** When the incoming blob has an empty or absent `modified`, or a `modified` in the future relative to the local clock, the condition at `SharingGroup.php:684` is true on *every* element, so the original re-runs `save()` + `captureSGOrgs()` + `captureSGServers()` + `captureCreatorOrg()` once per element; the patch runs them once. Consequences: N−1 fewer `modified` re-stamps and N−1 fewer AuditLog/SysLog rows, and — the only non-idempotent piece — `captureCreatorOrg` (`SharingGroup.php:820`) does a bare `create()` + `save()` with no dedupe check, so the original inserts N duplicate `sharing_group_orgs` rows where the patch inserts 1. **The return value is identical on every path** (proven over the 4000 cases, including the empty and absent modes); the state difference is an existing latent duplicate-row behaviour getting less wrong, not new wrong state. This is inherent to any memo of this function and is flagged here rather than left implicit.

**Untested and theoretically divergent:** two *different* blobs carrying the same uuid and the same `modified` within one process. The key does not cover `SharingGroupOrg`/`SharingGroupServer` contents, so on the empty-`modified` path the second blob's orgs/servers would be captured by the original and skipped by the patch. Not reachable on sync (`Event::__attachSharingGroups` copies one array onto every element) and not reachable in steady state (the early return at `684` skips `captureSGOrgs` anyway), but reachable with a hand-crafted REST payload. The benchmark always emits identical content per (uuid, mode), so this case is not covered.

**No invalidation.** The memo's lifetime is the model instance, i.e. one HTTP request or one pull job — background jobs run as subprocesses (`app/Console/Command/StartWorkerShell.php:73-99`), so there is no cross-request staleness window. Growth is bounded by distinct (user, server, uuid, modified) tuples holding an int, so unbounded growth is not a practical concern. A sharing group deleted or re-created mid-process by another code path would still resolve from the memo.

**Unbenchmarked coverage.** The `captureSGNew` return point (`665`, `return $this->id`) is not exercised by the benchmark — the original mirror returns `false` for unknown uuids rather than simulating creation. Equivalence is by inspection: the cache stores exactly the `$this->id` the original returns, and a subsequent uncached call would find the now-existing sharing group and return the same id via `captureSGExisting`.

## Testing

- **Lint:** `php -l` (PHP 8.3) on the actual patched `app/Model/SharingGroup.php` — clean. The syntax used is Cake 2 / PHP 5.4-compatible (`array()` literals, no typed properties).
- **Benchmark:** as described above, run serialised under a lock so no concurrent work polluted the timings, against the real MISP schema. Independently re-run and reproduced by a reviewer.
- **Correctness assertion:** 4000 interleaved randomised cases across four user types, both uuid cases, four `modified` modes and unknown uuids — **0 mismatches** against the unpatched logic.
- **Not done, explicitly:** no live MISP instance was available, so there is **no end-to-end test** — no real sync pull, no REST ingest, and no PHPUnit run. Everything above is static reading plus a standalone SQL-level mirror. A maintainer with a live pair of instances should confirm on a real pull before this leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

