### PR TITLE
[medium] perf: replace per-object attribute N+1 with one JOIN in ObjectsController::orphanedObjectDiagnostics

### DIFF
--- a/app/Controller/ObjectsController.php
+++ b/app/Controller/ObjectsController.php
@@ -1005,9 +1005,6 @@ class ObjectsController extends AppController
 
     public function orphanedObjectDiagnostics()
     {
-        $objectIds = $this->MispObject->find('list', array(
-            'fields' => array('id', 'event_id')
-        ));
         $template_uuids = $this->MispObject->ObjectTemplate->find('list', array(
             'recursive' => -1,
             'fields' => array('ObjectTemplate.version', 'ObjectTemplate.id', 'ObjectTemplate.uuid')
@@ -1039,15 +1036,35 @@ class ObjectsController extends AppController
         $count = 0;
         $capturedObjects = array();
         $unmappedAttributes = array();
-        foreach ($objectIds as $objectId => $event_id) {
-            $attributes = $this->MispObject->Attribute->find('all', array(
-                'conditions' => array(
-                    'Attribute.object_id' => $objectId,
-                    'Attribute.event_id !=' => $event_id,
-                    'Attribute.deleted' => 0
-                ),
-                'recursive' => -1
-            ));
+        // Fetch every attribute that points to an object belonging to a different event in a single join,
+        // instead of running one find() per object row on the instance.
+        $orphanedAttributes = $this->MispObject->Attribute->find('all', array(
+            'conditions' => array(
+                'Attribute.deleted' => 0
+            ),
+            'joins' => array(
+                array(
+                    'table' => $this->MispObject->table,
+                    'alias' => 'MispObject',
+                    'type' => 'inner',
+                    'conditions' => array(
+                        'MispObject.id = Attribute.object_id',
+                        'MispObject.event_id != Attribute.event_id'
+                    )
+                )
+            ),
+            // MispAttribute::$order (Attribute.event_id DESC) is what the per-object find() used to
+            // inherit from the model default; preserve it so that $original_event_id below still comes
+            // from the highest event_id when an object's orphaned attributes span multiple foreign events.
+            'order' => array('Attribute.object_id' => 'ASC', 'Attribute.event_id' => 'DESC', 'Attribute.id' => 'ASC'),
+            'recursive' => -1
+        ));
+        $attributesByObject = array();
+        foreach ($orphanedAttributes as $orphanedAttribute) {
+            $attributesByObject[$orphanedAttribute['Attribute']['object_id']][] = $orphanedAttribute;
+        }
+        unset($orphanedAttributes);
+        foreach ($attributesByObject as $objectId => $attributes) {
             $matched_template = false;
             if (!empty($attributes)) {
                 foreach ($templates as $template) {


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Orphaned-object diagnostics stops scanning the whole `objects` table with one find per row.

- **Problem** — `ObjectsController::orphanedObjectDiagnostics()` loaded the `id`/`event_id` pair for every row in the `objects` table with no conditions or limit, then ran one `Attribute` find per object row.
- **Fix** — Both are replaced by a single INNER JOIN of `attributes` to `objects` on the `event_id` mismatch, grouped by `object_id` in PHP.
- **Effect** — Objects with no mismatched attributes are never visited, so the site-admin recovery tool no longer scans the whole `objects` table.
<!-- /bluf -->

## What

`ObjectsController::orphanedObjectDiagnostics()` looked for attributes whose `event_id` differs from their parent object's by (a) loading the `id => event_id` list of **every row in the objects table** — no conditions, no limit, no pagination — and (b) issuing **one `Attribute->find('all')` per object row**.

This replaces both with a single INNER JOIN of `attributes` to `objects` on the mismatch predicate, grouped by `object_id` in PHP. Objects with no mismatched attributes are never visited, which is exactly what the existing `if (!empty($attributes))` guard did.

## Why it is hot

**Honest gate, stated up front: this is not a hot path, and the tier claim it was found under does not survive.**

* It is a manually invoked, site-admin-only legacy recovery tool. `app/View/Objects/orphaned_object_diagnostics.ctp:5` says verbatim: *"Due to a bug prior to version 2.4.89, a condition could cause objects to be overwritten on a pull, leading to orphaned object attributes. This script reconstructs the missing objects if any exist."*
* It is not linked from anywhere. Grepping `app/View/` and `app/webroot/js/` for `orphanedObjectDiagnostics|orphaned_object` returns only the action's own template. It is not on the admin diagnostics page either — `app/View/Elements/healthElements/diagnostics.ctp:594-600` exposes orphaned *attributes* (`/attributes/pruneOrphanedAttributes`) and orphaned *correlations* (`/servers/removeOrphanedCorrelations`), different actions.
* ACL: `'orphanedObjectDiagnostics' => array()` at `app/Controller/Component/ACLComponent.php:610` is an empty rule list (no permission flag, no `*`), so `!empty($controllerAclList[$action])` at `:1568` is false and access falls through to the `perm_site_admin` check at `:1609-1611`. No config setting gates it.
* Callers: only the route itself and the self-redirect at `app/Controller/ObjectsController.php:1200`.

So: zero executions on a healthy instance, a handful ever on an affected one. What is true is that **each** invocation costs `N_objects × fixed CakePHP find() overhead` regardless of how few orphans exist, and on a large instance that is tens of seconds of pure no-op round trips. Worth fixing on cost-per-invocation grounds, not on frequency — please rank it accordingly.

## Mechanism (file:line, base-side)

* `app/Controller/ObjectsController.php:1008-1010` — `$this->MispObject->find('list', ['fields' => ['id','event_id']])` over the whole objects table.
* `:1042-1050` — inside `foreach ($objectIds as $objectId => $event_id)`, one `$this->MispObject->Attribute->find('all', ...)` per object with `Attribute.object_id = $objectId AND Attribute.event_id != $event_id AND Attribute.deleted = 0`, `recursive => -1`.
* The predicate *is* the orphan pathology, so on a healthy instance essentially all N finds return zero rows and the body guarded by `!empty($attributes)` at `:1051` is skipped. Runtime is N × (SQL string build in `DboSource`, one server round trip, `Model::_filterResults` / `MispAttribute::afterFind` at `app/Model/MispAttribute.php:531`) producing nothing.
* The per-object predicate genuinely **cannot** be collapsed to `object_id IN (...)`, because the compared `event_id` differs per object. The join is what makes it one query.
* Patch: one `find('all')` with `'joins' => [['table' => $this->MispObject->table, 'alias' => 'MispObject', 'type' => 'inner', 'conditions' => ['MispObject.id = Attribute.object_id', 'MispObject.event_id != Attribute.event_id']]]`, `'conditions' => ['Attribute.deleted' => 0]`, grouped into `$attributesByObject` and fed to the unchanged matching body (now at `+1067` onwards).

`KEY object_id (object_id)` on attributes exists (`INSTALL/MYSQL.sql:119`); note honestly that `a.event_id != o.event_id` is a column-to-column comparison no index can serve, so the planner either drives from objects with in-DB ref seeks on `attributes.object_id` or scans attributes with `eq_ref` on the objects PK. Same row work the loop already performed — but one round trip instead of N+1. `EXPLAIN` on the patched join at N=40000: MispObject scanned via the `event_id` covering index (`Using temporary; Using filesort` for the ORDER BY), Attribute reached by `ref` on `KEY object_id`.

## Why existing caching does not already cover it

* No caching of any kind in the action (`:1006-1204`): no `Cache::read`/`Cache::write`, no `RedisTool`/`setupRedis`, no static or instance memo.
* CakePHP 2 `DboSource` only caches query results when `Model::$cacheQueries` is true, which is false by default — so N finds really are N round trips.
* No caller pre-fetches attributes in bulk; the only entry points are the route and the `:1200` self-redirect.
* The object templates **are** already correctly hydrated once outside the loop (`:1013-1036`), so the template side was never the problem — the SQL loop was the only remaining defect. This PR does not touch that fixed cost, which is why the multiplier falls off on small instances.

## Speedup

**MEASURED — 47.5×** (a second run of the same harness measured 56.0×), at N=40000 objects.

Method: the repo is mounted read-only in the bench container, so both shapes were mirrored in a standalone PHP 8.3 + PDO script against the real MISP schema in MariaDB, and run serialized under `flock`.

* ORIGINAL mirror: the unconditional object list, then per-object `SELECT ... WHERE object_id=? AND event_id!=? AND deleted=0 ORDER BY event_id DESC` — the `ORDER BY` is included because that is what Cake actually emits (`MispAttribute::$order` injected by `Model::buildQuery`).
* PATCHED mirror: the single join with the new three-column order.
* Raw numbers: **40001 queries / 43.40 s → 1 query / 0.913 s = 47.53×**.

Caveats, plainly: the ratio is N-proportional and this N is synthetic. **DERIVED** honest floor for realistic instances is **~5×**; at a few hundred objects the unchanged fixed template-load cost puts it nearer **2-3×**. Both sides of the bench are raw PDO, so the original loses Cake's SQL build, `_filterResults` and `MispAttribute::afterFind` on 40001 finds — meaning the measured figure is conservative, not inflated.

**Correctness assertion result: 0 mismatches** over 6200 objects across four seeded rounds, including an all-orphans round and a zero-orphans round, comparing the per-object `event_id` sequence raw and un-canonicalised, the row payloads, and the output of a verbatim copy of the controller's matching body (`$capturedObjects` / `$unmappedAttributes`).

Disclosed separately: **21 rows** (of 6200 objects) where the two raw fetches differ only in tie order *within* one `event_id`. The original's `ORDER BY event_id DESC` has no tiebreak and MariaDB's filesort over a non-unique key is unstable, so the original is nondeterministic there; the patch pins `Attribute.id ASC`. This affects `$original_timestamp` (first row's timestamp − 1) and the order within `$capturedObjects[...]['Attribute']` — the patch is a deterministic member of the set of outputs the original could already produce, not a change of result.

## Risk

Low, but the ordering nuances are the whole story and are spelled out rather than glossed:

* Read-only diagnostic until the POST branch at `:1159`; the grouped rows carry exactly the same Attribute fields the old `recursive => -1` find returned, so the matching logic is untouched.
* `objects.event_id` and `attributes.event_id` are both `int(11) NOT NULL` (`INSTALL/MYSQL.sql`), so the column-to-column join predicate is algebraically identical to the old PHP-side `'Attribute.event_id !=' => $event_id`.
* `object_id` is `NOT NULL DEFAULT 0`; `object_id = 0` and dangling-`object_id` rows are excluded by the INNER JOIN exactly as the object-driven loop excluded them.
* **No `MispObject.deleted` filter was added** — the original object list had none, so soft-deleted objects are still visited. Deliberate.
* Sequence-only change to the outer loop: the original `find('list')` had **no** `ORDER BY`, so object iteration order was optimizer-chosen (the bench's own EXPLAIN shows MariaDB preferring `KEY event_id` over PRIMARY for `SELECT id, event_id FROM objects`) — never guaranteed to be PK order. The patch pins `Attribute.object_id ASC`. Content is identical; the observable effect is `$capturedObjects` insertion order (view display order) and, in the POST branch, the order of `MispObject->save()` calls and hence which reconstructed object gets which new autoincrement id.
* Memory profile changes from one object's attributes at a time to all mismatched attributes instance-wide. That set is bounded by the number of genuine orphans, which is small by definition, so chunking was deliberately not taken. Flagged here so a maintainer can disagree.

## Testing

* `php -l` clean on the patched controller and on the benchmark harness.
* Benchmark run serialized under `flock` in a PHP 8.3 container against MariaDB loaded with the full MISP schema; four seeded rounds (6200 objects) plus the N=40000 timing round.
* Correctness assertion: 0 mismatches (see above), with the 21 tie-order-only differences reported rather than canonicalised away in the headline.
* Targeted regression check for the reviewed defect (below), seeded directly into MySQL and run through a verbatim copy of the controller's matching body: ORIGINAL → `Object.event_id=300, Attribute=[11]`; PATCHED → `300, [11]`; the previously rejected ordering → `200, [10]`. The check is shown to **discriminate** — it fails if the rejected ordering also passes — rather than merely to pass.
* **No live MISP instance was available for end-to-end testing.** The action was not exercised through the web UI, through its POST branch, or against real data; everything above is static analysis plus a standalone harness mirroring the two SQL shapes.

## Review note

An earlier revision of this patch was **rejected in review**, and the defect is worth recording.

The JOIN rewrite originally carried `ORDER BY Attribute.object_id ASC, Attribute.id ASC`. That silently dropped CakePHP's injected model default: the original per-object `find()` passed no `'order'`, so `Model::buildQuery` (`app/Lib/cakephp/lib/Cake/Model/Model.php:3098-3100`, `if ($query['order'] === null && $this->order !== null)`) injected `MispAttribute::$order = ['Attribute.event_id' => 'DESC']` (`app/Model/MispAttribute.php:386`) — i.e. each object's orphaned attributes were processed **highest event_id first**. An explicit `'order'` *replaces* that default rather than adding to it. So whenever one object's orphaned attributes span two foreign events, the rejected ordering flipped `$original_event_id`, and with it the reconstructed object's `event_id`, the captured/unmapped split, the `ObjectReference`/`Log` lookups, and the POST-branch writes.

Fixed by supplying the model default explicitly, in the middle of the sort key: `'order' => array('Attribute.object_id' => 'ASC', 'Attribute.event_id' => 'DESC', 'Attribute.id' => 'ASC')`, with a comment naming `MispAttribute::$order` as the reason. The repro above is now a permanent assertion in the harness.

Two review points accepted as non-blocking and carried forward honestly rather than argued away:

1. The outer `object_id ASC` is **not** "PK-faithful" — an earlier justification claimed the orderless `find('list')` returned PK order, which is wrong (see Risk above). It is a newly pinned deterministic order over one the original left unspecified; sequence-only.
2. The instance-wide result set is held in memory at once; chunking was considered and deliberately not taken because the set is bounded by the number of genuine orphans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

