### PR TITLE
fix: [sync] fix custom galaxy cluster sync on Server:push.

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -945,6 +945,7 @@ class Event extends AppModel
         if (!isset($server['Server']['internal'])) {
             throw new InvalidArgumentException('Invalid Server array provided.');
         }
+        $this->Server = ClassRegistry::init('Server');
 
         // This check is probably redundant, because it should be checked in also in `checkDistributionForPush`
         // But keep it here just for sure

--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -1302,7 +1302,7 @@ class Server extends AppModel
 
             // sync custom galaxy clusters if user is capable
             if ($push['canEditGalaxyCluster'] && $server['Server']['push_galaxy_clusters'] && "full" == $technique) {
-                $clustersSuccesses = $this->syncGalaxyClusters($serverSync, $this->data, $user, $technique='full');
+                $clustersSuccesses = $this->syncGalaxyClusters($serverSync, $server, $user, $technique='full');
             } else {
                 $clustersSuccesses = array();
             }
@@ -1380,13 +1380,14 @@ class Server extends AppModel
 
                     // Check if remote server supports galaxy cluster push, is set to push and if event will be pushed to
                     // server
+                    $reason = null;
                     $pushGalaxyClustersForEvent = $push['canEditGalaxyCluster'] &&
                         $server['Server']['push_galaxy_clusters'] &&
                         "full" !== $technique &&
-                        $this->Event->shouldBePushedToServer($event, $server);
+                        $this->Event->shouldBePushedToServer($event, $server, $reason);
 
                     if ($pushGalaxyClustersForEvent) {
-                        $this->syncGalaxyClusters($serverSync, $this->data, $user, $technique=$event['Event']['id'], $event=$event);
+                        $this->syncGalaxyClusters($serverSync, $server, $user, $technique=$event['Event']['id'], $event=$event);
                     }
 
                     $result = $this->Event->uploadEventToServer($event, $server, $serverSync);


### PR DESCRIPTION
Note: sync after event and cluster publication actions was working. It's only the Server:push function that was affected. This means this issue only popped up if initial sync didn't work for some reason (for example due to missing connection at time of publication).


Referring to https://github.com/MISP/MISP/pull/10991 for initial report. It required some extra modification to fully fix and test, hence the new PR. Sorry @elhoim !

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
