### PR TITLE
[medium] perf: cache galaxy dictionary and index content matching in EventReport::extractWithReplacements

### DIFF
--- a/app/Model/EventReport.php
+++ b/app/Model/EventReport.php
@@ -80,6 +80,8 @@ class EventReport extends AppModel
     const PICTURE_FOLDER_PATH =  APP . 'files/img/eventreports';
     const REDIS_KEY_PICTURE_ALIAS =  'eventreport_picture_alias';
     const REDIS_KEY_PICTURE_FILENAME_FROM_ALIAS =  'eventreport_picture_filename_from_alias';
+    const REDIS_KEY_EXTRACTION_DICTIONARY = 'eventreport_extraction_dictionary';
+    const EXTRACTION_DICTIONARY_TTL = 3600;
 
     const SUPPORTED_IMAGES = ['gif', 'jpg', 'jpeg', 'png', 'svg',];
     private $imageCache = [];
@@ -1303,14 +1305,13 @@ class EventReport extends AppModel
         if ($options['attack']) {
             $clusterConditions = ['GalaxyCluster.galaxy_id !=' => $mitreAttackGalaxyId];
         }
-        $clusters = $this->GalaxyCluster->find('all', [
-            'conditions' => $clusterConditions,
-            'contain' => $clusterContain
-        ]);
+        $dictionary = $this->getExtractionDictionary($mitreAttackGalaxyId, $clusterConditions, $clusterContain, $options);
 
         $originalContent = $report['EventReport']['content'];
         // Remove all existing event report markers
         $content = preg_replace("/@\[(attribute|tag|galaxymatrix)]\([^)]*\)/", '', $originalContent);
+        $contentIndex = $this->buildContentMatchIndex($content);
+        $originalContentIndex = $this->buildContentMatchIndex($originalContent);
 
         if ($options['tags']) {
             $this->Tag = ClassRegistry::init('Tag');
@@ -1320,12 +1321,12 @@ class EventReport extends AppModel
                 if (strlen($tagName) < 3) {
                     continue;
                 }
-                $found = $this->isValidReplacementTag($content, $tagName);
+                $found = $this->isValidReplacementTagIndexed($contentIndex, $tagName);
                 if ($found) {
                     $replacedContext[$tagName][$tagName] = $tag['Tag'];
                 } else {
                     $tagNameUpper = strtoupper($tagName);
-                    $found = $this->isValidReplacementTag($content, $tagNameUpper);
+                    $found = $this->isValidReplacementTagIndexed($contentIndex, $tagNameUpper);
                     if ($found) {
                         $replacedContext[$tagNameUpper][$tagName] = $tag['Tag'];
                     }
@@ -1333,26 +1334,26 @@ class EventReport extends AppModel
             }
         }
 
-        foreach ($clusters as $cluster) {
-            if (strlen($cluster['GalaxyCluster']['value']) > 2) {
-                $cluster['GalaxyCluster']['colour'] = '#0088cc';
-                $tagName = $cluster['GalaxyCluster']['tag_name'];
-                $found = $this->isValidReplacementTag($content, $tagName);
+        // Collect the matches first, in the very same order the dictionary was built in, so that
+        // only the handful of clusters that actually matched has to be hydrated from the database.
+        $matches = [];
+        foreach ($dictionary['clusters'] as $entry) {
+            if (strlen($entry['value']) > 2) {
+                $tagName = $entry['tag_name'];
+                $found = $this->isValidReplacementTagIndexed($contentIndex, $tagName);
                 if ($found) {
-                    $replacedContext[$tagName][$tagName] = $cluster['GalaxyCluster'];
+                    $matches[] = [$tagName, $tagName, $entry['id']];
                 }
-                $toSearch = ' ' . $cluster['GalaxyCluster']['value'] . ' ';
-                $found = strpos($originalContent, $toSearch) !== false;
+                $found = $this->containsPaddedValue($originalContentIndex, $entry['value']);
                 if ($found) {
-                    $replacedContext[$cluster['GalaxyCluster']['value']][$tagName] = $cluster['GalaxyCluster'];
+                    $matches[] = [$entry['value'], $tagName, $entry['id']];
                 }
                 if ($options['synonyms']) {
-                    foreach ($cluster['GalaxyElement'] as $element) {
-                        if (strlen($element['value']) >= $options['synonyms_min_characters']) {
-                            $toSearch = ' ' . $element['value'] . ' ';
-                            $found = strpos($content, $toSearch) !== false;
+                    foreach ($entry['synonyms'] as $synonym) {
+                        if (strlen($synonym) >= $options['synonyms_min_characters']) {
+                            $found = $this->containsPaddedValue($contentIndex, $synonym);
                             if ($found) {
-                                $replacedContext[$element['value']][$tagName] = $cluster['GalaxyCluster'];
+                                $matches[] = [$synonym, $tagName, $entry['id']];
                             }
                         }
                     }
@@ -1361,34 +1362,32 @@ class EventReport extends AppModel
         }
 
         if ($options['attack']) {
-            unset($clusterContain['Galaxy']);
-            $attackClusters = $this->GalaxyCluster->find('all', [
-                'conditions' => ['GalaxyCluster.galaxy_id' => $mitreAttackGalaxyId],
-                'contain' => $clusterContain
-            ]);
-            foreach ($attackClusters as $cluster) {
-                if (strlen($cluster['GalaxyCluster']['value']) > 2) {
-                    $cluster['GalaxyCluster']['colour'] = '#0088cc';
-                    $tagName = $cluster['GalaxyCluster']['tag_name'];
-                    $toSearch = ' ' . $cluster['GalaxyCluster']['value'] . ' ';
-                    $found = strpos($content, $toSearch) !== false;
+            foreach ($dictionary['attackClusters'] as $entry) {
+                if (strlen($entry['value']) > 2) {
+                    $tagName = $entry['tag_name'];
+                    $found = $this->containsPaddedValue($contentIndex, $entry['value']);
                     if ($found) {
-                        $replacedContext[$cluster['GalaxyCluster']['value']][$tagName] = $cluster['GalaxyCluster'];
+                        $matches[] = [$entry['value'], $tagName, $entry['id']];
                     } else {
-                        $clusterParts = explode(' - ', $cluster['GalaxyCluster']['value'], 2);
-                        $toSearch = ' ' . $clusterParts[0] . ' ';
-                        $found = strpos($content, $toSearch) !== false;
+                        $clusterParts = explode(' - ', $entry['value'], 2);
+                        $found = $this->containsPaddedValue($contentIndex, $clusterParts[0]);
                         if ($found) {
-                            $replacedContext[$clusterParts[0]][$tagName] = $cluster['GalaxyCluster'];
+                            $matches[] = [$clusterParts[0], $tagName, $entry['id']];
                         } elseif (isset($clusterParts[1])) {
-                            $toSearch = ' ' . $clusterParts[1] . ' ';
-                            $found = strpos($content, $toSearch) !== false;
+                            $found = $this->containsPaddedValue($contentIndex, $clusterParts[1]);
                             if ($found) {
-                                $replacedContext[$clusterParts[1]][$tagName] = $cluster['GalaxyCluster'];
+                                $matches[] = [$clusterParts[1], $tagName, $entry['id']];
                             }
                         }
                     }
                 }
+            }
+        }
+
+        $matchedClusters = $this->fetchExtractionClusterRows($matches, $clusterContain);
+        foreach ($matches as $match) {
+            if (isset($matchedClusters[$match[2]])) {
+                $replacedContext[$match[0]][$match[1]] = $matchedClusters[$match[2]];
             }
         }
         $toReturn = [
@@ -1424,6 +1423,268 @@ class EventReport extends AppModel
             $toReturn['contentWithReplacements'] = $content;
         }
         return $toReturn;
+    }
+
+    /**
+     * getExtractionDictionary Return the compact galaxy cluster dictionary used by extractWithReplacements
+     *
+     * The dictionary only contains the strings that have to be searched for in the report content plus the
+     * cluster id they belong to. It is cached in redis, keyed on a stamp of the galaxy cluster and galaxy
+     * element tables so that galaxy updates invalidate it, with a TTL as an additional backstop.
+     *
+     * @param  int|string $mitreAttackGalaxyId
+     * @param  array $clusterConditions
+     * @param  array $clusterContain
+     * @param  array $options
+     * @return array
+     */
+    private function getExtractionDictionary($mitreAttackGalaxyId, array $clusterConditions, array $clusterContain, array $options)
+    {
+        try {
+            $redis = $this->setupRedisWithException();
+        } catch (Exception $e) {
+            $redis = null;
+        }
+        $cacheKey = null;
+        if ($redis !== null) {
+            try {
+                $cacheKey = self::REDIS_KEY_EXTRACTION_DICTIONARY . ':' . md5(JsonTool::encode([
+                    $mitreAttackGalaxyId,
+                    $clusterConditions,
+                    $clusterContain,
+                    !empty($options['attack']),
+                    $this->getExtractionDictionaryStamp($clusterContain),
+                ]));
+                $data = $redis->get($cacheKey);
+                if ($data !== false) {
+                    $dictionary = RedisTool::deserialize(RedisTool::decompress($data));
+                    if (!empty($dictionary)) {
+                        return $dictionary;
+                    }
+                }
+            } catch (Exception $e) {
+                $cacheKey = null;
+            }
+        }
+        $dictionary = $this->buildExtractionDictionary($mitreAttackGalaxyId, $clusterConditions, $clusterContain, $options);
+        if ($cacheKey !== null) {
+            try {
+                $redis->setex($cacheKey, self::EXTRACTION_DICTIONARY_TTL, RedisTool::compress(RedisTool::serialize($dictionary)));
+            } catch (Exception $e) {
+                // A failing cache write must never break the extraction itself
+            }
+        }
+        return $dictionary;
+    }
+
+    /**
+     * getExtractionDictionaryStamp Cheap fingerprint of the galaxy data the dictionary is built from
+     *
+     * @param  array $clusterContain
+     * @return array
+     */
+    private function getExtractionDictionaryStamp(array $clusterContain)
+    {
+        $clusterStamp = $this->GalaxyCluster->find('first', [
+            'fields' => ['COUNT(*) AS cluster_count', 'MAX(GalaxyCluster.id) AS cluster_max_id', 'SUM(GalaxyCluster.version) AS cluster_sum_version'],
+            'recursive' => -1,
+            'callbacks' => false,
+        ]);
+        $stamp = $clusterStamp[0];
+        if (isset($clusterContain['GalaxyElement'])) {
+            $elementStamp = $this->GalaxyCluster->GalaxyElement->find('first', [
+                'fields' => ['MAX(GalaxyElement.id) AS element_max_id'],
+                'recursive' => -1,
+                'callbacks' => false,
+            ]);
+            $stamp['element_max_id'] = $elementStamp[0]['element_max_id'];
+            $stamp['synonym_count'] = $this->GalaxyCluster->GalaxyElement->find('count', [
+                'conditions' => ['GalaxyElement.key' => 'synonyms'],
+                'recursive' => -1,
+            ]);
+        }
+        return $stamp;
+    }
+
+    /**
+     * buildExtractionDictionary Build the compact dictionary from the very same queries the extraction used to run
+     *
+     * @param  int|string $mitreAttackGalaxyId
+     * @param  array $clusterConditions
+     * @param  array $clusterContain
+     * @param  array $options
+     * @return array
+     */
+    private function buildExtractionDictionary($mitreAttackGalaxyId, array $clusterConditions, array $clusterContain, array $options)
+    {
+        $dictionary = ['clusters' => [], 'attackClusters' => []];
+        $clusters = $this->GalaxyCluster->find('all', [
+            'conditions' => $clusterConditions,
+            'contain' => $clusterContain
+        ]);
+        foreach ($clusters as $cluster) {
+            $entry = [
+                'id' => $cluster['GalaxyCluster']['id'],
+                'tag_name' => $cluster['GalaxyCluster']['tag_name'],
+                'value' => $cluster['GalaxyCluster']['value'],
+                'synonyms' => [],
+            ];
+            if (!empty($cluster['GalaxyElement'])) {
+                foreach ($cluster['GalaxyElement'] as $element) {
+                    $entry['synonyms'][] = $element['value'];
+                }
+            }
+            $dictionary['clusters'][] = $entry;
+        }
+        if ($options['attack']) {
+            unset($clusterContain['Galaxy']);
+            $attackClusters = $this->GalaxyCluster->find('all', [
+                'conditions' => ['GalaxyCluster.galaxy_id' => $mitreAttackGalaxyId],
+                'contain' => $clusterContain
+            ]);
+            foreach ($attackClusters as $cluster) {
+                $dictionary['attackClusters'][] = [
+                    'id' => $cluster['GalaxyCluster']['id'],
+                    'tag_name' => $cluster['GalaxyCluster']['tag_name'],
+                    'value' => $cluster['GalaxyCluster']['value'],
+                ];
+            }
+        }
+        return $dictionary;
+    }
+
+    /**
+     * fetchExtractionClusterRows Hydrate only the clusters that produced a match
+     *
+     * @param  array $matches
+     * @param  array $clusterContain
+     * @return array Cluster id => GalaxyCluster row
+     */
+    private function fetchExtractionClusterRows(array $matches, array $clusterContain)
+    {
+        if (empty($matches)) {
+            return [];
+        }
+        $clusterIds = [];
+        foreach ($matches as $match) {
+            $clusterIds[$match[2]] = true;
+        }
+        $clusters = $this->GalaxyCluster->find('all', [
+            'conditions' => ['GalaxyCluster.id' => array_keys($clusterIds)],
+            'contain' => $clusterContain
+        ]);
+        $rows = [];
+        foreach ($clusters as $cluster) {
+            $cluster['GalaxyCluster']['colour'] = '#0088cc';
+            $rows[$cluster['GalaxyCluster']['id']] = $cluster['GalaxyCluster'];
+        }
+        return $rows;
+    }
+
+    /**
+     * buildContentMatchIndex Index a string so that a needle can be looked up without scanning the whole string
+     *
+     * @param  string $content
+     * @return array
+     */
+    private function buildContentMatchIndex($content)
+    {
+        $pieces = explode(' ', $content);
+        $pieceCount = count($pieces);
+        $wordPositions = [];
+        // Only a piece that has a space on both sides can start a space padded match
+        for ($i = 1; $i < $pieceCount - 1; $i++) {
+            $wordPositions[$pieces[$i]][] = $i;
+        }
+        $colonPositions = [];
+        $allColonPositions = [];
+        $offset = 0;
+        while (($position = strpos($content, ':', $offset)) !== false) {
+            $colonPositions[substr($content, $position, 2)][] = $position;
+            $allColonPositions[] = $position;
+            $offset = $position + 1;
+        }
+        return [
+            'content' => $content,
+            'length' => strlen($content),
+            'pieces' => $pieces,
+            'pieceCount' => $pieceCount,
+            'wordPositions' => $wordPositions,
+            'colonPositions' => $colonPositions,
+            'allColonPositions' => $allColonPositions,
+        ];
+    }
+
+    /**
+     * containsPaddedValue Equivalent of `strpos($content, ' ' . $value . ' ') !== false`, using the index
+     *
+     * @param  array $index
+     * @param  string $value
+     * @return bool
+     */
+    private function containsPaddedValue(array $index, $value)
+    {
+        if ($index['pieceCount'] < 3) {
+            return false;
+        }
+        $words = explode(' ', $value);
+        if (!isset($index['wordPositions'][$words[0]])) {
+            return false;
+        }
+        $wordCount = count($words);
+        $lastStart = $index['pieceCount'] - 1 - $wordCount;
+        foreach ($index['wordPositions'][$words[0]] as $start) {
+            if ($start > $lastStart) {
+                break;
+            }
+            $found = true;
+            for ($j = 1; $j < $wordCount; $j++) {
+                if ($index['pieces'][$start + $j] !== $words[$j]) {
+                    $found = false;
+                    break;
+                }
+            }
+            if ($found) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * isValidReplacementTagIndexed Search if tagName is in the indexed content
+     *
+     * A tag name containing ':' is searched for as a plain substring, any other one space padded.
+     *
+     * @param  array $index
+     * @param  string $tagName
+     * @return bool
+     */
+    private function isValidReplacementTagIndexed(array $index, $tagName)
+    {
+        $colonOffset = strpos($tagName, ':');
+        if ($colonOffset === false) {
+            return $this->containsPaddedValue($index, $tagName);
+        }
+        $key = substr($tagName, $colonOffset, 2);
+        if (strlen($key) === 1) {
+            $positions = $index['allColonPositions'];
+        } elseif (isset($index['colonPositions'][$key])) {
+            $positions = $index['colonPositions'][$key];
+        } else {
+            return false;
+        }
+        $needleLength = strlen($tagName);
+        foreach ($positions as $position) {
+            $start = $position - $colonOffset;
+            if ($start < 0 || $start + $needleLength > $index['length']) {
+                continue;
+            }
+            if (substr_compare($index['content'], $tagName, $start, $needleLength) === 0) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public function downloadMarkdownFromURL($user, $event_id, $url, $format = 'html')
@@ -1508,19 +1769,6 @@ class EventReport extends AppModel
             return false;
         }
         return $module;
-    }
-
-    /**
-     * findValidReplacementTag Search if tagName is in content
-     *
-     * @param  string $content
-     * @param  string $tagName
-     * @return bool
-     */
-    private function isValidReplacementTag($content, $tagName)
-    {
-        $toSearch = !str_contains($tagName, ':') ? ' ' . $tagName . ' ' : $tagName;
-        return str_contains($content, $toSearch);
     }
 
     public function attachTagsAfterReplacements($user, $replacedContext, $eventId)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Report entity extraction caches the galaxy dictionary and scans content once, not per entry.

- **Problem** — `EventReport::extractWithReplacements` rebuilt the whole galaxy-cluster and tag dictionary from the database on every call, then scanned the report content once per dictionary entry.
- **Fix** — Caches that dictionary in Redis under a data-version stamp, matches it against two content indexes built in a single pass, and hydrates only matched clusters by id, leaving `$replacedContext` identical in keys, ordering and payload.
- **Effect** — The three AJAX actions behind the report editor's extract-entities buttons get the win per user click; this is an interactive action, not an event or sync path.
<!-- /bluf -->

## What

`EventReport::extractWithReplacements` (`app/Model/EventReport.php:1280`) is the entity-extraction pass behind the event-report editor's "extract entities" actions. On every invocation it rebuilt the entire galaxy-cluster + tag dictionary from the database and then scanned the whole report content once per dictionary entry. This PR replaces "fetch everything, then scan the content once per row" with "load a compact cached dictionary, then scan the content once". The dictionary is built from the *identical* two `GalaxyCluster` finds, cached in Redis under a data-version stamp, and matched against two content indexes built in a single pass each; only the handful of matched clusters are then hydrated by id. `$replacedContext` — its keys, key order, inner tag-name order and payload rows — is unchanged.

## Why it is hot

Classified **T2** by the finding. That classification is disputed and I state it plainly: two of the three verifiers concluded it is overstated. This is **not** on the event add/edit/fetch/export, sync, feed-pull or export path. The only callers are three AJAX-only controller actions — `EventReportsController::extractAllFromReport` (`app/Controller/EventReportsController.php:457`), `::extractFromReport` (`:486`) and `::replaceSuggestionInReport` (`:515`) — reached solely from two explicit button handlers in the report editor (`app/webroot/js/markdownEditor/event-report.js:1219`, `:1310`). It runs **once per user click**, not once per event. A grep over the whole tree finds no other caller, and the function does not call itself; the frequency is therefore user-clicks-per-day, closer to T4 than to T2's per-event lifecycle work.

So: the **per-call** win is real and measured; the **aggregate** impact is that of a rare interactive action, and reviewers should weigh it as such.

**Gate (honest):** no MISP setting gates this code path. It requires (a) default galaxy clusters loaded — the standard post-install state, with `AdminShell::wipeDefaultClusters` (`app/Console/Command/AdminShell.php:1253-1258`) existing precisely as the opt-out — and (b) a user with `perm_add` (`ACLComponent.php:304-305`) clicking extract in the report editor.

## Mechanism

Per invocation, before this PR:

1. **Unbounded hydration, twice.** `app/Model/EventReport.php:1306-1309` runs `GalaxyCluster->find('all')` whose only condition is `GalaxyCluster.galaxy_id != <mitre-attack id>` (`:1303-1305`), with `contain` = Tag, Galaxy, and GalaxyElement filtered to `key = 'synonyms'` (`:1294-1301`). No limit, no field restriction. `:1363-1367` issues a **second** unbounded find for the mitre-attack galaxy.
2. **Per-row ORM cost.** Every returned row passes `GalaxyCluster::afterFind` (`app/Model/GalaxyCluster.php:133-161`), which `json_decode`s the `authors` column per row (`:136-138`). The `belongsTo` Tag/Galaxy associations are LEFT JOINs; the contained `hasMany` GalaxyElement rows come back as a separate `IN (...)` query and are merged in PHP by `DboSource::_mergeHasMany` (`app/Lib/cakephp/lib/Cake/Model/Datasource/DboSource.php:1601-1609`).
3. **Per-row full-content scanning.** The tags loop (`:1318-1333`) fetches every usable tag via `Tag::fetchUsableTags` (`app/Model/Tag.php:224-236`, `recursive => -1`, no limit) and per tag calls `isValidReplacementTag($content, $tagName)` (`:1323`) plus, on a miss, a second call with the uppercased name (`:1327-1328`). `isValidReplacementTag` (`:1520-1524`) is a plain `str_contains` over the full content. The cluster loop (`:1336-1360`) does `isValidReplacementTag` (`:1339`), `strpos($originalContent, ' ' . value . ' ')` (`:1344`), and one `strpos` per synonym element (`:1350-1355`). The attack loop (`:1370-1391`) does up to three more full-content `strpos` (`:1373`, `:1379`, `:1385`).

The request cost is therefore O(rows) DB hydration **plus** O(rows) × O(contentLength) byte scanning — both linear in the size of a dataset that is static between galaxy updates.

## Why existing caching does not already cover it

- `grep` for `Cache::`, `setupRedis`, `RedisTool`, `static $` and memoizing private properties across `app/Model/GalaxyCluster.php` and `app/Model/Tag.php` returns **zero** hits. Neither model caches anything. (`GalaxyCluster::$__assetCache` at `:28` is used only at `:2095-2128` for gcids/gcOwnerIds — unrelated to this path.)
- There is no instance-property memo: `$clusters` (`:1306`), `$attackClusters` (`:1364`) and `$tags` (`:1320`) are locals rebuilt on every call.
- No caller pre-fetches a dictionary — the signature (`:1280`) takes only `$user`, `$report`, `$options`, and the three call sites pass nothing extra.
- No file cache under `app/tmp/cache` is consulted.
- The only Redis use in `EventReport.php` is the report-picture alias store (`:1798-1875`, keys `REDIS_KEY_PICTURE_ALIAS` / `REDIS_KEY_PICTURE_FILENAME_FROM_ALIAS`) — unrelated to galaxies or tags.
- No option short-circuits the work: `$options['tags']/['synonyms']/['attack']` all default to true (`:1283-1289`) and the cluster find at `:1306` runs unconditionally regardless.
- Independent corroboration from elsewhere in this tree: `app/Lib/Tools/EventTemplateInstantiator.php:455-457` explicitly declines to reuse this path because "the broad synonym scan that `EventReport::extractWithReplacements` does walks every galaxy cluster in the DB, which would dominate instantiation latency."

## Speedup

### MEASURED

Benchmark: `/home/elhoim/tmp/misp-perf/bench/<key>/bench.php`, run under `flock` against MariaDB inside a container, on a seed generated from the real misp-galaxy checkout (`clusters/*.json`): **131 galaxies, 56,131 clusters, 71,549 galaxy_elements of which 7,770 are synonyms, 2,050 tags**, attack galaxy = `mitre-attack-pattern`. Report content 20,051 bytes, 5 iterations per side.

Implementer run:

```
=== correctness ===
dictionary slice: 3226 clusters, 181 attack clusters, 2050 tags
cases: 3000, non-empty results: 2223, total context keys: 135363, mismatches: 0

=== timing (full 56k cluster dataset) ===
cache build (cold path, once per galaxy update): 2.356s, 7.2 MB serialized
report content: 20051 bytes
full-dataset result keys: original 327, patched 327, identical: yes
original: 3.598 s/call
patched : 0.385 s/call
ratio   : 9.35x

TOTAL MISMATCHES: 0
```

Independent re-runs by the reviewer, twice, under host load average ~20: **4.39x** and **6.29x**, identical original-vs-patched results (270 keys) and 0 mismatches both times.

**The honest headline is a measured range of 4.4x–9.4x, not 9.35x.** The finding's floor was **4x**; every run clears it. The spread is contention plus a bench-DB difference: during the reviewer's runs another agent had reseeded the shared scratch `tags` table down to 200 rows (galaxy_clusters and galaxy_elements still matched the seed), which explains the 327-vs-270 key difference between runs. Fewer tags *shrinks* the original side's scanning cost, so that contamination biases the ratio **against** the patch, never toward it.

Two further biases against the patch: the bench's ORIGINAL side uses raw PDO, so CakePHP's own `DboSource` result mapping, Containable and `_mergeHasMany` overhead is **not** charged to it; and the container has no `redis`/`igbinary` extension, so the warm cache is a file plus the default JSON serializer path — production with igbinary/zstd deserializes faster. A side observation that is itself evidence for the finding: at the container's default `memory_limit=128M` the ORIGINAL side OOMs while hydrating the 56k rows; the reviewer had to run with `-d memory_limit=3G`. (That is a CLI-bench artefact, not a claim about a production request.)

### DERIVED

With C = 55,000 non-attack clusters, Ca = 1,000 attack clusters, S = 7,770 synonyms, T = 2,000 usable tags, L = 20,000 bytes of content, the full-content scans performed today are:

```
tags loop      (:1323 + :1328)  up to 2*T  =   4,000
cluster loop   (:1339 + :1344)       2*C   = 110,000
synonym loop   (:1350-1355)            S   =   7,770
attack loop    (:1373/:1379/:1385) up to 3*Ca = 3,000
                                    total ~ 124,770 scans x 20,000 bytes ~ 2.5 GB
```

plus ~56,000 rows hydrated through `GalaxyCluster::afterFind` with one `json_decode` each, a second query for the contained synonym rows, and their PHP-side merge.

After the patch the surviving per-call work is: the marker-stripping `preg_replace` at `:1313`, two single-pass index builds over L, O(pieces) hash lookups, a by-id refetch of the tens of matched clusters, and the unchanged two-pass `str_replace` at `:1399-1410`.

**I explicitly disown the finding's "25,000x" figure.** That ratio covers the scanning component alone and ignores the surviving dictionary-load cost. More importantly, PHP's `strpos`/`str_contains` is `memchr`-accelerated, so ~125k scans over 20 KB is tens-to-low-hundreds of milliseconds — the wall clock is dominated by the ORM hydration, not the byte comparison. The defensible derived floor is ~4x, and the measured 4.4x–9.4x sits just above it.

### Correctness assertions

- Part A, implementer: **3,000** generated report contents (0/1/5/40/600/4000/20000 bytes, seeded RNG) with planted cluster values, tag names, synonyms, attack value halves, uppercased tag names, and deliberate near-misses (needle glued to a neighbour, tab/newline delimiters, leading space, truncated first char, needles at the very first/last position, doubled spaces, embedded `@[tag](...)` markers); options varied per case. Compared with `===` (order-sensitive) on `$replacedContext` **and** on the output of the unchanged `replace=true` tail. **135,363 context keys, 0 mismatches.**
- Part A, reproduced independently by the reviewer: 3,000 reports, 109,498 context keys, **0 mismatches**.
- Independent differential fuzz by the reviewer (`fuzz.php`): **400,000 iterations × 4 comparisons = 1.6M cases** over an adversarial alphabet including single and double spaces, `:`, tabs, newlines, `="` and empty needles, comparing `containsPaddedValue` against `strpos($content, ' '.$value.' ') !== false` and `isValidReplacementTagIndexed` against the deleted `isValidReplacementTag`. **0 mismatches.**
- Full-dataset run: original and patched produced identical result sets through the real by-id refetch path.

## Risk

The finding named five semantics that must be preserved. Each, and how it is handled:

**(a) Space-padded matching, including no-match at the very start/end.** `containsPaddedValue` works on `explode(' ', $content)` pieces and only allows a match to start at piece index ≥ 1 and end at ≤ pieceCount−2 — structurally reproducing that only `0x20` counts as padding (tab/newline do not), that a value at the very start or end does not match, and that doubled spaces produce empty pieces. Multi-word values compare consecutive pieces. Fuzz-verified.

**(b) `':'`-containing tag names matched as bare substrings.** `isValidReplacementTagIndexed` takes the bare-substring branch, anchored on the *first* colon of the needle, bucketed by a 2-char content slice and verified with `substr_compare`, falling back to all colon positions when the colon is the needle's last character. No token-boundary assumption. Fuzz-verified.

**(c) The uppercased key spelling.** The tags loop is copied verbatim apart from the matcher swap and still stores under `$tagNameUpper`, so `attachTagsAfterReplacements` (`:1529-1538`) sees identical key spellings.

**(d) Per-user ACL.** `Tag::fetchUsableTags` is deliberately **not** cached and not changed — it stays inside the request, per user, with its `org_id`/`user_id`/`hide_tag` filtering. Only galaxy cluster data is cached, and the original fetched that with no ACL conditions at all, so there is no ACL regression.

**(e) Option combinations.** The cache key hashes `$mitreAttackGalaxyId`, `$clusterConditions`, `$clusterContain` (which encodes `prune_deprecated` via the Galaxy contain and `synonyms` via the GalaxyElement contain) and `$options['attack']`, on top of the data stamp. `synonyms_min_characters` and the `strlen > 2` guard are correctly absent from the key because all synonyms are stored and the length filter is applied at match time. The dictionary is built from the *identical* find rather than reimplemented SQL, so whatever the joins do to row inclusion is inherited.

Additional risks raised in review, none of which blocked approval:

- **Stale-cache window is real and accepted, not eliminated.** The key is stamped with `COUNT(*)`/`MAX(id)`/`SUM(version)` over `galaxy_clusters` plus `MAX(id)`/synonym `COUNT` over `galaxy_elements`, with a 3600s TTL backstop. An in-place edit of a cluster's `value`, `tag_name`, or a synonym's text that does **not** bump `version` and changes no id or row count leaves the dictionary stale for up to an hour. This is exactly the tradeoff the finding prescribed ("version-stamp the key"), so it is handled as specified — but it is a genuine behavioural window that did not exist before.
- **Silent skip under that window.** `if (isset($matchedClusters[$match[2]]))` drops a match whose cluster was deleted since the dictionary was built. The original would never have matched such a cluster either, so it degrades gracefully — but the skip is silent, with no logging.
- **Attack clusters are now refetched *with* the `Galaxy` contain.** The original did `unset($clusterContain['Galaxy'])` before the attack find; the patch moved that unset inside `buildExtractionDictionary` (a by-value parameter), so the `$clusterContain` reaching the refetch still carries `Galaxy`. In CakePHP 2 a `belongsTo` with conditions is a LEFT JOIN with the condition on the ON clause, and only `$cluster['GalaxyCluster']` is stored into `$replacedContext`, so the payload is unchanged — but it is an extra join per call and a deviation from the original query shape that a reader could mistake for a filter. Flagged, not fixed in this PR.
- **Silent cache no-populate.** If `RedisTool::serialize` ever throws (e.g. invalid UTF-8 in a cluster value under the default JSON serializer), the `catch` around the `setex` is silent, so the cache never populates and every call permanently pays the full build plus a wasted serialize attempt, with no diagnostic. Galaxy data comes from JSON files so this is unlikely, but the failure would be invisible.
- **Unverified (not a known defect).** `getExtractionDictionaryStamp` reads the aggregate row as `$clusterStamp[0][...]`. No CakePHP bootstrap was available to execute it. If the shape were wrong, PHP 8 emits a Warning and `null` rather than an exception, so the try/catch would not fire and invalidation would silently degrade to TTL-only. The `[0]['count(*)']` idiom is established elsewhere in MISP (`app/Model/EventTag.php:246`, `app/Model/AuditLog.php:423`, `app/Model/Event.php:780`), so this is very likely correct.

Failure mode overall: every serialization and Redis call is inside a `try/catch (Exception)` (and `JsonException extends Exception`), so a cache failure degrades to the uncached build — the pre-patch behaviour — rather than a 500. Cold path is the original cost plus one serialize+set (measured 2.356s build, 7.2 MB blob) and recurs only when the stamp changes or the TTL lapses.

## Testing

- `php -l` on the **patched** file: clean. (Note: the repo is mounted read-only in the bench container, so the file was copied out and linted there; linting the mount would have linted the original.)
- Correctness assertion, implementer: 3,000 generated cases / 135,363 context keys, order-sensitive `===` on `$replacedContext` and on the `replace=true` output — **0 mismatches**.
- Correctness assertion, reproduced independently by the reviewer: 3,000 cases / 109,498 keys — **0 mismatches**.
- Independent differential fuzz of the two new matchers against the originals: **1.6M comparisons, 0 mismatches**.
- Full-dataset timing benchmark on the real row counts (56,131 clusters / 71,549 elements), both sides asserted to produce identical results, serialized behind a lock: **9.35x** (implementer) and **4.39x / 6.29x** (reviewer, contended host).
- Scope check: `grep` confirms the removed private `isValidReplacementTag` has no other caller anywhere under `app/`. `App::uses('JsonTool', 'Tools')` and `App::uses('RedisTool', 'Tools')` are already at file scope in `app/Model/AppModel.php:27-28`, which loads before any model, so no new `App::uses` is needed. The Redis idiom is verbatim the one already used at `app/Model/Taxonomy.php:621/659`.
- The matcher helpers were mechanically diffed between `app/Model/EventReport.php` and the benchmark harness after dedenting — byte-identical apart from one comment line, so the correctness run exercises the shipped code and not a lookalike.

**No live MISP instance was available**, so there is no end-to-end test: the extraction was not exercised through a real CakePHP bootstrap, a real Redis, or the report-editor UI. The Redis code path and the aggregate-row shape in `getExtractionDictionaryStamp` are verified by code reading and by comparison with established MISP idioms only. Marked **draft** for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

