### PR TITLE
[medium] fix: [correlation] compare IPv6 CIDRs as binary ranges

### DIFF
--- a/app/Model/Correlation.php
+++ b/app/Model/Correlation.php
@@ -732,14 +732,17 @@ class Correlation extends AppModel
                         $conditions['value1 LIKE'] = $prefix . '%';
                     }
                 } else {
+                    list($startIp, $endIp) = $this->__ipv6CidrRange(
+                        $networkIp,
+                        $mask
+                    );
+                    // Text prefixes are unsafe because IPv6 zero compression
+                    // can produce different strings for addresses in a CIDR.
                     $conditions[] = 'IS_IPV6(value1)';
-                    // Just fetch IPv6 address that starts with given prefix. This is fast, because value1 is indexed.
-                    if ($mask >= 16) {
-                        $ipv6Parts = explode(':', rtrim($networkIp, ':'));
-                        $ipv6Parts = array_slice($ipv6Parts, 0, intval($mask / 16));
-                        $prefix = implode(':', $ipv6Parts);
-                        $conditions['value1 LIKE'] = $prefix . '%';
-                    }
+                    $conditions[
+                        'INET6_ATON(value1) BETWEEN INET6_ATON(?) ' .
+                        'AND INET6_ATON(?)'
+                    ] = [$startIp, $endIp];
                 }
             }
 
@@ -798,6 +801,36 @@ class Correlation extends AppModel
         $mask = -1 << (32 - $bits);
         $subnet &= $mask; # nb: in case the supplied subnet wasn't correctly aligned
         return ($ip & $mask) == $subnet;
+    }
+
+    /**
+     * @param string $ip IPv6 network address
+     * @param int $mask CIDR prefix length
+     * @return array First and last address in the range
+     */
+    private function __ipv6CidrRange($ip, $mask)
+    {
+        $packedIp = inet_pton($ip);
+        $startIp = $endIp = $packedIp;
+        $mask = (int)$mask;
+        $wholeBytes = intdiv($mask, 8);
+        $remainingBits = $mask % 8;
+
+        for ($index = $wholeBytes; $index < 16; $index++) {
+            if ($index === $wholeBytes && $remainingBits !== 0) {
+                $byteMask = (0xff << (8 - $remainingBits)) & 0xff;
+                $networkByte = ord($packedIp[$index]) & $byteMask;
+                $startIp[$index] = chr($networkByte);
+                $endIp[$index] = chr(
+                    $networkByte | ($byteMask ^ 0xff)
+                );
+            } else {
+                $startIp[$index] = "\x00";
+                $endIp[$index] = "\xff";
+            }
+        }
+
+        return [inet_ntop($startIp), inet_ntop($endIp)];
     }
 
     // Using solution from https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/IpUtils.php

--- a/tests/testlive_comprehensive_local.py
+++ b/tests/testlive_comprehensive_local.py
@@ -578,27 +578,55 @@ class TestComprehensive(unittest.TestCase):
             self.test_recorrelate()
 
     def test_advanced_correlations(self):
-        with MISPSetting(self.admin_misp_connector, {"MISP.enable_advanced_correlations": True}):
-            first = create_simple_event()
-            first.add_attribute("ip-src", "10.0.0.0/8")
-            first = check_response(self.admin_misp_connector.add_event(first))
+        identifier = gen_random_id()
+        network = int(identifier[:4], 16) or 1
+        host = int(identifier[4:], 16) or 1
+        values = (
+            "10.0.0.0/8",
+            "10.0.0.1",
+            f"2001:0:0:{network:x}:abcd:ef01:2345:{host:x}",
+            f"2001:0:0:{network:x}::/64",
+            f"2001:db8:{network:x}:1::/64",
+            f"2001:db8:{network:x}:1::1",
+            f"2001:db8:{network:x}:2:8000::1",
+            f"2001:db8:{network:x}:2:7fff:ffff:ffff:ffff",
+            f"2001:db8:{network:x}:2:8000::/65",
+        )
+        events = []
 
-            second = create_simple_event()
-            second.add_attribute("ip-src", "10.0.0.1")
-            second = check_response(self.admin_misp_connector.add_event(second))
-
-            # Reload to get event data with related events
-            first = check_response(self.admin_misp_connector.get_event(first))
-
+        with MISPSetting(
+            self.admin_misp_connector,
+            {"MISP.enable_advanced_correlations": True},
+        ):
             try:
-                self.assertEqual(1, len(first.RelatedEvent), first.RelatedEvent)
-                self.assertEqual(1, len(second.RelatedEvent), second.RelatedEvent)
-            except:
-                raise
+                for value in values:
+                    event = create_simple_event()
+                    event.add_attribute("ip-src", value)
+                    events.append(
+                        check_response(
+                            self.admin_misp_connector.add_event(event)
+                        )
+                    )
+
+                events = [
+                    check_response(
+                        self.admin_misp_connector.get_event(event)
+                    )
+                    for event in events
+                ]
+                related_counts = [
+                    len(getattr(event, "RelatedEvent", []))
+                    for event in events
+                ]
+                self.assertEqual(
+                    [1, 1, 1, 1, 1, 1, 1, 0, 1],
+                    related_counts,
+                )
             finally:
-                # Delete events
-                for event in (first, second):
-                    check_response(self.admin_misp_connector.delete_event(event))
+                for event in events:
+                    check_response(
+                        self.admin_misp_connector.delete_event(event)
+                    )
 
     def test_remove_orphaned_correlations(self):
         result = self.admin_misp_connector._check_response(self.admin_misp_connector._prepare_request('POST', 'servers/removeOrphanedCorrelations'))


### PR DESCRIPTION
## Problem

The MariaDB/MySQL candidate query for IPv6 CIDR correlations uses a textual value1 LIKE prefix. IPv6 zero compression makes that unsafe: a CIDR such as 2001:0:0:1::/64 and an in-range address such as 2001::1:abcd:ef01:2345:6789 have different text prefixes. When the plain IP already exists and the CIDR is added later, the candidate is discarded before the correct binary PHP containment check runs.

## Fix

Compute the first and last packed IPv6 address for the CIDR and filter candidates with INET6_ATON(value1) BETWEEN INET6_ATON(start) AND INET6_ATON(end). The existing PHP bit-mask check remains as the final verification. This handles compressed, expanded, aligned, and non-byte-aligned IPv6 ranges without a schema change. The non-MySQL path is unchanged.

## Tests

- Expanded the live advanced-correlation test to cover IPv4 and IPv6.
- Covers plain-IP-first and CIDR-first insertion orders.
- Reproduces the zero-compression mismatch that the previous LIKE filter misses.
- Covers an in-range and out-of-range address around a /65 boundary.
- PHP syntax and Python AST checks pass.
- Exercised the range helper for /0, /64, /65, and /128.
- Verified the generated binary predicate against MariaDB 10.11 with compressed and expanded values.