### PR TITLE
[medium] perf: batch the per-attribute uuid lookup in MispAttribute::editAttribute

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -5784,14 +5784,17 @@ class Event extends AppModel
             if (isset($data['Event']['Attribute'])) {
                 $data['Event']['Attribute'] = array_values($data['Event']['Attribute']);
                 $attributes = [];
-                foreach ($data['Event']['Attribute'] as $k => $attribute) {
-                    $nothingToChange = false;
-                    $result = $this->Attribute->editAttribute($attribute, $saveResult, $user, 0, false, $force, $nothingToChange, $server);
-                    if (is_array($result)) {
-                        $attributes[] = $result;
-                    }
-                    if (!$nothingToChange) {
-                        $changed = true;
+                foreach (array_chunk($data['Event']['Attribute'], 100) as $attributeChunk) {
+                    $existingAttributes = $this->Attribute->fetchExistingAttributesByUuid($attributeChunk);
+                    foreach ($attributeChunk as $attribute) {
+                        $nothingToChange = false;
+                        $result = $this->Attribute->editAttribute($attribute, $saveResult, $user, 0, false, $force, $nothingToChange, $server, $existingAttributes);
+                        if (is_array($result)) {
+                            $attributes[] = $result;
+                        }
+                        if (!$nothingToChange) {
+                            $changed = true;
+                        }
                     }
                 }
                 $this->Attribute->editAttributeBulk($attributes, $saveResult, $user, $server);

--- a/app/Model/MispAttribute.php
+++ b/app/Model/MispAttribute.php
@@ -3225,7 +3225,44 @@ class MispAttribute extends AppModel
         return $attribute;
     }
 
-    public function editAttribute($attribute, array $event, $user, $objectId, $log = false, $force = false, &$nothingToChange = false, $server = null)
+    /**
+     * Fetch the existing attribute rows for a batch of incoming attributes, keyed by uuid.
+     *
+     * The returned rows are in the same shape as the per-attribute find('first') that
+     * editAttribute() performs, so that the map can be handed to editAttribute() to spare it
+     * one query per attribute. A uuid missing from the map is not proof that no such attribute
+     * exists (the lookup here is byte exact, while the SQL comparison is collation based), so
+     * editAttribute() falls back to its own find when a uuid is not in the map. Non string uuids
+     * are skipped here and by editAttribute(), so they keep taking the original find() path.
+     *
+     * @param array $attributes Incoming attributes
+     * @return array uuid => attribute row
+     */
+    public function fetchExistingAttributesByUuid(array $attributes)
+    {
+        $uuids = array();
+        foreach ($attributes as $attribute) {
+            if (isset($attribute['uuid']) && is_string($attribute['uuid'])) {
+                $uuids[$attribute['uuid']] = true;
+            }
+        }
+        if (empty($uuids)) {
+            return array();
+        }
+        $existingAttributes = array();
+        foreach (array_chunk(array_keys($uuids), 100) as $chunk) {
+            $rows = $this->find('all', array(
+                'conditions' => array('Attribute.uuid' => $chunk),
+                'recursive' => -1,
+            ));
+            foreach ($rows as $row) {
+                $existingAttributes[$row['Attribute']['uuid']] = $row;
+            }
+        }
+        return $existingAttributes;
+    }
+
+    public function editAttribute($attribute, array $event, $user, $objectId, $log = false, $force = false, &$nothingToChange = false, $server = null, $existingAttributes = null)
     {
         if ($this->fast_update) {
             $this->Behaviors->unload('SysLogLogable.SysLogLogable');
@@ -3239,10 +3276,14 @@ class MispAttribute extends AppModel
         $attribute['_materialChange'] = false;
         unset($attribute['id']);
         if (isset($attribute['uuid'])) {
-            $existingAttribute = $this->find('first', array(
-                'conditions' => array('Attribute.uuid' => $attribute['uuid']),
-                'recursive' => -1,
-            ));
+            if ($existingAttributes !== null && is_string($attribute['uuid']) && isset($existingAttributes[$attribute['uuid']])) {
+                $existingAttribute = $existingAttributes[$attribute['uuid']];
+            } else {
+                $existingAttribute = $this->find('first', array(
+                    'conditions' => array('Attribute.uuid' => $attribute['uuid']),
+                    'recursive' => -1,
+                ));
+            }
             if (!empty($existingAttribute)) {
                 if ($existingAttribute['Attribute']['event_id'] != $eventId || $existingAttribute['Attribute']['object_id'] != $objectId) {
                     $change = 'An attribute was blocked from being saved due to a duplicate UUID. The uuid in question is: ' . $attribute['uuid'] . '. This can also be due to the same attribute (or an attribute with the same UUID) existing in a different event / object)';

--- a/app/Model/MispObject.php
+++ b/app/Model/MispObject.php
@@ -1344,13 +1344,18 @@ class MispObject extends AppModel
         $this->Event->captureAnalystData($user, $object, 'Object', $object['uuid']);
         if (!empty($object['Attribute'])) {
             $attributes = [];
-            foreach ($object['Attribute'] as $attribute) {
-                if (!empty($object['deleted'])) {
-                    $attribute['deleted'] = 1;
-                }
-                $result = $this->Attribute->editAttribute($attribute, $event, $user, $object['id'], false, $force);
-                if (is_array($result)) {
-                    $attributes[] = $result;
+            $objectAttributes = is_array($object['Attribute']) ? $object['Attribute'] : [];
+            foreach (array_chunk($objectAttributes, 100) as $attributeChunk) {
+                $existingAttributes = $this->Attribute->fetchExistingAttributesByUuid($attributeChunk);
+                foreach ($attributeChunk as $attribute) {
+                    if (!empty($object['deleted'])) {
+                        $attribute['deleted'] = 1;
+                    }
+                    $attributeNothingToChange = false;
+                    $result = $this->Attribute->editAttribute($attribute, $event, $user, $object['id'], false, $force, $attributeNothingToChange, null, $existingAttributes);
+                    if (is_array($result)) {
+                        $attributes[] = $result;
+                    }
                 }
             }
             $this->Attribute->editAttributeBulk($attributes, $event, $user, $server);


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Attribute uuid lookups on event edit become IN-list finds: 1000 point queries become 10.

- **Problem** — `MispAttribute::editAttribute()` resolves each incoming attribute's existing row with its own `find('first')` on `Attribute.uuid`, and both call sites (`Event::_edit`, `MispObject::editObject`) drive it one attribute at a time, so an event with N attributes issues N single-row queries before saving.
- **Fix** — Adds `fetchExistingAttributesByUuid()`, resolving uuids in IN-list finds chunked at 100 into a uuid-to-row map passed down via a new optional argument.
- **Effect** — Per 1000 attributes, 1000 point queries become 10, on every event edit, sync pull, feed ingest and REST push.
<!-- /bluf -->

## What

`MispAttribute::editAttribute()` resolves the pre-existing row for each incoming attribute with its own `find('first')` on `Attribute.uuid`. Both call sites drive it one attribute at a time, so an event carrying N attributes issues N single-row round-trips before anything is saved.

This adds `MispAttribute::fetchExistingAttributesByUuid()`, which resolves a batch of uuids with `Attribute.uuid IN (...)` finds chunked at 100 and returns a `uuid => row` map, and threads that map into `editAttribute()` through a new trailing optional `$existingAttributes` argument. Both call sites now walk their attributes in chunks of 100 and hand each chunk's map down. Per 1000 attributes: 1000 point queries become 10 IN-list queries.

## Why it is hot (tier + caller evidence)

Tier T1 - per incoming attribute on every edit of an existing event.

- `app/Model/MispAttribute.php:3242-3245` (pre-patch numbering) - the unconditional `find('first')` on `array('Attribute.uuid' => $attribute['uuid'])`, `recursive => -1`, no `fields`, no `callbacks => false`.
- `app/Model/Event.php:5789` - `Event::_edit` loops `$data['Event']['Attribute']` and calls `editAttribute()` per attribute, then `editAttributeBulk()` once at `Event.php:5796`.
- `app/Model/MispObject.php:1351` - `MispObject::editObject` does the same for object attributes.
- Callers of `Event::_edit`: `app/Model/Server.php:512` (sync pull), `app/Model/Feed.php:1018` and `:1214` (feed ingestion), `app/Controller/EventsController.php:4531` and `:4673` (REST edit / push receive), `app/Model/Event.php:7815`.

Honest gate: **none**. No config flag guards the loop; it runs whenever `$data['Event']['Attribute']` is set.

The asymmetry is sharpest on re-sync. At `app/Model/MispAttribute.php:3264-3266` an attribute whose incoming timestamp is not newer sets `$nothingToChange = true` and returns before reaching any save, so for unchanged attributes that lookup is the *entire* per-attribute cost - and an event whose timestamp bumps re-sends all N attributes, of which nearly all are unchanged.

## Mechanism (file:line)

- `app/Model/MispAttribute.php:3228-3261` (new) - `fetchExistingAttributesByUuid(array $attributes)`: collects string uuids, runs `find('all')` on `array('Attribute.uuid' => $chunk)` with `recursive => -1` over `array_chunk(..., 100)`, keys the rows by `$row['Attribute']['uuid']`. Chunk size 100 matches the size MISP already uses for bulk correlation writes (`app/Model/Behavior/DefaultCorrelationBehavior.php:165-172`).
- `app/Model/MispAttribute.php:3263` - `editAttribute()` gains a trailing optional `$existingAttributes = null`.
- `app/Model/MispAttribute.php:3279-3286` - the lookup becomes: use the map entry when the map was supplied, the uuid is a string and the key is present; otherwise fall through to the byte-identical original `find('first')`.
- `app/Model/Event.php:5787-5798` - the attribute loop is wrapped in `array_chunk($data['Event']['Attribute'], 100)`, one `fetchExistingAttributesByUuid()` per chunk, map passed down.
- `app/Model/MispObject.php:1347-1360` - the same shape for object attributes; passes an explicit `null` `$server` (matching the previous 6-arg default) and routes `$nothingToChange` into a discarded local so nothing leaks into `editObject`'s own out-param.

## Why existing caching does not already cover it

- `MispAttribute::$updateLookupTable` (`app/Model/MispAttribute.php:98`) is a `uuid => id` map, but it is written only in the post-save path (`MispAttribute.php:644`) and read in `editAttributeBulk` / `editAttributePostProcessing` (`:3337`, `:3354-3357`). It exists only *after* the write and cannot serve a pre-save lookup.
- No `beforeFind` on `MispAttribute` or `AppModel`; the only `find()` override (`app/Model/AppModel.php:4834`) validates the order clause and optionally attaches analyst data - no memoization.
- Cake 2's query cache is off by default (`Model::$cacheQueries = false`, `app/Lib/cakephp/lib/Cake/Model/Model.php:273`), and each uuid query is distinct anyway.
- `Event::_edit` prefetches only the *event* row (`app/Model/Event.php:5658-5668`, with `EventTag`/`Tag` contain), deliberately not its attributes.
- `MispObject::$__objectDuplicationCheckCache` (`app/Model/MispObject.php:134`) caches object rows by `template_uuid` only.
- No Redis/RedisTool, Cake `Cache`, or `app/tmp/cache` path caches attribute rows by uuid.

## Speedup

**MEASURED - 13.02x to 22.21x on `editAttribute`'s lookup loop.**

Bench method: a standalone PHP 8.3 harness (no live MISP) that mirrors the original per-attribute `find('first')` logic and the patched chunked-prefetch logic side by side, against a real `attributes` table of 50,000 rows carrying the production `UNIQUE KEY uuid` in MariaDB. Runs are `flock`-serialised on the bench host. Query counts are counted directly.

Raw numbers, resync-unchanged regime, 1000 attributes:
- run A (fixer, two repeats): 17.76x and 13.02x
- run B (independent reviewer reproduction): 22.21x
- all-changed regime: 20.28x / 10.31x / 22.83x on the loop
- all-new regime (every uuid a map miss, so prefetch **plus** N fallback point queries): 0.99x / 1.06x / 0.75x - no gain, no regression
- query count: 1000 -> 10

I report **13.02x**, the lowest unchanged-regime observation, as the headline. The spread is host load and per-query latency, not harness drift: the container's baseline `SELECT 1` round-trip median was 0.10-0.11 ms on the slower run and 0.086 ms on the faster one, against a full original-side iteration of ~0.73-1.14 ms. **The wall-clock multiple therefore shrinks on a lower-latency server; the portable, structural claim is the query-count reduction, 1000 point queries -> 10 IN-list queries per 1000 attributes.**

**DERIVED - end-to-end floors, which should stay attached wherever the number is quoted:**
- ~5x on `Event::_edit`'s attribute phase in the resync-unchanged regime (attributes short-circuit at `MispAttribute.php:3265`, no save and no correlation, so the lookups are essentially the whole phase).
- ~1.3x in the all-changed / `$force` regime, where `beforeSave`'s *second* per-row `find('first')` by id (`MispAttribute.php:546-551`), `saveMany` and correlation dominate. This patch removes one of two per-attribute reads and none of the writes.
- ~1.0x on pure-insert events. The prefetch is wasted work there, but it does not measurably cost anything.

**Correctness assertion result: 8440 comparisons (4220 corpus cases x 2 `$force` settings), 0 mismatches**, original vs patched outputs compared field by field, no deprecation notices emitted. The corpus includes 200 array-valued-uuid cases and 20 float-uuid cases; an explicit assertion confirms the array-uuid short-circuit branch actually fired 100/100 on **both** sides returning identical `[true, nothingToChange = true]`, so those cases are not passing vacuously by both sides treating the attribute as new.

## Risk

Low, and the delta is deliberately narrow.

- Same model, same conditions shape, `recursive => -1`, no `fields`, no `callbacks => false`, no `includeAnalystData` - so `afterFind` hydration (`MispAttribute.php:531-543`) is identical row for row.
- `uuid` is `UNIQUE` (`INSTALL/MYSQL.sql:117`), so `find('all')` cannot select a different row than `find('first')`.
- The prefetch carries **no** `event_id` / `object_id` condition, so cross-event rows land in the map and the duplicate-UUID guard at `MispAttribute.php:3247-3250` still fires exactly as before.
- A map *miss* (e.g. collation-vs-byte-exact divergence such as a trailing space, or any non-string uuid) falls back to the untouched original `find('first')`, so a miss is never observable. A false *hit* is impossible - keys come from the DB rows themselves.
- Chunking the **loop**, not merely the query, bounds the map to at most 100 rows regardless of event size. This answers the memory caveat raised in review against a whole-event map.
- `$existingAttributes` is appended **after** the already-optional `$server`, so there is no "optional before required" deprecation and all existing 4-arg callers (workflow modules) get `null` and take the original path unchanged.
- No writes occur inside `editAttribute` (`createLogEntry` and `captureSG` touch other tables), and all attribute writes are deferred to `editAttributeBulk` after the loop, so a per-chunk map cannot go stale within its chunk.
- A numeric-string uuid coerces to an int array key, but map keys come from 36-character DB uuids, so it always misses and falls back to the original find.

## Testing

- **Lint**: `php -l` clean on all three modified files against PHP 8.3.33. The `Deprecated: Optional parameter ...` lines PHP prints are pre-existing upstream signatures at `Event.php:6338`, `:6669`, `:9964` and `MispObject.php:507`, `:1041` - unrelated to and untouched by these hunks.
- **Benchmark**: as described above, `flock`-serialised, against a real 50,000-row `attributes` table with the production unique index, reproduced independently by a second reviewer.
- **Correctness assertion**: 8440 original-vs-patched comparisons, 0 mismatches, plus the explicit assertion that the array-uuid short-circuit branch fired on both sides.
- **Negative control**: running the harness with the guards removed from the patched side only reproduces the exact fatal described in the Review note, proving the harness detects the defect it claims to.
- **No live MISP instance was available**, so there is no end-to-end test of a real sync pull, feed ingestion or REST event edit. The end-to-end figures above are DERIVED from the code path, not measured. Maintainer review of the two call-site loops against a real sync is the gap I cannot close here.

## Review note

An earlier review of this patch found a genuine **blocker**, which is now fixed rather than papered over.

The defect: an array-valued (or float-valued) `uuid` on an incoming attribute was used directly as a PHP array key at the two new map sites - `$uuids[$attribute['uuid']] = true` in the prefetch, and `isset($existingAttributes[$attribute['uuid']])` in `editAttribute`. On PHP 8 that is an uncaught `TypeError` ("Cannot access offset of type array on array" / "... in isset or empty"). The **original** code completes such a request normally, because Cake's `DboSource::_parseKey` renders an array value as `uuid IN (...)` and matches the row. So the patch turned a working request into a fatal. A float uuid additionally raised an "Implicit conversion from float" deprecation.

The fix: one `is_string()` guard at each site, ordered **before** the index so PHP's `&&` short-circuits:
- `fetchExistingAttributesByUuid`: `if (isset($attribute['uuid']) && is_string($attribute['uuid']))`
- `editAttribute`: `if ($existingAttributes !== null && is_string($attribute['uuid']) && isset($existingAttributes[$attribute['uuid']]))`

A non-string uuid therefore never enters the map and never indexes it; it falls through to the byte-identical original `find('first')` and behaves exactly as it does on `2.5` today. The float deprecation is gone as a side effect of the same guard. The optimisation itself - the chunked prefetch, the per-chunk map hand-off, both call-site loop shapes - is untouched; the delta from the blocked version is exactly these two guards and one docblock sentence.

Regression coverage was added for the reviewer's exact cases and is in the 8440-comparison corpus above: 100 cases posting `"uuid": ["<uuid of an existing attribute of this event>"]` with a non-newer timestamp (the short-circuit branch), 100 posting a uuid owned by a *different* event (the duplicate-UUID-guard branch), and 20 float uuids. The reviewer re-tested the blocker independently and reproduced both fatal forms on unguarded code and neither on the shipped code.

One deliberate non-change worth flagging: the `is_array($object['Attribute'])` guard in `MispObject.php` was queried as scope creep and **kept on purpose**. `array_chunk()` on a truthy non-array value is a fatal `TypeError` on PHP 8, so dropping the guard would turn the original's warning-plus-skip into a fatal - strictly worse. With the guard the observable outcome (empty `$attributes`, one `editAttributeBulk([])`) is identical to the original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

