### PR TITLE
[medium] perf: batch decay-score sightings fetch in MispAttribute::fetchAttributes

### DIFF
--- a/app/Model/DecayingModelsFormulas/Base.php
+++ b/app/Model/DecayingModelsFormulas/Base.php
@@ -155,7 +155,7 @@ abstract class DecayingModelBase
         }
         $timestamp = time();
         if ($this::REQUIRES_SIGHTINGS) {
-            $attribute['Sighting'] = $this->Sighting->listSightings($user, $attribute['id'], 'attribute', false, false, false);
+            $attribute['Sighting'] = $this->Sighting->listSightingsForAttribute($user, $attribute['id']);
         }
         $elapsedTime = max(0, $timestamp - $last_sighting_timestamp);
         $scores = array(

--- a/app/Model/MispAttribute.php
+++ b/app/Model/MispAttribute.php
@@ -2347,6 +2347,23 @@ class MispAttribute extends AppModel
 
                 $this->attachTagsToAttributes($batch, $options);
         
+                if (!empty($options['includeDecayScore'])) {
+                    // Let the decaying models fetch the sightings of the whole batch at once
+                    if (!isset($this->Sighting)) {
+                        $this->Sighting = ClassRegistry::init('Sighting');
+                    }
+                    $attributeIdsForSightings = [];
+                    $eventOwnerOrgIdList = [];
+                    foreach ($batch as $attr) {
+                        if (isset($attr['Attribute']['deleted']) && !$attr['Attribute']['deleted'] && isset($attr['Event']['orgc_id'])) {
+                            $attributeIdsForSightings[] = $attr['Attribute']['id'];
+                            $eventOwnerOrgIdList[$attr['Event']['id']] = $attr['Event']['orgc_id'];
+                        }
+                    }
+                    $this->Sighting->setSightingsBatch($user, $attributeIdsForSightings, $eventOwnerOrgIdList);
+                    unset($attributeIdsForSightings, $eventOwnerOrgIdList);
+                }
+
                 // per-attribute pipeline
                 foreach ($batch as $attr) {
                     if (!empty($options['includeContext'])) {
@@ -2436,6 +2453,9 @@ class MispAttribute extends AppModel
                         continue;
                     }
                     $all[] = $attr;
+                }
+                if (!empty($options['includeDecayScore'])) {
+                    $this->Sighting->clearSightingsBatch();
                 }
                 // exit batching if done
                 if ($loop && count($batch) < $params['limit']) {

--- a/app/Model/Sighting.php
+++ b/app/Model/Sighting.php
@@ -28,6 +28,9 @@ class Sighting extends AppModel
 
     private $__blockedOrgs = null;
 
+    // Prefetched sightings for a set of already ACL-resolved attributes, see setSightingsBatch()
+    private $sightingsBatch = null;
+
     public $actsAs = array(
             'Containable',
     );
@@ -977,6 +980,24 @@ class Sighting extends AppModel
         if (empty($objectIds)) {
             throw new MethodNotAllowedException('Invalid object.');
         }
+        return $this->__fetchSightingsForObjects($user, $context, $objectIds, $eventOwnerOrgIdList, $orgId, $sightingsType, $orderDesc);
+    }
+
+    /**
+     * Fetch and ACL filter the sightings for objects that were already resolved and checked for access.
+     *
+     * @param array $user
+     * @param string $context 'attribute' or 'event'
+     * @param array $objectIds
+     * @param array $eventOwnerOrgIdList Event ID => Event owner (orgc) ID
+     * @param int|false $orgId
+     * @param int|false $sightingsType
+     * @param bool $orderDesc
+     * @return array
+     * @throws Exception
+     */
+    private function __fetchSightingsForObjects(array $user, $context, array $objectIds, array $eventOwnerOrgIdList, $orgId = false, $sightingsType = false, $orderDesc = true)
+    {
         $conditions = array(
             'Sighting.' . $context . '_id' => $objectIds
         );
@@ -1040,6 +1061,83 @@ class Sighting extends AppModel
             }
         }
         return $sightings;
+    }
+
+    /**
+     * Announce a set of attributes that were already fetched and ACL filtered by the caller, so that
+     * listSightingsForAttribute() can resolve all of them with a single query instead of one query set per attribute.
+     *
+     * Callers MUST pass attribute rows that were selected through MispAttribute::buildConditions() (as
+     * MispAttribute::fetchAttributes() does), because that is the very ACL that the listSightings() fallback
+     * applies through its own inner fetchAttributes(). Event::fetchEvent() must NOT be wired to this: its
+     * $conditionsAttributes carry no Object.distribution predicate and widen event visibility via
+     * MISP.delegation, so its attribute set is a strict superset and batching it would turn the
+     * MethodNotAllowedException('Invalid object.') that listSightings() raises for such an attribute into a
+     * successful decay score.
+     *
+     * @param array $user
+     * @param array $attributeIds Attribute IDs, all of them non deleted and visible for the given user
+     * @param array $eventOwnerOrgIdList Event ID => Event owner (orgc) ID, for every event of the given attributes
+     * @return void
+     */
+    public function setSightingsBatch(array $user, array $attributeIds, array $eventOwnerOrgIdList)
+    {
+        if (empty($attributeIds)) {
+            $this->sightingsBatch = null;
+            return;
+        }
+        $this->sightingsBatch = [
+            'user_id' => $user['id'] ?? null,
+            'attribute_ids' => array_flip($attributeIds),
+            'eventOwnerOrgIdList' => $eventOwnerOrgIdList,
+            'sightings' => null,
+        ];
+    }
+
+    /**
+     * @return void
+     */
+    public function clearSightingsBatch()
+    {
+        $this->sightingsBatch = null;
+    }
+
+    /**
+     * Sightings for a single attribute, in the same shape as listSightings($user, $id, 'attribute', false, false, false).
+     * If the attribute is part of the batch announced by setSightingsBatch(), all sightings of the batch are fetched at
+     * once with a single query, otherwise the generic (and much more expensive) listSightings is used.
+     *
+     * @param array $user
+     * @param int $attributeId
+     * @return array
+     * @throws Exception
+     */
+    public function listSightingsForAttribute(array $user, $attributeId)
+    {
+        if (
+            $this->sightingsBatch !== null &&
+            $this->sightingsBatch['user_id'] === ($user['id'] ?? null) &&
+            isset($this->sightingsBatch['attribute_ids'][$attributeId])
+        ) {
+            if ($this->sightingsBatch['sightings'] === null) {
+                $sightings = $this->__fetchSightingsForObjects(
+                    $user,
+                    'attribute',
+                    array_keys($this->sightingsBatch['attribute_ids']),
+                    $this->sightingsBatch['eventOwnerOrgIdList'],
+                    false,
+                    false,
+                    false
+                );
+                $grouped = [];
+                foreach ($sightings as $sighting) {
+                    $grouped[$sighting['Sighting']['attribute_id']][] = $sighting;
+                }
+                $this->sightingsBatch['sightings'] = $grouped;
+            }
+            return $this->sightingsBatch['sightings'][$attributeId] ?? [];
+        }
+        return $this->listSightings($user, [$attributeId], 'attribute', false, false, false);
     }
 
      /**


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Decaying formulas that require sightings resolve them one attribute at a time, so cost grows linearly.

- **Problem** — For formulas declaring `REQUIRES_SIGHTINGS`, `app/Model/DecayingModelsFormulas/Base.php` calls `Sighting::listSightings()` per attribute id, and each of those calls runs a full `fetchAttributes()` just to resolve ACL.
- **Fix** — Adds a batch entry point to `Sighting` and wires `MispAttribute::fetchAttributes()` to it, leaving `Event::fetchEvent()` byte-identical.
- **Effect** — Requests through `attributes/restSearch` with `includeDecayScore` or `excludeDecayed`, and an enabled Sightings-formula model mapped to the attribute type, get their sightings in one pass instead of N.
<!-- /bluf -->

## What

Adds a batch entry point to `Sighting` so that the `REQUIRES_SIGHTINGS` decaying formulas stop resolving their sightings one attribute at a time, and wires `MispAttribute::fetchAttributes()` to it.

Scope, stated up front: **only `MispAttribute::fetchAttributes()` callers are accelerated** — `attributes/restSearch` and everything else that goes through that method with `includeDecayScore` / `excludeDecayed`. `Event::fetchEvent()` (i.e. `events/restSearch`) is **not** touched and is byte-identical to before; see [Review note](#review-note) for why that driver was deliberately left alone.

## Why it is hot

Tier T1.

Gate (all must hold): `includeDecayScore = 1` — or `excludeDecayed`, which forces it at `app/Model/MispAttribute.php:2200-2202` — on a request that goes through `MispAttribute::fetchAttributes()` (`/attributes/restSearch` et al), **and** at least one *enabled* decaying model whose `formula` is `Sightings` (`app/Model/DecayingModelsFormulas/Sightings.php:6`) is associated with the attribute's type via `DecayingModelMapping` (`app/Model/DecayingModel.php:627-636`).

Caller evidence:

- `app/Model/DecayingModelsFormulas/Base.php:157` — when the formula class declares `REQUIRES_SIGHTINGS = true`, `computeCurrentScore()` calls `$this->Sighting->listSightings($user, $attribute['id'], 'attribute', false, false, false)` for a **single** attribute id.
- `app/Model/Sighting.php:960` — `listSightings()` resolves the ACL for the `'attribute'` context by running a full `$this->Event->Attribute->fetchAttributes($user, ['conditions' => ['Attribute.id' => $ids, 'Attribute.deleted' => 0], 'flatten' => 1])`, then issues the sightings find at `:988`.
- That inner `fetchAttributes()` for one id costs an unconditional `ThreatLevel->find('all')` (`app/Model/MispAttribute.php:2321-2324`), the main find with two joins plus `contain => ['AttributeTag']` which Containable resolves as a second query (`:2317-2337`), and `attachTagsToAttributes()` (`:2355` → `:2526`) which issues a `Tag` find when the attribute is tagged — **4-5 queries per attribute, per mapped Sightings-formula model**, of which only the last carries information the formula needs.
- Driver: the per-attribute pipeline inside the 50000-row batch loop at `app/Model/MispAttribute.php:2356+`, calling `attachScoresToAttribute` (`app/Model/DecayingModel.php:625`), which loops every associated model → `getScore` (`:659`) → `:723` `computeCurrentScore`. The cost therefore multiplies by the number of enabled Sightings-formula models mapped to the attribute type.

Honest gate note: with no enabled `Sightings`-formula model mapped to the attribute types in the response, `REQUIRES_SIGHTINGS` is never true and this path costs nothing — the patch is then inert (the batch is announced but never consumed, which is one array build and no query). The win is real only under the gate above.

## Mechanism

- `app/Model/Sighting.php:999` — the tail of `listSightings()` (conditions, `contain => Organisation.name`, `order date_sighting`, site-admin short circuit, `EVENT_OWNER`/`HOST_ORG` and `SIGHTING_REPORTER` policy filters, anonymise pass) is extracted **verbatim** into a private `__fetchSightingsForObjects()`. `listSightings()` itself keeps its signature, its `fetchAttributes()`-based ACL resolution and its `MethodNotAllowedException('Invalid object.')`.
- `app/Model/Sighting.php:1083` — `setSightingsBatch(array $user, array $attributeIds, array $eventOwnerOrgIdList)` records a set of attribute rows the caller has *already* fetched and ACL-filtered (ids flipped into a lookup, plus the event → `orgc_id` map the policy filters need), keyed on `$user['id']`. `clearSightingsBatch()` at `:1100` drops it.
- `app/Model/Sighting.php:1115` — `listSightingsForAttribute(array $user, $attributeId)`: if the id is in the announced batch for this user, the sightings for the **whole** batch are fetched with one `Sighting.attribute_id IN (...)` query on first use, filtered by `__fetchSightingsForObjects()`, then grouped by `attribute_id` and served per attribute. Any id not in the batch falls through to the unchanged `listSightings($user, [$id], 'attribute', false, false, false)`.
- `app/Model/DecayingModelsFormulas/Base.php:158` — `computeCurrentScore()` now calls `listSightingsForAttribute()`.
- `app/Model/MispAttribute.php:2350-2366` — `fetchAttributes()` announces the batch just before its per-attribute pipeline when `includeDecayScore` is set, from rows it already holds, filtered to `isset($attr['Attribute']['deleted']) && !$attr['Attribute']['deleted'] && isset($attr['Event']['orgc_id'])`; cleared at `:2457` after the loop.

119 insertions, 1 deletion, across 3 files. Purely additive apart from the one call-site swap at `Base.php:158`.

## Why existing caching does not already cover it

- `DecayingModel` caches **models only**, never sightings or attributes: `modelCacheForType` (`app/Model/DecayingModel.php:631-636`), `defaultModelsCache` (`:674-679`), `__registered_model_classes` (`:461-467`).
- `app/Model/Sighting.php` has no Redis and no `Cache::` memo of any kind; `listSightings()` is the only entry point for this data and, before this patch, was always handed a single id from `Base.php:157`.
- Inside `fetchAttributes()` the only memoized pieces are `self::$hasDeletedIndex` (`app/Model/MispAttribute.php:2282-2286`) and `SharingGroup::authorizedIds` (`app/Model/SharingGroup.php:505-529`, instance-cached by role + org). Neither removes the per-call queries, and `ThreatLevel->find('all')` at `MispAttribute.php:2321` is unconditional per call with no cache.
- No hidden count query masks the cost either: `$result_count` defaults to `false` (`MispAttribute.php:2091`), so the `find('count')` at `:2298` is skipped.

## Speedup

**MEASURED**, on the sightings-fetch sub-path of `computeCurrentScore` — *not* on total `restSearch` wall time. `getLastSightingForAttribute` is charged to both sides and is unaffected.

Method: no live MISP instance was available, so both code paths were mirrored in a standalone PHP 8.3 CLI harness against MariaDB carrying the real MISP schema (200 attributes / 400 sightings seeded). The harness reproduces the original path (per-attribute ACL resolution, including the `MethodNotAllowedException('Invalid object.')` throw on an empty ACL result) and the patched path (announced batch + fallback). Its ACL SQL mirrors `MispAttribute::buildConditions`, including the `Attribute.object_id = 0 OR Object.distribution IN (1,2,3,5)` object clause. Timings are the **min of 5 trials** to cut contention noise on a shared box.

Raw numbers, policy `EVENT_OWNER`, non site-admin, anonymise off:

| N attributes | original | patched | speedup |
|---|---|---|---|
| 4 | 21.360 ms | 5.013 ms | **4.26x** |
| 20 | 100.201 ms | 18.012 ms | **5.56x** |
| 100 | 486.545 ms | 87.788 ms | **5.54x** |

An independent run of the same harness on the same box gave 3.69x / 5.32x / 8.17x. Taking both runs together, the honest claim is **~3.7x-8.2x** depending on N, with 3.7x as the observed floor. It is not a single number: the ratio grows with the number of attributes in the batch because the original issues 4-5 queries per attribute while the patched path issues one query for the whole batch.

Correctness assertion result: **9600 attribute results compared, 0 mismatches** (4 `Plugin.Sightings_policy` values x site-admin/not x user org x anonymise on/off). ACL-boundary regression check: **0 failures** (3 cases, below).

## Risk

Medium-low, and lower than the finding's original estimate now that the Event driver is out of scope.

- The policy filters at `Sighting.php:1000-1032` need `eventOwnerOrgIdList[eventId] => orgc_id`. `MispAttribute::fetchAttributes()` already selects `Event.orgc_id` (`MispAttribute.php:2207`), and rows lacking it are excluded from the batch and take the unchanged fallback.
- The batch is a **subset** of what `listSightings`' inner `fetchAttributes()` would return for the same user: same `$user`, same `MispAttribute::buildConditions` ACL (its `aclConditionsCache` is keyed by role + org), and the patch's `!deleted` filter matches the inner call's forced `Attribute.deleted => 0` — so `perm_sync` rows fetched with `deleted = 'only'` / `deleted = 1` correctly stay on the throwing fallback. Grouping happens *after* the policy and anonymise filtering, so per-attribute results are unchanged.
- Known follow-up, not fixed here to keep this diff identical to what was reviewed: the per-attribute loop in `fetchAttributes()` is not wrapped in `try { ... } finally { clearSightingsBatch(); }`, so an exception thrown mid-loop (Warninglist, Correlation, `massageTags`) would leave `$sightingsBatch` set on the `ClassRegistry` `Sighting` singleton. The `$user['id']` guard means this can never widen an ACL, and a web request dies at that point anyway; the worst case is a stale sightings read later in the same process. Happy to add the `finally` here if you would like it in this PR.
- Theoretical, pre-existing: the batch passes a multi-event `eventOwnerOrgIdList` into the `EVENT_OWNER`/`HOST_ORG` and `SIGHTING_REPORTER` filters where the single-attribute path passes a one-event list. Results can only differ if a sighting row's `event_id` disagrees with its attribute's `event_id` — inconsistent data, on which the original already hits an undefined array key.
- `Base.php:175`'s pre-existing `'context'` bug and `DecayingModel.php:517` / `:569` are intentionally left untouched — out of scope for a perf change.

## Review note

This patch was revised after an internal review caught a real defect in the first version, which is worth stating plainly rather than hiding.

**The defect.** The first version also batched the *other* driver, `Event::fetchEvent()` (`app/Model/Event.php:3419`). That is unsound: `Event::fetchEvent`'s `$conditionsAttributes` (`Event.php:3028-3040`) carry **no** `Object.distribution` predicate and additionally widen event visibility via `MISP.delegation`. `$event['Attribute']` is therefore a **strict superset** of what `listSightings`' inner `fetchAttributes()` (i.e. `MispAttribute::buildConditions`) returns. For an attribute in that gap — say an attribute with `distribution = 3` inside an object with `distribution = 0`, on another org's event — the original code throws `MethodNotAllowedException('Invalid object.')` and the request 405s, whereas the batched version happily returned sightings and a decay score. A silent ACL widening, not just a perf regression.

**How it is handled now.** `app/Model/Event.php` is fully reverted — `git diff --quiet HEAD -- app/Model/Event.php` passes — so `Base.php:158` is reached from that driver with no batch announced, `listSightingsForAttribute()` falls through to `listSightings($user, [$id], 'attribute', false, false, false)`, and the throw still fires. `events/restSearch` is byte-identical to before. The remaining driver, `MispAttribute::fetchAttributes()`, feeds the batch from the very same `buildConditions` ACL that the fallback would apply, so no such gap exists there. `setSightingsBatch()` carries a docblock precondition (`Sighting.php:1067-1081`) stating that callers must pass `buildConditions`-selected rows and that `Event::fetchEvent()` must **not** be wired to it, with the reason, so it is not re-added by accident.

**Cost of the fix, stated honestly.** The optimisation no longer covers `events/restSearch` at all. Predicate-scoping the Event batch was considered and rejected: the harness cannot prove the object and delegation clauses are the *only* divergences between `Event::fetchEvent`'s conditions and `buildConditions`, and guessing wrong there is exactly the class of bug just described.

**Harness honesty.** Of the three ACL-boundary regression cases, case A (Event-driver superset ids, no batch — both sides throw) is vacuous as written, since after the fix both sides call the same single-attribute path. Case C is the one with teeth: it replays the *rejected* behaviour by announcing the superset as a batch, and shows the original's `'Invalid object.'` throw turning into 3 scored attributes. The divergence is reproducible, so the harness would catch a re-added Event batch.

## Testing

- **Lint**: `php -l` (PHP 8.3) clean on all three modified files; `git diff --check` clean (no trailing whitespace on added lines).
- **Benchmark**: standalone PHP 8.3 CLI harness against a MariaDB instance carrying the full MISP schema, mirroring both the original and the patched logic, ACL SQL mirroring `MispAttribute::buildConditions` (object-distribution clause included), min of 5 trials, runs serialized under a lock. Results in [Speedup](#speedup).
- **Correctness assertion**: 9600 attribute results compared between the two paths across 4 `Plugin.Sightings_policy` values x site-admin/not x user org x anonymise on/off — **0 mismatches**.
- **ACL-boundary regression check**: 3 cases (superset ids with no batch; `buildConditions`-filtered ids batched; and the "teeth" case replaying the rejected Event-driver batch) — **0 failures**, with case C reproducing the divergence as expected.
- **No live MISP instance was available**, so there is **no end-to-end testing** of `/attributes/restSearch` with `includeDecayScore` against a running server. The behaviour-preservation argument rests on the verbatim extraction of `listSightings`' tail, the subset argument for the batch, and the harness above. A maintainer sanity-check on a real instance with an enabled `Sightings`-formula decaying model would be very welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

