### PR TITLE
[medium] perf: replace save()+refetch with one atomic UPDATE in Workflow::__incrementWorkflowExecutionCount

### DIFF
--- a/app/Model/Workflow.php
+++ b/app/Model/Workflow.php
@@ -1355,9 +1355,15 @@ class Workflow extends AppModel
 
     private function __incrementWorkflowExecutionCount(array $workflow): array
     {
+        // Atomic, callback-free counter bump. Using save() here would run the model and behavior
+        // callbacks (re-fetch of the row, graph JSON encode/decode, audit log entry) and would
+        // require an additional fetchWorkflow() to get the updated row.
+        $this->updateAll(
+            ['Workflow.counter' => 'Workflow.counter + 1'],
+            ['Workflow.id' => (int)$workflow['Workflow']['id']]
+        );
         $workflow['Workflow']['counter'] = intval($workflow['Workflow']['counter']) + 1;
-        $this->save($workflow, ['fieldList' => ['counter']]);
-        return $this->fetchWorkflow($workflow['Workflow']['id']);
+        return $workflow;
     }
 
     /**


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Workflow counter increments become one atomic UPDATE instead of a save plus refetch.

- **Problem** — `Workflow::__incrementWorkflowExecutionCount()` exists only to add 1 to `workflows.counter`, but does it with a full Cake `Model::save()` with callbacks plus an unconditional `fetchWorkflow()` re-SELECT, once per workflow execution from `__runWorkflow`.
- **Fix** — Replaces the pair with a single atomic `updateAll(['Workflow.counter' => 'Workflow.counter + 1'])` and an in-memory bump of the array already in hand.
- **Effect** — On instances with `Plugin.Workflow_enable` on, the attribute-after-save trigger fires per saved attribute, so an import stops paying a save-plus-refetch for each one.
<!-- /bluf -->

## What

`Workflow::__incrementWorkflowExecutionCount()` (`app/Model/Workflow.php:1356-1361`) exists only to add 1 to `workflows.counter`, but it does so with a full Cake `Model::save()` with callbacks plus an unconditional `fetchWorkflow()` re-SELECT. It is called once per workflow execution from `__runWorkflow` (`app/Model/Workflow.php:642`). This PR replaces the pair with a single callback-free atomic statement and an in-memory bump of the array that is already in hand:

```php
$this->updateAll(
    ['Workflow.counter' => 'Workflow.counter + 1'],
    ['Workflow.id' => (int)$workflow['Workflow']['id']]
);
$workflow['Workflow']['counter'] = intval($workflow['Workflow']['counter']) + 1;
return $workflow;
```

One file, one hunk.

## Why it is hot

Tier T1 (per-item work in a loop), but gated — stated plainly:

- `Plugin.Workflow_enable` **ships as `false`** (`app/Model/Server.php:8660-8666`). Nothing here runs on a default install.
- On top of that, `isTriggerCallable` (`app/Model/AppModel.php:4653-4668`) requires the per-trigger setting `Plugin.Workflow_triggers_<trigger_id>` to be enabled **and** at least one workflow listening to that trigger (`app/Model/Workflow.php:198-217, 297-300`).

When those are on, the multiplicity is genuinely per-item: `MispAttribute::afterSave` calls `executeTrigger('attribute-after-save', ...)` for **every saved attribute** (`app/Model/MispAttribute.php:697-738`), and MISP's own module declares `trigger_overhead = OVERHEAD_HIGH` with the message "the workflow will be run for as many time as there are Attributes" (`app/Model/WorkflowModules/trigger/Module_attribute_after_save.php:14-20`). So on an install with workflows enabled, a single event import pays this bookkeeping once per attribute.

## Mechanism

What the old two lines actually cost, per execution:

1. **`exists()` → `SELECT COUNT`.** `Model::save` is atomic by default (`app/Lib/cakephp/lib/Cake/Model/Model.php:1741-1755`); `_doSave` calls `$this->set($data)` (`Model.php:1809`), which keeps **every** column in `$Model->data` even though the whitelist is `['counter']` — the whitelist only filters the UPDATE column list. It then calls `$this->exists()` (`Model.php:1828`), an uncached `find('count')` (`Model.php:2917-2936`).
2. **A second full-row `SELECT`, with callbacks.** `Workflow::actsAs` declares `SysLogLogable` with `'change' => 'full'` (`app/Model/Workflow.php:16-24`), and the `logs` table has a `change` column (`INSTALL/MYSQL.sql:758-772`), so `LogableBehavior::beforeSave` (`app/Plugin/Assets/models/behaviors/LogableBehavior.php:374-383`) re-reads the whole row. Callbacks are on, so `Workflow::afterFind` (`Workflow.php:109-127`) runs: `JsonTool::decode` of the entire graph blob, `__getTriggersIDPerWorkflow` (Redis `sMembers`, `Workflow.php:375-384`), `getModuleByID` → `getModules` → `getModulesByType` (`Workflow.php:1285-1311, 1336-1354`) which `uasort`s the trigger/logic/action module lists, and `getEnabledAdHocWorkflows` (a second `sMembers`, `Workflow.php:229-239`).
3. **`Workflow::beforeSave` re-JSON-encodes the graph** (`Workflow.php:129-136`).
4. **The `UPDATE`** — the only statement anyone wanted.
5. **`INSERT INTO logs`.** `SysLogLogableBehavior::afterSave` (`app/Plugin/SysLogLogable/Model/Behavior/SysLogLogableBehavior.php:7-26`) is enabled whenever `MISP.log_new_audit` is off, the shipped default (`app/Model/Server.php:6646-6652`), and the diff is non-empty because `set()` kept all columns while `defaults['ignore']` holds only the primary key (`LogableBehavior.php:74-84`).
6. **`Workflow::afterSave` → `updateListeningTriggers`** (`Workflow.php:138-141, 321-353`) decodes the graph a **second** time, does another `sMembers` and two `array_diff`s.
7. **`fetchWorkflow`** (`Workflow.php:1424-1445` → `fetchWorkflows` `1370-1402` → `find('all')`) re-SELECTs the identical row and runs `afterFind` a **second** time (a third graph decode + 2 `sMembers` + 3 more `uasort`s).

Totals per execution: **5 SQL statements** on the synchronous hot path (7 in a background worker, where the increment is not inside an enclosing transaction and pays its own BEGIN/COMMIT — `DboSource::begin` with `useNestedTransactions = false` emits no nested BEGIN, `DboSource.php:2416-2423`), **5 Redis round-trips**, **3 JSON decodes + 1 encode** of the full graph blob (two of the decodes from the two `afterFind` passes, the third from `updateListeningTriggers`), and **6 `uasort` passes** over the 67 shipped module configs (19 trigger + 13 logic + 35 action, counted under `app/Model/WorkflowModules/`) ≈ 2400 closure comparisons, plus two 67-element linear scans in `getModuleByID`.

The replacement: `Model::updateAll` → `DboSource::update` with **no model or behavior callbacks** (`Model.php:2672-2674`). With conditions supplied, `_prepareUpdateFields` sets `quoteValues = false` so `'Workflow.counter + 1'` is emitted as a raw SQL snippet, and `_matchRecords` (`DboSource.php:2268-2291`) returns the conditions directly with no pre-SELECT because `Workflow.id` passes `hasField`. `Workflow::$belongsTo` is empty, so it renders one single-table `UPDATE`.

## Why existing caching does not already cover it

Searched `Workflow.php` for every memo:

- The only caches are `$this->module_initialized` guarding `loadAllWorkflowModules` (`Workflow.php:1017-1021`) and the static `$enabled` global-flag memo in `checkTriggerEnabled` (`Workflow.php:198-204`). Neither covers this path — `module_initialized` prevents re-*loading* the modules, but the three `uasort`s downstream of it still run on every call.
- `getModulesByType` copies `$this->loaded_modules` into locals before sorting (`Workflow.php:1289-1296`), so the sort result is **discarded each call**; the sort is genuinely repeated, not memoized.
- The Redis keys defined at `Workflow.php:78-79` hold only trigger↔workflow id sets, never the row or the decoded graph. `RedisTool::init` memoizes the *connection* (`app/Lib/Tools/RedisTool.php:18-22`), so the 5 Redis calls are real round-trips, not connects.
- No `Cache::read`/`Cache::write`, no instance property holding the workflow row anywhere in `Workflow.php`.
- `LogableBehavior` has no old-row memo — `$this->old` is overwritten on each `beforeSave` (`LogableBehavior.php:375-380`).
- Cake 2's `Model::exists()` has no `_exists` cache.

## Speedup

**DERIVED (floor): 4x.** From statement count alone on the named helper: 5 SQL → 1, 5 Redis → 0, 4 JSON codecs of the graph blob → 0, 6 `uasort` passes over 67 configs → 0. Charging only 0.3 ms per local DB round-trip and 0.05 ms per Redis round-trip for the 7-statement autocommit case gives `(7*0.3 + 5*0.05) = 2.35 ms → 0.3 ms = 7.8x`, before counting the JSON codecs and ~2400 sort comparisons. The per-round-trip figures are estimates, so **4x is the honest floor** that is claimed here, not the 7.8x.

**MEASURED.** Method: a standalone bench (no live MISP available — see Testing) run against the real MariaDB with the real `workflows` and `logs` schema, an 11 KB realistic 12-node drawflow graph blob, and 67 stubbed module configs matching the shipped 19/13/35 counts. ORIGINAL mirrors the Cake 2 `save()` path as five *real* SQL statements (`SELECT COUNT`, full-row `SELECT`, `UPDATE`, a real `INSERT` into a growing `logs` table, the `fetchWorkflow` re-`SELECT`) plus the same PHP work (2 × `afterFind` = 2 graph decodes + 6 `uasort`s + 2 linear scans, the `beforeSave` encode, `updateListeningTriggers`' second decode and `array_diff`s). PATCHED is the single `UPDATE ... SET counter = counter + 1 WHERE id = ?` plus the in-memory bump. Both sides re-prepare per call, matching Cake's `_execute`. **The original's 5 Redis `sMembers` are NOT charged** (no php-redis in the bench container), so every ratio below undercharges the original.

Two modes:

- **Mode A — inside an enclosing transaction.** This is the shipped synchronous path: `MISP.background_jobs` ships falsy (`app/Model/Server.php:6134-6140`), so attribute-after-save runs inside the attribute save's open transaction and Cake emits no nested BEGIN/COMMIT. Neither variant pays a commit of its own, so this isolates statement count + CPU.
- **Mode B — autocommit.** Models the enqueued-worker case (`attribute-after-save` declares `blocking = false`, so with background jobs on the execution is offloaded, `Workflow.php:562-586`). The original's 4 write-path statements are wrapped in ONE transaction (Cake's atomic save) so both sides pay exactly one durable commit. This host runs `innodb_flush_log_at_trx_commit = 1` (~6 ms/commit).

Raw output, implementer's run:

```
graph blob size: 10988 bytes, module configs: 67
correctness: 3000 iterations, 0 mismatches
[in enclosing transaction - T1 hot path]
original: 9.642 s for 2000 iters (4.8208 ms/call)
patched : 0.643 s for 2000 iters (0.3215 ms/call)
speedup : 14.99x
[autocommit - fsync-bound]
original: 6.268 s for 500 iters (12.5356 ms/call)
patched : 3.104 s for 500 iters (6.2074 ms/call)
speedup : 2.02x
```

**The headline number did not fully reproduce, and that is disclosed here rather than buried.** An independent reviewer re-ran the *unmodified* bench under the same lock on the same host and got **Mode A 8.51x, Mode B 1.86x** (correctness 3000 iterations / 0 mismatches, identical). An earlier run of the same code gave Mode A 12.34x. So the honest reading is: **Mode A is somewhere in the 8.5–15x band with substantial run-to-run spread on a shared host, and 8.5x is the figure to trust**; Mode B is ~1.9–2.0x. Both are above the derived 4x floor only in Mode A — **the ≥4x claim is defensible on the synchronous in-transaction path, not on the background-worker path.** The Mode A/Mode B gap is entirely the commit fsync, charged to both sides: Mode A shows 4.82 ms of statements+PHP for the original vs 0.32 ms patched, and Mode B is that same delta plus a ~6 ms storage constant on each side. The ~1.9x is a property of this host's commit latency, not of the code. Installs with `MISP.background_jobs` enabled — a large share of production deployments, though not the shipped default — get the Mode B figure.

**Correctness assertion: 3000 iterations with varying start counters, 0 mismatches.** Each iteration compares the full returned array with `!==` (identical keys, values *and* PHP types, including the `afterFind`-derived `data`, `listening_triggers` and `enabled`) plus the resulting DB counter. PDO on PHP 8.3 returns native ints (verified `int(7)`), so `intval() + 1` matches the re-fetched value's type exactly.

## Risk

From the finding, plus everything the reviewer raised:

1. **No audit row per counter change (intended, pre-declared).** Previously one `INSERT INTO logs` per workflow execution — log-table growth proportional to attribute count, arguably a bug rather than a feature. Verified non-functional: `Log::afterSave` (`app/Model/Log.php:235`) explicitly excludes `model === 'Workflow'` from the log-after-save trigger, and nothing else reads or counts `model='Workflow' action='edit'` rows outside the audit UI. Real graph edits via `addWorkflow`/`editWorkflow` still go through `save()` and still produce audit rows.
2. **`updateAll` bypasses `beforeSave`/`afterSave`, so `updateListeningTriggers` no longer runs on a counter bump.** Correct, because the graph is unchanged — and it must stay in place on the real edit paths, which it does: `Workflow::afterSave` (`Workflow.php:138-141`) is untouched by this diff and still fires from `addWorkflow`/`editWorkflow`, so the trigger↔workflow Redis sets stay correct.
3. **Callers relying on a freshly-hydrated return row.** `Workflow.php:642` is the only caller. Both `__runWorkflow` entry points (`Workflow.php:525` `executeWorkflow` → `fetchWorkflow`, `Workflow.php:624` `executeWorkflowForTrigger` → `fetchWorkflowByTrigger`) build `$workflow` with identical params (`defaultContain`, `recursive -1`, no `fields`), i.e. it is already `afterFind`-processed. Downstream of line 642 only `$workflow['Workflow']['data']` and `['id']` are read. `workflows` has no `modified`/`updated` column, and `beforeSave`'s timestamp default was never persisted under `fieldList=['counter']`, so no column other than `counter` was ever written. `$this->id` / `$this->data` are not read after the increment.
4. **Returned `counter` is now caller-snapshot+1 rather than a DB read-back** (reviewer). Under concurrent executions the *returned* value can lag the DB value. Immaterial: nothing downstream in `__runWorkflow` reads `counter`, and the views (`Workflows/index.ctp`, `view.ctp`, `triggers.ctp`, `WorkflowsController.php:130`) fetch their own rows. Note the DB value itself is now **more** correct — see 6.
5. **Changed error path** (reviewer). If the workflow row is deleted between `fetchWorkflowByTrigger` and the increment, the old code's `fetchWorkflow($id, true)` threw `NotFoundException`; the new code affects 0 rows and returns the stale array. Likewise a failed UPDATE: previously `save()` returned false and the re-fetch showed the un-bumped counter, now the in-memory bump happens regardless. Both are races with no consumer, but they are genuinely changed behaviour and are recorded here rather than glossed.
6. **Bonus correctness fix.** `counter = counter + 1` is atomic, whereas the old read-modify-write silently lost increments under concurrent executions.
7. **Type nuance.** On PHP < 8.1 PDO returned `counter` as a string, so the old return would have been a string where the new one is an int. Moot for MISP 2.5 (PHP 8.x, verified `int`), and nothing outside line 1365 reads `['counter']` (grepped `Model/WorkflowModules` and `Lib/Tools/Workflow*`).
8. **Bench fidelity nit** (reviewer, no effect on the ratio). The bench's patched path issues `UPDATE workflows AS Workflow SET Workflow.counter = ...`, whereas Cake actually renders ``UPDATE `workflows` SET `counter` = counter + 1 WHERE `id` = N`` (alias is null; `_prepareUpdateFields` strips it). Same single-statement plan.

## Testing

- **Lint:** `php -l` clean on the patched file (PHP 8.3), confirmed independently by the reviewer.
- **Benchmark:** the standalone bench described under Speedup, run serialized under a lock against a real MariaDB with the real MISP schema. Run by the implementer and **re-run independently by a reviewer on the unmodified bench**, which is how the 14.99x-vs-8.51x spread above was caught.
- **Correctness assertion:** 3000 iterations, varying start counters, full-array `!==` comparison plus DB counter check — **0 mismatches**, reproduced by the reviewer.
- **ORM semantics** were re-derived from the vendored Cake source rather than assumed: `updateAll` → `DboSource::update`, `quoteValues = false` with conditions present, `_matchRecords` short-circuit via `hasField('id')`, empty `belongsTo` so no JOIN, no virtual fields, and no `AppModel::updateAll` override. `counter` is `int(11) NOT NULL DEFAULT 0`, so the expression is always defined.
- **No live MISP instance was available for end-to-end testing.** This change has not been exercised against a running MISP with workflows enabled, a real Redis, and a real trigger firing. That verification is the main thing a maintainer should add before this leaves draft — hence the draft status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

