### PR TITLE
[medium] perf: memoize decoded push_rules and resolved org UUIDs in Server::eventFilterPushableServers

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -223,7 +223,16 @@ class Server extends AppModel
         ),
     );
 
+    /** @var array Compiled push rules, keyed by server ID. See Server::compilePushRules(). */
+    private $compiledPushRules = array();
+
     public $validEventIndexFilters = array('searchall', 'searchpublished', 'searchorg', 'searchtag', 'searcheventid', 'searchdate', 'searcheventinfo', 'searchthreatlevel', 'searchdistribution', 'searchanalysis', 'searchattribute');
+
+    public function afterSave($created, $options = array())
+    {
+        $this->compiledPushRules = array();
+        return parent::afterSave($created, $options);
+    }
 
     public function beforeSave($options = array())
     {
@@ -4546,7 +4555,8 @@ class Server extends AppModel
             $eventTags[] = $tag['tag_id'];
         }
         foreach ($servers as $server) {
-            $push_rules = json_decode($server['Server']['push_rules'], true);
+            $compiled = $this->compilePushRules($server);
+            $push_rules = $compiled['rules'];
             if (!empty($push_rules['tags']['OR'])) {
                 $intersection = array_intersect($push_rules['tags']['OR'], $eventTags);
                 if (empty($intersection)) {
@@ -4560,13 +4570,13 @@ class Server extends AppModel
                 }
             }
             if (!empty($push_rules['orgs']['OR'])) {
-                $convertedRule = $this->convertUUIDsToIDs($push_rules['orgs']['OR']);
+                $convertedRule = $compiled['orgs']['OR'];
                 if (!in_array($event['Event']['orgc_id'], $convertedRule)) {
                     continue;
                 }
             }
             if (!empty($push_rules['orgs']['NOT'])) {
-                $convertedRule = $this->convertUUIDsToIDs($push_rules['orgs']['NOT']);
+                $convertedRule = $compiled['orgs']['NOT'];
                 if (in_array($event['Event']['orgc_id'], $convertedRule)) {
                     continue;
                 }
@@ -4574,6 +4584,35 @@ class Server extends AppModel
             $validServers[] = $server;
         }
         return $validServers;
+    }
+
+    /**
+     * Decode a server's push rules and resolve the org UUIDs contained in them to org IDs.
+     * The result is memoized per server ID, as it is invariant for the whole push run.
+     *
+     * @param array $server
+     * @return array
+     */
+    private function compilePushRules(array $server): array
+    {
+        $serverId = isset($server['Server']['id']) ? $server['Server']['id'] : null;
+        $raw = $server['Server']['push_rules'];
+        if ($serverId !== null && isset($this->compiledPushRules[$serverId]) && $this->compiledPushRules[$serverId]['raw'] === $raw) {
+            return $this->compiledPushRules[$serverId];
+        }
+        $push_rules = json_decode($raw, true);
+        $compiled = [
+            'raw' => $raw,
+            'rules' => $push_rules,
+            'orgs' => [
+                'OR' => !empty($push_rules['orgs']['OR']) ? $this->convertUUIDsToIDs($push_rules['orgs']['OR']) : [],
+                'NOT' => !empty($push_rules['orgs']['NOT']) ? $this->convertUUIDsToIDs($push_rules['orgs']['NOT']) : [],
+            ],
+        ];
+        if ($serverId !== null) {
+            $this->compiledPushRules[$serverId] = $compiled;
+        }
+        return $compiled;
     }
 
     private function convertUUIDsToIDs($orgs): array


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Push rules are decoded and org UUIDs resolved once per push run, not per candidate event.

- **Problem** — `Server::getEventIdsForPush()` calls `Server::eventFilterPushableServers()` once per candidate event, and that method re-decodes the server's `push_rules` JSON and re-resolves the rules' org UUIDs to ids with a query on every iteration, though the server and its rules are fixed for the whole run.
- **Fix** — Hoists that work into a per-server memo built by a new private `compilePushRules()` and cleared by a new `Server::afterSave()`, leaving the filter logic unchanged.
- **Effect** — A scheduled full push now decodes once and does at most two org lookups per run instead of per event.
<!-- /bluf -->

## What

`Server::getEventIdsForPush()` pre-filters the candidate event set with a loop at `app/Model/Server.php:1493-1500` that calls `Server::eventFilterPushableServers($event, [$server])` once per candidate event. That method re-decodes the server's `push_rules` JSON and, when org rules are configured, re-resolves the org UUIDs in those rules to org IDs with a real database query — on every single iteration, even though `$server` and its rules are fixed for the entire push run. This change hoists that loop-invariant work into a private per-server memo (`Server::$compiledPushRules`, built by a new private `compilePushRules()` and cleared by a new `Server::afterSave()`), so the decode happens once and the org lookups happen at most twice per push run instead of once or twice per event. The filter body itself is unchanged apart from reading the two converted org arrays from the memo.

## Why it is hot

Tier T2 — the loop body runs once per candidate event, per push run.

The trigger is the push job (`app/Controller/ServersController.php:1112`, `app/Console/Command/ServerShell.php:197` and `:750`). The scheduled push task at `ServerShell.php:730-751` (`'process_id' => 'Part of scheduled push'`) calls `push(..., 'full', ...)` for every server with `push=1`. With technique `'full'`, the condition key is `'Event.id' > 0` (`Server.php:1291-1292`), so the candidate find at `Server.php:1353` (conditions built at `1326-1348`) returns **every published event with distribution>0, or distribution=4 in a shared sharing group** — i.e. the whole corpus, on every scheduled run, not a small incremental delta (`lastpushedid` is only consulted by the `'incremental'` branch at `:1295`).

**The gate, stated honestly:** this path only runs when the server has push enabled and technique is `'full'` or `'incremental'` (`app/Model/Server.php:1287-1295`), **and** the server's `push_rules` JSON contains a non-empty `orgs.OR` or `orgs.NOT` (`app/Model/Server.php:4562/4568`). With no org rules configured, only the `json_decode` is hoisted, which is well under 2x and is **not** claimed here.

A further honest narrowing: the premium ratio applies to technique `'full'`, where N is the whole published corpus and the loop dominates. For a small `'incremental'` push, N is single-digit and the one remote HTTP round trip at `:1508` dwarfs everything — see Speedup.

## Mechanism

- `app/Model/Server.php:1491-1512` — `getEventIdsForPush`; the pre-filter loop at `1493-1500` calls `$this->eventFilterPushableServers($event, [$server])` once per candidate event. The only remote round trip (`filterEventIdsForPush`, `:1508`) is **outside** the loop.
- `app/Model/Server.php:4541-4576` — `eventFilterPushableServers`; `json_decode($server['Server']['push_rules'], true)` at `:4549` on every call, then `convertUUIDsToIDs($push_rules['orgs']['OR'])` at `:4563` and `...['orgs']['NOT']` at `:4569`, each gated on `!empty(...)`.
- `app/Model/Server.php:4579-4595` — `convertUUIDsToIDs`; issues `$this->Organisation->find('column', ...)` at `:4587-4592`, unconditionally (it fires even when the UUID list is empty, so numeric-ID-only rules still pay a query). `Server belongsTo Organisation` at `Server.php:35-39`, so the association resolves to a real model.
- `find('column')` is a **genuine SQL find**, not an array helper: registered at `app/Model/AppModel.php:121` (`$this->findMethods['column'] = true`) and implemented at `AppModel.php:4359-4391` — the `before` branch only rewrites `fields`/`recursive`, the `after` branch only runs `array_column` over the returned rows (`4387-4389`). The read still goes through `DboSource`.
- `app/Model/Organisation.php:177-190` — the model that query hits has an `afterFind` that `json_decode`s `restricted_to_domain` per returned row. It adds cost; it does not short-circuit or cache.

Net: **N `json_decode`s and up to 2N MySQL round trips** before the single HTTP call, all of it invariant.

## Why existing caching does not already cover it

- **CakePHP's DboSource query cache is off.** This is the mechanism that would have neutralised the claim. `Model::$cacheQueries` defaults to `false` (`app/Lib/cakephp/lib/Cake/Model/Model.php:273`); `DboSource::read()` passes `$Model->cacheQueries` into `fetchAll()` (`DboSource.php:1226`); `_addToCache`/`getQueryCache` (`DboSource.php:3724/3736`) are only consulted when that flag is set. Grepping the whole `app/` tree outside `app/Lib/cakephp` for `cacheQueries` returns **zero** hits, so MISP never enables it. The configured datasource is `Database/MysqlObserverExtended` (`app/Config/database.php:33`) and `MysqlExtended.php` overrides no `fetchAll`/`read`/cache path. Every iteration is a genuine round trip.
- **No memo on the path.** Reading `eventFilterPushableServers` (`4541-4577`), `convertUUIDsToIDs` (`4579-4595`) and `getEventIdsForPush` (`1491-1512`) in full: no static array, no instance property, no `Cache::read/write`, no Redis/`setupRedis`, no prefetched org map. `getEventIdsForPush` builds `$request` only.
- **`ServerSyncTool`'s memo does not apply.** It memoizes other sync data (`info()` at `app/Lib/Tools/ServerSyncTool.php:458`, `cachedUserInfo()` at `:486`) and does expose a decoded, per-instance cached `pushRules()` (`:553` → `decodeRule` at `:751`) — but that memo covers only the `json_decode`, is **never consulted** by `Server.php:4549`, and does not resolve org UUIDs to IDs at all.
- **No caller pre-resolves the rules.** All six call sites of `eventFilterPushableServers` (`Server.php:1495`, `Event.php:956`, `:982`, `:1066`, `:6126`, `Sighting.php:1393`) pass a freshly built `[$server]` or a fresh find result, so nothing upstream carries a compiled rule set down as a parameter.
- `organisations.uuid` is a `UNIQUE KEY` (`INSTALL/MYSQL.sql:1035`), so each query is index-served — but it is still a full Cake find round trip.

## Speedup

**Scope: the pre-filter loop at `Server.php:1493-1500` only.** The single `filterEventIdsForPush` HTTP call at `:1508` is outside the loop, is untouched by this change, and is excluded — exactly as the derivation scopes it. **The headline number must not be read as end-to-end.**

### DERIVED (from the source, no measurement)

Per iteration today, with org rules configured: 1 `json_decode` (`:4549`) + 1 or 2 `Organisation->find('column')` round trips (`:4563`/`:4569` → `:4587`) + 2 `array_intersect` over the event's tag list (`:4551`/`:4557`) + one array append. After hoisting: 2 `array_intersect` plus the array append; the decode and the org queries run once for the whole push.

- DB round trips over the loop: **up to 2N → 2**
- `json_decode` count: **N → 1**

The remaining per-iteration work is two `array_intersect` calls over arrays of a handful of ids plus an append — pure userland array work, no I/O. A Cake find round trip (DboSource query build, PDO execute, fetch, `Organisation::afterFind`'s per-row pass, `_findColumn`'s `array_column` pass) costs at least an order of magnitude more, and there are one or two per iteration. **DERIVED floor: ≥10x on this loop.** 10x is reported as an honest floor rather than the far larger ratio implied by real socket latency, because no latency constant is derivable from the code.

### MEASURED

Benchmark: `bench.php` mirrors both arms as standalone code — `eventFilterPushableServers_orig` (verbatim copy of the 2.5 body) and a `PatchedServer` class (verbatim copy of the patched body plus `compilePushRules`) — both calling one shared `convertUUIDsToIDs` that issues the **real SQL** of `Organisation->find('column', ['fields' => ['id'], 'conditions' => ['uuid' => $toConvert]])` through PDO against MariaDB (database `perf`, unix socket), against a seeded `organisations` table of 1500 rows with the real `UNIQUE uuid` index. The dominant cost is present, not stubbed. Workload: N=5000 synthetic events (deterministic `mt_srand`, 0-4 random tag ids, `orgc_id` 1-40), representing a technique `'full'` push. Runs are serialized behind an flock so concurrent work cannot pollute timings.

Raw output:

```
orgs seeded: 1500
correctness cases: 12600  mismatches: 0
N=5000 events, 1 server (orgs.OR + orgs.NOT configured)
results identical: yes (551 kept)
ORIGINAL loop : 5.3989s  (queries: <=10000)
PATCHED  loop : 0.0166s  (queries: 2)
speedup       : 324.72x
single orgs.OR rule: ORIGINAL 3.6166s  PATCHED 0.0178s  speedup 203.18x (queries 5000 -> 1, both exact)
FINAL mismatches: 0
```

Two corrections a reader should carry:

1. **The `queries: <=10000` figure on the ORIGINAL line is a hardcoded `2*N` upper bound printed by the harness, not a counted value.** For this workload only ~12% of events pass the `orgs.OR` check and go on to issue the `NOT` query, so the true count is around 1.1N. Timings and the measured ratio are unaffected; only that printed number overstates. The `PATCHED` count of 2 **is** counted, which is what proves the memo held across all 5000 iterations. The single-`orgs.OR` line's counts (5000 → 1) are both exact.
2. **The baseline is conservative/understated.** The raw PDO query omits CakePHP's DboSource query build, `Organisation::afterFind`'s per-row `json_decode`, and `_findColumn`'s `array_column` pass — all of which the real original path pays on every query. A networked MySQL rather than a unix socket in a single container would widen the gap further.

Reproducibility: an independent reviewer re-ran the benchmark twice behind the same lock and obtained **364.39x** and **201.89x** (single-`orgs.OR` variant 223.97x / 356.04x), so the reported 324.72x is in-band and reproducible.

### Correctness assertion

- **12600 comparisons, 0 mismatches.** 10 rule variants (`orgs.OR` uuids; mixed uuid + numeric id; unknown-uuid-only; `orgs.NOT`; OR+NOT together; tags+orgs; `tags.NOT`+`orgs.NOT`; tags only; empty rules; empty orgs arrays) over 300 events in three call shapes: two servers with different ids and rules in one call, a single server, and the same server id whose `push_rules` string changes between calls (the memo-invalidation case). Compared with `===`.
- **368 additional independent edge cases, 0 mismatches**, written by the reviewer: `null` / `''` / invalid-JSON / scalar-JSON / `false` `push_rules`, int vs string `orgc_id`, `'0'` and `null` `orgc_id`, uppercase UUIDs, unknown-uuid-only NOT rules, servers with no `id` key, and a single call mixing id-bearing and id-less servers.

### End-to-end caveat

`getEventIdsForPush` as a whole also contains the one `filterEventIdsForPush` HTTP call at `:1508`, which is untouched. For a technique `'full'` push where N is the whole corpus, that single call is amortized away and the loop dominates. For a small `'incremental'` push, it dominates instead and the whole-function gain approaches 1x. The 324.7x figure is loop-scoped.

## Risk

From the finding:

- Behaviour is preserved **only if** the memo is keyed on `$server['Server']['id']` — `eventFilterPushableServers` accepts a *list* of servers at `:4548`, so a single flat memo would be wrong. It is keyed on the id here, and additionally validated against the raw `push_rules` string, which makes it correct even when a Server row is saved through a different model instance or via `updateAll` (which never fires `afterSave`). Servers passed without an `'id'` key skip the memo entirely and fall back to exactly the original behaviour.
- Within one push the server row is fixed (it is re-saved only *after* the loop, at `Server.php:1411`), so intra-request staleness is not a concern; a long-lived worker process needs the `afterSave` invalidation, which is added.
- `convertUUIDsToIDs` merges non-UUID entries through untouched (`:4581-4586`); it is called here **unmodified**, so mixed id/uuid handling is preserved. Deliberately **no** `array_flip`/`isset` rewrite was made, precisely because that would change `"5"` vs `5` comparison semantics.

Raised in review, and accepted:

- **Org resolution is now eager.** `compilePushRules` resolves `orgs.OR`/`orgs.NOT` on first call even when a tags rule would have short-circuited before ever reaching the org checks. An edge benchmark confirms it (tags-reject-all workload: original 0 queries, patched 1). This is a constant 1-2 extra queries per push run with **no change to returned output**, but it does mean an `Organisation` query can now fire — and in principle throw — on a path where the original never queried. Bounded and constant in N.
- **Memo staleness is bounded but non-zero.** An `Organisation` row created *after* the memo is built, in the same process, whose UUID is already listed in an unchanged `push_rules` string, would be picked up by the original and not by this patch. The finding's risk field explicitly accepts this ("already the semantics for the tag rules"), and no same-process push path creates orgs, so it is theoretical.

## Testing

- **Lint:** `php -l` on the patched `app/Model/Server.php` under PHP 8.3 — *No syntax errors detected*. The two `Optional parameter declared before required parameter` deprecation notices are **pre-existing** in the 2.5 file (around line 1585) and unrelated to this change.
- **Benchmark:** as described above, run serialized behind an flock so no concurrent work polluted the timings; re-run independently twice by a reviewer with consistent results.
- **Correctness assertion:** 12600 comparisons (0 mismatches) plus 368 independent edge cases (0 mismatches), comparing the original and patched filter outputs with `===`.
- **Static review:** all six call sites of `eventFilterPushableServers` (`Server.php:1495`, `Event.php:956/982/1066/6126`, `Sighting.php:1393`) checked — all pass arrays carrying `Server.id`. `app/Test/` grepped: the only `push_rules` tests target `Collection::isPushableForServerSyncRules`, a different method, and no test asserts an `Organisation` query count. `Server::afterSave` correctly calls `parent` (`AppModel` defines none; it resolves to `Model.php:3825`), and overriding the model method does not suppress the AuditLog/SysLogLogable behaviour callbacks, which dispatch through `CakeEventManager`.
- **`git diff` audit:** one file, 42 insertions / 3 deletions, no reformatting and no unrelated edits.

**No live MISP instance was available, so no end-to-end testing was performed.** The change is verified by static reading, lint, a standalone benchmark that drives the real SQL through PDO against a real MariaDB schema, and differential correctness assertions between the original and patched filter bodies — not by an actual sync between two running instances. Marked draft accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

