### PR TITLE
fix: [UI] correct broken sync buttons on servers index (default theme)

### DIFF
--- a/app/View/Servers/index.ctp
+++ b/app/View/Servers/index.ctp
@@ -239,11 +239,8 @@
                     'title' => __('Explore')
                 ],
                 [
-                    'url' => $baseurl . '/servers/pull',
-                    'url_params_data_paths' => [
-                        'Server.id',
-                        'update'
-                    ],
+                    'url' => $baseurl . '/servers/pull/%s/update',
+                    'url_replace' => ['Server.id'],
                     'icon' => 'sync',
                     'title' => __('Pull updates to events that already exist locally'),
                     'postLink' => true,
@@ -255,11 +252,8 @@
                     ]
                 ],
                 [
-                    'url' => $baseurl . '/servers/pull',
-                    'url_params_data_paths' => [
-                        'Server.id',
-                        'full'
-                    ],
+                    'url' => $baseurl . '/servers/pull/%s/full',
+                    'url_replace' => ['Server.id'],
                     'icon' => 'arrow-circle-down',
                     'title' => __('Pull all'),
                     'postLink' => true,
@@ -271,11 +265,8 @@
                     ]
                 ],
                 [
-                    'url' => $baseurl . '/servers/pull',
-                    'url_params_data_paths' => [
-                        'Server.id',
-                        'pull_relevant_clusters'
-                    ],
+                    'url' => $baseurl . '/servers/pull/%s/pull_relevant_clusters',
+                    'url_replace' => ['Server.id'],
                     'icon' => 'tags',
                     'title' => __('Pull known relevant custom clusters'),
                     'postLink' => true,
@@ -287,11 +278,8 @@
                     ]
                 ],
                 [
-                    'url' => $baseurl . '/servers/push',
-                    'url_params_data_paths' => [
-                        'Server.id',
-                        'full'
-                    ],
+                    'url' => $baseurl . '/servers/push/%s/full',
+                    'url_replace' => ['Server.id'],
                     'icon' => 'arrow-circle-up',
                     'title' => __('Push all'),
                     'postLink' => true,


### PR DESCRIPTION
#### What does it do?

Fixes regression from https://github.com/MISP/MISP/commit/6a991702f71a3cac76341b4923577c54a0190cc0

Buttons on the index page didn't have the correct extra params anymore. So clicking the push button ended up giving a 500 for example (due to missing /full).

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
