### PR TITLE
new: [feed] Add TweetFeed community IOC feed

### DIFF
--- a/app/files/feed-metadata/defaults.json
+++ b/app/files/feed-metadata/defaults.json
@@ -2505,5 +2505,25 @@
       "exportable": true,
       "hide_tag": false
     }
+  },
+  {
+    "Feed": {
+      "name": "TweetFeed",
+      "provider": "tweetfeed.live",
+      "url": "https://tweetfeed.live/misp",
+      "rules": "{\"tags\":{\"OR\":[],\"NOT\":[]},\"orgs\":{\"OR\":[],\"NOT\":[]}}",
+      "enabled": false,
+      "distribution": "3",
+      "default": false,
+      "source_format": "misp",
+      "fixed_event": false,
+      "delta_merge": false,
+      "publish": false,
+      "override_ids": false,
+      "settings": "{\"csv\":{\"value\":\"\",\"delimiter\":\"\"},\"common\":{\"excluderegex\":\"\"}}",
+      "input_source": "network",
+      "delete_local_file": false,
+      "lookup_visible": false
+    }
   }
 ]


### PR DESCRIPTION
#### What does it do?

Adds [TweetFeed](https://tweetfeed.live) to the default feed metadata.

TweetFeed aggregates indicators posted by the security community on Twitter/X — URLs, domains, IPs, MD5 and SHA256 — and republishes them in native MISP feed format. Data is CC0, no account or key required.

- **Layout**: one Event per day over a 365-day horizon, refreshed every 15 minutes. Identifiers are `uuid5` so they are stable across pulls.
- **Bandwidth**: an Event is only re-stamped when its content actually changes, so after the initial sync a subscriber re-fetches just the current day.
- **Feed cache**: `hashes.csv` is published for `Feed::getCache()`, covering the most recent 31 days.
- **Tags** applied at Event level: `TweetFeed`, `type:OSINT`, `tlp:clear`.
- Feed URL is the directory (`https://tweetfeed.live/misp`); MISP appends `/manifest.json` itself.

Verified against a live MISP 2.5.44 instance before opening this: all 365 events and 112,857 attributes import cleanly, `searchCaches` resolves a known indicator to the feed, and no attribute is rejected by `AttributeValidationTool`. The entry is `enabled: false` / `default: false`, like the other community feeds.

#### Questions

- [ ] Does it require a DB change? — **No**
- [ ] Are you using it in production? — **Yes**, it is the feed I publish
- [ ] Does it require a change in the API (PyMISP for example)? — **No**


---

*Replaces #10950 (same content, same branch). While signing the commit as requested there, a force-push from a shallow clone made GitHub auto-close it, and it can no longer be reopened. The commit is now signed and verified.*
