### PR TITLE
fix: [events] fix broken event graph loading

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -74,7 +74,7 @@ class EventsController extends AppController
         // Posted by hand-built AJAX (the UiBeta publish toggle, the collections
         // panel), which sends the CSRF token as a header. None of the three take
         // body fields a form hash would protect.
-        $this->_csrfTokenHeaderOnly(['publish', 'unpublish', 'restSearch']);
+        $this->_csrfTokenHeaderOnly(['publish', 'unpublish', 'restSearch','getEventGraphReferences','getEventGraphTags','getEventGraphGeneric']);
 
         // if not admin or own org, check private as well..
         if (!$this->_isSiteAdmin() && in_array($this->request->action, ['index', 'proposalEventIndex'], true)) {

--- a/app/webroot/js/event-graph.js
+++ b/app/webroot/js/event-graph.js
@@ -1482,6 +1482,7 @@ class DataHandler {
                 type: 'post',
                 contentType: 'application/json',
                 data: JSON.stringify( payload ),
+                headers: {'X-CSRF-Token': (window.csrfToken || '')},
                 processData: false,
                 success: function( data, textStatus, jQxhr ){
                     if (updateOnly === undefined || updateOnly === false) {
@@ -1515,6 +1516,8 @@ class DataHandler {
                     }
                 },
                 error: function( jqXhr, textStatus, errorThrown ){
+                    eventGraph.network_loading(false, "");
+                    showMessage('fail', 'Could not fetch the event graph data');
                     console.log( errorThrown );
                 }
             });


### PR DESCRIPTION
#### What does it do?

2 things:
1. fixes #11098 : Event graph is currently broken, it doesn't load as you get a "bad request" error for the ajax request. This seems to be due to the recent security hardening. Adding actions to _csrfTokenHeaderOnly and sending csrftoken on the request seems to do the trick.
2. Adds an error message when the load fails. It was just giving an endless "Fetching data" otherwise.

##### Executed tests
Verified both fixes manually on a live instance afterwards.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
