### PR TITLE
[medium] perf: batch analyst-data attach for multi-row finds in AnalystDataParentBehavior::afterFind

### DIFF
--- a/app/Model/Behavior/AnalystDataParentBehavior.php
+++ b/app/Model/Behavior/AnalystDataParentBehavior.php
@@ -12,12 +12,38 @@ class AnalystDataParentBehavior extends ModelBehavior
 
 
 
-    public function attachAnalystData(Model $model, array $object, array $types = ['Note', 'Opinion', 'Relationship'])
+    public function attachAnalystData(Model $model, array $object, array $types = ['Note', 'Opinion', 'Relationship'], $prefetched = null, $prefetchedInbound = null)
     {
         // No uuid, nothing to attach
         if (empty($object['uuid'])) {
             return $object;
         }
+        $this->__setContext();
+
+        $method = 'attach' . ($this->__isRest ? 'Flat' : 'Nested') . 'AnalystData';
+        $fetchRecursive = !empty($model->includeAnalystDataRecursive);
+        $data = $this->$method($object, $types, $fetchRecursive, $prefetched);
+
+        // include inbound relationship
+        if ($prefetchedInbound === null) {
+            $inbound = $this->Relationship->getInboundRelationships($this->__currentUser, $model->alias, $object['uuid']);
+        } else {
+            $inbound = isset($prefetchedInbound[$object['uuid']]) ? $prefetchedInbound[$object['uuid']] : [];
+            if ($this->__isRest && $fetchRecursive) {
+                // The batched inbound query ran with the recursion disabled - replay it here so the
+                // fetchedUUIDFromRecursion memo is written in the same order as the per-row path.
+                $this->Relationship = ClassRegistry::init('Relationship');
+                foreach ($inbound as $i => $relationship) {
+                    $inbound[$i]['Relationship'] = $this->__fetchChildrenFor('Relationship', $relationship['Relationship']);
+                }
+            }
+        }
+        $data['RelationshipInbound'] = Hash::extract($inbound, '{n}.Relationship');
+        return $data;
+    }
+
+    private function __setContext()
+    {
         if (empty($this->__currentUser)) {
             $user_id = Configure::read('CurrentUserId');
             $this->User = ClassRegistry::init('User');
@@ -28,23 +54,15 @@ class AnalystDataParentBehavior extends ModelBehavior
         if (empty($this->__isRest)) {
             $this->__isRest = Configure::read('CurrentRequestIsRest');
         }
-
-        $method = 'attach' . ($this->__isRest ? 'Flat' : 'Nested') . 'AnalystData';
-        $fetchRecursive = !empty($model->includeAnalystDataRecursive);
-        $data = $this->$method($object, $types, $fetchRecursive);
-
-        // include inbound relationship
-        $data['RelationshipInbound'] = Hash::extract($this->Relationship->getInboundRelationships($this->__currentUser, $model->alias, $object['uuid']), '{n}.Relationship');
-        return $data;
     }
 
-    private function attachFlatAnalystData(array $object, array $types, $fetchRecursive): array
+    private function attachFlatAnalystData(array $object, array $types, $fetchRecursive, $prefetched = null): array
     {
         $data = [];
         foreach ($types as $type) {
             $this->{$type} = ClassRegistry::init($type);
             $this->{$type}->fetchRecursive = $fetchRecursive;
-            $temp = $this->{$type}->fetchForUuid($object['uuid'], $this->__currentUser);
+            $temp = $this->__elementsForUuid($type, $object['uuid'], $prefetched, $fetchRecursive);
             if (!empty($temp)) {
                 foreach ($temp as $k => $temp_element) {
                     $data[$type][] = $temp_element[$type];
@@ -62,7 +80,7 @@ class AnalystDataParentBehavior extends ModelBehavior
         return $data;
     }
 
-    private function attachNestedAnalystData(array $object, array $types, $fetchRecursive): array
+    private function attachNestedAnalystData(array $object, array $types, $fetchRecursive, $prefetched = null): array
     {
         $data = [];
         foreach ($types as $type) {
@@ -72,7 +90,7 @@ class AnalystDataParentBehavior extends ModelBehavior
             // deeper call below short-circuit. Reset explicitly: the model is a registry
             // singleton and may still be flagged from an earlier fetch in this request.
             $this->{$type}->fetchRecursive = false;
-            $temp = $this->{$type}->fetchForUuid($object['uuid'], $this->__currentUser);
+            $temp = $this->__elementsForUuid($type, $object['uuid'], $prefetched, false);
             if (!empty($temp)) {
                 foreach ($temp as $k => $temp_element) {
                     if (in_array($type, ['Note', 'Opinion', 'Relationship'])) {
@@ -83,6 +101,91 @@ class AnalystDataParentBehavior extends ModelBehavior
             }
         }
         return $data;
+    }
+
+    /**
+     * Return the analyst data elements of a given type for a single uuid, in the row shape
+     * fetchForUuid() produces ([['Note' => [...]], ...]). When $prefetched is provided the rows
+     * come from the batched fetch instead of a dedicated query.
+     */
+    private function __elementsForUuid($type, $uuid, $prefetched, $fetchRecursive)
+    {
+        if ($prefetched === null) {
+            return $this->{$type}->fetchForUuid($uuid, $this->__currentUser);
+        }
+        if (empty($prefetched[$type][$uuid])) {
+            return [];
+        }
+        // Copy: the recursed shape must never be written back into the prefetch cache, so that a
+        // uuid appearing on two rows behaves exactly like two separate fetchForUuid() calls.
+        $elements = $prefetched[$type][$uuid];
+        $rows = [];
+        foreach ($elements as $element) {
+            if ($fetchRecursive) {
+                $element = $this->__fetchChildrenFor($type, $element);
+            }
+            $rows[] = [$type => $element];
+        }
+        return $rows;
+    }
+
+    /**
+     * Replay of the recursion block of AnalystData::afterFind() (AnalystData.php:172-179) for one
+     * prefetched element. The batched queries deliberately run with fetchRecursive disabled: that
+     * block writes to AnalystData::$fetchedUUIDFromRecursion, a per-model memo that is never reset,
+     * and which decides whether a given analyst element carries its nested children or only
+     * '_max_depth_reached'. Hoisting the queries is safe, hoisting that memo write is not - the same
+     * Relationship row is reachable both outbound (object_uuid) and inbound (related_object_uuid),
+     * so whichever sighting comes first wins. Running the recursion here, from the per-row loop,
+     * keeps the memo write order byte-identical to the unbatched path.
+     */
+    private function __fetchChildrenFor($type, array $element): array
+    {
+        $Note = ClassRegistry::init('Note');
+        $Opinion = ClassRegistry::init('Opinion');
+        $Note->fetchRecursive = false;
+        $Opinion->fetchRecursive = false;
+        // Relationship::afterFind() appends related_object AFTER parent::afterFind() has appended
+        // the recursion keys. The batched find ran the two in the opposite order, so re-append it
+        // here to keep the key order (and therefore the serialised JSON) identical.
+        $hasRelated = array_key_exists('related_object', $element);
+        if ($hasRelated) {
+            $related = $element['related_object'];
+            unset($element['related_object']);
+        }
+        $user = $this->{$type}->current_user ?? $this->__currentUser;
+        $element = $this->{$type}->fetchChildNotesAndOpinions($user, $element, false);
+        if ($hasRelated) {
+            $element['related_object'] = $related;
+        }
+        $Note->fetchRecursive = true;
+        $Opinion->fetchRecursive = true;
+        return $element;
+    }
+
+    /**
+     * Batched equivalent of the per-uuid fetchForUuid() calls done by attach*AnalystData():
+     * one IN-list query per type instead of one query per type per row. The IN-list is chunked at
+     * 1000 like the other bulk helpers in this file. The caller owns the fetchRecursive flag.
+     * Returns [type][object_uuid] => list of elements.
+     */
+    private function __prefetchAnalystData(Model $model, array $uuids, array $types)
+    {
+        $prefetched = [];
+        foreach ($types as $type) {
+            $prefetched[$type] = [];
+        }
+        foreach (array_chunk($uuids, 1000) as $uuid_chunk) {
+            foreach ($types as $type) {
+                $temp = $this->{$type}->fetchForUuids($uuid_chunk, $this->__currentUser);
+                foreach ($temp as $uuid => $elementsByType) {
+                    if (!empty($elementsByType[$type])) {
+                        $prefetched[$type][$uuid] = $elementsByType[$type];
+                    }
+                }
+            }
+        }
+        return $prefetched;
     }
 
     public function fetchAnalystDataBulk(Model $model, array $uuids, array $types = ['Note', 'Opinion', 'Relationship']) {
@@ -164,9 +267,43 @@ class AnalystDataParentBehavior extends ModelBehavior
     public function afterFind(Model $model, $results, $primary = false)
     {
         if (!empty($model->includeAnalystData)) {
+            $types = ['Note', 'Opinion', 'Relationship'];
+            $prefetched = null;
+            $prefetchedInbound = null;
+            $uuids = [];
+            foreach ($results as $item) {
+                if (isset($item[$model->alias]) && !empty($item[$model->alias]['uuid'])) {
+                    $uuids[$item[$model->alias]['uuid']] = true;
+                }
+            }
+            // With more than one row the per-row attach costs 4 queries per row (3 fetchForUuid +
+            // 1 inbound relationship lookup). Batch them into 4 IN-list queries for the whole set
+            // and hand the results to attachAnalystData(), which keeps the per-row shape untouched.
+            if (count($uuids) > 1) {
+                $this->__setContext();
+                $uuids = array_keys($uuids);
+                // The batched finds must not trigger AnalystData::afterFind()'s recursion: it writes
+                // to a never-reset per-model memo whose order decides which sighting of an element
+                // keeps its children. attach*AnalystData() replays that recursion per row instead.
+                foreach ($types as $type) {
+                    $this->{$type} = ClassRegistry::init($type);
+                    $this->{$type}->fetchRecursive = false;
+                }
+                $prefetched = $this->__prefetchAnalystData($model, $uuids, $types);
+                $this->Relationship = ClassRegistry::init('Relationship');
+                $prefetchedInbound = [];
+                foreach (array_chunk($uuids, 1000) as $uuid_chunk) {
+                    $prefetchedInbound += $this->Relationship->getInboundRelationshipsBulk($this->__currentUser, $model->alias, $uuid_chunk);
+                }
+                // Leave the flag exactly as the per-row path would have left it.
+                $restore = $this->__isRest ? !empty($model->includeAnalystDataRecursive) : false;
+                foreach ($types as $type) {
+                    $this->{$type}->fetchRecursive = $restore;
+                }
+            }
             foreach ($results as $k => $item) {
                 if (isset($item[$model->alias])) {
-                    $results[$k] = array_merge($results[$k], $this->attachAnalystData($model, $item[$model->alias]));
+                    $results[$k] = array_merge($results[$k], $this->attachAnalystData($model, $item[$model->alias], $types, $prefetched, $prefetchedInbound));
                 }
             }
         }

--- a/app/Model/Relationship.php
+++ b/app/Model/Relationship.php
@@ -183,6 +183,47 @@ class Relationship extends AnalystData
 
     public function getInboundRelationships(array $user, $object_type, $object_uuid): array
     {
+        $inboundRelations = $this->find('all', [
+            'recursive' => -1,
+            'conditions' => $this->buildInboundConditions($user, $object_type, $object_uuid),
+            'contain' => ['Org', 'Orgc', 'SharingGroup'],
+        ]);
+
+        foreach ($inboundRelations as $i => $relationship) {
+            $relationship = $relationship['Relationship'];
+            $inboundRelations[$i]['Relationship']['related_object'] = $this->getRelatedElement($this->__currentUser, $relationship['object_type'], $relationship['object_uuid']);
+        }
+
+        return $inboundRelations;
+    }
+
+    /**
+     * Same as getInboundRelationships(), but for a list of uuids at once - one IN-list query
+     * instead of one query per uuid. Returns the relationships grouped by related_object_uuid.
+     */
+    public function getInboundRelationshipsBulk(array $user, $object_type, array $object_uuids): array
+    {
+        if (empty($object_uuids)) {
+            return [];
+        }
+        $inboundRelations = $this->find('all', [
+            'recursive' => -1,
+            'conditions' => $this->buildInboundConditions($user, $object_type, $object_uuids),
+            'contain' => ['Org', 'Orgc', 'SharingGroup'],
+        ]);
+
+        $results = [];
+        foreach ($inboundRelations as $i => $relationship) {
+            $relationship = $relationship['Relationship'];
+            $inboundRelations[$i]['Relationship']['related_object'] = $this->getRelatedElement($this->__currentUser, $relationship['object_type'], $relationship['object_uuid']);
+            $results[$relationship['related_object_uuid']][] = $inboundRelations[$i];
+        }
+
+        return $results;
+    }
+
+    private function buildInboundConditions(array $user, $object_type, $object_uuid): array
+    {
         $conditions = [
             'related_object_type' => $object_type,
             'related_object_uuid' => $object_uuid,
@@ -204,18 +245,7 @@ class Relationship extends AnalystData
                 ]
             ];
         }
-        $inboundRelations = $this->find('all', [
-            'recursive' => -1,
-            'conditions' => $conditions,
-            'contain' => ['Org', 'Orgc', 'SharingGroup'],
-        ]);
-
-        foreach ($inboundRelations as $i => $relationship) {
-            $relationship = $relationship['Relationship'];
-            $inboundRelations[$i]['Relationship']['related_object'] = $this->getRelatedElement($this->__currentUser, $relationship['object_type'], $relationship['object_uuid']);
-        }
-
-        return $inboundRelations;
+        return $conditions;
     }
 
     public function countRelationships(): array


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Analyst-data attach runs per result row, so a multi-event find issues lookups proportional to row count.

- **Problem** — `AnalystDataParentBehavior::afterFind()` attaches Notes, Opinions and inbound and outbound Relationships one result row at a time.
- **Fix** — Prefetches all four in IN-list queries for the whole result set and threads them through `attachAnalystData`, `attachFlatAnalystData` and `attachNestedAnalystData`, adding a `getInboundRelationshipsBulk()` to `Relationship.php` that shares its condition builder with the existing single-row method; the original path is kept for single-row finds.
- **Effect** — Only calls with `includeAnalystData=1` over multiple events benefit, with per-row assembly and output unchanged; `/events/view` is unaffected.
<!-- /bluf -->

## What

`AnalystDataParentBehavior::afterFind()` attaches analyst data (Notes, Opinions, Relationships, inbound Relationships) one result row at a time. This batches the underlying lookups for the whole result set into four IN-list queries, independent of the row count, while keeping the per-row assembly - and the observable output - unchanged.

Two files change:

- `app/Model/Behavior/AnalystDataParentBehavior.php` - batched prefetch in `afterFind()`, threaded into `attachAnalystData()` / `attachFlatAnalystData()` / `attachNestedAnalystData()`.
- `app/Model/Relationship.php` - new `getInboundRelationshipsBulk()`, sharing a condition builder with the existing `getInboundRelationships()` (extracted verbatim, no behaviour change to the existing method).

## Why it is hot

Tier: **T2**, behind an explicit opt-in gate.

Gate (stated honestly): `includeAnalystData=1` on a `fetchEvent`/REST call **and** more than one row in the find. Single-event `/events/view` is unaffected and gains nothing - the patch falls back to the original per-row path when `count($uuids) <= 1`.

Caller evidence:

- `app/Model/Event.php:38-48` - `Event` declares `AnalystDataParent` in `$actsAs`, so the behavior's `afterFind()` runs on every `Event` find.
- `app/Model/Event.php:3251-3252` - `fetchEvent()` sets `$this->includeAnalystData` / `includeAnalystDataRecursive` on the `Event` registry singleton immediately before the main find at `app/Model/Event.php:3260`. Default is `false` (`Event.php:2962-2965`), and `RestSearchComponent.php:135` whitelists the parameter.
- `app/Model/Event.php:9317-9324` - `restSearch` calls `fetchEvent()` once per memory-sized chunk of event ids (`clusterEventIds`, `Event.php:9347-9360`), with `limit`/`page` stripped, so a chunk routinely holds tens to hundreds of events. This is the multi-row path.
- `app/Controller/EventsController.php:774-775` - the paginated `/events` index is another multi-row find with the flag set.
- `app/Lib/cakephp/lib/Cake/Model/Model.php:3369-3374` - CakePHP fires `Model.afterFind` **once** with the whole primary result set, so all rows are in hand and batching is mechanically available.
- In-tree forcing caller: `app/Lib/Tools/WorkflowBaseModule.php:423` sets `includeAnalystData` on a multi-event `restSearch` (behind `Plugin.Workflow_enable`).

## Mechanism

Before, per row (`AnalystDataParentBehavior.php:164-172` -> `:15-39`):

- 3 x `fetchForUuid()` - one `find('all')` per type Note/Opinion/Relationship keyed on `object_uuid` (`app/Model/Behavior/AnalystDataBehavior.php:42-46`), reached via `attachFlatAnalystData():47` (REST) or `attachNestedAnalystData():75` (UI).
- 1 x `getInboundRelationships()` `find('all')` on `related_object_uuid` (`app/Model/Relationship.php:207-211`).

That is 4 SQL round-trips per row, with no early exit for rows that have no analyst data. For E rows: 4E queries.

After:

- `AnalystDataParentBehavior::afterFind()` collects the row uuids and, when there is more than one, calls the new private `__prefetchAnalystData()` - three IN-list `fetchForUuids()` finds (`AnalystDataBehavior.php:72-81`, already returns rows keyed by `object_uuid`) - plus `Relationship::getInboundRelationshipsBulk()`, one IN-list find on `related_object_uuid` grouped by that column. IN-lists are chunked at 1000, matching the existing bulk helpers in the same file.
- `attachAnalystData()` gains optional `$prefetched` / `$prefetchedInbound` arguments. When they are `null` (single row, or the pre-existing callers) it behaves exactly as before. When present, the new private `__elementsForUuid()` serves the rows out of the prefetch in the same shape `fetchForUuid()` returns.
- Indexes used are the existing ones: `notes/opinions/relationships.object_uuid` (`MYSQL.sql:822, 994, 1094`) and `relationships.related_object_uuid` (`MYSQL.sql:1101`).

Base find count: 4E -> 4, independent of E.

## Why existing caching does not already cover it

- The only memos on this path are `__currentUser` (`AnalystDataParentBehavior.php:21-27`) and `__valid_sharing_groups` (`AnalystDataBehavior.php:27-29`). They remove ACL lookups, not the per-uuid finds.
- No `Cache::read/write`, no `RedisTool`/`setupRedis`, and no uuid-keyed static or instance array anywhere in `AnalystDataParentBehavior.php` or `AnalystDataBehavior.php`. `fetchForUuid()` issues a fresh find on every call.
- `AnalystData::$fetchedUUIDFromRecursion` (`app/Model/AnalystData.php:65`) memoizes only child-recursion uuids - it does not memoize the per-parent `fetchForUuid()`.
- The bulk API already exists in this very file (`fetchAnalystDataBulk():88`, `attachAnalystDataBulk():111`) but is wired only for the child collections - `Event.php:3414` (Attribute), `:3469` (Object), `:3478` (EventReport). Nothing bulk-attaches the parent rows. Neither helper is a drop-in here either: `fetchAnalystDataBulk()` does no child pass at all and `attachAnalystDataBulk()` hardcodes depth 1 (`:146`), while the flat path uses the default depth 2 (`AnalystData.php:458`) and the nested path depth 5 (`:79`). Hence the new, narrower prefetch rather than a call into the existing helper.

## Speedup

**MEASURED, and lower than the finding claimed.**

Method: the worktree is not mounted into the benchmark container, so the real CakePHP code could not be executed. Instead a standalone PHP 8.3 / PDO script mirrors the original and the patched logic against the **full MISP schema** in MariaDB - including the parts that do *not* get faster: `fetchChildNotesAndOpinions` at depth 2 (2 child queries per element, 2 `hasMoreNotesOrOpinions` probes on a memo hit), the per-type never-reset recursion memo, and `getRelatedElement`. Both sides pay them. Runs were serialized under a lock file.

Raw numbers (six runs, two independent operators, shared box so noisy):

| E (rows per find) | run A | run B | run C | independent re-run |
|---|---|---|---|---|
| 4 | 2.11x | 1.50x | 2.42x | 1.82x |
| 50 | 3.16x | 2.79x | 3.07x | 2.85x |
| 200 | 3.24x | 2.84x | 3.44x | 2.78x |

**DERIVED** ratio: `(4E + C) / (4 + C)`, where C is the per-element child-recursion / `getRelatedElement` cost that the batch does not remove. The finding derived a flat `4E/4 = E` and claimed a `>=4x` floor at E>=4; **that omits C and is not met at any tested E** - at the finding's own E=4 anchor the measured figure is ~1.5-2.4x. The honest number is **~3x at E=50**, the typical `restSearch` chunk size. I would rather this be re-tiered below the >=4x premium claim than have the claim stand.

Two further honesty notes on the number:
- The bench likely **overstates** the gain: `getRelatedElement` is mirrored as a cheap `SELECT id, uuid FROM relationships WHERE uuid = ?`, whereas the real `Relationship::getRelatedElement()` runs `fetchSimpleEvent` / `fetchAttributeSimple` / `fetchObjectSimple` per inbound and outbound row. Real C is larger, so the real ratio is lower.
- The seed has analyst data on 10% of events. The ratio improves as analyst data gets sparser and degrades as it gets denser; the bench does not establish which is typical.

**Correctness assertion**: strict comparison (raw `!==`, array key insertion order significant) of the original vs patched output over a 400-batch / 3082-row sweep with E from 1 to 12 - including the E=1 single-row fallback and the empty-uuid, duplicate-uuid and no-analyst-data rows: **0 mismatches**. The harness is discriminating, not merely permissive: it carries a control mirror of the pre-fix variant of this patch, which fails **8/16** on the two-sighting ordering case and **5/5** on the duplicate-uuid case against the same assertion.

## Risk

Non-blocking issues that a reviewer flagged and I chose to disclose rather than paper over:

- **Collation asymmetry (new, low).** `object_uuid` / `related_object_uuid` are `ascii_general_ci`, so SQL `=` is case- and trailing-space-insensitive, while the batched path's PHP lookups (`$prefetched[$type][$uuid]`, `$prefetchedInbound[$uuid]`) are exact string keys. A row whose stored uuid differs in case from the parent row's uuid would be returned by the per-row query but dropped by the batched one. This is the same class as the pre-existing `fetchAnalystDataBulk`/`attachAnalystDataBulk` pattern, but this patch extends it to parent rows and, for the first time, to the inbound direction.
- **Implicit ordering dependency.** On a recursion-memo hit, `fetchChildNotesAndOpinions()` falls into `hasMoreNotesOrOpinions()`, which dereferences `$this->Note` / `$this->Opinion` on the type model. The replay in `__fetchChildrenFor()` sets only local handles. It is safe because every memo write happens inside a miss-path call that assigns `$this->Note` one line later (`AnalystData.php:465-467`), so a hit implies a prior assignment - but that is an unstated dependency on statement order in another file, worth an explicit assignment or a comment if a maintainer prefers.
- **Guard divergence.** The replay omits the original's `!empty($v[$alias]['uuid'])` guard (`AnalystData.php:172`). Unreachable in practice (`uuid` is `NOT NULL UNIQUE` in `MYSQL.sql`), but it is a divergence from the mirrored block.
- **Deliberately out of scope.** The finding also asked to reset `Event->includeAnalystData` after the `fetchEvent` find so later `Event` finds in the same request do not re-enter the attach. That lives in `Event.php`, outside the two files here, and would change which later finds attach analyst data - a behaviour change, not a correctness fix, so it is not in this PR. Likewise no `ORDER BY` was added to `fetchForUuids()` (concern raised), because that would also change the pre-existing `attachAnalystDataBulk` path used by the Attribute/Object/EventReport collections.
- **Unchanged surfaces.** `getInboundRelationships()` keeps its exact behaviour (the condition builder was extracted byte-faithfully). `count($uuids) <= 1`, empty-uuid and no-analyst-data rows all take the untouched original path. `RelationshipInbound` is always present via `Hash::extract`, `[]` when there are no inbound rows.

## Testing

- `php -l` clean on both changed files under PHP 8.3.
- Benchmark: standalone PDO mirror against the full MISP schema in MariaDB, serialized runs, numbers above.
- Correctness assertion: strict `!==` output comparison over 400 batches / 3082 rows, 0 mismatches, with a deliberately-broken control mirror that fails the same assertion 8/16 and 5/5.
- **No live MISP instance was available for end-to-end testing.** The real CakePHP code path was never executed - the worktree is not mounted into the benchmark container. No PHPUnit run. What is proven is the query-count reduction and the output-ordering mechanism, in a hand-written mirror; what is not proven is the behaviour of the actual `Model`/`Behavior` stack under a real request. Please treat that as the main reason this is a draft.

## Review note

An earlier revision of this patch was rejected in review for a genuine, observable output divergence, and this is the fixed version.

The defect: on the gated path `Event.php:3252` forces `fetchRecursive` true, so `AnalystData::afterFind()` (`AnalystData.php:172-179`) recurses and writes the **never-reset** `$fetchedUUIDFromRecursion` memo at *find* time. A `Relationship` row is reachable twice on the same registry singleton - outbound via `fetchForUuid(s)` (`object_uuid`) and inbound via `getInboundRelationships*` (`related_object_uuid`). The first sighting gets its nested Note/Opinion children; the second short-circuits to `_max_depth_reached`. The rejected patch hoisted every outbound prefetch ahead of the inbound bulk query, which flipped *which* sighting carried the children for a result order of `[B, A]` - a silent payload change.

The fix: the batched finds now run with `fetchRecursive` forced **false** on all three type models for the entire batched phase (outbound prefetch *and* inbound bulk), so the bulk queries write nothing to the memo. The recursion is then **replayed per row from the unchanged per-row loop**, in the exact original sequence - Note, Opinion, Relationship-outbound for a row, then that row's inbound - so the memo write order is byte-identical to the unbatched path. The optimisation survives because the replayed queries are the per-element C term the original already paid; the base finds still go 4E -> 4. Prefetched elements are copied before the replay and never written back, so a uuid appearing on two rows behaves exactly like two separate `fetchForUuid()` calls.

A second divergence of the same class was found while fixing the first and is also handled: `Relationship::afterFind()` appends `related_object` *after* `parent::afterFind()` has appended the recursion keys, whereas the batched find appended it first. Since `json_encode` preserves insertion order, that alone would have changed the emitted bytes; `__fetchChildrenFor()` now lifts the key out and re-appends it around the replay.

The regression bench was rewritten around this: it keeps the rejected variant as a control mirror, so the harness demonstrably distinguishes the two (control fails 8/16 and 5/5, fixed passes 0/16 and 0/5). The previous bench could not tell them apart at all.

Separately, the review's main remaining reservation was the **tier, not the code**: the measured speedup is 1.8x-2.9x, below the finding's claimed and "verified" 4x at every E measured, and the bench understates C. That is reflected in the Speedup section above rather than being carried forward as a 4x claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

