### PR TITLE
fix: [eventReport] correctly allow pasting of pictures from clipboard…

### DIFF
--- a/app/webroot/js/markdownEditor/event-report.js
+++ b/app/webroot/js/markdownEditor/event-report.js
@@ -176,7 +176,7 @@ function pasteImg(cm, event) {
         const $checkboxLabel = $('<label for="checkboxSaveAsAttachment">').text('Save the picture as an attachment (create an Attribute).')
         if (!isUserSiteAdmin) {
             $checkbox.prop('disabled', true)
-            $checkboxLabel.css('cursor', 'not-allowed').title('You must be a site-admin to use local instance picture.')
+            $checkboxLabel.css('cursor', 'not-allowed').attr('title', 'You must be a site-admin to use local instance picture.')
         }
         const $checkboxContainer = $('<div>').addClass('checkbox').append(
             $checkbox,


### PR DESCRIPTION
… into event reports, as non site-admin

#### What does it do?

Fixes a regression issue introduced in https://github.com/MISP/MISP/commit/ea0e1e8227535201d7e8b60855de222b09f14c37 

Makes it possible for non site-admins to paste images into event reports again.

<img width="1102" height="882" alt="image" src="https://github.com/user-attachments/assets/c5c81640-bc1c-4bba-86d4-2bed31ba398d" />

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
