### PR TITLE
fix: [UI:events index] correctly set index filter when trashing is_ex…

### DIFF
--- a/app/webroot/js/misp.js
+++ b/app/webroot/js/misp.js
@@ -2722,9 +2722,9 @@ function indexFilterClearRow(field) {
         filtering.published = 2;
     } else if (field == "hasproposal") {
         filtering.hasproposal = 2;
-    } else if (field == "extending") {
+    } else if (field == "is_extension") {
         filtering.is_extension = 2;
-    } else if (field == "extended") {
+    } else if (field == "is_extended") {
         filtering.is_extended = 2;
     } else if (differentFilters.indexOf(field) != -1) {
         filtering[field] = "";


### PR DESCRIPTION
…tension or is_extended filter

#### What does it do?

Fixes an issue where UI didn't properly reload event index when you trashed the is_extending or is_extended filter.

<img width="1157" height="556" alt="image" src="https://github.com/user-attachments/assets/23af6b2e-80eb-4ab9-8e52-698d9f18257d" />

#### Tests executed
Manually verified after.

**Before**
When you click the trash icon -> filter becomes empty string, which causes an issue, event index filters out things it shouldn't after apply

**After**
When you click the trash icon -> filter is fully unset, event index is properly reloaded on apply

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
