### PR TITLE
[high] fix: [workflow] Splunk HEC export never sends, and its fix would activate a TLS-verification bypass (#9680)

### DIFF
--- a/app/Model/WorkflowModules/action/Module_splunk_hec_export.php
+++ b/app/Model/WorkflowModules/action/Module_splunk_hec_export.php
@@ -8,7 +8,7 @@ class Module_splunk_hec_export extends Module_webhook
 {
     public $id = 'splunk-hec-export';
     public $name = 'Splunk HEC export';
-    public $version = '0.2';
+    public $version = '0.3';
     public $description = 'Export Event Data to Splunk HTTP Event Collector. Due to the potential high amount of requests, it\'s recommended to put this module after a `concurrent_task` logic module.';
     public $icon_path = 'Splunk.png';
     public $support_filters = false;
@@ -118,10 +118,10 @@ class Module_splunk_hec_export extends Module_webhook
             $splunk_events = $extracted_events;
         }
 
-        return $this->sendToSplunk($splunk_events, $params['hec_token']['value'], $params['url']['value'], $params['source_type']['value']);
+        return $this->sendToSplunk($splunk_events, $params['hec_token']['value'], $params['url']['value'], $params['source_type']['value'], !empty($params['verify_tls']['value']), $errors);
     }
 
-    protected function sendToSplunk(array $splunk_events, $token, $url, $source_type): bool
+    protected function sendToSplunk(array $splunk_events, $token, $url, $source_type, bool $verify_tls = true, array &$errors = []): bool
     {
         foreach ($splunk_events as $splunk_event) {
             try {
@@ -129,7 +129,7 @@ class Module_splunk_hec_export extends Module_webhook
                     'Authorization' => "Splunk {$token}",
                 ];
                 $serverConfig = [
-                    'Server' => ['self_signed' => empty($params['verify_tls']['value'])]
+                    'Server' => ['self_signed' => !$verify_tls]
                 ];
 
                 $hec_event = [
@@ -144,6 +144,7 @@ class Module_splunk_hec_export extends Module_webhook
                     'json',
                     $hec_event,
                     $headers,
+                    'post',
                     $serverConfig
                 );
                 if (!$response->isOk()) {


### PR DESCRIPTION
## BLUF

- **Priority: high.** The `Splunk HEC export` workflow action module (`Module_splunk_hec_export`) has been **100% non-functional** since commit `05714df9d4d51a67ae133db8cd2103312e53ef3b` added a `$requestMethod` parameter to `Module_webhook::doRequest()`. It cannot complete a single send.
- **The visible symptom** is the one reported in #9680: `Undefined variable: response` in `Module_webhook.php`, followed by `Error: Call to a member function isOk() on null`. `sendToSplunk()` passes `$serverConfig` into `doRequest()`'s 5th positional parameter, which is `$requestMethod` — the `switch` matches no case, `$response` is never assigned, and the module fatals before any HTTP request leaves MISP.
- **Hiding behind it is a TLS-verification bypass.** `$serverConfig` is built from an *undefined local* `$params`, so `self_signed` is unconditionally `true` — peer verification off, regardless of the module's own `verify_tls` setting.
- **These are not two independent bugs — they are one bug and its own tripwire.** Fixing only the request method would take the module from "never sends" straight to "sends over an unverified TLS connection". That is why both are fixed in a single PR, and it is the most important thing to understand when reviewing this change.
- **A third defect:** every `$errors[]` inside `sendToSplunk()` writes to an undefined local (`$errors` is `exec()`'s by-reference parameter, not `sendToSplunk()`'s), so all error messages were silently discarded and the user saw a bare failure with no reason.
- **Scope:** one file, 5 changed lines plus a module version bump. `Module_webhook.php` is untouched.

Fixes #9680.

## The three defects

### 1. Argument order — the reported bug

`Module_webhook::doRequest()` is declared:

```php
protected function doRequest($url, $contentType, $data, $headers = [], $requestMethod = 'post', $serverConfig = null)
```

`sendToSplunk()` called it as `doRequest($url, 'json', $hec_event, $headers, $serverConfig)`. The array lands in `$requestMethod`, `switch ($requestMethod)` matches none of `post`/`get`/`put`/`delete`, `$response` is never assigned, and `return $response;` emits the undefined-variable warning before `!$response->isOk()` throws on `null`. `$serverConfig` stays `null` for the whole call.

Fixed by inserting the explicit `'post'` argument.

### 2. Undefined `$params` — a latent TLS-verification bypass

```php
$serverConfig = ['Server' => ['self_signed' => empty($params['verify_tls']['value'])]];
```

`sendToSplunk(array $splunk_events, $token, $url, $source_type)` has no `$params` parameter, and the class property is `$this->params`, so `$params` here is an undefined local. `empty(undefined)` is `true`, so `self_signed` is hardcoded `true` — and per `SyncTool::setupHttpSocket()` (`app/Lib/Tools/SyncTool.php`, lines 24–33) that sets `ssl_allow_self_signed`, `ssl_verify_peer_name = false` and (with no pinned CA) `ssl_verify_peer = false`. The user's `verify_tls` selection was never consulted.

Today this is unreachable because of defect 1. **Fixing defect 1 alone would activate it.**

The fix threads the real value into `sendToSplunk()`:

```php
$this->sendToSplunk(..., !empty($params['verify_tls']['value']), $errors);
...
'Server' => ['self_signed' => !$verify_tls]
```

**On polarity** — `self_signed` means "tolerate a self-signed certificate", so it must be the *negation* of verify_tls being enabled. The chain:

| `verify_tls` param | `!empty(...)` → `$verify_tls` | `self_signed` | `SyncTool` result |
|---|---|---|---|
| `'1'` (the default) | `true` | `false` | nothing relaxed — peer certificate verified |
| `'0'` | `false` | `true` | `ssl_allow_self_signed`, peer/peer-name verification off |

The parameter defaults to `1`, and `WorkflowBaseModule::getParamsWithValues()` falls back to `default` when a saved node has no stored value (`$param['value'] ?? ($param['default'] ?? '')`). So a workflow node saved before this change gets `verify_tls = 1` and therefore verification **on** — the secure direction, not a silent relaxation.

### 3. Dead error reporting

`$errors` is the by-reference parameter of `exec()`, not of `sendToSplunk()`, so `$errors[]` inside `sendToSplunk()` appended to a fresh undefined local that was discarded on return. Fixed by threading `array &$errors = []` through. The new parameters are appended with defaults, so the method signature stays backward compatible.

## Credit and history

The request-method hunk is **PR #9681 by @skalvaro**, verbatim. @Benni0 (the module's original author) diagnosed the regression there, identifying commit `05714df9d4d51a67ae133db8cd2103312e53ef3b` as the cause and asking for a merge. That PR targeted base **`2.4`** and was closed unmerged on 2025-03-17 — which is why the fix never reached `2.5` and #9680 is still open. This PR re-lands it against `2.5`, plus the two defects that sit behind it.

## Testing

Run under the container's PHP 8.3 with a full CakePHP bootstrap against the real `Module_webhook::doRequest()` / `SyncTool` / `HttpSocketExtended` stack (no stubs on the code under test), driving `sendToSplunk()` by reflection. A throwaway Python HTTP listener on a high local port stood in for the HEC endpoint.

**Done:**

- `php -l` — clean.
- **Before the fix, live run against the listener:** `Warning: Undefined variable $response` in `Module_webhook.php`, then `Error: Call to a member function isOk() on null` — exactly the stacktrace in #9680. The listener received **no request at all**, confirming nothing is ever sent.
- **After the fix, live run:** returns `true`, and the listener logged a real request:
  ```
  POST /services/collector/event
    Authorization: Splunk 00000000-0000-0000-000000000000
    Content-Type: application/json
    BODY: {"event":{"Event":{"id":"1","info":"harness event"}},"sourcetype":"misp:event"}
  ```
- **Error threading (defect 3):** pointed the fixed module at a listener path returning HTTP 500 — returns `false` with `errors = ["Something went wrong with the request or the remote side is having issues. Body returned: {\"text\":\"Incorrect index\",\"code\":7}"]`. Before the fix, that array was always empty.
- **Polarity (defect 2):** a subclass overriding `doRequest()` recorded the arguments it actually receives.
  - original module: `requestMethod = {"Server":{"self_signed":true}}`, `serverConfig = null` — the array in the wrong slot, and `self_signed` true regardless of input.
  - fixed, `verify_tls = 1`: `requestMethod = "post"`, `serverConfig = {"Server":{"self_signed":false}}`.
  - fixed, `verify_tls = 0`: `requestMethod = "post"`, `serverConfig = {"Server":{"self_signed":true}}`.

**Not done:**

- No test against a **real Splunk HEC endpoint** — the listener only mimics HEC's response shape (`{"text":"Success","code":0}` / an error code).
- No test over **actual HTTPS**. The polarity is verified at the `self_signed` flag handed to `SyncTool`, and `SyncTool::setupHttpSocket()`'s handling of that flag was read but not exercised with a self-signed certificate end to end.
- **No end-to-end run through the workflow engine** — `exec()` was not driven from a live workflow execution with a real `WorkflowRoamingData`; `sendToSplunk()` was invoked directly, with `exec()`'s argument wiring verified by reading.
- No test of the `data_extraction_model` / `event_per_attribute` paths — untouched by this change.
