### PR TITLE
[medium] new: [correlation] add host-aware advanced correlations

### DIFF
--- a/app/Lib/Tools/CorrelationHostTool.php
+++ b/app/Lib/Tools/CorrelationHostTool.php
@@ -1,0 +1,239 @@
+<?php
+
+class CorrelationHostTool
+{
+    const DOMAIN_TYPES = [
+        'domain',
+        'hostname',
+        'domain|ip',
+        'hostname|port',
+    ];
+
+    const IP_TYPES = [
+        'ip-src',
+        'ip-dst',
+        'ip-src|port',
+        'ip-dst|port',
+    ];
+
+    const URL_TYPE = 'url';
+
+    public static function supportedTypes()
+    {
+        return array_merge(
+            self::DOMAIN_TYPES,
+            self::IP_TYPES,
+            [self::URL_TYPE]
+        );
+    }
+
+    public static function supportsType($type)
+    {
+        return in_array($type, self::supportedTypes(), true);
+    }
+
+    /**
+     * Return the value shared by two host-related attributes.
+     *
+     * Exact non-URL values are handled by MISP's normal correlation path.
+     * This method only returns relationships added by host-aware matching.
+     *
+     * @param array $source Simple Attribute array
+     * @param array $target Simple Attribute array
+     * @return string|null
+     */
+    public static function correlationValue(array $source, array $target)
+    {
+        if (!self::supportsType($source['type']) ||
+            !self::supportsType($target['type'])) {
+            return null;
+        }
+
+        $sourceIsUrl = $source['type'] === self::URL_TYPE;
+        $targetIsUrl = $target['type'] === self::URL_TYPE;
+        if ($sourceIsUrl && $targetIsUrl) {
+            return null;
+        }
+
+        foreach (self::extractHostTokens($source) as $sourceToken) {
+            foreach (self::extractHostTokens($target) as $targetToken) {
+                if ($sourceToken['kind'] !== $targetToken['kind']) {
+                    continue;
+                }
+
+                if ($sourceToken['kind'] === 'ip') {
+                    if (($sourceIsUrl || $targetIsUrl) &&
+                        $sourceToken['value'] === $targetToken['value']) {
+                        return $sourceToken['value'];
+                    }
+                    continue;
+                }
+
+                $matchingDomain = self::matchingDomain(
+                    $sourceToken['value'],
+                    $targetToken['value']
+                );
+                if ($matchingDomain === null) {
+                    continue;
+                }
+
+                if ($sourceIsUrl || $targetIsUrl ||
+                    $sourceToken['value'] !== $targetToken['value']) {
+                    return $matchingDomain;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Extract normalized DNS names and IP addresses represented by an
+     * Attribute. URL values contribute only their parsed host component.
+     *
+     * @param array $attribute Simple Attribute array
+     * @return array
+     */
+    public static function extractHostTokens(array $attribute)
+    {
+        $type = $attribute['type'];
+        $value1 = $attribute['value1'] ?? '';
+        $value2 = $attribute['value2'] ?? '';
+
+        if ($type === self::URL_TYPE) {
+            $host = self::extractUrlHost($value1);
+            return $host === null ? [] : [self::makeToken($host)];
+        }
+
+        if (in_array($type, self::IP_TYPES, true)) {
+            $host = self::normalizeHost($value1);
+            return self::isIp($host) ? [self::makeToken($host)] : [];
+        }
+
+        if (!in_array($type, self::DOMAIN_TYPES, true)) {
+            return [];
+        }
+
+        $tokens = [];
+        $host = self::normalizeHost($value1);
+        if ($host !== null && !self::isIp($host)) {
+            $tokens[] = self::makeToken($host);
+        }
+        if ($type === 'domain|ip') {
+            $ip = self::normalizeHost($value2);
+            if (self::isIp($ip)) {
+                $tokens[] = self::makeToken($ip);
+            }
+        }
+        return $tokens;
+    }
+
+    /**
+     * Values used to find a small candidate set before exact PHP matching.
+     *
+     * @param array $attribute Simple Attribute array
+     * @return array
+     */
+    public static function candidateSearchValues(array $attribute)
+    {
+        $values = [];
+        foreach (self::extractHostTokens($attribute) as $token) {
+            $values[] = $token['value'];
+            if ($token['kind'] === 'domain') {
+                $values = array_merge(
+                    $values,
+                    self::parentDomains($token['value'])
+                );
+            }
+        }
+        return array_values(array_unique($values));
+    }
+
+    private static function extractUrlHost($url)
+    {
+        $url = trim($url);
+        if ($url === '') {
+            return null;
+        }
+
+        $host = @parse_url($url, PHP_URL_HOST);
+        if ($host === null &&
+            !preg_match('/^[a-z][a-z0-9+.-]*:/i', $url)) {
+            $host = @parse_url('//' . ltrim($url, '/'), PHP_URL_HOST);
+        }
+        if (!is_string($host)) {
+            return null;
+        }
+        return self::normalizeHost($host);
+    }
+
+    private static function normalizeHost($host)
+    {
+        if (!is_string($host)) {
+            return null;
+        }
+        $host = trim($host);
+        if (strlen($host) > 1 && $host[0] === '[' &&
+            substr($host, -1) === ']') {
+            $host = substr($host, 1, -1);
+        }
+        $host = strtolower(rtrim($host, '.'));
+        if ($host === '') {
+            return null;
+        }
+
+        if (filter_var($host, FILTER_VALIDATE_IP)) {
+            $binary = @inet_pton($host);
+            return $binary === false ? $host : inet_ntop($binary);
+        }
+
+        if (strlen($host) > 253 ||
+            preg_match('/[\s\/@\[\]]/', $host)) {
+            return null;
+        }
+        return $host;
+    }
+
+    private static function makeToken($host)
+    {
+        return [
+            'kind' => self::isIp($host) ? 'ip' : 'domain',
+            'value' => $host,
+        ];
+    }
+
+    private static function isIp($host)
+    {
+        return is_string($host) &&
+            filter_var($host, FILTER_VALIDATE_IP) !== false;
+    }
+
+    private static function matchingDomain($first, $second)
+    {
+        if ($first === $second) {
+            return $first;
+        }
+        if (self::isSubdomain($first, $second)) {
+            return $second;
+        }
+        if (self::isSubdomain($second, $first)) {
+            return $first;
+        }
+        return null;
+    }
+
+    private static function isSubdomain($candidate, $parent)
+    {
+        return str_ends_with($candidate, '.' . $parent);
+    }
+
+    private static function parentDomains($host)
+    {
+        $labels = explode('.', $host);
+        $parents = [];
+        while (count($labels) > 2) {
+            array_shift($labels);
+            $parents[] = implode('.', $labels);
+        }
+        return $parents;
+    }
+}

--- a/app/Model/Correlation.php
+++ b/app/Model/Correlation.php
@@ -1,5 +1,6 @@
 <?php
 App::uses('AppModel', 'Model');
+App::uses('CorrelationHostTool', 'Tools');
 
 /**
  * @property MispAttribute $Attribute
@@ -314,25 +315,172 @@ class Correlation extends AppModel
         if (!$this->advancedCorrelationEnabled) {
             return [];
         }
-        $extraConditions = $this->__buildAdvancedCorrelationConditions($correlatingAttribute);
-        if (empty($extraConditions)) {
+        $extraConditions = $this->__buildAdvancedCorrelationConditions(
+            $correlatingAttribute
+        );
+        $correlations = [];
+        if (!empty($extraConditions)) {
+            $correlations = $this->Attribute->find('all', [
+                'conditions' => [
+                    'AND' => $extraConditions,
+                    'NOT' => [
+                        'Attribute.type' =>
+                            MispAttribute::NON_CORRELATING_TYPES,
+                    ],
+                    'Attribute.disable_correlation' => 0,
+                    'Event.disable_correlation' => 0,
+                    'Attribute.deleted' => 0
+                ],
+                'recursive' => -1,
+                'fields' => $this->getFieldRules(),
+                'contain' => $this->getContainRules(),
+                'order' => [],
+            ]);
+        }
+        return array_merge(
+            $correlations,
+            $this->__findHostCorrelations($correlatingAttribute)
+        );
+    }
+
+    /**
+     * Find candidate attributes that share a DNS or IP host relationship.
+     * SQL narrows the candidate set; CorrelationHostTool performs the exact
+     * structural check so values in URL paths, queries, or user-info do not
+     * correlate.
+     *
+     * @param array $attribute Attribute and optional Event/Object data
+     * @param array $conditions Additional target Attribute conditions
+     * @return array
+     */
+    private function __findHostCorrelations(
+        array $attribute,
+        array $conditions = []
+    ) {
+        if (!CorrelationHostTool::supportsType(
+            $attribute['Attribute']['type']
+        )) {
             return [];
         }
-        return $this->Attribute->find('all', [
-            'conditions' => [
-                'AND' => $extraConditions,
-                'NOT' => [
-                    'Attribute.type' => MispAttribute::NON_CORRELATING_TYPES,
-                ],
-                'Attribute.disable_correlation' => 0,
-                'Event.disable_correlation' => 0,
-                'Attribute.deleted' => 0
-            ],
+
+        $searchValues = CorrelationHostTool::candidateSearchValues(
+            $attribute['Attribute']
+        );
+        if (empty($searchValues)) {
+            return [];
+        }
+
+        $valueConditions = [];
+        foreach ($searchValues as $searchValue) {
+            $escapedSearchValue = addcslashes($searchValue, '\\%_');
+            $valueConditions[] = [
+                'Attribute.value1 LIKE' =>
+                    '%' . $escapedSearchValue . '%',
+            ];
+            $valueConditions[] = ['Attribute.value2' => $searchValue];
+        }
+        $baseConditions = [
+            'Attribute.type' => CorrelationHostTool::supportedTypes(),
+            'Attribute.disable_correlation' => 0,
+            'Event.disable_correlation' => 0,
+            'Attribute.deleted' => 0,
+            'OR' => $valueConditions,
+        ];
+        if (!empty($conditions)) {
+            $baseConditions = ['AND' => [$baseConditions, $conditions]];
+        }
+
+        $candidates = $this->Attribute->find('all', [
+            'conditions' => $baseConditions,
             'recursive' => -1,
             'fields' => $this->getFieldRules(),
             'contain' => $this->getContainRules(),
             'order' => [],
         ]);
+
+        $matches = [];
+        foreach ($candidates as $candidate) {
+            $value = CorrelationHostTool::correlationValue(
+                $attribute['Attribute'],
+                $candidate['Attribute']
+            );
+            if ($value === null ||
+                $this->__preventExcludedCorrelations($value)) {
+                continue;
+            }
+            $candidate['AdvancedCorrelation']['value'] = $value;
+            $matches[] = $candidate;
+        }
+        return $matches;
+    }
+
+    /**
+     * @param array $attribute Attribute and optional Event/Object data
+     * @param bool $full Whether a full re-correlation is running
+     * @return array
+     */
+    private function __buildHostCorrelationEntries(array $attribute, $full)
+    {
+        if (!$this->advancedCorrelationEnabled ||
+            !CorrelationHostTool::supportsType(
+                $attribute['Attribute']['type']
+            )) {
+            return [];
+        }
+
+        $conditions = [
+            'Attribute.event_id !=' => $attribute['Attribute']['event_id'],
+        ];
+        if ($full) {
+            $conditions['Attribute.id >'] = $attribute['Attribute']['id'];
+        }
+        $conditions = $this->CorrelationRule->attachCustomCorrelationRules(
+            $attribute,
+            $conditions
+        );
+        $matches = $this->__findHostCorrelations($attribute, $conditions);
+        $matchesByValue = [];
+        foreach ($matches as $match) {
+            $value = $match['AdvancedCorrelation']['value'];
+            $matchesByValue[$value][] = $match;
+        }
+
+        $correlations = [];
+        $correlationLimit = $this->OverCorrelatingValue->getLimit();
+        foreach ($matchesByValue as $value => $valueMatches) {
+            if ($full && $this->OverCorrelatingValue->isBlocked($value)) {
+                continue;
+            }
+            if (count($valueMatches) > $correlationLimit) {
+                $this->OverCorrelatingValue->block($value);
+                continue;
+            }
+            if (!$full &&
+                !isset(
+                    $attribute['Attribute']['skip_overcorrelation_unblock']
+                )) {
+                $this->OverCorrelatingValue->unblock($value);
+            }
+
+            foreach ($valueMatches as $match) {
+                unset($match['AdvancedCorrelation']);
+                if ($attribute['Attribute']['id'] >
+                    $match['Attribute']['id']) {
+                    $correlations[] = $this->createCorrelationEntry(
+                        $value,
+                        $attribute,
+                        $match
+                    );
+                } else {
+                    $correlations[] = $this->createCorrelationEntry(
+                        $value,
+                        $match,
+                        $attribute
+                    );
+                }
+            }
+        }
+        return $correlations;
     }
 
     private function __getMatchingAttributes($value)
@@ -397,7 +545,15 @@ class Correlation extends AppModel
                     if ($correlatingAttribute['Attribute']['event_id'] === $extraCorrelation['Attribute']['event_id']) {
                         continue;
                     }
-                    $correlations[] = $this->createCorrelationEntry($value, $correlatingAttribute, $extraCorrelation);
+                    $correlationValue =
+                        $extraCorrelation['AdvancedCorrelation']['value'] ??
+                        $value;
+                    unset($extraCorrelation['AdvancedCorrelation']);
+                    $correlations[] = $this->createCorrelationEntry(
+                        $correlationValue,
+                        $correlatingAttribute,
+                        $extraCorrelation
+                    );
                     //$correlations = $this->createCorrelationEntry($value, $extraCorrelation, $correlatingAttribute, $correlations);
                 }
             }
@@ -611,6 +767,10 @@ class Correlation extends AppModel
                 }
             }
         }
+        $correlations = array_merge(
+            $correlations,
+            $this->__buildHostCorrelationEntries($a, $full)
+        );
         if (empty($correlations)) {
             return true;
         }

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -5855,7 +5855,13 @@ class Server extends AppModel
                 ],
                 'enable_advanced_correlations' => [
                     'level' => 0,
-                    'description' => __('Enable some performance heavy correlations (currently CIDR correlation)'),
+                    'description' => __(
+                        'Enable performance heavy correlations, including ' .
+                        'CIDR and fuzzy hash matching, plus host ' .
+                        'relationships between domains, hostnames, URLs ' .
+                        'and IP addresses. Advanced correlations are not ' .
+                        'available with the On Demand engine.'
+                    ),
                     'value' => false,
                     'test' => 'testBool',
                     'type' => 'boolean',

--- a/app/Test/CorrelationHostToolTest.php
+++ b/app/Test/CorrelationHostToolTest.php
@@ -1,0 +1,225 @@
+<?php
+require_once __DIR__ . '/../Lib/Tools/CorrelationHostTool.php';
+
+use PHPUnit\Framework\TestCase;
+
+class CorrelationHostToolTest extends TestCase
+{
+    public function testDomainCorrelatesWithSubdomain(): void
+    {
+        $domain = $this->makeAttribute('domain', 'example.com');
+        $hostname = $this->makeAttribute('hostname', 'c2.example.com');
+
+        $this->assertSame(
+            'example.com',
+            CorrelationHostTool::correlationValue($domain, $hostname)
+        );
+        $this->assertSame(
+            'example.com',
+            CorrelationHostTool::correlationValue($hostname, $domain)
+        );
+    }
+
+    public function testExactDomainMatchIsLeftToNormalCorrelation(): void
+    {
+        $domain = $this->makeAttribute('domain', 'example.com');
+        $hostname = $this->makeAttribute('hostname', 'example.com');
+
+        $this->assertNull(
+            CorrelationHostTool::correlationValue($domain, $hostname)
+        );
+    }
+
+    public function testDomainMatchRequiresDnsLabelBoundary(): void
+    {
+        $domain = $this->makeAttribute('domain', 'example.com');
+        $lookalike = $this->makeAttribute('hostname', 'notexample.com');
+
+        $this->assertNull(
+            CorrelationHostTool::correlationValue($domain, $lookalike)
+        );
+    }
+
+    public function testDomainCorrelatesWithUrlHost(): void
+    {
+        $domain = $this->makeAttribute('domain', 'example.com');
+        $url = $this->makeAttribute(
+            'url',
+            'https://User:Pass@C2.Example.COM.:8443/download'
+        );
+
+        $this->assertSame(
+            'example.com',
+            CorrelationHostTool::correlationValue($domain, $url)
+        );
+        $this->assertSame(
+            'example.com',
+            CorrelationHostTool::correlationValue($url, $domain)
+        );
+    }
+
+    public function testSchemeLessUrlHostCorrelates(): void
+    {
+        $hostname = $this->makeAttribute('hostname', 'c2.example.com');
+        $url = $this->makeAttribute('url', 'c2.example.com/download');
+
+        $this->assertSame(
+            'c2.example.com',
+            CorrelationHostTool::correlationValue($url, $hostname)
+        );
+    }
+
+    public function testDomainInUrlPathDoesNotCorrelate(): void
+    {
+        $domain = $this->makeAttribute('domain', 'example.com');
+        $url = $this->makeAttribute(
+            'url',
+            'https://unrelated.test/path/example.com'
+        );
+
+        $this->assertNull(
+            CorrelationHostTool::correlationValue($domain, $url)
+        );
+    }
+
+    public function testDomainInUrlQueryDoesNotCorrelate(): void
+    {
+        $domain = $this->makeAttribute('domain', 'example.com');
+        $url = $this->makeAttribute(
+            'url',
+            'https://unrelated.test/?redirect=https://example.com/'
+        );
+
+        $this->assertNull(
+            CorrelationHostTool::correlationValue($domain, $url)
+        );
+    }
+
+    public function testDomainInUrlUserInfoDoesNotCorrelate(): void
+    {
+        $domain = $this->makeAttribute('domain', 'example.com');
+        $url = $this->makeAttribute(
+            'url',
+            'https://example.com@unrelated.test/download'
+        );
+
+        $this->assertNull(
+            CorrelationHostTool::correlationValue($domain, $url)
+        );
+    }
+
+    public function testIpv4CorrelatesWithUrlHost(): void
+    {
+        $ip = $this->makeAttribute('ip-dst', '192.0.2.42');
+        $url = $this->makeAttribute('url', 'https://192.0.2.42:8443/a');
+
+        $this->assertSame(
+            '192.0.2.42',
+            CorrelationHostTool::correlationValue($ip, $url)
+        );
+        $this->assertSame(
+            '192.0.2.42',
+            CorrelationHostTool::correlationValue($url, $ip)
+        );
+    }
+
+    public function testPortCompositesCorrelateByHostOnly(): void
+    {
+        $hostname = $this->makeAttribute(
+            'hostname|port',
+            'c2.example.com',
+            '443'
+        );
+        $ip = $this->makeAttribute('ip-dst|port', '192.0.2.42', '443');
+        $hostnameUrl = $this->makeAttribute(
+            'url',
+            'https://c2.example.com:8443/a'
+        );
+        $ipUrl = $this->makeAttribute('url', 'https://192.0.2.42:8443/a');
+
+        $this->assertSame(
+            'c2.example.com',
+            CorrelationHostTool::correlationValue($hostname, $hostnameUrl)
+        );
+        $this->assertSame(
+            '192.0.2.42',
+            CorrelationHostTool::correlationValue($ip, $ipUrl)
+        );
+    }
+
+    public function testIpInUrlPathDoesNotCorrelate(): void
+    {
+        $ip = $this->makeAttribute('ip-src', '192.0.2.42');
+        $url = $this->makeAttribute(
+            'url',
+            'https://unrelated.test/192.0.2.42'
+        );
+
+        $this->assertNull(
+            CorrelationHostTool::correlationValue($ip, $url)
+        );
+    }
+
+    public function testIpv6FormsAreCanonicalized(): void
+    {
+        $ip = $this->makeAttribute('ip-src', '2001:0db8:0:0:0:0:0:1');
+        $url = $this->makeAttribute('url', 'https://[2001:db8::1]/a');
+
+        $this->assertSame(
+            '2001:db8::1',
+            CorrelationHostTool::correlationValue($ip, $url)
+        );
+    }
+
+    public function testDomainIpCanCorrelateByEitherComponent(): void
+    {
+        $domainIp = $this->makeAttribute(
+            'domain|ip',
+            'example.com',
+            '192.0.2.42'
+        );
+        $domainUrl = $this->makeAttribute(
+            'url',
+            'https://c2.example.com/a'
+        );
+        $ipUrl = $this->makeAttribute('url', 'https://192.0.2.42/a');
+
+        $this->assertSame(
+            'example.com',
+            CorrelationHostTool::correlationValue($domainIp, $domainUrl)
+        );
+        $this->assertSame(
+            '192.0.2.42',
+            CorrelationHostTool::correlationValue($domainIp, $ipUrl)
+        );
+    }
+
+    public function testUrlsDoNotCorrelateDirectlyByHost(): void
+    {
+        $first = $this->makeAttribute('url', 'https://example.com/one');
+        $second = $this->makeAttribute('url', 'https://example.com/two');
+
+        $this->assertNull(
+            CorrelationHostTool::correlationValue($first, $second)
+        );
+    }
+
+    public function testCandidateValuesContainParentDomains(): void
+    {
+        $url = $this->makeAttribute('url', 'https://a.b.example.com/path');
+
+        $this->assertSame(
+            ['a.b.example.com', 'b.example.com', 'example.com'],
+            CorrelationHostTool::candidateSearchValues($url)
+        );
+    }
+
+    private function makeAttribute($type, $value1, $value2 = '')
+    {
+        return [
+            'type' => $type,
+            'value1' => $value1,
+            'value2' => $value2,
+        ];
+    }
+}

--- a/tests/testlive_comprehensive_local.py
+++ b/tests/testlive_comprehensive_local.py
@@ -600,6 +600,62 @@ class TestComprehensive(unittest.TestCase):
                 for event in (first, second):
                     check_response(self.admin_misp_connector.delete_event(event))
 
+    def test_advanced_host_correlations(self):
+        identifier = gen_random_id()
+        domain = f"advanced-{identifier}.example.com"
+        hostname = f"c2.{domain}"
+        ip = f"192.0.2.{int(identifier[:2], 16) % 254 + 1}"
+        events = []
+
+        with MISPSetting(
+            self.admin_misp_connector,
+            {"MISP.enable_advanced_correlations": True},
+        ):
+            values = (
+                (
+                    "url",
+                    f"https://unrelated.invalid/{domain}?address={ip}",
+                ),
+                ("domain", domain),
+                ("hostname", hostname),
+                ("url", f"https://{hostname}:8443/download"),
+                ("ip-dst", ip),
+                ("url", f"https://{ip}/payload"),
+            )
+            try:
+                for attribute_type, value in values:
+                    event = create_simple_event()
+                    event.add_attribute(attribute_type, value)
+                    events.append(
+                        check_response(
+                            self.admin_misp_connector.add_event(event)
+                        )
+                    )
+
+                events = [
+                    check_response(
+                        self.admin_misp_connector.get_event(event)
+                    )
+                    for event in events
+                ]
+                related_counts = [
+                    len(getattr(event, "RelatedEvent", []))
+                    for event in events
+                ]
+                self.assertEqual([0, 2, 2, 2, 1, 1], related_counts)
+            finally:
+                for event in events:
+                    check_response(
+                        self.admin_misp_connector.delete_event(event)
+                    )
+
+    def test_advanced_host_correlations_noacl(self):
+        with MISPSetting(
+            self.admin_misp_connector,
+            {"MISP.correlation_engine": "NoAcl"},
+        ):
+            self.test_advanced_host_correlations()
+
     def test_remove_orphaned_correlations(self):
         result = self.admin_misp_connector._check_response(self.admin_misp_connector._prepare_request('POST', 'servers/removeOrphanedCorrelations'))
         check_response(result)


### PR DESCRIPTION
## Summary

- Correlate parent domains with their hostnames and subdomains.
- Correlate domain/hostname attributes with the parsed host of URL attributes.
- Correlate IP attributes with exact IP-literal URL hosts, including bracketed IPv6.
- Support domain|ip, hostname|port, ip-src|port, and ip-dst|port attributes.
- Keep URL-to-URL host matching disabled to avoid broadening existing URL semantics.

## Implementation

The database query only identifies likely candidates. CorrelationHostTool then parses URL hosts and performs exact structural matching, preventing false positives from URL paths, queries, and user-info. Host-aware matching is gated by MISP.enable_advanced_correlations and is skipped by the On Demand engine, consistent with the existing advanced-correlation behavior.

The normal correlation exclusions, custom correlation rules, disabled/deleted state, and over-correlation limit are applied. No schema change is required and the feature remains disabled by default.

## Tests

- CorrelationHostToolTest: 15 tests, 20 assertions passing.
- PHP syntax checks pass for all changed PHP files.
- Python live-test module compiles successfully.
- Live integration coverage was added for the Default and NoAcl engines; it was not executed locally because the available live MISP instance was not built from this branch.