### PR TITLE
[medium] perf: lazy per-id module resolution in Workflow::loadAllWorkflowModules

### DIFF
--- a/app/Model/SharingGroup.php
+++ b/app/Model/SharingGroup.php
@@ -78,6 +78,9 @@ class SharingGroup extends AppModel
 
     private $authorizedIds = [];
 
+    /** @var array|null Memoised result of `fetchAllSharingGroup()` */
+    private $__allSharingGroups = null;
+
     public function beforeValidate($options = array())
     {
         if (empty($this->data['SharingGroup']['uuid'])) {
@@ -1049,8 +1052,11 @@ class SharingGroup extends AppModel
      */
     public function fetchAllSharingGroup(): array
     {
-        return $this->find('all', [
-            'recursive' => -1,
-        ]);
+        if (is_null($this->__allSharingGroups)) {
+            $this->__allSharingGroups = $this->find('all', [
+                'recursive' => -1,
+            ]);
+        }
+        return $this->__allSharingGroups;
     }
 }

--- a/app/Model/Workflow.php
+++ b/app/Model/Workflow.php
@@ -3,6 +3,7 @@ App::uses('AppModel', 'Model');
 App::uses('WorkflowBaseModule', 'Model/WorkflowModules');
 App::uses('WorkflowGraphTool', 'Tools');
 App::uses('Folder', 'Utility');
+App::uses('Cache', 'Cache');
 
 class WorkflowDuplicatedModuleIDException extends Exception {}
 class TriggerNotFoundException extends Exception {}
@@ -69,6 +70,7 @@ class Workflow extends AppModel
     private $error_while_loading = [];
 
     private $module_initialized = false;
+    private $module_file_index = null;
     private $modules_enabled_by_default = ['generic-if', 'distribution-if', 'published-if', 'organisation-if', 'tag-if', 'concurrent-task', 'stop-execution', 'webhook', 'push-zmq'];
 
     const CAPTURE_FIELDS_EDIT = ['name', 'description', 'timestamp', 'data', 'debug_enabled'];
@@ -81,6 +83,7 @@ class Workflow extends AppModel
     const REDIS_KEY_TRIGGER_PER_WORKFLOW = 'workflow:trigger_list:%s';
     const REDIS_KEY_MODULES_ENABLED = 'workflow:modules_enabled';
     const REDIS_KEY_ADHOC_WORKFLOW_ENABLED = 'workflow:adhoc_workflow_enabled';
+    const CACHE_KEY_MODULE_FILE_INDEX = 'workflow_module_file_index';
 
     public function __construct($id = false, $table = null, $ds = null)
     {
@@ -549,7 +552,7 @@ class Workflow extends AppModel
      */
     public function executeWorkflowForTriggerRouter($trigger_id, array $data, array &$blockingErrors=[], array $logging=[]): bool
     {
-        $this->loadAllWorkflowModules();
+        $this->__loadWorkflowModule('trigger', $trigger_id);
 
         if (empty($this->loaded_modules['trigger'][$trigger_id])) {
             throw new TriggerNotFoundException(__('Unknown trigger `%s`', $trigger_id));
@@ -905,7 +908,7 @@ class Workflow extends AppModel
 
     public function getModuleClass($node)
     {
-        $this->loadAllWorkflowModules();
+        $this->__loadWorkflowModule($node['data']['module_type'], $node['data']['id']);
         $moduleClass = $this->loaded_classes[$node['data']['module_type']][$node['data']['id']] ?? null;
         return $moduleClass;
     }
@@ -921,7 +924,7 @@ class Workflow extends AppModel
      */
     public function getModuleClassByType($module_type, $id, $throwException=false)
     {
-        $this->loadAllWorkflowModules();
+        $this->__loadWorkflowModule($module_type, $id);
         $moduleClass = $this->loaded_classes[$module_type][$id] ?? null;
         if (is_null($moduleClass) && !empty($throwException)) {
             if ($module_type == 'trigger') {
@@ -944,7 +947,7 @@ class Workflow extends AppModel
      */
     public function getModuleConfigByType($module_type, $id, $throwException=false): ?array
     {
-        $this->loadAllWorkflowModules();
+        $this->__loadWorkflowModule($module_type, $id);
         $moduleConfig = $this->loaded_modules[$module_type][$id] ?? null;
         if (is_null($moduleConfig) && !empty($throwException)) {
             throw new ModuleNotFoundException(__('Unknown module `%s` for module type `%s`', $id, $module_type));
@@ -1012,6 +1015,148 @@ class Workflow extends AppModel
             }
         }
         return $modules;
+    }
+
+    /**
+     * __loadWorkflowModule Make sure the requested module is available in `loaded_modules` and `loaded_classes`.
+     *
+     * Only the requested module gets included and instanced, based on a cached `id` -> file index.
+     * Any situation the index cannot answer (ad-hoc triggers, misp-module actions, unknown ids,
+     * stale index, loading error) falls back on the full `loadAllWorkflowModules()`.
+     *
+     * @param string $module_type
+     * @param string $id
+     * @return void
+     */
+    private function __loadWorkflowModule($module_type, $id)
+    {
+        if ($this->module_initialized) {
+            return;
+        }
+        if (isset($this->loaded_classes[$module_type][$id])) {
+            return;
+        }
+        if (empty($module_type) || empty($id) || !in_array($module_type, ['trigger', 'logic', 'action'])) {
+            $this->loadAllWorkflowModules();
+            return;
+        }
+        $index = $this->__getModuleFileIndex();
+        if (empty($index[$module_type][$id])) {
+            $this->loadAllWorkflowModules();
+            return;
+        }
+        $entry = $index[$module_type][$id];
+        $isCustom = !empty($entry['is_custom']);
+        $filepath = sprintf('%s%s/%s', (!empty($isCustom) ? Workflow::CUSTOM_MODULE_ROOT_PATH : Workflow::MODULE_ROOT_PATH), $module_type, $entry['filename']);
+        $instancedClass = $this->__getClassFromModuleFile($filepath);
+        if (empty($instancedClass) || is_string($instancedClass) || $instancedClass->id !== $id) {
+            // The index no longer reflects the module files, let the full loading routine rebuild everything
+            $this->__invalidateModuleFileIndex();
+            $this->loadAllWorkflowModules();
+            return;
+        }
+        $config = $instancedClass->getConfig();
+        $config['module_type'] = $module_type;
+        if (!empty($isCustom)) {
+            $config['is_custom'] = true;
+            $instancedClass->is_custom = true;
+        }
+        $this->loaded_modules[$module_type][$id] = $config;
+        $this->loaded_classes[$module_type][$id] = $instancedClass;
+        $this->__mergeGlobalConfigIntoLoadedModule($module_type, $id);
+    }
+
+    /**
+     * __getModuleFileIndex Get the `id` -> file index of all PHP modules, keyed on the module directories' mtime
+     *
+     * @return array
+     */
+    private function __getModuleFileIndex(): array
+    {
+        if (!is_null($this->module_file_index)) {
+            return $this->module_file_index;
+        }
+        $signature = Workflow::__getModuleDirectoriesSignature();
+        try {
+            $cached = Cache::read(Workflow::CACHE_KEY_MODULE_FILE_INDEX);
+        } catch (Exception $e) {
+            $cached = false;
+        }
+        if (!empty($cached['signature']) && $cached['signature'] === $signature && isset($cached['index'])) {
+            $this->module_file_index = $cached['index'];
+            return $this->module_file_index;
+        }
+        // Building the index performs the same full scan as `loadAllWorkflowModules()`, duplicated
+        // module ids therefore still throw before anything gets cached.
+        $index = $this->__buildModuleFileIndex();
+        try {
+            Cache::write(Workflow::CACHE_KEY_MODULE_FILE_INDEX, ['signature' => $signature, 'index' => $index]);
+        } catch (Exception $e) {
+            // Not being able to persist the index only costs performance
+        }
+        $this->module_file_index = $index;
+        return $this->module_file_index;
+    }
+
+    private function __invalidateModuleFileIndex()
+    {
+        $this->module_file_index = null;
+        try {
+            Cache::delete(Workflow::CACHE_KEY_MODULE_FILE_INDEX);
+        } catch (Exception $e) {
+            // Nothing to do, the index will be rebuilt on the next signature mismatch
+        }
+    }
+
+    private function __buildModuleFileIndex(): array
+    {
+        $index = ['trigger' => [], 'logic' => [], 'action' => []];
+        $phpModuleFiles = Workflow::__listPHPModuleFiles();
+        foreach ($phpModuleFiles as $type => $files) {
+            if ($type == 'custom') {
+                continue;
+            }
+            $index[$type] = $this->__indexModuleFiles($type, $files, false);
+        }
+        // Custom PHP modules from Lib take precedence over the core ones, as they do when fully loaded
+        foreach ($phpModuleFiles['custom'] as $type => $files) {
+            $index[$type] = array_merge($index[$type], $this->__indexModuleFiles($type, $files, true));
+        }
+        return $index;
+    }
+
+    private function __indexModuleFiles($type, $files, $isCustom=false): array
+    {
+        $entries = [];
+        $classModuleFromFiles = $this->__getClassFromModuleFiles($type, $files, $isCustom);
+        foreach ($classModuleFromFiles['instancedClasses'] as $id => $instancedClass) {
+            $entries[$id] = [
+                'filename' => sprintf('%s.php', get_class($instancedClass)),
+                'is_custom' => !empty($isCustom),
+            ];
+        }
+        return $entries;
+    }
+
+    /**
+     * __getModuleDirectoriesSignature Signature of the module directories, used to invalidate the file index
+     *
+     * @return string
+     */
+    private static function __getModuleDirectoriesSignature(): string
+    {
+        $dirs = [
+            Workflow::MODULE_ROOT_PATH . 'trigger',
+            Workflow::MODULE_ROOT_PATH . 'logic',
+            Workflow::MODULE_ROOT_PATH . 'action',
+            Workflow::CUSTOM_MODULE_ROOT_PATH . 'logic',
+            Workflow::CUSTOM_MODULE_ROOT_PATH . 'action',
+        ];
+        $signature = [];
+        foreach ($dirs as $dir) {
+            $signature[] = sprintf('%s:%s', $dir, is_dir($dir) ? @filemtime($dir) : '-');
+        }
+        return implode('|', $signature);
     }
 
     public function loadAllWorkflowModules()
@@ -1092,6 +1237,34 @@ class Workflow extends AppModel
             $action['disabled'] = $module_disabled;
             $this->loaded_classes['action'][$action['id']]->disabled = $module_disabled;
         });
+    }
+
+    /**
+     * __mergeGlobalConfigIntoLoadedModule Same as `__mergeGlobalConfigIntoLoadedModules()` but for a single module
+     *
+     * @param string $module_type
+     * @param string $id
+     * @return void
+     */
+    private function __mergeGlobalConfigIntoLoadedModule($module_type, $id)
+    {
+        if ($module_type == 'trigger') {
+            $trigger = &$this->loaded_modules['trigger'][$id];
+            if (!empty($trigger['is_adhoc'])) {
+                $module_disabled = !in_array($trigger['id'], $this->getEnabledAdHocWorkflows());
+            } else {
+                $module_disabled = empty(Configure::read(sprintf('Plugin.Workflow_triggers_%s', $trigger['id'])));
+            }
+            $trigger['html_template'] = !empty($trigger['html_template']) ? $trigger['html_template'] : 'trigger';
+            $trigger['disabled'] = $module_disabled;
+            $this->loaded_classes['trigger'][$trigger['id']]->disabled = $module_disabled;
+            $this->loaded_classes['trigger'][$trigger['id']]->html_template = !empty($trigger['html_template']) ? $trigger['html_template'] : 'trigger';
+            unset($trigger);
+        } else {
+            $module_disabled = !in_array($id, $this->getEnabledModules());
+            $this->loaded_modules[$module_type][$id]['disabled'] = $module_disabled;
+            $this->loaded_classes[$module_type][$id]->disabled = $module_disabled;
+        }
     }
 
     private function __getEnabledModulesFromModuleService()


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Workflow runs resolve one module by id instead of loading all 67 module files per request.

- **Problem** — `Workflow::loadAllWorkflowModules()` is the prologue of every workflow entry point, `include_once`-ing and reflecting all 67 files under `app/Model/WorkflowModules/` plus ~12 DB queries that only feed the workflow editor's pickers, though execution needs one module at a time.
- **Fix** — Adds a lazy, cached, id-keyed resolution path backed by a filename index for the four id-keyed entry points, falling back to the full scan when the index cannot answer, and memoises `SharingGroup::fetchAllSharingGroup()`.
- **Effect** — Instances running `Plugin.Workflow_enable` stop paying the full inventory per triggered request.
<!-- /bluf -->

> All line numbers refer to the `2.5` base **before** this patch.

## What

`Workflow::loadAllWorkflowModules()` (`app/Model/Workflow.php:1017`) is the mandatory prologue of every workflow entry point. On every request that fires a callable trigger it scans 5 module directories, then `include_once` + `ReflectionClass::newInstance()` + `getConfig()` for **all 67** module files under `app/Model/WorkflowModules/` (19 trigger + 13 logic + 35 action), and issues ~12 DB queries whose only purpose is to populate select/picker option lists for the workflow **editor UI**. Nothing on the execution path needs that inventory: `executeWorkflowForTriggerRouter` reads exactly one trigger's `disabled`/`blocking` flags (`:554-562`), and the graph walk resolves modules one id at a time. This PR adds a lazy, cached, id-keyed resolution path (`__loadWorkflowModule($module_type, $id)`) backed by an `id -> [filename, is_custom]` file index, and wires it into the four id-keyed entry points. Every case the index cannot answer falls back to the unchanged `loadAllWorkflowModules()`. Independently, `SharingGroup::fetchAllSharingGroup()` (`app/Model/SharingGroup.php:1050-1055`) is memoised, collapsing its 4 identical unfielded scans per load to 1.

## Why it is hot

Tier T3, but **conditional — this must be stated plainly**. The path only runs when:

- `Plugin.Workflow_enable` is true — and its shipped default is **false** (`app/Model/Server.php:8660-8666`), enforced by `AppModel::isTriggerCallable` (`app/Model/AppModel.php:4653-4661`);
- `Plugin.Workflow_triggers_<trigger_id>` is set (`Workflow.php:212-217`);
- at least one workflow is registered in the Redis listening set for that trigger (`checkTriggerListenedTo`, `Workflow.php:297-300`).

On an instance where workflows *are* in use, it is per-request-that-writes. There are 20 `executeTrigger` call sites, including `app/Model/MispAttribute.php:738` (attribute after-save), `app/Model/Event.php:429`, `:530`, `:577`, `:5618`, `:6446`, `app/Model/Log.php:238` (log after-save), `app/Model/MispObject.php:344`, `app/Model/EventTag.php:58`, `app/Model/AttributeTag.php:66`, `app/Model/Sighting.php:119`, `app/Model/User.php:330`, `:359`.

The load also happens unconditionally on the workflow editor/index controller paths — **those paths are deliberately left unchanged by this PR** (see Risk 3).

The sharpest case: the load at `Workflow.php:552` happens *before* the non-blocking branch at `:562-583`. So a php-fpm request whose trigger is non-blocking builds the entire 67-class inventory and runs all the queries purely to then hand the work to `Job::createJob` + `enqueue` — and the background worker (`:606`) pays for it a second time.

## Mechanism

What is slow, per call to `loadAllWorkflowModules()` (`Workflow.php:1017-1067`):

1. **5 directory scans.** `__listPHPModuleFiles` (`:1160-1180`) runs `Folder::find` over `Model/WorkflowModules/{trigger,logic,action}` plus `Lib/WorkflowModules/{logic,action}`.
2. **67 include + reflect + construct.** `__getClassFromModuleFiles` (`:1182-1207`) calls `__getClassFromModuleFile` (`:1250-1276`: `include_once` + `new ReflectionClass` + `newInstance()`) for every file, then `getConfig()`, which is itself a `ReflectionObject` property walk (`app/Model/WorkflowModules/WorkflowBaseModule.php:100-109`) over the public properties declared at `WorkflowBaseModule.php:3-24` plus subclass additions — on the order of 1000-1600 reflected property reads in total.
3. **~12 DB queries from module constructors**, all for editor dropdowns:
   - `app/Model/WorkflowModules/action/Module_send_mail.php:22` — `User->find('all', ['recursive' => -1])` with no `fields`, i.e. an unfielded `SELECT *` over the whole `users` table (31 columns, 2 of them `longtext`, `INSTALL/MYSQL.sql:1694-1733`);
   - `action/Module_send_log_mail.php:4` — `extends Module_send_mail` with no own constructor, so that whole-`users` read happens a **second** time;
   - `SharingGroup::fetchAllSharingGroup()` (`app/Model/SharingGroup.php:1050-1055`, a bare unfielded `find('all', ['recursive' => -1])` with no memo) called from `action/Module_add_analyst_data.php:54`, `action/Module_attribute_distribution_operation.php:32`, `action/Module_event_distribution_operation.php:33` and `logic/Module_distribution_if.php:37` — **4 identical full `sharing_groups` scans**;
   - `action/Module_add_to_warninglist.php:29`;
   - `action/Module_attach_decay_score.php:25`;
   - `logic/Module_organisation_if.php:27` — `find('list')` ordered by `LOWER(name)`, unindexable (`organisations` has only PRIMARY / UNIQUE name / uuid, `INSTALL/MYSQL.sql:1018-1036`);
   - `action/Module_run_workflow.php:25` — `fetchAdHocWorkflows`;
   - `action/Module_assign_country_from_enrichment.php:73` -> `:127` `_fetchCountryGalaxyClusters()` — a `Galaxy` find with a contained `GalaxyCluster`.
4. **`fetchAdHocWorkflows` again** at `:1053` (`:1436-1447`), plus 2 Redis `sMembers` (`:1070-1094` via `:220-240`).

Resolution is *already* keyed by id — `$this->loaded_classes[$type][$id]` at `:908`, `:925`, `:948` — so an id -> file index plus on-demand instantiation is a drop-in.

## Why existing caching does not already cover it

- The only guard is `$this->module_initialized` (`Workflow.php:1017-1021`, set at `:1067`) plus one `Workflow` instance per process via `ClassRegistry` (`AppModel.php:4663-4665`). That makes the cost **once per request/process, not per attribute** — and the analysis below is sized on exactly that basis, not on a per-attribute inflation.
- Beyond that there is *no* cache. `grep -nE 'Cache::|apcu|static \$' app/Model/Workflow.php` returns only the `setupRedisWithException` calls at `:223`, `:234`, `:252`, `:268`, `:304`, `:324`, `:365`, `:382` — the enabled-module and listening-trigger *sets*. There is no cached module inventory and no cached module config. `WorkflowBaseModule.php` has no static memo.
- `SharingGroup::fetchAllSharingGroup()` has no memo, which is why the 4 calls really are 4 queries.
- `Folder::find` is a live `scandir` on every call.
- The misp-modules HTTP GET inside `__getModulesFromModuleService` (`:1044`, `:1107-1120` -> `Module::getModules`, `app/Model/Module.php:98-109`) is **excluded from all arithmetic below** in both the before and after case. It is inert in default config anyway: `Module::sendRequest` (`Module.php:316-321`) throws before opening a socket when `__getModuleServer` (`Module.php:188-192`) sees `Plugin.Action_services_enable` falsey, and that default is false (`Server.php:8611-8617`). It is also a separate issue in its own right.

## Speedup

### MEASURED

`Workflow.php` is too CakePHP-coupled to run in-process, so **the real class was not executed**. Both algorithms were mirrored line-for-line as standalone classes and benchmarked: `BenchWorkflowOriginal` reproduces `loadAllWorkflowModules` (5 scandirs, `include_once` + `ReflectionClass::newInstance` + `getConfig()` per file, the duplicate-id throw, custom-over-core `array_merge`, `fetchAdHocWorkflows`, `__mergeGlobalConfigIntoLoadedModules`); `BenchWorkflowPatched` reproduces the lazy path. The synthetic module tree mirrors the real shape exactly — 19 trigger + 13 logic + 35 action = 67 files, each extending a base carrying `WorkflowBaseModule`'s 17 public properties and the identical `ReflectionObject` `getConfig()` walk, plus 2 custom `Lib` modules, one of which deliberately reuses a core id to exercise custom precedence. **The dominant cost is not stubbed out**: all constructor queries are real SQL against MariaDB at realistic sizes (users 200 with the unfielded `SELECT *`, issued twice; sharing_groups 60 x4 unfielded; organisations 1520 with `ORDER BY LOWER(name)`; warninglists 120; decaying_models 30; galaxy_clusters 300; workflows 40 with 5 adhoc). Run with `opcache.enable_cli=1` and serialised behind a lock; 60 iterations per scenario, each constructing a fresh engine.

```
correctness: compared=3240 mismatches=0
queries per router request: original=12 patched=0
queries per 3-module resolve: original=12 patched=2
queries per full load (editor path): original=12 patched=9

iterations per scenario: 60
router path      : original 38.313 ms | patched 0.346 ms | speedup 110.69x
3-module resolve : original 36.317 ms | patched 0.848 ms | speedup 42.83x
full load (editor, SG memo only): original 42.012 ms | patched 34.286 ms | speedup 1.23x
opcache enabled: yes
```

An independent re-run of the same bench on the same machine produced **281.92x** and **329.28x** on the Router path (38.01x / 50.12x on the 3-module resolve). **The conservative 110.69x is what is reported here.** The full-load/editor figure (1.23x, and 0.80x-1.09x on re-runs) is run-to-run noise — correctly so, since that path is the original algorithm minus one `sharing_groups` query.

**Correctness assertion: 3240 comparisons, 0 mismatches.** 40 randomised global-config scenarios (each cycling `Plugin.Workflow_triggers_*`, the enabled-module set and the enabled-adhoc set, so `disabled` takes both values) x 81 cases — all 19+13+35 core ids, both custom ids, 5 adhoc ids, 3 unknown ids across two types, and a bogus `module_type`. Each case compares the full config array with strict `===` and **without `ksort`**, so key *order* divergence is also caught, plus the instance's class name, `id`, `disabled`, `html_template`, `is_custom` and `params` (which carry the live DB-derived option lists).

Bench biases, and their direction — both run **against** the patch, so the real-world gain is larger, not smaller: raw PDO under-costs Cake's ORM hydration, and `include_once` is amortised across one CLI process whereas php-fpm re-executes all 67 class declarations per request.

### DERIVED (from the code, holding the excluded HTTP call constant)

Per request that fires a callable trigger, component by component:

| component | before | after (Router path) | ratio |
|---|---|---|---|
| directory scans | 5 | 0 (cache hit) | 5 -> 0 |
| class constructions | 67 | <=3 | >=22x |
| reflected property reads | ~1600 | ~72 | >=22x |
| DB queries | ~12 | <=1 | >=12x |

The two whole-`users` reads and all four whole-`sharing_groups` reads disappear entirely on the Router path. What survives the fix is the 2 Redis `sMembers` and 1-3 module constructions. **Honest floor for the named function in default config: 4x.** If `Plugin.Action_services_enable` is turned **on**, the 1s-timeout localhost GET sits in both numerator and denominator and the honest floor falls to roughly **2-2.5x** — still a win, but stated here for completeness.

## Risk

1. **Index invalidation is directory-mtime only.** The signature is built from the mtimes of the 5 module directories. Adding or removing a module file bumps a dir mtime, so a newly dropped custom module is picked up and a deleted one is dropped — the load-bearing case, since `Lib/WorkflowModules` is user-editable. Editing an **existing** file in place to change its `$id` does *not* bump the dir mtime; that case is caught by an explicit `$instancedClass->id !== $id` guard which invalidates the index and falls back to the full load. **Residual gap**: if such an in-place edit creates a *duplicate* id, the stale index resolves the id to the file it recorded, the guard passes, and `WorkflowDuplicatedModuleIDException` is not thrown, whereas today's code throws on every request until the ids are made unique. That is "loudly broken" becoming "silently serves one of the two"; it is not a data-correctness regression and it self-heals at the next add/remove in that directory. Including per-file mtimes in the signature would close it. Separately, `filemtime`'s 1-second granularity can freeze a signature mid-checkout — consequence there is performance-only (every lookup misses and pays a full load).
2. **This is the first consumer of Cake `Cache` in MISP models** (everything else goes through `RedisTool`). `app/Config/bootstrap.default.php:85` configures `Cache::config('default', ['engine' => 'File'])` writing under `app/tmp/cache`. **Maintainers: please confirm `app/tmp/cache` is expected to be writable by the php-fpm and worker users.** If it is not, `Cache::write` does *not* throw — `lib/Cake/Cache/Cache.php:319-328` calls `trigger_error(..., E_USER_WARNING)` — so the `try/catch` here does not catch it, and the result is one `E_USER_WARNING` per request into `error.log` plus a full index rebuild every request (i.e. today's cost, no speedup). Degradation, not a correctness break: `Cache::read`/`write` both return `false` safely when the config is absent or uninitialised, and the code falls back to the full load. The `default` config's TTL is 1h, so the index cold-rebuilds hourly; a cold build costs the same scan as today plus one extra construction.
3. **Scope is deliberately narrower than a full lazy conversion.** `executeWorkflow` (`:497`), `executeWorkflowForTrigger` (`:606`), `genGraphDataForTrigger` (`:1571`) and all editor/index paths (`getModulesByType`, `attachNotificationToModules`) still call `loadAllWorkflowModules()` unchanged. The reason is `__runWorkflow`'s direct read of `$this->loaded_modules['logic'][$moduleClass->id]` at `:850` during the graph walk, which assumes a complete inventory; making full execution lazy is not provably behaviour-preserving without deeper work. **Consequence: the worker-side saving described above is not realised** — the background worker and the blocking-execution path are byte-identical to before. What this PR delivers is the php-fpm Router/enqueue half plus every id-keyed module lookup.
4. `getModuleClass($node)` now dereferences `$node['data']['module_type']` and `$node['data']['id']` as function arguments, one line before the original `:909` read them inside a `??` expression. `??` suppresses undefined-index diagnostics for its whole left-hand chain, so a node lacking `data.module_type` used to return `null` silently and now emits two PHP 8 "Undefined array key" warnings before still returning `null` (`empty($module_type)` -> full load -> `?? null`). **The return value is unchanged.** `WorkflowGraphTool::cleanGraphData` only strips `_frames` and real drawflow nodes always carry `data.module_type`/`data.id`, so this is a latent-warning nit rather than a live path.
5. On a cached-index hit the lazy path does not populate `$this->error_while_loading` nor write the per-broken-module `Log` rows that `__logLoadingError` creates today. Both consumers of `getModuleLoadingError()` (`app/Controller/WorkflowsController.php:109` and `:553`) sit behind `getModulesByType()` -> full load, so the reported value is unaffected; the only change is less duplicate log spam.
6. The index stores `get_class($instancedClass) . '.php'` rather than the filename it scanned. These agree because `__getClassFromModuleFile` derives the class name from the basename, but PHP class names are case-insensitive while Linux filenames are not — a file whose declared class differs in case would yield a non-existent path, which fails to include, hits the `empty($instancedClass)` branch and falls back to the full load. Self-correcting, at a performance and log-noise cost.
7. **Nothing live is cached.** The index holds only `filename` and `is_custom` — never module config, never `params`. No org, user or sharing-group data is ever persisted, and each module's option lists are rebuilt as live as they are today, because the module is constructed fresh on each request.
8. `WorkflowDuplicatedModuleIDException` is preserved for the normal case: the index is built through `__getClassFromModuleFiles`, which throws *before* `Cache::write` is reached, so a duplicated id is never cached and every subsequent request rebuilds and throws — exactly as today. (See 1 for the one residual case.)
9. **SharingGroup memo scope.** `fetchAllSharingGroup()` has exactly 4 callers, all workflow module constructors populating dropdown option lists (`logic/Module_distribution_if.php:37`, `action/Module_attribute_distribution_operation.php:32`, `action/Module_add_analyst_data.php:54`, `action/Module_event_distribution_operation.php:33`), all obtaining the model via `ClassRegistry::init('SharingGroup')` so they share one instance and one memo. It therefore cannot go stale within a request. A `fields` list was deliberately *not* added, as that would change the return shape. Staleness within a long-lived worker process is pre-existing: module option lists are already frozen for the process lifetime by `$module_initialized` plus the `ClassRegistry` `Workflow` singleton.

Behaviour-preservation argument: `__loadWorkflowModule` is a strict narrowing. It returns immediately if `$module_initialized` or if the id is already loaded, and delegates to the untouched `loadAllWorkflowModules()` for every case the file index cannot answer — unknown `module_type`, empty id, ad-hoc trigger ids (`fetchAdHocWorkflows` uses `Workflow.trigger_id LIKE adhoc_%`, so file-module ids can never collide), misp-module action ids, an index miss, a stale entry, and a module that fails to load. Because `loadAllWorkflowModules` wholesale **reassigns** `loaded_modules[$type]` / `loaded_classes[$type]` (`:1031-1032`) rather than merging, any lazily-populated state is fully replaced on fallback, so ordering, key sets and content converge to today's exactly — including the `array_merge` custom-over-core precedence, which the index build mirrors. The Redis-driven `disabled` / `html_template` flags are applied to each lazily built module by a new `__mergeGlobalConfigIntoLoadedModule()` that is a per-module transcription of `__mergeGlobalConfigIntoLoadedModules()`. `TriggerNotFoundException` / `ModuleNotFoundException` error paths are reached identically.

## Testing

- `php -l` clean on both changed files under PHP 8.3.
- Standalone mirror benchmark as described above, run under a lock with `opcache.enable_cli=1`, plus an independent re-run by a second reviewer that reproduced the result with margin.
- Correctness assertion: 3240 comparisons (40 randomised global-config scenarios x 81 cases), **0 mismatches**, strict `===` without `ksort`.
- **No live MISP instance was available.** There was no end-to-end run, no PHPUnit suite run, and the real `Workflow.php` was never executed — both algorithms were mirrored line-for-line in standalone classes against a synthetic module tree of the exact real shape and a seeded MariaDB. Review of the diff against a live workflow-enabled instance is warranted before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

