### PR TITLE
new: [feed] Add phishunt.io active phishing URLs feed

### DIFF
--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -2505,5 +2505,25 @@
       "exportable": true,
       "hide_tag": false
     }
+  },
+  {
+    "Feed": {
+      "name": "phishunt.io active phishing URLs",
+      "provider": "phishunt.io",
+      "url": "https://phishunt.io/feed.txt",
+      "rules": "",
+      "enabled": false,
+      "distribution": "3",
+      "default": false,
+      "source_format": "freetext",
+      "fixed_event": true,
+      "delta_merge": true,
+      "publish": false,
+      "override_ids": false,
+      "settings": "{\"csv\":{\"value\":\"\",\"delimiter\":\",\"},\"common\":{\"excluderegex\":\"\"}}",
+      "input_source": "network",
+      "delete_local_file": false,
+      "lookup_visible": true
+    }
   }
 ]


### PR DESCRIPTION
#### What does it do?

Adds [phishunt.io](https://phishunt.io) to the default feed metadata.

phishunt.io detects phishing sites in near real time: it watches Certificate Transparency logs, classifies new hostnames against a curated brand roster, scores each candidate (page content, screenshot, hosting and registration signals, third-party corroboration) and publishes the live ones. Data is CC0, no account or key required.

- **Format**: `freetext`, one URL per line at `https://phishunt.io/feed.txt`, same shape as the OpenPhish entry. Refreshed hourly.
- **Population**: active phishing URLs only (about 970 at the time of writing). A URL leaves the feed when the page dies or is taken down, so the entry uses `fixed_event` + `delta_merge`: MISP keeps one event and drops the attributes that are no longer served.
- **Why a default entry**: several MISP instances already pull this feed. Some of them are configured as `source_format: misp` and request `/feed.txt/manifest.json`, which does not exist. A default entry with the right format removes that guess.
- Richer views of the same population (JSON/CSV with brand, IP, ASN, country, certificate, score and source flags, STIX bundle, DNS blocklists) are documented at https://phishunt.io/api/ for anyone who wants more than the URL list.
- The entry is `enabled: false` / `default: false`, like the other community feeds.

#### Questions

- [ ] Does it require a DB change? - **No**
- [ ] Are you using it in production? - **Yes**, it is the feed I publish
- [ ] Does it require a change in the API (PyMISP for example)? - **No**
