### PR TITLE
[medium] perf: fetch sightings once per batch instead of per attribute in MispAttribute::fetchAttributes

### DIFF
--- a/app/Model/MispAttribute.php
+++ b/app/Model/MispAttribute.php
@@ -2346,6 +2346,12 @@ class MispAttribute extends AppModel
                 }
 
                 $this->attachTagsToAttributes($batch, $options);
+
+                if (!empty($options['includeSightings'])) {
+                    // Fetch sightings for the whole batch at once instead of two queries per attribute.
+                    // Conditions are built from the raw joined Event fields, before the context substitution below.
+                    $sightingsByAttributeId = $this->Sighting->attachToAttributes($batch, $user);
+                }
         
                 // per-attribute pipeline
                 foreach ($batch as $attr) {
@@ -2364,10 +2370,8 @@ class MispAttribute extends AppModel
                     }
                     $attr['Event']['ThreatLevel'] = $threat_levels[$attr['Event']['threat_level_id']]['ThreatLevel'] ?? '';
                     if (!empty($options['includeSightings'])) {
-                        $tmp = $attr['Attribute'];
-                        $tmp['Event'] = $attr['Event'];
                         $attr['Attribute']['Sighting'] =
-                            $this->Sighting->attachToEvent($tmp, $user, $tmp['id']);
+                            $sightingsByAttributeId[$attr['Attribute']['id']] ?? [];
                     }
                     if (!empty($options['includeCorrelations'])) {
                         $fields = ['id','event_id','object_id','object_relation','category','type','value','uuid','timestamp','distribution','sharing_group_id','to_ids','comment'];

--- a/app/Model/Sighting.php
+++ b/app/Model/Sighting.php
@@ -435,9 +435,10 @@ class Sighting extends AppModel
     /**
      * @param array $user
      * @param array $attributes Attributes with `Attribute.id`, `Event.id` and `Event.org_id` fields
+     * @param array $reporterCache isReporter results keyed by event ID, shared across chunks
      * @return array
      */
-    private function createConditionsByAttributes(array $user, array $attributes)
+    private function createConditionsByAttributes(array $user, array $attributes, array &$reporterCache = [])
     {
         $sightingsPolicy = $this->sightingsPolicy();
 
@@ -461,23 +462,52 @@ class Sighting extends AppModel
             }
         }
 
-        // Create conditions for merged attributes
+        // Create conditions for merged attributes. Under every policy the per event conditions collapse to at most
+        // two distinct shapes (no org filter for own events, one fixed org filter for foreign events), so group the
+        // attribute IDs by shape instead of emitting one `OR` branch per event - a chunk spanning thousands of events
+        // would otherwise produce thousands of `OR` branches, which is much slower than a single large `IN` list.
         $hostOrgId = Configure::read('MISP.host_org_id');
-        $conditions = [];
+        $unfilteredIds = []; // attribute IDs that need no org filter
+        $orgFilteredIds = []; // attribute IDs that need the org filter below
+        $orgFilter = null;
         foreach ($attributesByEventId as $eventId => $eventAttributes) {
-            $attributeConditions = ['Sighting.attribute_id' => $eventAttributes['ids']];
+            $filtered = false;
             if (!$eventAttributes['ownEvent']) {
                 if ($sightingsPolicy === self::SIGHTING_POLICY_EVENT_OWNER) {
-                    $attributeConditions['Sighting.org_id'] = $userOrgId;
+                    $orgFilter = $userOrgId;
+                    $filtered = true;
                 } else if ($sightingsPolicy === self::SIGHTING_POLICY_SIGHTING_REPORTER) {
-                    if (!$this->isReporter($eventId, $userOrgId)) {
+                    if (!isset($reporterCache[$eventId])) {
+                        $reporterCache[$eventId] = $this->isReporter($eventId, $userOrgId);
+                    }
+                    if (!$reporterCache[$eventId]) {
                         continue; // skip event
                     }
                 } else if ($sightingsPolicy === self::SIGHTING_POLICY_HOST_ORG) {
-                    $attributeConditions['Sighting.org_id'] = [$userOrgId, $hostOrgId];
+                    $orgFilter = [$userOrgId, $hostOrgId];
+                    $filtered = true;
                 }
             }
-            $conditions['OR'][] = $attributeConditions;
+            if ($filtered) {
+                foreach ($eventAttributes['ids'] as $id) {
+                    $orgFilteredIds[] = $id;
+                }
+            } else {
+                foreach ($eventAttributes['ids'] as $id) {
+                    $unfilteredIds[] = $id;
+                }
+            }
+        }
+
+        $conditions = [];
+        if (!empty($unfilteredIds)) {
+            $conditions['OR'][] = ['Sighting.attribute_id' => $unfilteredIds];
+        }
+        if (!empty($orgFilteredIds)) {
+            $conditions['OR'][] = [
+                'Sighting.attribute_id' => $orgFilteredIds,
+                'Sighting.org_id' => $orgFilter,
+            ];
         }
         return $conditions;
     }
@@ -730,6 +760,56 @@ class Sighting extends AppModel
             }
             $conditions['Sighting.uuid >'] = $uuids[$count - 1];
         }
+    }
+
+    /**
+     * Bulk variant of `attachToEvent` for a whole batch of attributes. Instead of running two queries per attribute,
+     * sightings for all provided attributes are fetched with a few grouped queries.
+     *
+     * @param array $attributes Attributes with `Attribute.id`, `Attribute.uuid`, `Event.id` and `Event.org_id` fields
+     * @param array $user
+     * @param bool $forSync
+     * @return array Sightings grouped by attribute ID
+     */
+    public function attachToAttributes(array $attributes, array $user, $forSync = false)
+    {
+        if (empty($attributes)) {
+            return [];
+        }
+
+        $attributeUuids = [];
+        foreach ($attributes as $attribute) {
+            $attributeUuids[$attribute['Attribute']['id']] = $attribute['Attribute']['uuid'];
+        }
+
+        $sightings = [];
+        $reporterCache = []; // memoize isReporter per event ID across chunks
+        // Chunk attributes to keep the generated `IN` conditions reasonably sized
+        foreach (array_chunk($attributes, 5000) as $chunk) {
+            $conditions = $this->createConditionsByAttributes($user, $chunk, $reporterCache);
+            if (empty($conditions)) {
+                continue; // user is not allowed to see any sighting for this chunk
+            }
+            $chunkSightings = $this->find('all', [
+                'conditions' => $conditions,
+                'recursive' => -1,
+            ]);
+            foreach ($chunkSightings as $sighting) {
+                $sighting['Sighting']['attribute_uuid'] = $attributeUuids[$sighting['Sighting']['attribute_id']];
+                $sightings[] = $sighting;
+            }
+        }
+        if (empty($sightings)) {
+            return [];
+        }
+
+        $sightings = $this->attachOrgToSightings($sightings, $user, $forSync);
+
+        $grouped = [];
+        foreach ($sightings as $sighting) {
+            $grouped[$sighting['attribute_id']][] = $sighting;
+        }
+        return $grouped;
     }
 
     /**


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Sightings are fetched once per 5000-attribute chunk instead of twice per attribute.

- **Problem** — When `includeSightings` is requested, `MispAttribute::fetchAttributes` attaches sightings one attribute at a time, and each call runs an extra `Attribute` find just to recover the uuid before the sightings query, so even an attribute with no sightings costs two round trips.
- **Fix** — Adds a bulk `Sighting::attachToAttributes` and calls it once per 5000-attribute chunk, mirroring the existing bulk `Sightingdb::attachToAttributes` on the same path.
- **Effect** — `restSearch` requests asking for sightings drop from two queries per attribute to one grouped query per chunk.
<!-- /bluf -->

## What

When `includeSightings` is requested, `MispAttribute::fetchAttributes` attaches sightings one attribute at a time. This replaces that with a single grouped query per 5000-attribute chunk via a new bulk entry point `Sighting::attachToAttributes`, mirroring the bulk path `Sightingdb::attachToAttributes` that already exists on the same code path.

Two files touched: `app/Model/MispAttribute.php`, `app/Model/Sighting.php` (+95 / -11).

## Why it is hot

Tier T1.

Honest gate: `includeSightings` must be truthy. It is a user-supplied `restSearch` parameter (`app/Controller/Component/RestSearchComponent.php:46`, plumbed at `app/Model/MispAttribute.php:2181` and `:3695`) and is forced to `1` unconditionally by `app/Lib/Export/AttackSightingsExport.php:8` and `app/Lib/Export/ReportFromEvent.php:39,53`. No server configuration is required, but a request that does not ask for sightings is unaffected by this patch.

Caller evidence:

- `app/Model/MispAttribute.php:2288` fixes the batch size at `$params['limit'] = 50000;`.
- `app/Model/MispAttribute.php:2349` opens `foreach ($batch as $attr)` over that batch.
- Before this patch, `app/Model/MispAttribute.php:2366-2371` called `$this->Sighting->attachToEvent($tmp, $user, $tmp['id'])` once per attribute, passing the attribute id as an int.
- In `Sighting::attachToEvent` (`app/Model/Sighting.php:823`) an int takes the `is_numeric($attribute)` branch, which runs an extra `Attribute.find('first')` purely to recover `Attribute.uuid`, then the sightings `find('all')`. Both execute **before** the `if (empty($sightings)) return [];` early exit, so an attribute with zero sightings still costs two round trips.
- Under `SIGHTING_POLICY_SIGHTING_REPORTER`, `createConditions` additionally calls the unmemoized `isReporter` (a `hasAny`), a third round trip per attribute.
- The export driver reaches this per attribute row from the `restSearch` streaming loop (`app/Model/MispAttribute.php:3850`).

So a full 50,000-attribute batch costs ~100,000 round trips on this step alone.

## Mechanism

`app/Model/Sighting.php:774` - new `public function attachToAttributes(array $attributes, array $user, $forSync = false)`. It chunks the batch at 5000 attributes, calls the model's existing `createConditionsByAttributes` for policy-correct conditions, runs one `find('all', ['conditions' => ..., 'recursive' => -1])` per chunk, stamps `attribute_uuid` from the in-hand `Attribute.uuid`, then calls `attachOrgToSightings` **once** over the merged set and returns rows grouped by `Sighting.attribute_id`.

`app/Model/Sighting.php:441` - `createConditionsByAttributes` now groups attribute ids by *condition shape* instead of emitting one `OR` branch per event. Under every policy the per-event conditions collapse to at most two shapes: own events (and `REPORTER`-surviving foreign events) need no org filter; foreign events need one fixed org filter (`EVENT_OWNER`: `org_id = user_org`; `HOST_ORG`: `org_id IN (user_org, host_org)`). The generated `WHERE` therefore has at most two `OR` branches, each with one large `IN` list, regardless of event cardinality. `isReporter` results are memoized per event id in a `$reporterCache` threaded by reference across chunks.

`app/Model/MispAttribute.php:2349-2353` - the bulk call is placed after `attachTagsToAttributes` and **before** the `includeContext` Event substitution, so conditions are built from the raw joined `Event.id` / `Event.org_id` fields rather than the substituted context array.

`app/Model/MispAttribute.php:2372-2374` - the in-loop body becomes `$attr['Attribute']['Sighting'] = $sightingsByAttributeId[$attr['Attribute']['id']] ?? [];`.

`sightings` carries `KEY attribute_id (attribute_id)` (`INSTALL/MYSQL.sql:1413`), so the `IN` list is an index range scan.

## Why existing caching does not already cover it

Every *other* per-attribute step in this loop is already batched, which is exactly what leaves the sighting attach dominant: `$this->orgs_cache` for Event Org/Orgc (`MispAttribute.php:47`, populated `:2356-2363`), ThreatLevel fetched once before the loop (`:2320-2323`), `attachTagsToAttributes` for the whole batch (`:2348`), `__attachEventTagsToAttributes` with a by-reference cache (`:2556`), one `__fetchEventsForAttributeContext` for all event ids (`:2338`).

For `Sighting` specifically there was nothing: no static array, no instance memo, no `setupRedis`/`RedisTool` on this path, no CakePHP `Cache::read/write`, no `app/tmp` cache. `Sighting::$orgCache` (`Sighting.php:23`) does exist, but `attachOrgToSightings` ends with `$this->orgCache = [];` (`Sighting.php:725`) - and the old call site invoked `attachOrgToSightings` once per attribute, so the `getOrganisationById` memo was destroyed after every single attribute. This patch does not remove that wipe; it simply calls `attachOrgToSightings` once per batch, so the cache now survives the batch as intended.

The bulk condition primitive `createConditionsByAttributes` already existed but was reachable from exactly one caller, `Sighting::attributesStatistics` (`Sighting.php:385`) - never from the export path.

## Speedup

**MEASURED (sighting-attach step only): 54.3x at the worst shape.** An independent re-run of the same harness measured 62.3x at that shape; the lower figure is quoted as the headline.

Bench method: PHP 8.3 CLI + MariaDB with the full MISP schema, in a container. Because the CakePHP application could not be booted, both the original and the patched logic were mirrored as standalone PDO code against a **2,011,422-row** `sightings` table (2M background rows spread over 4.4M attribute ids / 100k events, all disjoint from the test ranges, `ANALYZE`d). The harness sweeps events-per-chunk while holding the chunk at 5000 attributes (50x100, 500x10, 1000x5, 2500x2, 5000x1) and times three variants: `original` (two point queries per attribute plus the uuid find), `patched_old` (the earlier rejected per-event-branch builder, kept verbatim), `patched_new` (this patch).

Raw numbers at the worst shape (5000-attribute chunk spanning 5000 distinct events, one attribute per event, default `SIGHTING_POLICY_EVENT_OWNER`, non-site-admin, foreign events):

| variant | time | queries | vs original |
|---|---|---|---|
| original | 8.109s | 10,661 | 1.00x |
| `patched_old` (rejected) | 25.806s | 6 | **0.31x - a loss** |
| `patched_new` (this patch) | 0.149s | 6 | **54.3x** |

Full sweep with this patch: 112.9x / 55.1x / 121.6x / 100.1x / 54.3x (worst 54.3x). The independent re-run: 62.30x / 95.24x / 104.04x / 82.06x / 103.79x (worst 62.3x).

`EXPLAIN` at the worst shape is an explicit printed assertion in the bench: `OR branches: 2`, `type=range key=attribute_id rows=5000` - an index range scan, not a table scan.

Two honesty caveats:

1. The raw-PDO harness **understates the original side**: a real CakePHP `find` carries `beforeFind` -> `DboSource::read` -> `buildStatement` -> `fetchAll` -> `_filterResults` -> `afterFind`, roughly 10k times per chunk. The measured ratio is therefore conservative in this patch's disfavour.
2. **DERIVED, not measured: the enclosing `restSearch`/export request improves by >=4x**, not 54x. That path remains bounded by PHP hydration and export serialisation; 4x is the honest floor for the enclosing request with `includeSightings=1`, and it is an Amdahl-style derivation, not a wall-clock measurement.

**Correctness assertion result: 0 mismatches.** The bulk result is compared with strict `===` (including per-attribute sighting ordering) against the original per-attribute path across all eight sightings-policy configurations - `EVENT_OWNER` own / foreign / anonymise, `EVERYONE`, `HOST_ORG`, `SIGHTING_REPORTER` matching, `SIGHTING_REPORTER` all-skip, site admin - on both the most clustered (50 events x 100 attributes) and least clustered (5000 events x 1 attribute) shapes, plus all 25,000 test attributes in one call spanning five chunks. `SIGHTING_REPORTER` with a non-reporting org (every event skipped) returns zero sightings on both sides.

## Risk

- **`Sighting.event_id` predicate dropped (non-blocking).** The old per-attribute path always added `Sighting.event_id = <event>` alongside the attribute filter; the bulk path filters on `attribute_id` (+ org) only. Attribute ids are globally unique and sightings always carry their attribute's event, so this is benign for consistent data; the only divergence needs an attribute whose `LEFT JOIN` on `events` misses. Reintroducing a per-event predicate is precisely what recreates the branch explosion this patch removes, so it is left as-is. It stayed `===`-identical across every tested configuration and shape.
- **New peak-memory shape (non-blocking).** `attachToAttributes` accumulates the whole batch's sighting rows in `$sightings` before `attachOrgToSightings`, a transient copy of up to a 50k-attribute batch's sightings. Bounded and small next to `$all[]`, which already retains them, but it is a different allocation profile from the per-attribute path.
- **Policy fidelity** depends on `Event.id` and `Event.org_id` being present and *raw*. `fetchAttributes` selects both (`MispAttribute.php:2209`), and the call is placed before the `includeContext` Event substitution for that reason.
- **Data-leak guard preserved bit-for-bit.** `OR` branches are appended only for non-empty buckets, so an all-skip `SIGHTING_REPORTER` policy still yields exactly `[]`, never `['OR' => []]` (which would match everything).
- **Ordering** is unchanged: no `order` clause was added, per-attribute rows return PK-ascending under a range scan just as under the original point query, and the comparison above is strict including order.
- The change to `createConditionsByAttributes` also benefits the pre-existing caller `Sighting::attributesStatistics` (`Sighting.php:385`), where the same branch explosion was latent. Its result feeds `fetchGroupedSightings`, which passes `$conditions` straight into `find()` with its own explicit `group`/`order` and never inspects `$conditions['OR']`, so it is structure-agnostic.

## Testing

- **Lint:** `php -l` clean on both modified files under PHP 8.3.
- **Benchmark:** as described above, run serialized under a lock; three-way original / rejected-patch / this-patch comparison over a 2M-row background table, with a printed `EXPLAIN` assertion.
- **Correctness assertion:** 0 mismatches, strict `===` including ordering, across 8 policy configurations x 2 clustering shapes plus a full multi-chunk run.
- **No live MISP instance was available for end-to-end testing.** The CakePHP application was not booted; the original and patched logic were mirrored in a standalone harness against the real MISP schema. This has not been exercised through an actual `restSearch` request, an `AttackSightingsExport`, or `ReportFromEvent`. Review and a real-instance smoke test of those three entry points are the right next step - hence draft.

## Review note

An earlier revision of this patch was rejected in review, and the defect is worth stating plainly because it inverts the result.

That revision built the bulk conditions by emitting **one `OR` branch per distinct event**. Since `attachToAttributes` chunks by raw attribute count (5000), a chunk spanning many events produced thousands of `OR` branches - `O(rows x branches)` predicate cost. The reviewer measured it as a genuine **loss** against the original beyond roughly 1500-2000 events per chunk: 11.2s at 2500 events, 24.5s at 5000, against a flat 7.85s for the original.

The fix is the shape-grouping described under Mechanism: attribute ids are bucketed by condition shape rather than by event id, so the `WHERE` has at most two `OR` branches regardless of how many events a chunk spans. The crossover into loss is gone (full sweep now 54.3x-121.6x, worst shape 54.3x).

Two things make that claim checkable rather than asserted: the bench **keeps the rejected builder verbatim as `patched_old`**, and it still loses at the same shapes (0.31x at 5000x1) on the same table in the same run - so the comparison is against a reproduced regression, not a strawman. And the `EXPLAIN` output the first review flagged as unexamined (`type=ALL` on an under-sized bench table) is now an explicit printed assertion showing `type=range key=attribute_id`.

Also addressed while fixing this: `isReporter` is now memoized per event id across chunk boundaries, so an event spanning two chunks no longer re-issues the `hasAny`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

