### PR TITLE
[medium] perf: indexed HMAC lookup before bcrypt in AuthKey::getAuthUserByAuthKey

### DIFF
--- a/INSTALL/MYSQL.sql
+++ b/INSTALL/MYSQL.sql
@@ -158,6 +158,7 @@ CREATE TABLE `auth_keys` (
   `authkey` varchar(72) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
   `authkey_start` varchar(4) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
   `authkey_end` varchar(4) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+  `authkey_hmac` varchar(128) CHARACTER SET ascii COLLATE ascii_general_ci DEFAULT NULL,
   `created` int(10) unsigned NOT NULL,
   `expiration` int(10) unsigned NOT NULL,
   `read_only` tinyint(1) NOT NULL DEFAULT 0,
@@ -168,6 +169,7 @@ CREATE TABLE `auth_keys` (
   PRIMARY KEY (`id`),
   KEY `authkey_start` (`authkey_start`),
   KEY `authkey_end` (`authkey_end`),
+  KEY `authkey_hmac` (`authkey_hmac`),
   KEY `created` (`created`),
   KEY `expiration` (`expiration`),
   KEY `user_id` (`user_id`)

--- a/app/Controller/AuthKeysController.php
+++ b/app/Controller/AuthKeysController.php
@@ -44,6 +44,7 @@ class AuthKeysController extends AppController
                         $authKey['AuthKey']['last_used'] = $lastUsed;
                     }
                     unset($authKey['AuthKey']['authkey']);
+                    unset($authKey['AuthKey']['authkey_hmac']);
                 }
                 return $authKeys;
             }
@@ -169,6 +170,7 @@ class AuthKeysController extends AppController
             'conditions' => $this->__prepareConditions(),
             'afterFind' => function (array $authKey) {
                 unset($authKey['AuthKey']['authkey']);
+                unset($authKey['AuthKey']['authkey_hmac']);
                 if (is_array($authKey['AuthKey']['allowed_ips'])) {
                     $authKey['AuthKey']['allowed_ips'] = implode("\n", $authKey['AuthKey']['allowed_ips']);
                 }
@@ -223,6 +225,7 @@ class AuthKeysController extends AppController
             ],
             'afterFind' => function (array $authKey, array $savedData) { // remove hashed key from response
                 unset($authKey['AuthKey']['authkey']);
+                unset($authKey['AuthKey']['authkey_hmac']);
                 $authKey['AuthKey']['authkey_raw'] = $savedData['AuthKey']['authkey_raw'];
                 return $authKey;
             }
@@ -274,6 +277,7 @@ class AuthKeysController extends AppController
             'conditions' => $this->__prepareConditions(),
             'afterFind' => function (array $authKey) {
                 unset($authKey['AuthKey']['authkey']);
+                unset($authKey['AuthKey']['authkey_hmac']);
                 return $authKey;
             }
         ]);

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -98,7 +98,8 @@ class AppModel extends Model
         135 => false, 136 => true, 137 => false, 138 => false, 139 => false, 140 => false,
         141 => false, 142 => false, 143 => false, 144 => false, 145 => false, 146 => false,
         147 => false, 148 => false, 149 => false, 150 => false, 151 => false, 152 => false,
-        153 => false, 154 => false, 157 => false, 158 => false, 159 => false
+        153 => false, 154 => false, 157 => false, 158 => false, 159 => false,
+        160 => false
     );
 
     const ADVANCED_UPDATES_DESCRIPTION = array(
@@ -2725,6 +2726,15 @@ class AppModel extends Model
                 // Collection sync per-server toggles (T1.2).
                 $sqlArray[] = "ALTER TABLE `servers` ADD `push_collections` tinyint(1) NOT NULL DEFAULT 0 AFTER `pull_galaxy_clusters`;";
                 $sqlArray[] = "ALTER TABLE `servers` ADD `pull_collections` tinyint(1) NOT NULL DEFAULT 0 AFTER `push_collections`;";
+                break;
+            case 160:
+                // Indexed keyed-hash lookup column for advanced auth keys, so resolving an authkey
+                // no longer requires a bcrypt verify per candidate row on every REST request. Plain
+                // KEY rather than UNIQUE: beforeValidate accepts a caller supplied key, and the
+                // column is NULL for every pre-existing row until it is lazily backfilled on first
+                // use. The bcrypt column and its lookup path stay as the fallback.
+                $sqlArray[] = "ALTER TABLE `auth_keys` ADD `authkey_hmac` varchar(128) CHARACTER SET ascii COLLATE ascii_general_ci DEFAULT NULL AFTER `authkey_end`;";
+                $indexArray[] = array('auth_keys', 'authkey_hmac');
                 break;
             case 'fixNonEmptySharingGroupID':
                 $sqlArray[] = 'UPDATE `events` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';

--- a/app/Model/AuthKey.php
+++ b/app/Model/AuthKey.php
@@ -10,6 +10,9 @@ class AuthKey extends AppModel
 {
     public $recursive = -1;
 
+    /** @var string|null|false Memoised HMAC key, false when not yet loaded */
+    private $hmacKey = false;
+
     public $actsAs = array(
         'AuditLog',
         'SysLogLogable.SysLogLogable' => array(
@@ -52,6 +55,9 @@ class AuthKey extends AppModel
             $this->data['AuthKey']['authkey'] = $this->getHasher()->hash($authkey);
             $this->data['AuthKey']['authkey_start'] = substr($authkey, 0, 4);
             $this->data['AuthKey']['authkey_end'] = substr($authkey, -4);
+            if ($this->hasField('authkey_hmac')) {
+                $this->data['AuthKey']['authkey_hmac'] = $this->hmacAuthKey($authkey);
+            }
             $this->data['AuthKey']['authkey_raw'] = $authkey;
         }
 
@@ -174,38 +180,109 @@ class AuthKey extends AppModel
      */
     public function getAuthUserByAuthKey($authkey, $includeExpired = false)
     {
-        $start = substr($authkey, 0, 4);
-        $end = substr($authkey, -4);
-
-        $conditions = [
-            'authkey_start' => $start,
-            'authkey_end' => $end,
-        ];
-
+        $expirationConditions = [];
         if (!$includeExpired) {
-            $conditions['OR'] = [
+            $expirationConditions['OR'] = [
                 'expiration >' => time(),
                 'expiration' => 0
             ];
         }
+        $fields = ['id', 'authkey', 'user_id', 'expiration', 'allowed_ips', 'read_only', 'unique_ips'];
+
+        // Fast path: single indexed lookup on the keyed hash of the authkey. Rows created before this
+        // column existed have it empty and fall through to the bcrypt path below, which fills it in.
+        // hasField guards the window between deploying this code and running the db_version 160
+        // migration - without it the lookup would reference a column that does not exist yet.
+        $hmac = $this->hasField('authkey_hmac') ? $this->hmacAuthKey($authkey) : null;
+        if ($hmac !== null) {
+            $matchedAuthkey = $this->find('first', [
+                'recursive' => -1,
+                'fields' => $fields,
+                'conditions' => array_merge(['authkey_hmac' => $hmac], $expirationConditions),
+            ]);
+            if (!empty($matchedAuthkey)) {
+                return $this->authUserForAuthKey($matchedAuthkey);
+            }
+        }
+
+        $conditions = array_merge([
+            'authkey_start' => substr($authkey, 0, 4),
+            'authkey_end' => substr($authkey, -4),
+        ], $expirationConditions);
 
         $possibleAuthkeys = $this->find('all', [
             'recursive' => -1,
-            'fields' => ['id', 'authkey', 'user_id', 'expiration', 'allowed_ips', 'read_only', 'unique_ips'],
+            'fields' => $fields,
             'conditions' => $conditions,
         ]);
         $passwordHasher = $this->getHasher();
         foreach ($possibleAuthkeys as $possibleAuthkey) {
             if ($passwordHasher->check($authkey, $possibleAuthkey['AuthKey']['authkey'])) {
-                $this->updateUniqueIp($possibleAuthkey);
-                $user = $this->User->getAuthUser($possibleAuthkey['AuthKey']['user_id']);
-                if ($user) {
-                    $user = $this->setUserData($user, $possibleAuthkey);
+                if ($hmac !== null) {
+                    // Lazy migration - the plaintext key is in hand exactly here. updateAll to avoid
+                    // firing the audit log behaviours for what is a pure lookup-index backfill.
+                    $this->updateAll(
+                        ['AuthKey.authkey_hmac' => $this->getDataSource()->value($hmac, 'string')],
+                        ['AuthKey.id' => $possibleAuthkey['AuthKey']['id']]
+                    );
                 }
-                return $user;
+                return $this->authUserForAuthKey($possibleAuthkey);
             }
         }
         return false;
+    }
+
+    /**
+     * Keyed hash of an authkey, used as an indexed lookup value. Uses the same secret as the
+     * `Security.api_key_quick_lookup` cache in AppController.
+     * @param string $authkey
+     * @return string|null Null when no HMAC key is available, in which case the caller must fall back.
+     */
+    private function hmacAuthKey($authkey)
+    {
+        $hmacKey = $this->getHmacKey();
+        if ($hmacKey === null) {
+            return null;
+        }
+        return hash_hmac('sha512', $authkey, $hmacKey);
+    }
+
+    /**
+     * @return string|null
+     */
+    private function getHmacKey()
+    {
+        if ($this->hmacKey !== false) {
+            return $this->hmacKey;
+        }
+        $this->hmacKey = null;
+        $hmacKeyFile = APP . 'Config/hmac_key.php';
+        if (file_exists($hmacKeyFile)) {
+            include $hmacKeyFile;
+        } elseif (is_writable(APP . 'Config')) {
+            App::uses('RandomTool', 'Tools');
+            $hmac_key = RandomTool::random_str(true, 40);
+            file_put_contents($hmacKeyFile, sprintf('<?php%s$hmac_key = \'%s\';', PHP_EOL, $hmac_key));
+        }
+        if (!empty($hmac_key) && is_string($hmac_key)) {
+            $this->hmacKey = $hmac_key;
+        }
+        return $this->hmacKey;
+    }
+
+    /**
+     * @param array $authkey Row as fetched by getAuthUserByAuthKey
+     * @return array|false
+     * @throws Exception
+     */
+    private function authUserForAuthKey(array $authkey)
+    {
+        $this->updateUniqueIp($authkey);
+        $user = $this->User->getAuthUser($authkey['AuthKey']['user_id']);
+        if ($user) {
+            $user = $this->setUserData($user, $authkey);
+        }
+        return $user;
     }
 
     /**

--- a/app/Model/Behavior/AuditLogBehavior.php
+++ b/app/Model/Behavior/AuditLogBehavior.php
@@ -384,7 +384,7 @@ class AuditLogBehavior extends ModelBehavior
             if ($value == $old) {
                 continue;
             }
-            $sanitiseFields = ['password', 'api_key', 'authkey', 'headers', 'api_token', 'token', 'key'];
+            $sanitiseFields = ['password', 'api_key', 'authkey', 'authkey_hmac', 'headers', 'api_token', 'token', 'key'];
             if (in_array($key, $sanitiseFields) || ($key === 'value' && $model->name === 'SystemSetting' && SystemSetting::isSensitive($model->data[$model->alias]['setting']))) {
                 $value = '*****';
                 if ($old !== null) {

--- a/app/Plugin/SysLogLogable/Model/Behavior/SysLogLogableBehavior.php
+++ b/app/Plugin/SysLogLogable/Model/Behavior/SysLogLogableBehavior.php
@@ -79,7 +79,7 @@ class SysLogLogableBehavior extends LogableBehavior
 				}
 				// TODO Audit, removed 'revision' as well
 				if ($key != 'lastpushedid' && $key!= 'timestamp' && $key != 'revision' && $key != 'modified' && !in_array($key, $this->settings[$Model->alias]['ignore']) && $value != $old && in_array($key, $db_fields)) {
-					$sanitiseFields = ['password', 'api_key', 'authkey', 'headers', 'api_token', 'token', 'key'];
+					$sanitiseFields = ['password', 'api_key', 'authkey', 'authkey_hmac', 'headers', 'api_token', 'token', 'key'];
 					if (in_array($key, $sanitiseFields) || $key === 'authkey' && Configure::read('Security.do_not_log_authkeys')) {
 						$old = $value = '*****';
 					}

--- a/db_schema.json
+++ b/db_schema.json
@@ -911,6 +911,17 @@
                 "extra": ""
             },
             {
+                "column_name": "authkey_hmac",
+                "is_nullable": "YES",
+                "data_type": "varchar",
+                "character_maximum_length": "128",
+                "numeric_precision": null,
+                "collation_name": "ascii_general_ci",
+                "column_type": "varchar(128)",
+                "column_default": "NULL",
+                "extra": ""
+            },
+            {
                 "column_name": "created",
                 "is_nullable": "NO",
                 "data_type": "int",
@@ -10945,6 +10956,7 @@
         },
         "auth_keys": {
             "authkey_end": false,
+            "authkey_hmac": false,
             "authkey_start": false,
             "created": false,
             "expiration": false,
@@ -11518,5 +11530,5 @@
             "uuid": false
         }
     },
-    "db_version": "159"
+    "db_version": "160"
 }


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Cut a bcrypt hash out of every authenticated REST request.

- **Problem** — with `Security.advanced_authkeys` enabled (the shipped default), `AuthKey::getAuthUserByAuthKey()` selects every row sharing the 4-character prefix pair and runs a **bcrypt verify per candidate**: ~105 ms of pure hashing on *each* authenticated call.
- **Fix** — add an indexed `auth_keys.authkey_hmac` column, keyed by the existing `hmac_key.php` secret, and try it as one indexed `SELECT` first. The bcrypt path is untouched and stays as the fallback, lazily backfilling the column.
- **Cost** — needs a schema update (`INSTALL/MYSQL.sql`, `db_schema.json`); no external behaviour changes.
- **CI** — red *because* the optimisation works: the one failing test races a background worker it used to outlast. See **CI status** below; fix is MISP/PyMISP#1482.
<!-- /bluf -->

## What

With advanced authkeys enabled, every REST/automation request resolves its API key through `AuthKey::getAuthUserByAuthKey` (`app/Model/AuthKey.php:175`, pre-patch), which SELECTs the `auth_keys` rows sharing the 4-char `authkey_start`/`authkey_end` prefix pair and then runs a bcrypt `password_verify` per candidate row. This PR adds an indexed `auth_keys.authkey_hmac` column holding `hash_hmac('sha512', $authkey, $hmac_key)` under the **same** `app/Config/hmac_key.php` secret MISP already uses for its Redis fast-authkey cache, and tries a single indexed equality SELECT on it before falling back to the unchanged bcrypt candidate loop. On a successful bcrypt verify the HMAC is written back via `updateAll` (callbacks bypassed, so no spurious audit rows) — lazy migration, since the plaintext key is in hand exactly at that moment and existing bcrypt rows cannot be converted offline. `beforeValidate` populates the column for newly created keys. The bcrypt column and its verification path are untouched and remain the fallback.

## Why it is hot

Tier **T3**. Path per REST request: `AppController::beforeFilter` -> `__loginByAuthKey` (`app/Controller/AppController.php:263`, defined `:490`) -> `_checkAuthUser` (`:1239`) -> `AuthKey::getAuthUserByAuthKey`. It runs once for **every** REST/automation request — the multiplier is the whole API surface, and it is not amortised (see below).

The gate, stated plainly:

* `Security.advanced_authkeys` must be true. Its *setting-definition* default is `false` (`app/Model/Server.php:7368`), but the shipped `app/Config/config.default.php:11` sets it to `true`, so a stock install of recent MISP is on this path. With it off, `_checkAuthUser` takes `User::getAuthUserByAuthkey` instead — a plain indexed equality match on `users.authkey` with no bcrypt — and nothing here is reached.
* `Security.api_key_quick_lookup` must be false — it is the default (`app/Model/Server.php:7337`).
* The request must be REST/automation (`app/Controller/AppController.php:260-263`).
* `Security.authkey_keep_session` = false (default, `app/Model/Server.php:7383`) is what makes the cost per-request rather than per-session.

## Mechanism

* `app/Model/AuthKey.php:191-195` (pre-patch) SELECTs candidate rows on `authkey_start`/`authkey_end` (both indexed, `INSTALL/MYSQL.sql:169-170`).
* `app/Model/AuthKey.php:197-198` (pre-patch) runs `BlowfishConstantPasswordHasher::check` -> `password_verify` (`app/Controller/Component/Auth/BlowfishConstantPasswordHasher.php:26`) once per candidate row.
* The stored hash comes from `password_hash($password, PASSWORD_BCRYPT)` with no options (`BlowfishConstantPasswordHasher.php:12`), so PHP's default cost applies — cost 10 on the PHP 8.3 bench container (read from `password_get_info`, not inferred from a timing). Cost 10 = 2^10 EksBlowfish iterations, each running ExpandKey twice, each ExpandKey = (18 P-array + 1024 S-box entries)/2 words per block = 521 block encryptions -> ~1,067,008 Blowfish block encryptions of 16 Feistel rounds each, on the critical path of every API call.
* The candidate loop is additionally unbounded in principle: any number of keys can share a 4+4-char prefix pair, and each collision costs another full bcrypt. The fix collapses that to one row lookup for migrated rows.

## Why existing caching does not already cover it

1. **The Redis fast-lookup exists and I read it.** `AppController.php:1243-1250` reads `misp:fast_authkey_lookup:<hmac-sha512>` and `:1270-1277` writes it back with a 180 s TTL (the HMAC key is lazily created at `:1252-1255`). It is gated on `Security.api_key_quick_lookup`, which **defaults to false**, is `SETTING_CRITICAL`, and trades revocation lag — a revoked key stays valid for up to `api_key_quick_lookup_expiration` (default 180 s). This PR has **zero** revocation lag: deleting the row removes the key immediately.
2. **Session reuse does not amortise it.** `__loginByAuthKey` only short-circuits on an existing session when `Security.authkey_keep_session` is true (default false), and `AppController.php:1012` explicitly calls `$this->Session->destroy()` after every authed REST request when it is off. So even a cookie-carrying client (PyMISP uses a `requests.Session`) gets no reuse: one bcrypt verify per request, forever.
3. **No memo in `AuthKey`.** `getAuthUserByAuthKey` has no memo array, and the process-per-request PHP-FPM model would not help if it did.
4. **The downstream user fetch has no cache either** (`User::getAuthUser` -> `getAuthUserByConditions`, `app/Model/User.php:710-771`). `describeAuthFields` *does* memoize its field list in a static (`User.php:967-972`) — that part is already mitigated and is not claimed here.
5. **`updateAPIAccessTime` is not a per-request write** — `last_api_access` is guarded by `< time()-3600` unless `MISP.store_api_access_time` is on (default false). Checked and excluded.

## Speedup

**MEASURED.** `bench.php` implements both algorithms as raw-PDO functions mirroring `getAuthUserByAuthKey`, run against seeded tables in database `perf` inside the bench container, serialized behind `flock`. Seed: 1000 rows whose `authkey` column is a genuine `password_hash(..., PASSWORD_BCRYPT)` of a 40-char `[a-zA-Z0-9]` key, with the real column/index set; 10% expired; 5% of keys deliberately constructed to share **both** the 4-char start and the 4-char end with an earlier key so the original candidate loop really runs more than one verify. The user SELECT with its three `belongsTo` LEFT JOINs is inside **both** denominators, so the ratio is not manufactured by deleting work from the patched side; the fallback branch and the backfill UPDATE are modelled on the patched side too.

```
seeding 1000 bcrypt rows...
seeded.
inputs: 1600 over 1000 seeded keys
phase A (authkey_hmac all NULL): mismatches=0  fastpath=0 slowpath=1600
backfilled rows after phase A: 900
phase B (fully migrated):        mismatches=0  fastpath=900 slowpath=700
TOTAL CORRECTNESS MISMATCHES: 0

timed resolutions: 300
ORIGINAL: 43.852 s total, 146.174 ms/resolution
PATCHED : 0.658 s total, 2.194 ms/resolution
SPEEDUP : 66.61x
bcrypt cost in use: {"algo":"2y","algoName":"bcrypt","options":{"cost":10}}

addendum (same container, serialized):
single password_verify: 104.51 ms (cost 10)
avg candidate rows per (start,end) group among live keys: 1.000
```

An independent re-run of the same bench behind the lock reproduced 0 mismatches in both phases and gave 162.310 ms vs 1.990 ms = **81.55x**, i.e. the same regime.

**Correctness assertion (MEASURED):** 1600 mixed inputs — all 1000 seeded keys including the expired ones, 300 unknown keys, and 300 unknown keys deliberately colliding on start+end with a real key — compared as `(resolved auth_keys.id, resolved user id)` or `false` against the original algorithm, in two states: phase A with `authkey_hmac` all NULL (pre-migration) and phase B fully migrated. **0 mismatches in both phases**, 3200 comparisons total. The 700 phase-B slow-path hits are exactly the expired and unknown keys, which correctly still take the fallback and correctly still resolve to `false`.

**DERIVED.** The measured absolute figure is inflated by this container's pathologically slow bcrypt (104.5 ms/verify, roughly 10-20x a server-class CPU), and the bench is a raw-PDO mirror, so CakePHP ORM overhead (find() construction, Containable, afterFind) is absent from **both** sides and would compress the real-deployment ratio. The honest arithmetic against the measured 2.19 ms bcrypt-free remainder:

* server-class 50 ms bcrypt: `(50 + 2.19) / 2.19` = **~24x**
* the finding's deliberately lowballed 5.3 ms bcrypt (an absurdly optimistic 15 cycles/Blowfish block at 3 GHz): `(5.3 + 2.19) / 2.19` = **~3.4x**

The finding's own floor is derived independently of this container: 1 bcrypt at 5.3 ms + <=1.5 ms for two indexed equality SELECTs over a local socket, against the ~1.5 ms remainder, = **4.5x**; at a realistic 10-21 ms bcrypt it is ~9x. Note that the 3.4x figure pairs a fast server CPU's bcrypt against *this slow container's* SQL/PHP remainder, which is not an internally coherent machine; on any single consistent machine the ratio is at or above the finding's 4x floor. Either way the claim is comfortably above 2x, and the replacement work — one HMAC-SHA512 over a 40-byte key, a single SHA-512 compression pair — is well under 5 microseconds and disappears into the rounding.

No claim is made about the end-to-end HTTP request: Cake bootstrap, routing and rendering are outside this path and unmeasured.

## Risk

**MEDIUM**, per the finding, plus what review surfaced:

* **`app/Config/hmac_key.php` becomes load-bearing for lookups.** Losing or rotating it silently degrades every key back to the bcrypt path until re-migrated — correct, just slow. The fallback is therefore *kept*, not deleted: `getHmacKey()` returns null on a missing/unwritable/malformed file and every caller then takes the original path; a rotated key misses the fast path, falls back to bcrypt, and the write-back re-migrates the row under the new key. A rotated or lost key produces misses, never false accepts.
* **New side effect:** `getHmacKey()` now creates `hmac_key.php` on any advanced-authkey resolution or key creation, whereas previously it was only created when `Security.api_key_quick_lookup` was enabled (`AppController.php:1252-1255`). An `is_writable()` guard was added that `AppController` lacks, but `file_put_contents` is still non-atomic, so two concurrent first-requests can each generate a key and one loses — yielding one transient wrong backfill that self-heals on the next slow-path hit. The file is gitignored (`.gitignore:110`), so it does not dirty a working tree. Not externally observable in any response.
* **Migration.** `db_version` 160 in `AppModel::updates` + `case 160` (`ALTER TABLE auth_keys ADD authkey_hmac varchar(128) ascii DEFAULT NULL AFTER authkey_end`, plus the `$indexArray` entry), mirrored into `INSTALL/MYSQL.sql` and `db_schema.json`. Plain `KEY`, not `UNIQUE`, because `beforeValidate` accepts a caller-supplied authkey and pre-existing rows are all NULL. Both the lookup and the `beforeValidate` write are additionally gated on `hasField('authkey_hmac')`, so an instance running this code before `runUpdates` has applied 160 falls back silently instead of 500-ing every REST auth request; `updateDatabase` calls `cleanCacheFiles()` so the cached model schema is cleared afterwards and `hasField` flips to true.
* **Fresh installs:** the `ALTER` in migration 160 will log a duplicate-column error on a fresh install, because `INSTALL/MYSQL.sql` already carries the column while it still seeds `admin_settings.db_version` at `126`. This is the pre-existing MISP pattern for every migration since 126 (e.g. 159's `servers.push_collections` is likewise already in `MYSQL.sql`), and `updateDatabase` logs and continues past such errors. Not a regression introduced here, but worth knowing it is not clean.
* **One extra UPDATE per key** on its first post-deploy use (the lazy backfill). It uses `updateAll`, so audit/syslog callbacks are bypassed and no spurious log rows are emitted — verified. Expired rows are never backfilled (both queries exclude them) and simply keep taking the correct `false`-returning path.
* **Theoretical row-selection difference:** the fast path is a `find('first')` ordered by the `authkey_hmac` index, the fallback is a loop over the start/end candidate set. If two non-expired rows ever hold the *same* plaintext authkey (possible via caller-supplied keys), the two paths could resolve to a different `auth_keys.id`. Both resolve to a valid, authorised row and the returned `$user` is derived from `user_id`, so no ACL or response-shape change — but it is not bit-identical. The ordering among equally-valid duplicate rows was unspecified before, so this is not a regression.
* **Security posture is unchanged.** Storing a keyed hash is a weaker primitive than bcrypt only if an attacker holds both the DB *and* the HMAC key file — and that attacker already has the Redis fast-lookup surface MISP ships today, under the very same secret (`AppController.php:1245`). Authkeys are enforced at 40 chars of `[a-zA-Z0-9]` (`AppController.php:521`), ~2^238, so a slow hash buys nothing against offline brute force. Comparison is a DB equality on a hash, not on user input, so no user-controlled timing signal is introduced beyond what an indexed lookup already leaks.
* **Follow-up, not in this diff:** the backstop sanitise lists in `app/Model/AuditLog.php:240` and `app/Model/Log.php:176` still enumerate `['password','api_key','authkey',...]` without `authkey_hmac`. No demonstrated leak — `AuditLogBehavior` and `SysLogLogableBehavior` (both patched here) mask the value before it reaches either, and the HMAC is not itself a usable credential since authentication still requires presenting the plaintext — but a future direct writer of an `AuthKey` change array would trip over the inconsistency.

## CI status — blocked on MISP/PyMISP#1482

`testlive_comprehensive::test_search_publish_timestamp` fails on both build legs. It is not a
defect in this change; it is this change working.

The test asserts that a `publish_timestamp='5s'` search returns exactly one event immediately
after creating it, while publishing is done by a background worker on a roughly 5-second tick.
Nothing between `add_event()` and the assertion waits for that worker — the three invalid-query
searches in between were load-bearing purely as a delay. This PR removes a bcrypt verification
from every authenticated REST request, so those queries now return before the worker has
published, and the search correctly matches nothing.

The suite runtime is the evidence:

| branch | `testlive_comprehensive`, same 85 tests | result |
| --- | --- | --- |
| this PR | **145.6s**, **146.9s** | fails that one test |
| #11074, #11084, #11085, #11086, #11087, #11088 (12 runs) | 190.3s – 216.7s | all green |

This PR is the only one below 190s and the only one that fails. A ~29% drop in end-to-end suite
time is roughly what removing a per-request bcrypt verify should produce, so the failure is a
side effect of the optimisation landing, not of it breaking something.

The upstream fix is **MISP/PyMISP#1482**, which makes the test wait for the publish worker
instead of relying on incidental latency. Once that is merged and MISP's PyMISP submodule picks
it up, this PR should go green with no change to the code here.

## Testing

* `php -l` clean on all five modified PHP files, linted from copies of the **worktree** files inside the PHP 8.3 bench container.
* `bench.php` run behind `flock` in the bench container against the full MISP schema in a scratch database: 300 timed resolutions per side, plus a same-container addendum measuring a single `password_verify` (104.51 ms, cost 10) and the average candidate-row count per `(start,end)` group (1.000 among live keys), confirming the measured 146 ms/resolution is ~1 bcrypt + 2 indexed queries rather than a pathological loop.
* Correctness assertion: 1600 mixed inputs x 2 migration states, 0 mismatches, as above. Independently re-run by a reviewer with the same 0-mismatch result.
* Reviewed for behaviour preservation: identical field list and expiration predicate on both paths, extracted `authUserForAuthKey()` reproduces the original body verbatim including the `if ($user)` guard, no in-place rewrite of `authkey` exists anywhere (`resetAuthKey` expires the old row and creates a new one) so `authkey_hmac` cannot go stale against it, CRUD `edit` whitelists only `comment/allowed_ips/expiration/read_only` so the column is not user-settable, and all four `AuthKeysController` `afterFind` sites unset it beside `authkey` so REST responses are unchanged.
* **No live MISP instance was available for end-to-end testing.** The migration has not been exercised against a real running install, and no HTTP-level REST authentication test was performed. That verification is left to the maintainers, which is part of why this is a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




